### PR TITLE
Fix test failures

### DIFF
--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -14116,6 +14116,11 @@ Rows_query_log_event::Rows_query_log_event(const char *buf, uint event_len,
 
 Rows_query_log_event::~Rows_query_log_event()
 {
+#if defined(MYSQL_SERVER) && defined(HAVE_REPLICATION)
+  // reset the the query set during do_apply_event() before freeing up
+  // the m_rows_query.
+  thd->reset_query();
+#endif
   my_free(m_rows_query);
 }
 

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -14119,7 +14119,12 @@ Rows_query_log_event::~Rows_query_log_event()
 #if defined(MYSQL_SERVER) && defined(HAVE_REPLICATION)
   // reset the the query set during do_apply_event() before freeing up
   // the m_rows_query.
-  thd->reset_query();
+  if (thd) {
+    mysql_mutex_lock(&thd->LOCK_thd_data);
+    if (thd->query() == m_rows_query)
+      thd->set_query(CSET_STRING(), false);
+    mysql_mutex_unlock(&thd->LOCK_thd_data);
+  }
 #endif
   my_free(m_rows_query);
 }

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -4919,11 +4919,13 @@ void THD::set_command(enum enum_server_command command)
 
 /** Assign a new value to thd->query.  */
 
-void THD::set_query(const CSET_STRING &string_arg)
+void THD::set_query(const CSET_STRING &string_arg, bool need_lock)
 {
-  mysql_mutex_lock(&LOCK_thd_data);
+  if (need_lock)
+    mysql_mutex_lock(&LOCK_thd_data);
   set_query_inner(string_arg);
-  mysql_mutex_unlock(&LOCK_thd_data);
+  if (need_lock)
+    mysql_mutex_unlock(&LOCK_thd_data);
 
 #ifdef HAVE_PSI_THREAD_INTERFACE
   PSI_THREAD_CALL(set_thread_info)(query(), query_length());

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -4427,7 +4427,8 @@ public:
   {
     set_query(CSET_STRING(query_arg, query_length_arg, charset()));
   }
-  void set_query(const CSET_STRING &str); /* Mutex protected */
+  void set_query(const CSET_STRING &str,
+                 bool need_lock = true); /* Mutex protected */
   void reset_query()               /* Mutex protected */
   { set_query(CSET_STRING()); }
   void set_query_and_id(char *query_arg, uint32 query_length_arg,


### PR DESCRIPTION
During recovery thd is null, so we need to guard against this. I think it is also
better to check for the current we are resetting thd query value which was set
when applying the same rows query log event.

Squash with: 42bdfc801d579722efc5d2d9eedc9c37cd7c9fe0

Test Plan: mtr
