### PR TITLE
Adding innodb_force_index_records_in_range session variable

### DIFF
--- a/mysql-test/suite/sys_vars/r/innodb_force_index_records_in_range_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_force_index_records_in_range_basic.result
@@ -1,0 +1,26 @@
+SET GLOBAL innodb_force_index_records_in_range = 128;
+SELECT @@GLOBAL.innodb_force_index_records_in_range;
+@@GLOBAL.innodb_force_index_records_in_range
+128
+SET SESSION innodb_force_index_records_in_range=1000000;
+SELECT @@SESSION.innodb_force_index_records_in_range;
+@@SESSION.innodb_force_index_records_in_range
+1000000
+SET SESSION innodb_force_index_records_in_range=0;
+SELECT @@SESSION.innodb_force_index_records_in_range;
+@@SESSION.innodb_force_index_records_in_range
+0
+SET SESSION innodb_force_index_records_in_range=16384;
+SELECT @@SESSION.innodb_force_index_records_in_range;
+@@SESSION.innodb_force_index_records_in_range
+16384
+SET GLOBAL innodb_force_index_records_in_range=-1;
+Warnings:
+Warning	1292	Truncated incorrect innodb_force_index_records_in_ra value: '-1'
+SELECT @@GLOBAL.innodb_force_index_records_in_range;
+@@GLOBAL.innodb_force_index_records_in_range
+0
+SET GLOBAL innodb_force_index_records_in_range = default;
+SELECT @@GLOBAL.innodb_force_index_records_in_range;
+@@GLOBAL.innodb_force_index_records_in_range
+0

--- a/mysql-test/suite/sys_vars/t/innodb_force_index_records_in_range_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_force_index_records_in_range_basic.test
@@ -1,0 +1,14 @@
+--source include/have_innodb.inc
+
+SET GLOBAL innodb_force_index_records_in_range = 128;
+SELECT @@GLOBAL.innodb_force_index_records_in_range;
+SET SESSION innodb_force_index_records_in_range=1000000;
+SELECT @@SESSION.innodb_force_index_records_in_range;
+SET SESSION innodb_force_index_records_in_range=0;
+SELECT @@SESSION.innodb_force_index_records_in_range;
+SET SESSION innodb_force_index_records_in_range=16384;
+SELECT @@SESSION.innodb_force_index_records_in_range;
+SET GLOBAL innodb_force_index_records_in_range=-1;
+SELECT @@GLOBAL.innodb_force_index_records_in_range;
+SET GLOBAL innodb_force_index_records_in_range = default;
+SELECT @@GLOBAL.innodb_force_index_records_in_range;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -612,6 +612,13 @@ static MYSQL_THDVAR_BOOL(stats_on_metadata,
   "statistics. (OFF by default)",
   NULL, NULL, FALSE);
 
+static MYSQL_THDVAR_ULONG(force_index_records_in_range,
+  PLUGIN_VAR_RQCMDARG,
+  "Used to override the result of records_in_range() when FORCE INDEX is used.",
+  nullptr, nullptr, 0,
+  /* min */ 0, /* max */ ULONG_MAX, 0);
+
+
 static SHOW_VAR innodb_status_variables[]= {
   {"adaptive_hash_hits",
   (char*) &export_vars.innodb_hash_searches,		  SHOW_LONG},
@@ -11638,6 +11645,13 @@ ha_innobase::records_in_range(
 
 	prebuilt->trx->op_info = (char*)"estimating records in index range";
 
+	if (table->force_index) {
+		ha_rows force_rows = THDVAR(ha_thd(), force_index_records_in_range);
+		if (force_rows) {
+			DBUG_RETURN(force_rows);
+		}
+	}
+
 	/* In case MySQL calls this in the middle of a SELECT query, release
 	possible adaptive hash latch to avoid deadlocks of threads */
 
@@ -18701,6 +18715,7 @@ static struct st_mysql_sys_var* innobase_system_variables[]= {
 #ifndef DBUG_OFF
   MYSQL_SYSVAR(force_recovery_crash),
 #endif /* !DBUG_OFF */
+  MYSQL_SYSVAR(force_index_records_in_range),
   MYSQL_SYSVAR(ft_cache_size),
   MYSQL_SYSVAR(ft_total_cache_size),
   MYSQL_SYSVAR(ft_result_cache_limit),

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -618,7 +618,6 @@ static MYSQL_THDVAR_ULONG(force_index_records_in_range,
   nullptr, nullptr, 0,
   /* min */ 0, /* max */ ULONG_MAX, 0);
 
-
 static SHOW_VAR innodb_status_variables[]= {
   {"adaptive_hash_hits",
   (char*) &export_vars.innodb_hash_searches,		  SHOW_LONG},
@@ -11648,7 +11647,8 @@ ha_innobase::records_in_range(
 	if (table->force_index) {
 		ha_rows force_rows = THDVAR(ha_thd(), force_index_records_in_range);
 		if (force_rows) {
-			DBUG_RETURN(force_rows);
+			n_rows = force_rows;
+			goto func_exit;
 		}
 	}
 


### PR DESCRIPTION
Summary:
Add a variable to skip records_in_range when force index is being used.

Test Plan:
mtr