### PR TITLE
Change type Save_in_field_args.FuncType to signed char

### DIFF
--- a/sql/item.h
+++ b/sql/item.h
@@ -649,7 +649,7 @@ typedef void (*Cond_traverser) (const Item *item, void *arg);
 // This class is the arguments for the partial update
 class Save_in_field_args : public Sql_alloc {
  public:
-  enum class FuncType : char {
+  enum class FuncType : signed char {
     FUNC_UNKNOWN = -1,
     FUNC_SET,
     FUNC_UNSET,


### PR DESCRIPTION
This was a char. On POWER platforms char is unsigned and as such
failed to compile because the enum had a -1 value.

closes #271
