### PR TITLE
Added #include <limits>

### DIFF
--- a/fbson/FbsonJsonParser.h
+++ b/fbson/FbsonJsonParser.h
@@ -56,6 +56,7 @@
 #define FBSON_FBSONPARSER_H
 
 #include <cmath>
+#include <limits>
 #include "FbsonDocument.h"
 #include "FbsonWriter.h"
 


### PR DESCRIPTION
Added necessary #include <limits> (FbsonJsonParser.h won't compile if it will be used separately).
The reason why tests have passed fine is because gtest/gtest.h contains #include <limits>
