### PR TITLE
[regex/regexp.c] fix the memory leak

### DIFF
--- a/regex/regexp.c
+++ b/regex/regexp.c
@@ -332,8 +332,10 @@ int		excompat;	/* \( \) operators like in unix ex */
     regnpar = 1;
     regcode = r->program;
     regc(MAGIC);
-    if (reg(0, &flags) == NULL)
+    if (reg(0, &flags) == NULL) {
+	free(r);
 	return ((regexp *) NULL);
+    }
 
     /* Dig out information for optimizations. */
     r->regstart = '\0';		/* Worst-case defaults. */


### PR DESCRIPTION
Greetings. On line number `336` of '[regex/regexp.c](https://github.com/facebook/mysql-5.6/blob/webscalesql-5.6.27.75/regex/regexp.c#L336)' there is a memory leak, which is an error. Memory is a finite resource within our running programs. Sure in very short running simple programs, failing to free memory won't have a noticeable effect. However on long running programs, failing to free memory means we will be consuming a finite resource without replenishing it. Eventually it will run out and our program will abruptly crash. This is why we must free memory.
