### PR TITLE
Port MySQL Bug #77226: Target sql_embedded should depend on GenDigest…

### DIFF
--- a/libmysqld/CMakeLists.txt
+++ b/libmysqld/CMakeLists.txt
@@ -86,7 +86,7 @@ ENDIF()
 
 ADD_CONVENIENCE_LIBRARY(sql_embedded ${SQL_EMBEDDED_SOURCES})
 DTRACE_INSTRUMENT(sql_embedded)
-ADD_DEPENDENCIES(sql_embedded GenError GenServerSource)
+ADD_DEPENDENCIES(sql_embedded GenError GenServerSource GenDigestServerSource)
 
 # On Windows, static embedded server library is called mysqlserver.lib
 # On Unix, it is libmysqld.a


### PR DESCRIPTION
See: https://bugs.mysql.com/bug.php?id=77226
Compile error:

```
[ 57%] Building CXX object libmysqld/CMakeFiles/sql_embedded.dir/__/sql/sql_yacc.cc.o
mysql-5.6/sql/sql_yacc.yy:67:23: fatal error: lex_token.h: No such file or directory
 #include "lex_token.h"
                       ^
compilation terminated.
make[2]: *** [libmysqld/CMakeFiles/sql_embedded.dir/__/sql/sql_yacc.cc.o] Error 1
make[1]: *** [libmysqld/CMakeFiles/sql_embedded.dir/all] Error 2
make: *** [all] Error 2
```
