### PR TITLE
mysqlbinlog - char -> signed char fix for Power

### DIFF
--- a/client/mysqlbinlog.cc
+++ b/client/mysqlbinlog.cc
@@ -182,7 +182,7 @@ static bool empty_begin_query_ev = false;
 static Log_event* begin_query_ev_cache = nullptr;
 static string cur_database= "";
 
-enum class Check_database_decision : char {
+enum class Check_database_decision : signed char {
   EMPTY_EVENT_DATABASE = 2,
   CHANGED = 1,
   OK = 0,


### PR DESCRIPTION
like #271 / #273 Power has char as a unsigned type by default. As -1 forms a valid enum value change Check_database_decision to signed char.
