### PR TITLE
fix mysqlbinlog memory leak for fake rotate event when reading from remote server 

### DIFF
--- a/client/mysqlbinlog.cc
+++ b/client/mysqlbinlog.cc
@@ -3047,7 +3047,7 @@ connected:
             if ((rev->ident_len != logname_len) ||
                 memcmp(rev->new_log_ident, logname, logname_len))
             {
-	      reset_temp_buf_and_delete(rev);
+              reset_temp_buf_and_delete(rev);
               DBUG_RETURN(OK_CONTINUE);
             }
             /*
@@ -3056,7 +3056,7 @@ connected:
               log. If we are running with to_last_remote_log, we print it,
               because it serves as a useful marker between binlogs then.
             */
-	    reset_temp_buf_and_delete(rev);
+            reset_temp_buf_and_delete(rev);
             continue;
           }
           /*
@@ -3163,7 +3163,7 @@ connected:
         }
         if (ev)
         {
-          reset_temp_buf_and_delete(rev);
+          reset_temp_buf_and_delete(ev);
         }
       }
       else

--- a/client/mysqlbinlog.cc
+++ b/client/mysqlbinlog.cc
@@ -242,6 +242,21 @@ static Exit_status dump_single_log(PRINT_EVENT_INFO *print_event_info,
 static Exit_status dump_multiple_logs(int argc, char **argv);
 static Exit_status safe_connect();
 
+/**
+  The function represents Log_event delete wrapper
+  to reset possibly active temp_buf member.
+  It's to be invoked in context where the member is
+  not bound with dynamically allocated memory and therefore can
+  be reset as simple as with plain assignment to NULL.
+ 
+  @param ev  a pointer to Log_event instance
+*/
+inline void reset_temp_buf_and_delete(Log_event *ev)
+{
+  ev->temp_buf= NULL;
+  delete ev;
+}
+
 /*
   This strucure is used to store the event and the log postion of the events 
   which is later used to print the event details from correct log postions.
@@ -3032,6 +3047,7 @@ connected:
             if ((rev->ident_len != logname_len) ||
                 memcmp(rev->new_log_ident, logname, logname_len))
             {
+	      reset_temp_buf_and_delete(rev);
               DBUG_RETURN(OK_CONTINUE);
             }
             /*
@@ -3040,6 +3056,7 @@ connected:
               log. If we are running with to_last_remote_log, we print it,
               because it serves as a useful marker between binlogs then.
             */
+	    reset_temp_buf_and_delete(rev);
             continue;
           }
           /*
@@ -3146,8 +3163,7 @@ connected:
         }
         if (ev)
         {
-          ev->temp_buf=0;
-          delete ev;
+          reset_temp_buf_and_delete(rev);
         }
       }
       else


### PR DESCRIPTION
missed 'delete' for fake (as defined by ev->when == 0) Rotate event in case binlog is read from a running server (remote dumping)
