### PR TITLE
Multi-tenancy plugin framework

### DIFF
--- a/cmake/abi_check.cmake
+++ b/cmake/abi_check.cmake
@@ -44,6 +44,7 @@ IF(CMAKE_COMPILER_IS_GNUCC AND RUN_ABI_CHECK)
     ${CMAKE_SOURCE_DIR}/include/mysql/psi/psi_abi_v2.h
     ${CMAKE_SOURCE_DIR}/include/mysql/client_plugin.h
     ${CMAKE_SOURCE_DIR}/include/mysql/plugin_auth.h
+    ${CMAKE_SOURCE_DIR}/include/mysql/plugin_multi_tenancy.h
   )
 
   ADD_CUSTOM_TARGET(abi_check ALL

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -31,6 +31,7 @@ SET(HEADERS_ABI
   mysql/plugin_audit.h
   mysql/plugin_ftparser.h
   mysql/plugin_validate_password.h
+  mysql/plugin_multi_tenancy.h
 )
 
 SET(HEADERS 

--- a/include/mysql/plugin.h
+++ b/include/mysql/plugin.h
@@ -87,7 +87,8 @@ typedef struct st_mysql_xid MYSQL_XID;
 #define MYSQL_REPLICATION_PLUGIN     6	/* The replication plugin type */
 #define MYSQL_AUTHENTICATION_PLUGIN  7  /* The authentication plugin type */
 #define MYSQL_VALIDATE_PASSWORD_PLUGIN  8   /* validate password plugin type */
-#define MYSQL_MAX_PLUGIN_TYPE_NUM    9  /* The number of plugin types   */
+#define MYSQL_MULTI_TENANCY_PLUGIN   9  /* The multi-tenancy plugin type */
+#define MYSQL_MAX_PLUGIN_TYPE_NUM    10 /* The number of plugin types   */
 
 /* We use the following strings to define licenses for plugins */
 #define PLUGIN_LICENSE_PROPRIETARY 0

--- a/include/mysql/plugin_multi_tenancy.h
+++ b/include/mysql/plugin_multi_tenancy.h
@@ -1,0 +1,70 @@
+/* Copyright (c) 2016, Facebook. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+
+#ifndef _mysql_multi_tenancy_h
+#define _mysql_multi_tenancy_h
+
+/*************************************************************************
+ *   API for Multi-Tenancy plugin. (MYSQL_MULTI_TENANCY_PLUGIN)
+ */
+
+
+#include "plugin.h"
+
+#define MYSQL_MULTI_TENANCY_INTERFACE_VERSION 0x0100
+
+// Resource isolation types that a multi-tenancy plugin will handle.
+// Currently connection and query limits are two resource types. More will be
+// supported in the future.
+enum class enum_multi_tenancy_resource_type
+{
+  MULTI_TENANCY_RESOURCE_CONNECTION,
+  MULTI_TENANCY_RESOURCE_QUERY,
+
+  MULTI_TENANCY_NUM_RESOURCE_TYPES
+};
+
+// Callback function return types.
+// - ACCEPT: resource can be granted
+// - WAIT: may need to wait for resource to be freed up
+// - REJECT: resource cannot be granted
+// - FALLBACK: plugin is disabled
+enum class enum_multi_tenancy_return_type
+{
+  MULTI_TENANCY_RET_ACCEPT = 0,
+  MULTI_TENANCY_RET_WAIT,
+  MULTI_TENANCY_RET_REJECT,
+
+  MULTI_TENANCY_RET_FALLBACK,
+  MULTI_TENANCY_NUM_RETURN_TYPES
+};
+
+typedef enum enum_multi_tenancy_resource_type MT_RESOURCE_TYPE;
+typedef enum enum_multi_tenancy_return_type MT_RETURN_TYPE;
+typedef std::unordered_map<std::string, std::string> ATTRS_MAP_T;
+
+// Plugin descriptor struct
+struct st_mysql_multi_tenancy
+{
+  int interface_version;
+  MT_RETURN_TYPE (*request_resource)
+    (MYSQL_THD, MT_RESOURCE_TYPE type, const ATTRS_MAP_T *);
+  MT_RETURN_TYPE (*release_resource)
+    (MYSQL_THD, MT_RESOURCE_TYPE type, const ATTRS_MAP_T *);
+};
+
+#endif

--- a/include/mysql/plugin_multi_tenancy.h.pp
+++ b/include/mysql/plugin_multi_tenancy.h.pp
@@ -1,0 +1,296 @@
+#include "plugin.h"
+typedef void * MYSQL_PLUGIN;
+#include <mysql/services.h>
+#include <mysql/service_my_snprintf.h>
+extern struct my_snprintf_service_st {
+  size_t (*my_snprintf_type)(char*, size_t, const char*, ...);
+  size_t (*my_vsnprintf_type)(char *, size_t, const char*, va_list);
+} *my_snprintf_service;
+size_t my_snprintf(char* to, size_t n, const char* fmt, ...);
+size_t my_vsnprintf(char *to, size_t n, const char* fmt, va_list ap);
+#include <mysql/service_thd_alloc.h>
+struct st_mysql_lex_string
+{
+  char *str;
+  size_t length;
+};
+typedef struct st_mysql_lex_string MYSQL_LEX_STRING;
+extern struct thd_alloc_service_st {
+  void *(*thd_alloc_func)(void*, unsigned int);
+  void *(*thd_calloc_func)(void*, unsigned int);
+  char *(*thd_strdup_func)(void*, const char *);
+  char *(*thd_strmake_func)(void*, const char *, unsigned int);
+  void *(*thd_memdup_func)(void*, const void*, unsigned int);
+  MYSQL_LEX_STRING *(*thd_make_lex_string_func)(void*, MYSQL_LEX_STRING *,
+                                        const char *, unsigned int, int);
+} *thd_alloc_service;
+void *thd_alloc(void* thd, unsigned int size);
+void *thd_calloc(void* thd, unsigned int size);
+char *thd_strdup(void* thd, const char *str);
+char *thd_strmake(void* thd, const char *str, unsigned int size);
+void *thd_memdup(void* thd, const void* str, unsigned int size);
+MYSQL_LEX_STRING *thd_make_lex_string(void* thd, MYSQL_LEX_STRING *lex_str,
+                                      const char *str, unsigned int size,
+                                      int allocate_lex_string);
+#include <mysql/service_thd_wait.h>
+typedef enum _thd_wait_type_e {
+  THD_WAIT_SLEEP= 1,
+  THD_WAIT_DISKIO= 2,
+  THD_WAIT_ROW_LOCK= 3,
+  THD_WAIT_GLOBAL_LOCK= 4,
+  THD_WAIT_META_DATA_LOCK= 5,
+  THD_WAIT_TABLE_LOCK= 6,
+  THD_WAIT_USER_LOCK= 7,
+  THD_WAIT_BINLOG= 8,
+  THD_WAIT_GROUP_COMMIT= 9,
+  THD_WAIT_SYNC= 10,
+  THD_WAIT_LAST= 11
+} thd_wait_type;
+extern struct thd_wait_service_st {
+  void (*thd_wait_begin_func)(void*, int);
+  void (*thd_wait_end_func)(void*);
+} *thd_wait_service;
+void thd_wait_begin(void* thd, int wait_type);
+void thd_wait_end(void* thd);
+#include <mysql/service_thread_scheduler.h>
+struct scheduler_functions;
+extern struct my_thread_scheduler_service {
+  int (*set)(struct scheduler_functions *scheduler);
+  int (*reset)();
+} *my_thread_scheduler_service;
+int my_thread_scheduler_set(struct scheduler_functions *scheduler);
+int my_thread_scheduler_reset();
+#include <mysql/service_my_plugin_log.h>
+enum plugin_log_level
+{
+  MY_ERROR_LEVEL,
+  MY_WARNING_LEVEL,
+  MY_INFORMATION_LEVEL
+};
+extern struct my_plugin_log_service
+{
+  int (*my_plugin_log_message)(MYSQL_PLUGIN *, enum plugin_log_level, const char *, ...);
+} *my_plugin_log_service;
+int my_plugin_log_message(MYSQL_PLUGIN *plugin, enum plugin_log_level level,
+                          const char *format, ...);
+#include <mysql/service_mysql_string.h>
+typedef void *mysql_string_iterator_handle;
+typedef void *mysql_string_handle;
+extern struct mysql_string_service_st {
+  int (*mysql_string_convert_to_char_ptr_type)
+       (mysql_string_handle, const char *, char *, unsigned int, int *);
+  mysql_string_iterator_handle (*mysql_string_get_iterator_type)
+                                (mysql_string_handle);
+  int (*mysql_string_iterator_next_type)(mysql_string_iterator_handle);
+  int (*mysql_string_iterator_isupper_type)(mysql_string_iterator_handle);
+  int (*mysql_string_iterator_islower_type)(mysql_string_iterator_handle);
+  int (*mysql_string_iterator_isdigit_type)(mysql_string_iterator_handle);
+  mysql_string_handle (*mysql_string_to_lowercase_type)(mysql_string_handle);
+  void (*mysql_string_free_type)(mysql_string_handle);
+  void (*mysql_string_iterator_free_type)(mysql_string_iterator_handle);
+} *mysql_string_service;
+int mysql_string_convert_to_char_ptr(mysql_string_handle string_handle,
+                                     const char *charset_name, char *buffer,
+                                     unsigned int buffer_size, int *error);
+mysql_string_iterator_handle mysql_string_get_iterator(mysql_string_handle
+                                                       string_handle);
+int mysql_string_iterator_next(mysql_string_iterator_handle iterator_handle);
+int mysql_string_iterator_isupper(mysql_string_iterator_handle iterator_handle);
+int mysql_string_iterator_islower(mysql_string_iterator_handle iterator_handle);
+int mysql_string_iterator_isdigit(mysql_string_iterator_handle iterator_handle);
+mysql_string_handle mysql_string_to_lowercase(mysql_string_handle
+                                              string_handle);
+void mysql_string_free(mysql_string_handle);
+void mysql_string_iterator_free(mysql_string_iterator_handle);
+struct st_mysql_xid {
+  long formatID;
+  long gtrid_length;
+  long bqual_length;
+  char data[128];
+};
+typedef struct st_mysql_xid MYSQL_XID;
+enum enum_mysql_show_type
+{
+  SHOW_UNDEF, SHOW_BOOL,
+  SHOW_INT,
+  SHOW_LONG,
+  SHOW_LONGLONG,
+  SHOW_SIGNED_INT,
+  SHOW_SIGNED_LONG,
+  SHOW_SIGNED_LONGLONG,
+  SHOW_CHAR, SHOW_CHAR_PTR,
+  SHOW_ARRAY, SHOW_FUNC, SHOW_DOUBLE,
+  SHOW_TIMER,
+  SHOW_always_last
+};
+struct st_mysql_show_var {
+  const char *name;
+  char *value;
+  enum enum_mysql_show_type type;
+};
+typedef int (*mysql_show_var_func)(void*, struct st_mysql_show_var*, char *);
+struct st_mysql_sys_var;
+struct st_mysql_value;
+typedef int (*mysql_var_check_func)(void* thd,
+                                    struct st_mysql_sys_var *var,
+                                    void *save, struct st_mysql_value *value);
+typedef void (*mysql_var_update_func)(void* thd,
+                                      struct st_mysql_sys_var *var,
+                                      void *var_ptr, const void *save);
+struct st_mysql_plugin
+{
+  int type;
+  void *info;
+  const char *name;
+  const char *author;
+  const char *descr;
+  int license;
+  int (*init)(MYSQL_PLUGIN);
+  int (*deinit)(MYSQL_PLUGIN);
+  unsigned int version;
+  struct st_mysql_show_var *status_vars;
+  struct st_mysql_sys_var **system_vars;
+  void * __reserved1;
+  unsigned long flags;
+};
+#include "plugin_ftparser.h"
+#include "plugin.h"
+enum enum_ftparser_mode
+{
+  MYSQL_FTPARSER_SIMPLE_MODE= 0,
+  MYSQL_FTPARSER_WITH_STOPWORDS= 1,
+  MYSQL_FTPARSER_FULL_BOOLEAN_INFO= 2
+};
+enum enum_ft_token_type
+{
+  FT_TOKEN_EOF= 0,
+  FT_TOKEN_WORD= 1,
+  FT_TOKEN_LEFT_PAREN= 2,
+  FT_TOKEN_RIGHT_PAREN= 3,
+  FT_TOKEN_STOPWORD= 4
+};
+typedef struct st_mysql_ftparser_boolean_info
+{
+  enum enum_ft_token_type type;
+  int yesno;
+  int weight_adjust;
+  char wasign;
+  char trunc;
+  char prev;
+  char *quot;
+} MYSQL_FTPARSER_BOOLEAN_INFO;
+typedef struct st_mysql_ftparser_param
+{
+  int (*mysql_parse)(struct st_mysql_ftparser_param *,
+                     char *doc, int doc_len);
+  int (*mysql_add_word)(struct st_mysql_ftparser_param *,
+                        char *word, int word_len,
+                        MYSQL_FTPARSER_BOOLEAN_INFO *boolean_info);
+  void *ftparser_state;
+  void *mysql_ftparam;
+  const struct charset_info_st *cs;
+  char *doc;
+  int length;
+  int flags;
+  enum enum_ftparser_mode mode;
+} MYSQL_FTPARSER_PARAM;
+struct st_mysql_ftparser
+{
+  int interface_version;
+  int (*parse)(MYSQL_FTPARSER_PARAM *param);
+  int (*init)(MYSQL_FTPARSER_PARAM *param);
+  int (*deinit)(MYSQL_FTPARSER_PARAM *param);
+};
+struct st_mysql_daemon
+{
+  int interface_version;
+};
+struct st_mysql_information_schema
+{
+  int interface_version;
+};
+struct st_mysql_storage_engine
+{
+  int interface_version;
+};
+struct handlerton;
+ struct Mysql_replication {
+   int interface_version;
+ };
+struct st_mysql_value
+{
+  int (*value_type)(struct st_mysql_value *);
+  const char *(*val_str)(struct st_mysql_value *, char *buffer, int *length);
+  int (*val_real)(struct st_mysql_value *, double *realbuf);
+  int (*val_int)(struct st_mysql_value *, long long *intbuf);
+  int (*is_unsigned)(struct st_mysql_value *);
+};
+struct st_slave_gtid_info
+{
+  unsigned int id;
+  const char* db;
+  const char* gtid;
+};
+int thd_in_lock_tables(const void* thd);
+int thd_tablespace_op(const void* thd);
+long long thd_test_options(const void* thd, long long test_options);
+int thd_sql_command(const void* thd);
+const char *thd_proc_info(void* thd, const char *info);
+void **thd_ha_data(const void* thd, const struct handlerton *hton);
+void thd_storage_lock_wait(void* thd, long long value);
+int thd_tx_isolation(const void* thd);
+int thd_tx_is_read_only(const void* thd);
+char *thd_security_context(void* thd, char *buffer, unsigned int length,
+                           unsigned int max_query_len);
+void thd_inc_row_count(void* thd);
+int thd_allow_batch(void* thd);
+void thd_store_lsn(void* thd, unsigned long long lsn, int db_type);
+int mysql_tmpfile(const char *prefix);
+int mysql_tmpfile_path(const char *path, const char *prefix);
+int thd_killed(const void* thd);
+void thd_set_kill_status(const void* thd);
+void thd_binlog_pos(const void* thd,
+                    const char **file_var,
+                    unsigned long long *pos_var,
+                    const char **gtid_var,
+                    const char **max_gtid_var);
+void thd_slave_gtid_info(const void* thd, void *slave_gtid_info);
+unsigned long thd_get_thread_id(const void* thd);
+void thd_get_xid(const void* thd, MYSQL_XID *xid);
+void mysql_query_cache_invalidate4(void* thd,
+                                   const char *key, unsigned int key_length,
+                                   int using_trx);
+void *thd_get_ha_data(const void* thd, const struct handlerton *hton);
+void thd_set_ha_data(void* thd, const struct handlerton *hton,
+                     const void *ha_data);
+char mysql_bin_log_is_open(void);
+void mysql_bin_log_lock_commits(void);
+void mysql_bin_log_unlock_commits(char* binlog_file,
+                                  unsigned long long* binlog_pos,
+                                  char** gtid_executed,
+                                  int* gtid_executed_length);
+enum class enum_multi_tenancy_resource_type
+{
+  MULTI_TENANCY_RESOURCE_CONNECTION,
+  MULTI_TENANCY_RESOURCE_QUERY,
+  MULTI_TENANCY_NUM_RESOURCE_TYPES
+};
+enum class enum_multi_tenancy_return_type
+{
+  MULTI_TENANCY_RET_ACCEPT = 0,
+  MULTI_TENANCY_RET_WAIT,
+  MULTI_TENANCY_RET_REJECT,
+  MULTI_TENANCY_RET_FALLBACK,
+  MULTI_TENANCY_NUM_RETURN_TYPES
+};
+typedef enum enum_multi_tenancy_resource_type MT_RESOURCE_TYPE;
+typedef enum enum_multi_tenancy_return_type MT_RETURN_TYPE;
+typedef std::unordered_map<std::string, std::string> ATTRS_MAP_T;
+struct st_mysql_multi_tenancy
+{
+  int interface_version;
+  MT_RETURN_TYPE (*request_resource)
+    (void*, MT_RESOURCE_TYPE type, const ATTRS_MAP_T *);
+  MT_RETURN_TYPE (*release_resource)
+    (void*, MT_RESOURCE_TYPE type, const ATTRS_MAP_T *);
+};

--- a/mysql-test/include/have_mt_simple.inc
+++ b/mysql-test/include/have_mt_simple.inc
@@ -1,0 +1,21 @@
+#
+# Check if server has support for loading plugins
+#
+if (`SELECT @@have_dynamic_loading != 'YES'`) {
+  --skip simple parser requires dynamic loading
+}
+
+#
+# Check if the variable MT_SIMPLE is set
+#
+if (!$MT_SIMPLE) {
+  --skip mt_simple requires the environment variable \$MT_SIMPLE to be set (normally done by mtr)
+}
+
+#
+# Check if --plugin-dir was setup for simple parser
+#
+if (`SELECT CONCAT('--plugin-dir=', REPLACE(@@plugin_dir, '\\\\', '/')) != '$MT_SIMPLE_OPT/'`) {
+  --skip mt_simple requires that --plugin-dir is set to the udf plugin dir (either the .opt file does not contain \$UDF_EXAMPLE_LIB_OPT or another plugin is in use)
+}
+

--- a/mysql-test/include/plugin.defs
+++ b/mysql-test/include/plugin.defs
@@ -46,3 +46,4 @@ libmemcached       plugin/innodb_memcached/daemon_memcached DAEMON_MEMCACHED dae
 innodb_engine      plugin/innodb_memcached/innodb_memcache INNODB_ENGINE
 validate_password  plugin/password_validation VALIDATE_PASSWORD validate_password
 mysql_no_login     plugin/mysql_no_login      MYSQL_NO_LOGIN    mysql_no_login
+mt_simple          plugin/mt_simple   MT_SIMPLE

--- a/mysql-test/r/admission_control.result
+++ b/mysql-test/r/admission_control.result
@@ -30,6 +30,35 @@ Verify the waiting queries received wakeup signal.
 select count(*) from t1;
 count(*)
 15
+set @save_admission_control_by_trx = @@global.admission_control_by_trx;
+select @save_admission_control_by_trx;
+@save_admission_control_by_trx
+0
+# By default, open transaction has no effect on running queries
+select count(*) from t1;
+count(*)
+15
+# Test: open transactions will take slots in running queries,
+#       and will not be blocked
+set @@global.admission_control_by_trx = true;
+SELECT @@global.admission_control_by_trx;
+@@global.admission_control_by_trx
+1
+Open transaction is able to continue running queries
+connection con_max_wait
+New queries will be rejected
+select * from t1;
+ERROR HY000: Maximum waiting queries 6 reached for database `test_db`
+New transactions will be rejected
+begin;
+ERROR HY000: Maximum waiting queries 6 reached for database `test_db`
+Committing a transaction will free up the running query slots
+The waiting queries will be unblocked
+set @@global.admission_control_by_trx = @save_admission_control_by_trx;
+select @@global.admission_control_by_trx;
+@@global.admission_control_by_trx
+0
+# End of open transaction test
 Run parallel load and drop the database.
 set @@global.max_waiting_queries=0;
 Cleanup.

--- a/mysql-test/r/admission_control_hang.result
+++ b/mysql-test/r/admission_control_hang.result
@@ -15,12 +15,19 @@ update t1 set a=2 where a=1;
 update t1 set a=2 where a=1;
 update t1 set a=2 where a=1;
 update t1 set a=2 where a=1;
-set @@global.admission_control_filter = 'ALTER,BEGIN,COMMIT,CREATE,DELETE,DROP,INSERT,LOAD,SELECT,SET,REPLACE,TRUNCATE,UPDATE,SHOW';
+set @@global.admission_control_filter = 'ALTER,BEGIN,COMMIT,CREATE,DELETE,DROP,INSERT,LOAD,SELECT,SET,REPLACE,TRUNCATE,UPDATE,SHOW,ROLLBACK';
+select @@global.admission_control_filter;
+@@global.admission_control_filter
+ALTER,BEGIN,COMMIT,CREATE,DELETE,DROP,INSERT,LOAD,SELECT,SET,REPLACE,ROLLBACK,TRUNCATE,UPDATE,SHOW
 create table t2(a int) engine=innodb;
 begin;
 insert into t2 values(1);
 update t2 set a=2 where a=1;
 commit;
+SHOW TABLES LIKE 't2';
+Tables_in_test_db (t2)
+t2
+begin;
 alter table t2 rename t3;
 select * from t3;
 a
@@ -28,12 +35,50 @@ a
 delete from t3;
 set @val = 1;
 truncate table t3;
+rollback;
 drop table t3;
+set @save_admission_control_by_trx = @@global.admission_control_by_trx;
+select @save_admission_control_by_trx;
+@save_admission_control_by_trx
+0
+# Turn on admission_control_by_trx
+set @@global.admission_control_by_trx = true;
+SELECT @@global.admission_control_by_trx;
+@@global.admission_control_by_trx
+1
+create table t2(a int) engine=innodb;
+begin;
+insert into t2 values(1);
+update t2 set a=2 where a=1;
+commit;
 SHOW TABLES LIKE 't2';
 Tables_in_test_db (t2)
-set @@global.admission_control_filter = 'ROLLBACK';
+t2
+begin;
+alter table t2 rename t3;
+select * from t3;
+a
+2
+delete from t3;
+set @val = 1;
+truncate table t3;
 rollback;
+drop table t3;
+set @@global.admission_control_filter = default;
+select @@global.admission_control_filter;
+@@global.admission_control_filter
+
+select count(*) from t1;
+count(*)
+1
+set @@global.admission_control_by_trx = @save_admission_control_by_trx;
+select @@global.admission_control_by_trx;
+@@global.admission_control_by_trx
+0
 set @@global.admission_control_filter = 'COMMIT';
+select @@global.admission_control_filter;
+@@global.admission_control_filter
+COMMIT
 commit;
 set @@global.max_running_queries = @start_max_running_queries;
 set @@global.innodb_lock_wait_timeout = @start_innodb_lock_wait_timeout;

--- a/mysql-test/r/mt_simple_plugin.result
+++ b/mysql-test/r/mt_simple_plugin.result
@@ -1,0 +1,61 @@
+install plugin mt_simple soname 'mt_simple.so';
+select * from information_schema.plugins where plugin_name like 'mt_simple';
+PLUGIN_NAME	PLUGIN_VERSION	PLUGIN_STATUS	PLUGIN_TYPE	PLUGIN_TYPE_VERSION	PLUGIN_LIBRARY	PLUGIN_LIBRARY_VERSION	PLUGIN_AUTHOR	PLUGIN_DESCRIPTION	PLUGIN_LICENSE	LOAD_OPTION
+MT_SIMPLE	1.0	ACTIVE	MULTI TENANCY	1.0	mt_simple.so	1.4	Tian Xia	Simple multi_tenancy	GPL	ON
+show global variables like 'mt_simple_%';
+Variable_name	Value
+mt_simple_on	ON
+show global status like 'mt_simple_%';
+Variable_name	Value
+mt_simple_open_conns	0
+mt_simple_open_db_conns	0
+mt_simple_open_role_conns	0
+mt_simple_running_queries	0
+create table t1(a text, b text);
+drop table t1;
+show global status like 'mt_simple_%';
+Variable_name	Value
+mt_simple_open_conns	10
+mt_simple_open_db_conns	0
+mt_simple_open_role_conns	0
+mt_simple_running_queries	0
+set global mt_simple_on = 0;
+show global status like 'mt_simple_%';
+Variable_name	Value
+mt_simple_open_conns	10
+mt_simple_open_db_conns	0
+mt_simple_open_role_conns	0
+mt_simple_running_queries	0
+set global mt_simple_on = 1;
+show global status like 'mt_simple_%';
+Variable_name	Value
+mt_simple_open_conns	0
+mt_simple_open_db_conns	0
+mt_simple_open_role_conns	0
+mt_simple_running_queries	0
+uninstall plugin mt_simple;
+Warnings:
+Warning	1620	Plugin is busy and will be uninstalled on shutdown
+select * from information_schema.plugins where plugin_name like 'mt_simple';
+PLUGIN_NAME	PLUGIN_VERSION	PLUGIN_STATUS	PLUGIN_TYPE	PLUGIN_TYPE_VERSION	PLUGIN_LIBRARY	PLUGIN_LIBRARY_VERSION	PLUGIN_AUTHOR	PLUGIN_DESCRIPTION	PLUGIN_LICENSE	LOAD_OPTION
+MT_SIMPLE	1.0	DELETED	MULTI TENANCY	1.0	mt_simple.so	1.4	Tian Xia	Simple multi_tenancy	GPL	ON
+show global variables like 'mt_simple_%';
+Variable_name	Value
+mt_simple_on	ON
+show global status like 'mt_simple_%';
+Variable_name	Value
+mt_simple_open_conns	0
+mt_simple_open_db_conns	0
+mt_simple_open_role_conns	0
+mt_simple_running_queries	0
+show global variables like 'mt_simple_%';
+Variable_name	Value
+mt_simple_on	ON
+show global status like 'mt_simple_%';
+Variable_name	Value
+mt_simple_open_conns	0
+mt_simple_open_db_conns	0
+mt_simple_open_role_conns	0
+mt_simple_running_queries	0
+select * from information_schema.plugins where plugin_name like 'mt_simple';
+PLUGIN_NAME	PLUGIN_VERSION	PLUGIN_STATUS	PLUGIN_TYPE	PLUGIN_TYPE_VERSION	PLUGIN_LIBRARY	PLUGIN_LIBRARY_VERSION	PLUGIN_AUTHOR	PLUGIN_DESCRIPTION	PLUGIN_LICENSE	LOAD_OPTION

--- a/mysql-test/r/mysqld--help-notwin-profiling.result
+++ b/mysql-test/r/mysqld--help-notwin-profiling.result
@@ -12,6 +12,8 @@ The following options may be given as the first argument:
  Option used by mysql-test for debugging and testing of
  replication.
  --admin-port=#      Port number to use for connections from admin.
+ --admission-control-by-trx 
+ Allow open transactions to go through admission control
  --admission-control-filter=name 
  Commands that are skipped in admission control checks.
  The legal values are: ALTER, BEGIN, COMMIT, CREATE,
@@ -1612,6 +1614,7 @@ The following options may be given as the first argument:
 Variables (--variable-name=value)
 abort-slave-event-count 0
 admin-port 0
+admission-control-by-trx FALSE
 admission-control-filter 
 allow-document-type FALSE
 allow-multiple-engines FALSE

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -12,6 +12,8 @@ The following options may be given as the first argument:
  Option used by mysql-test for debugging and testing of
  replication.
  --admin-port=#      Port number to use for connections from admin.
+ --admission-control-by-trx 
+ Allow open transactions to go through admission control
  --admission-control-filter=name 
  Commands that are skipped in admission control checks.
  The legal values are: ALTER, BEGIN, COMMIT, CREATE,
@@ -1610,6 +1612,7 @@ The following options may be given as the first argument:
 Variables (--variable-name=value)
 abort-slave-event-count 0
 admin-port 0
+admission-control-by-trx FALSE
 admission-control-filter 
 allow-document-type FALSE
 allow-multiple-engines FALSE

--- a/mysql-test/suite/sys_vars/r/admission_control_by_trx_basic.result
+++ b/mysql-test/suite/sys_vars/r/admission_control_by_trx_basic.result
@@ -1,0 +1,42 @@
+SET @start_admission_control_by_trx = @@global.admission_control_by_trx;
+SELECT @start_admission_control_by_trx;
+@start_admission_control_by_trx
+0
+SET @@global.admission_control_by_trx = DEFAULT;
+SELECT @@global.admission_control_by_trx;
+@@global.admission_control_by_trx
+0
+SET @@global.admission_control_by_trx = false;
+SELECT @@global.admission_control_by_trx;
+@@global.admission_control_by_trx
+0
+SET @@global.admission_control_by_trx = true;
+SELECT @@global.admission_control_by_trx;
+@@global.admission_control_by_trx
+1
+SET @@global.admission_control_by_trx = 1;
+SELECT @@global.admission_control_by_trx;
+@@global.admission_control_by_trx
+1
+SET @@global.admission_control_by_trx = 0;
+SELECT @@global.admission_control_by_trx;
+@@global.admission_control_by_trx
+0
+SET @@global.admission_control_by_trx = -1;
+ERROR 42000: Variable 'admission_control_by_trx' can't be set to the value of '-1'
+SELECT @@global.admission_control_by_trx;
+@@global.admission_control_by_trx
+0
+SET @@global.admission_control_by_trx = 100;
+ERROR 42000: Variable 'admission_control_by_trx' can't be set to the value of '100'
+SELECT @@global.admission_control_by_trx;
+@@global.admission_control_by_trx
+0
+SET @@session.admission_control_by_trx = 10;
+ERROR HY000: Variable 'admission_control_by_trx' is a GLOBAL variable and should be set with SET GLOBAL
+SELECT @@session.admission_control_by_trx;
+ERROR HY000: Variable 'admission_control_by_trx' is a GLOBAL variable
+SET @@global.admission_control_by_trx = @start_admission_control_by_trx;
+SELECT @@global.admission_control_by_trx;
+@@global.admission_control_by_trx
+0

--- a/mysql-test/suite/sys_vars/t/admission_control_by_trx_basic.test
+++ b/mysql-test/suite/sys_vars/t/admission_control_by_trx_basic.test
@@ -1,0 +1,34 @@
+--source include/not_embedded.inc
+
+SET @start_admission_control_by_trx = @@global.admission_control_by_trx;
+SELECT @start_admission_control_by_trx;
+
+SET @@global.admission_control_by_trx = DEFAULT;
+SELECT @@global.admission_control_by_trx;
+
+SET @@global.admission_control_by_trx = false;
+SELECT @@global.admission_control_by_trx;
+
+SET @@global.admission_control_by_trx = true;
+SELECT @@global.admission_control_by_trx;
+
+SET @@global.admission_control_by_trx = 1;
+SELECT @@global.admission_control_by_trx;
+
+SET @@global.admission_control_by_trx = 0;
+SELECT @@global.admission_control_by_trx;
+
+--Error ER_WRONG_VALUE_FOR_VAR
+SET @@global.admission_control_by_trx = -1;
+SELECT @@global.admission_control_by_trx;
+--Error ER_WRONG_VALUE_FOR_VAR
+SET @@global.admission_control_by_trx = 100;
+SELECT @@global.admission_control_by_trx;
+
+--ERROR ER_GLOBAL_VARIABLE
+SET @@session.admission_control_by_trx = 10;
+--ERROR ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.admission_control_by_trx;
+
+SET @@global.admission_control_by_trx = @start_admission_control_by_trx;
+SELECT @@global.admission_control_by_trx;

--- a/mysql-test/t/admission_control.test
+++ b/mysql-test/t/admission_control.test
@@ -115,6 +115,114 @@ connection default;
 --echo Verify the waiting queries received wakeup signal.
 select count(*) from t1;
 
+set @save_admission_control_by_trx = @@global.admission_control_by_trx;
+select @save_admission_control_by_trx;
+--echo # By default, open transaction has no effect on running queries
+disable_query_log;
+disable_result_log;
+let $i= 10; # max_running_queries is 10
+while($i)
+{
+  connection con$i;
+  # 10 Open transactions
+  begin;
+  select count(*) from t1;
+  dec $i;
+}
+enable_query_log;
+enable_result_log;
+# query will succeed
+connection con11;
+select count(*) from t1;
+
+--echo # Test: open transactions will take slots in running queries,
+--echo #       and will not be blocked
+connection default;
+set @@global.admission_control_by_trx = true;
+SELECT @@global.admission_control_by_trx;
+disable_query_log;
+disable_result_log;
+let $i= 10; # max_running_queries is 10
+while($i)
+{
+  connection con$i;
+  # Open transactions will take up slots in running queue
+  begin;
+  select count(*) from t1;
+  dec $i;
+}
+let $i= 16; # max_waiting_queries is 6
+while ($i != 10)
+{
+  # These queries will be in waiting queue
+  connection con$i;
+  send select count(*) from t1;
+  dec $i;
+}
+enable_query_log;
+enable_result_log;
+
+connection default;
+let $wait_timeout= 300;
+let $wait_condition=
+  select count(*)=6 from information_schema.processlist where state='waiting for admission';
+source include/wait_condition.inc;
+
+--echo Open transaction is able to continue running queries
+disable_query_log;
+disable_result_log;
+let $i= 10;
+while($i)
+{
+  connection con$i;
+  select count(*) from t1;
+  dec $i;
+}
+enable_query_log;
+enable_result_log;
+
+connect (con_max_wait, localhost, test_user,,test_db);
+echo connection con_max_wait;
+connection con_max_wait;
+--echo New queries will be rejected
+error ER_DB_ADMISSION_CONTROL;
+select * from t1;
+--echo New transactions will be rejected
+error ER_DB_ADMISSION_CONTROL;
+begin;
+disconnect con_max_wait;
+
+--echo Committing a transaction will free up the running query slots
+disable_query_log;
+let $i= 10;
+while($i)
+{
+  connection con$i;
+  commit;
+  dec $i;
+}
+enable_query_log;
+
+--echo The waiting queries will be unblocked
+disable_query_log;
+disable_result_log;
+let $i= 16;
+while ($i != 10)
+{
+  connection con$i;
+  reap;
+  dec $i;
+}
+enable_query_log;
+enable_result_log;
+
+# restore admission_control_by_trx
+connection default;
+set @@global.admission_control_by_trx = @save_admission_control_by_trx;
+select @@global.admission_control_by_trx;
+--echo # End of open transaction test
+
+connection default;
 --echo Run parallel load and drop the database.
 # Verify the waiting queries will receive the signal from DROP DATABASE
 # and exit with appropriate error ER_NO_SUCH_TABLE. max_waiting_queries=0

--- a/mysql-test/t/admission_control_hang.test
+++ b/mysql-test/t/admission_control_hang.test
@@ -34,7 +34,8 @@ while($i)
 }
 
 connection default;
-set @@global.admission_control_filter = 'ALTER,BEGIN,COMMIT,CREATE,DELETE,DROP,INSERT,LOAD,SELECT,SET,REPLACE,TRUNCATE,UPDATE,SHOW';
+set @@global.admission_control_filter = 'ALTER,BEGIN,COMMIT,CREATE,DELETE,DROP,INSERT,LOAD,SELECT,SET,REPLACE,TRUNCATE,UPDATE,SHOW,ROLLBACK';
+select @@global.admission_control_filter;
 
 # Verify the commands filtered above run fine.
 connection con6;
@@ -43,20 +44,56 @@ begin;
 insert into t2 values(1);
 update t2 set a=2 where a=1;
 commit;
+SHOW TABLES LIKE 't2';
+begin;
 alter table t2 rename t3;
 select * from t3;
 delete from t3;
 set @val = 1;
 truncate table t3;
+rollback;
 drop table t3;
+
+# Verify that admission_control_by_trx will honor the filters
+connection default;
+set @save_admission_control_by_trx = @@global.admission_control_by_trx;
+select @save_admission_control_by_trx;
+--echo # Turn on admission_control_by_trx
+set @@global.admission_control_by_trx = true;
+SELECT @@global.admission_control_by_trx;
+
+connection con6;
+create table t2(a int) engine=innodb;
+begin;
+insert into t2 values(1);
+update t2 set a=2 where a=1;
+commit;
 SHOW TABLES LIKE 't2';
+begin;
+alter table t2 rename t3;
+select * from t3;
+delete from t3;
+set @val = 1;
+truncate table t3;
+rollback;
+drop table t3;
 
 connection default;
-set @@global.admission_control_filter = 'ROLLBACK';
-rollback;
+set @@global.admission_control_filter = default;
+select @@global.admission_control_filter;
+
+# open transaction will be able to go through
+connection con5;
+select count(*) from t1;
+
+# restore admission_control_by_trx
+connection default;
+set @@global.admission_control_by_trx = @save_admission_control_by_trx;
+select @@global.admission_control_by_trx;
 
 connection default;
 set @@global.admission_control_filter = 'COMMIT';
+select @@global.admission_control_filter;
 
 connection con5;
 # Without the COMMIT filter set above, this query gets blocked until conflicting

--- a/mysql-test/t/mt_simple_plugin-master.opt
+++ b/mysql-test/t/mt_simple_plugin-master.opt
@@ -1,0 +1,1 @@
+$MT_SIMPLE_OPT

--- a/mysql-test/t/mt_simple_plugin.test
+++ b/mysql-test/t/mt_simple_plugin.test
@@ -1,0 +1,88 @@
+--source include/have_mt_simple.inc
+
+--replace_regex /\.dll/.so/
+eval install plugin mt_simple soname '$MT_SIMPLE';
+select * from information_schema.plugins where plugin_name like 'mt_simple';
+show global variables like 'mt_simple_%';
+show global status like 'mt_simple_%';
+
+# queries for sanity
+create table t1(a text, b text);
+drop table t1;
+
+# Add 10 connections
+disable_query_log;
+disable_result_log;
+let $i= 10;
+while ($i)
+{
+  connect (con$i, localhost, root,,);
+  dec $i;
+}
+enable_query_log;
+enable_result_log;
+
+connection default;
+show global status like 'mt_simple_%';
+
+# now turn off the plugin
+set global mt_simple_on = 0;
+
+# add more connections which should not be counted by mt_simple
+disable_query_log;
+disable_result_log;
+let $i= 20;
+while ($i > 10)
+{
+  connect (con$i, localhost, root,,);
+  dec $i;
+}
+enable_query_log;
+enable_result_log;
+
+connection default;
+show global status like 'mt_simple_%';
+set global mt_simple_on = 1;
+
+disable_query_log;
+disable_result_log;
+let $i= 20;
+while ($i)
+{
+  disconnect con$i;
+  dec $i;
+}
+enable_query_log;
+enable_result_log;
+
+connection default;
+show global status like 'mt_simple_%';
+
+# uninstall will set the plugin to DELETED state
+# and will be unloaded when during server restart
+uninstall plugin mt_simple;
+select * from information_schema.plugins where plugin_name like 'mt_simple';
+
+show global variables like 'mt_simple_%';
+show global status like 'mt_simple_%';
+
+# Since the plugin is in DELETED state, new connections will not use mt_simple
+disable_query_log;
+disable_result_log;
+let $i= 10;
+while ($i)
+{
+  connect (con$i, localhost, root,,);
+  dec $i;
+}
+enable_query_log;
+enable_result_log;
+
+connection default;
+show global variables like 'mt_simple_%';
+show global status like 'mt_simple_%';
+
+# restart server
+--source include/restart_mysqld.inc
+# after restart, the plugin should be unloaded
+select * from information_schema.plugins where plugin_name like 'mt_simple';

--- a/plugin/mt_simple/CMakeLists.txt
+++ b/plugin/mt_simple/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (c) 2016, Facebook. All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+MYSQL_ADD_PLUGIN(mt_simple mt_simple.cc
+  MODULE_ONLY MODULE_OUTPUT_NAME "mt_simple")

--- a/plugin/mt_simple/mt_simple.cc
+++ b/plugin/mt_simple/mt_simple.cc
@@ -1,0 +1,256 @@
+/* Copyright (c) 2016, Facebook. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+
+#include <stdio.h>
+#include "mysqld.h"
+#include "my_atomic.h"
+#include <mysql/plugin.h>
+#include <mysql/plugin_multi_tenancy.h>
+
+
+/*
+ * Dummy multi-tenancy plugin
+ */
+
+
+// Number of open connections
+static int number_of_conns;
+// Number of running queries
+static int number_of_queries;
+// Number of conns with db in conn attrs
+static int number_of_db_conns;
+// Number of conns with role in conn attrs
+static int number_of_role_conns;
+
+extern LEX_STRING INFORMATION_SCHEMA_NAME;
+extern LEX_STRING PERFORMANCE_SCHEMA_DB_NAME;
+extern LEX_STRING MYSQL_SCHEMA_NAME;
+
+static MYSQL_PLUGIN plugin_info_ptr;
+static char plugin_on;
+
+static void plugin_on_set(
+    THD *thd __attribute__((unused)),
+    struct st_mysql_sys_var *var __attribute__((unused)),
+    void *var_ptr __attribute__((unused)),
+    const void *save)
+{
+  if (*(my_bool*) save)
+  {
+    plugin_on = 1;
+    my_plugin_log_message(&plugin_info_ptr, MY_INFORMATION_LEVEL,
+                          "mt_simple plugin on");
+  }
+  else
+  {
+    plugin_on = 0;
+    my_plugin_log_message(&plugin_info_ptr, MY_INFORMATION_LEVEL,
+                          "mt_simple plugin off");
+  }
+}
+
+static MYSQL_SYSVAR_BOOL(on,
+                         plugin_on,
+                         PLUGIN_VAR_NOCMDARG,
+                         "Turns the plugin on and off.",
+                         nullptr,
+                         plugin_on_set,
+                         1);
+
+/*
+ * Initialize the plugin at server start or plugin installation.
+ */
+static int mt_simple_plugin_init(MYSQL_PLUGIN plugin_ref)
+{
+  plugin_info_ptr= plugin_ref;
+  number_of_conns = 0;
+  number_of_queries = 0;
+  number_of_db_conns = 0;
+  number_of_role_conns = 0;
+  my_plugin_log_message(&plugin_info_ptr, MY_INFORMATION_LEVEL,
+                        "mt_simple plugin initiated");
+  return(0);
+}
+
+
+/*
+ * Terminate the plugin at server shutdown or plugin deinstallation.
+ */
+static int mt_simple_plugin_deinit(void *arg __attribute__((unused)))
+{
+  my_plugin_log_message(&plugin_info_ptr, MY_INFORMATION_LEVEL,
+                        "mt_simple plugin deinitiated");
+  return(0);
+}
+
+
+/*
+ * Increment stats
+ */
+static MT_RETURN_TYPE mt_simple_request_resource(
+    MYSQL_THD thd, MT_RESOURCE_TYPE type, const ATTRS_MAP_T *resource_attr)
+{
+  if (!plugin_on)
+    return MT_RETURN_TYPE::MULTI_TENANCY_RET_FALLBACK;
+
+  switch(type)
+  {
+    case MT_RESOURCE_TYPE::MULTI_TENANCY_RESOURCE_CONNECTION:
+      {
+        if (!resource_attr)
+          break;
+
+        auto iter_db = resource_attr->find("db");
+        auto iter_role = resource_attr->find("role");
+        // ignore system schemas
+        if (iter_db != resource_attr->end())
+        {
+          const char *db = iter_db->second.c_str();
+          if (strcmp(db, INFORMATION_SCHEMA_NAME.str) &&
+              strcmp(db, PERFORMANCE_SCHEMA_DB_NAME.str) &&
+              strcmp(db, MYSQL_SCHEMA_NAME.str))
+            my_atomic_add32(&number_of_db_conns, 1);
+        }
+        else if (iter_role != resource_attr->end())
+            my_atomic_add32(&number_of_role_conns, 1);
+        else
+            my_atomic_add32(&number_of_conns, 1);
+
+        break;
+      }
+
+    case MT_RESOURCE_TYPE::MULTI_TENANCY_RESOURCE_QUERY:
+      {
+        my_atomic_add32(&number_of_queries, 1);
+        break;
+      }
+
+    default:
+      return MT_RETURN_TYPE::MULTI_TENANCY_RET_ACCEPT;
+  }
+
+  return MT_RETURN_TYPE::MULTI_TENANCY_RET_ACCEPT;
+}
+
+
+/*
+ * Decrement stats
+ */
+static MT_RETURN_TYPE mt_simple_release_resource(
+    MYSQL_THD thd, MT_RESOURCE_TYPE type, const ATTRS_MAP_T *resource_attr)
+{
+  if (!plugin_on)
+    return MT_RETURN_TYPE::MULTI_TENANCY_RET_FALLBACK;
+
+  switch(type)
+  {
+    case MT_RESOURCE_TYPE::MULTI_TENANCY_RESOURCE_CONNECTION:
+      {
+        if (!resource_attr)
+          break;
+
+        auto iter_db = resource_attr->find("db");
+        auto iter_role = resource_attr->find("role");
+        // ignore system schemas
+        if (iter_db != resource_attr->end() && number_of_db_conns > 0)
+        {
+          const char *db = iter_db->second.c_str();
+          if (strcmp(db, INFORMATION_SCHEMA_NAME.str) &&
+              strcmp(db, PERFORMANCE_SCHEMA_DB_NAME.str) &&
+              strcmp(db, MYSQL_SCHEMA_NAME.str))
+            my_atomic_add32(&number_of_db_conns, -1);
+        }
+        else if (iter_role != resource_attr->end() && number_of_role_conns > 0)
+            my_atomic_add32(&number_of_role_conns, -1);
+        else if (number_of_conns > 0)
+            my_atomic_add32(&number_of_conns, -1);
+
+        break;
+      }
+
+    case MT_RESOURCE_TYPE::MULTI_TENANCY_RESOURCE_QUERY:
+      {
+        if (number_of_queries > 0)
+          my_atomic_add32(&number_of_queries, -1);
+        break;
+      }
+
+    default:
+      return MT_RETURN_TYPE::MULTI_TENANCY_RET_ACCEPT;
+  }
+
+  return MT_RETURN_TYPE::MULTI_TENANCY_RET_ACCEPT;
+}
+
+/*
+ * Plugin type-specific descriptor
+ */
+static struct st_mysql_multi_tenancy mt_simple_descriptor=
+{
+  MYSQL_MULTI_TENANCY_INTERFACE_VERSION, /* interface version    */
+  mt_simple_request_resource,
+  mt_simple_release_resource
+};
+
+
+static struct st_mysql_sys_var* simple_vars[]=
+{
+  MYSQL_SYSVAR(on),
+  NULL
+};
+
+/*
+ * Plugin status variables for SHOW STATUS
+ */
+static struct st_mysql_show_var simple_status[]=
+{
+  { "mt_simple_open_conns",
+    (char *) &number_of_conns,
+    SHOW_INT },
+  { "mt_simple_open_db_conns",
+    (char *) &number_of_db_conns,
+    SHOW_INT },
+  { "mt_simple_open_role_conns",
+    (char *) &number_of_role_conns,
+    SHOW_INT },
+  { "mt_simple_running_queries",
+    (char *) &number_of_queries,
+    SHOW_INT },
+  { 0, 0, SHOW_UNDEF }
+};
+
+
+/*
+ * Plugin library descriptor
+ */
+mysql_declare_plugin(mt_simple)
+{
+  MYSQL_MULTI_TENANCY_PLUGIN, /* type                            */
+  &mt_simple_descriptor,      /* descriptor                      */
+  "MT_SIMPLE",                /* name                            */
+  "Tian Xia",                 /* author                          */
+  "Simple multi_tenancy",     /* description                     */
+  PLUGIN_LICENSE_GPL,
+  mt_simple_plugin_init,      /* init function (when loaded)     */
+  mt_simple_plugin_deinit,    /* deinit function (when unloaded) */
+  0x0100,                     /* version                         */
+  simple_status,              /* status variables                */
+  simple_vars,                /* system variables                */
+  NULL,
+  0,
+}
+mysql_declare_plugin_end;

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -153,6 +153,7 @@ SET(SQL_SHARED_SOURCES
   sql_load.cc
   sql_locale.cc
   sql_manager.cc
+  sql_multi_tenancy.cc
   sql_optimizer.cc
   sql_parse.cc
   sql_partition.cc

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -76,6 +76,7 @@
 #include "debug_sync.h"
 #include "sql_callback.h"
 #include "opt_trace_context.h"
+#include "sql_multi_tenancy.h"
 
 #include "global_threads.h"
 #include "mysqld.h"
@@ -686,7 +687,8 @@ ulong binlog_stmt_cache_use= 0, binlog_stmt_cache_disk_use= 0;
 ulong max_connections, max_connect_errors;
 uint max_nonsuper_connections;
 ulong opt_max_running_queries, opt_max_waiting_queries;
-AC *db_ac;
+my_bool opt_admission_control_by_trx= 0;
+extern AC *db_ac;
 ulong rpl_stop_slave_timeout= LONG_TIMEOUT;
 my_bool log_bin_use_v1_row_events= 0;
 bool thread_cache_size_specified= false;

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -42,7 +42,6 @@
 class THD;
 struct handlerton;
 class Time_zone;
-class AC;
 
 struct scheduler_functions;
 
@@ -198,7 +197,6 @@ private:
   lsn_map **maps;
 };
 
-extern AC* db_ac;
 /*
   This forward declaration is used from C files where the real
   definition is included before.  Since C does not allow repeated
@@ -907,6 +905,7 @@ extern MYSQL_PLUGIN_IMPORT ulong max_connections;
 extern ulong max_digest_length;
 extern ulong max_connect_errors, connect_timeout;
 extern ulong opt_max_running_queries, opt_max_waiting_queries;
+extern my_bool opt_admission_control_by_trx;
 extern my_bool opt_slave_allow_batching;
 extern my_bool allow_slave_start;
 extern LEX_CSTRING reason_slave_blocked;

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -7239,6 +7239,8 @@ ER_FILESORT_MAX_FILE_SIZE_EXCEEDED
 ER_SLAVE_GTID_INFO_WITHOUT_ROCKSDB
   eng "slave_gtid_info can be set to OPTIMIZED only with RocksDB engine."
 
+ER_MULTI_TENANCY_MAX_CONNECTION
+  eng "Maximum connections reached for `%s`"
 #
 #  End of 5.6 error messages.
 #

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -42,6 +42,7 @@
                                      THR_LOCK_INFO */
 #include "opt_trace_context.h"    /* Opt_trace_context */
 #include "rpl_gtid.h"
+#include "sql_multi_tenancy.h"
 
 #include "sql_digest_stream.h"            // sql_digest_state
 
@@ -690,6 +691,9 @@ typedef struct system_variables
 
   plugin_ref table_plugin;
   plugin_ref temp_table_plugin;
+
+  // global multi-tenancy plugin
+  plugin_ref multi_tenancy_plugin;
 
   /* Only charset part of these variables is sensible */
   const CHARSET_INFO *character_set_filesystem;
@@ -2282,41 +2286,6 @@ my_micro_time_to_timeval(ulonglong micro_time, struct timeval *tm)
 }
 
 /**
-  Per-thread information used in admission control.
-*/
-struct st_ac_node {
-#ifdef HAVE_PSI_INTERFACE
-  PSI_mutex_key key_lock;
-  PSI_cond_key key_cond;
-  PSI_mutex_info key_lock_info[1]=
-  {
-    {&key_lock, "st_ac_node::lock", 0}
-  };
-  PSI_cond_info key_cond_info[1]=
-  {
-    {&key_cond, "st_ac_node::cond", 0}
-  };
-#endif
-  mysql_mutex_t lock;
-  mysql_cond_t cond;
-  st_ac_node() {
-#ifdef HAVE_PSI_INTERFACE
-    mysql_mutex_register("sql", key_lock_info,
-                         array_elements(key_lock_info));
-    mysql_cond_register("sql", key_cond_info,
-                        array_elements(key_cond_info));
-#endif
-    mysql_mutex_init(key_lock, &lock, MY_MUTEX_INIT_FAST);
-    mysql_cond_init(key_cond, &cond, NULL);
-  }
-
-  ~st_ac_node () {
-    mysql_mutex_destroy(&lock);
-    mysql_cond_destroy(&cond);
-  }
-};
-
-/**
   @class THD
   For each client connection we create a separate thread with THD serving as
   a thread/connection descriptor
@@ -2446,6 +2415,8 @@ public:
   /* record the transaction time (including in-fly) */
   ulonglong trx_time = 0;
 
+  /* whether the session is already in admission control for queries */
+  bool is_in_ac = false;
   /**
     @note
     Some members of THD (currently 'Statement::db',
@@ -4488,6 +4459,14 @@ public:
     set_attrs_map(attrs, length, connection_attrs_map, false);
     mysql_mutex_unlock(&LOCK_thd_data);
   }
+  void update_connection_attrs(
+      const std::unordered_map<std::string, std::string> &attrs_map)
+  {
+    mysql_mutex_lock(&LOCK_thd_data);
+    for (const auto &attrs : attrs_map)
+      connection_attrs_map[attrs.first] = attrs.second;
+    mysql_mutex_unlock(&LOCK_thd_data);
+  }
 
   std::unordered_map<std::string, std::string> query_attrs_map;
   std::unordered_map<std::string, std::string> connection_attrs_map;
@@ -4614,208 +4593,6 @@ public:
   bool skip_unique_check();
   // protected by LOCK_thd_data
   std::string row_query;
-};
-
-/**
-  Class used in admission control.
-
-  Every entity (database or table or user name) will have this
-  object created and stored in the global map AC::ac_map.
-
-*/
-class Ac_info {
-  friend class AC;
-#ifdef HAVE_PSI_INTERFACE
-  PSI_mutex_key key_lock;
-  PSI_mutex_info key_lock_info[1]=
-  {
-    {&key_lock, "Ac_info::lock", 0}
-  };
-#endif
-  // Queue to track the running and waiting threads.
-  std::deque<std::shared_ptr<st_ac_node>> queue;
-  std::atomic<unsigned long> waiting_queries;
-  // Protects the queue.
-  mysql_mutex_t lock;
-public:
-  Ac_info() {
-#ifdef HAVE_PSI_INTERFACE
-    mysql_mutex_register("sql", key_lock_info,
-                         array_elements(key_lock_info));
-#endif
-    mysql_mutex_init(key_lock, &lock, MY_MUTEX_INIT_FAST);
-    waiting_queries = 0;
-  }
-  ~Ac_info() {
-    mysql_mutex_destroy(&lock);
-  }
-  // Disable copy constructor.
-  Ac_info(const Ac_info&) = delete;
-  Ac_info& operator=(const Ac_info&) = delete;
-};
-
-/**
-  Global class used to enforce per admission control limits.
-*/
-class AC {
-  // This map is protected by the rwlock LOCK_ac.
-  std::unordered_map<std::string, std::shared_ptr<Ac_info>> ac_map;
-  // Variables to track global limits
-  ulong max_running_queries, max_waiting_queries;
-  /**
-    Protects ac_map and max_running_queries/max_waiting_queries.
-
-    Locking order followed is LOCK_ac, Ac_info::lock, st_ac_node::lock.
-  */
-  mysql_rwlock_t LOCK_ac;
-#ifdef HAVE_PSI_INTERFACE
-  PSI_rwlock_key key_rwlock_LOCK_ac;
-  PSI_rwlock_info key_rwlock_LOCK_ac_info[1]=
-  {
-    {&key_rwlock_LOCK_ac, "AC::rwlock", 0}
-  };
-#endif
-
-  std::atomic<ulonglong> total_aborted_queries;
-
-public:
-  AC() {
-#ifdef HAVE_PSI_INTERFACE
-    mysql_rwlock_register("sql", key_rwlock_LOCK_ac_info,
-                          array_elements(key_rwlock_LOCK_ac_info));
-#endif
-    mysql_rwlock_init(key_rwlock_LOCK_ac, &LOCK_ac);
-    max_running_queries = 0;
-    max_waiting_queries = 0;
-    total_aborted_queries = 0;
-  }
-
-  ~AC() {
-    mysql_rwlock_destroy(&LOCK_ac);
-  }
-  // Disable copy constructor.
-  AC(const AC&) = delete;
-  AC& operator=(const AC&) = delete;
-
-  inline void signal(std::shared_ptr<st_ac_node>& ac_node) {
-    DBUG_ASSERT(ac_node && ac_node.get());
-    mysql_mutex_lock(&ac_node->lock);
-    mysql_cond_signal(&ac_node->cond);
-    mysql_mutex_unlock(&ac_node->lock);
-  }
-
-  /*
-   * Removes a dropped entity info from the global map.
-   */
-  void remove(const char* entity) {
-    std::string str(entity);
-    // First take a read lock to unblock any waiting queries.
-    mysql_rwlock_rdlock(&LOCK_ac);
-    auto it = ac_map.find(str);
-    if (it != ac_map.end()) {
-      auto ac_info  = it->second;
-      mysql_mutex_lock(&ac_info->lock);
-      while (ac_info->waiting_queries) {
-        for (uint i = max_running_queries; i < ac_info->queue.size(); ++i) {
-          signal(ac_info->queue[i]);
-        }
-      }
-      mysql_mutex_unlock(&ac_info->lock);
-    }
-    mysql_rwlock_unlock(&LOCK_ac);
-    mysql_rwlock_wrlock(&LOCK_ac);
-    it = ac_map.find(std::string(str));
-    if (it != ac_map.end()) {
-      ac_map.erase(it);
-    }
-    mysql_rwlock_unlock(&LOCK_ac);
-  }
-
-  void insert(const std::string &entity) {
-    mysql_rwlock_wrlock(&LOCK_ac);
-    if (ac_map.find(entity) == ac_map.end()) {
-      ac_map[entity] = std::make_shared<Ac_info>();
-    }
-    mysql_rwlock_unlock(&LOCK_ac);
-  }
-
-  void update_max_running_queries(ulong val) {
-    // lock to protect against erasing map iterators.
-    mysql_rwlock_wrlock(&LOCK_ac);
-    ulong old_val = max_running_queries;
-    max_running_queries = val;
-    // Signal any waiting threads which are below the new limit. Note 0 is a
-    // special case where every waiting thread needs to be signalled.
-    if (val > old_val || !val) {
-      for (auto &it: ac_map) {
-        auto &ac_info = it.second;
-        mysql_mutex_lock(&ac_info->lock);
-        for (uint i = old_val;
-             (!val || i < val) && i < ac_info->queue.size(); ++i) {
-          signal(ac_info->queue[i]);
-        }
-        mysql_mutex_unlock(&ac_info->lock);
-      }
-    }
-    mysql_rwlock_unlock(&LOCK_ac);
-  }
-
-  void update_max_waiting_queries(ulong val) {
-    mysql_rwlock_wrlock(&LOCK_ac);
-    max_waiting_queries = val;
-    mysql_rwlock_unlock(&LOCK_ac);
-  }
-
-  inline ulong get_max_running_queries() {
-    mysql_rwlock_rdlock(&LOCK_ac);
-    ulong res = max_running_queries;
-    mysql_rwlock_unlock(&LOCK_ac);
-    return res;
-  }
-
-  inline ulong get_max_waiting_queries() {
-    mysql_rwlock_rdlock(&LOCK_ac);
-    ulong res = max_waiting_queries;
-    mysql_rwlock_unlock(&LOCK_ac);
-    return res;
-  }
-
-  bool admission_control_enter(THD*, const std::string&);
-  void admission_control_exit(THD*, const std::string&);
-  void wait_for_signal(THD*, std::shared_ptr<st_ac_node>&,
-                       std::shared_ptr<Ac_info> ac_info);
-
-  ulonglong get_total_aborted_queries() const {
-    return total_aborted_queries;
-  }
-  ulong get_total_running_queries() {
-    ulonglong res= 0;
-    mysql_rwlock_rdlock(&LOCK_ac);
-    for (auto it : ac_map)
-    {
-      auto &ac_info = it.second;
-      mysql_mutex_lock(&ac_info->lock);
-      res += ac_info->queue.size() < max_running_queries ?
-        ac_info->queue.size() : max_running_queries;
-      mysql_mutex_unlock(&ac_info->lock);
-    }
-    mysql_rwlock_unlock(&LOCK_ac);
-    return res;
-  }
-  ulong get_total_waiting_queries() {
-    ulonglong res= 0;
-    mysql_rwlock_rdlock(&LOCK_ac);
-    for (auto it : ac_map)
-    {
-      auto &ac_info = it.second;
-      mysql_mutex_lock(&ac_info->lock);
-      if (ac_info->queue.size() > max_running_queries)
-        res += ac_info->queue.size() - max_running_queries;
-      mysql_mutex_unlock(&ac_info->lock);
-    }
-    mysql_rwlock_unlock(&LOCK_ac);
-    return res;
-  }
 };
 
 /*

--- a/sql/sql_db.cc
+++ b/sql/sql_db.cc
@@ -46,6 +46,7 @@
 #endif
 #include "debug_sync.h"
 #include "sql_show.h"
+#include "sql_multi_tenancy.h"
 
 #define MAX_DROP_TABLE_Q_LEN      1024
 

--- a/sql/sql_multi_tenancy.cc
+++ b/sql/sql_multi_tenancy.cc
@@ -1,0 +1,560 @@
+/* Copyright (c) 2016, Facebook. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+
+#include "sql_acl.h"
+#include "sql_priv.h"
+#include "sql_multi_tenancy.h"
+#include "global_threads.h"
+
+
+#ifndef EMBEDDED_LIBRARY
+
+
+/*
+  @param sql_command command the thread is currently executing
+
+  @return true Skips the current query in admission control
+          false Admission control checks are applied for this query
+*/
+static bool filter_command(enum_sql_command sql_command)
+{
+  switch (sql_command) {
+    case SQLCOM_ALTER_TABLE:
+    case SQLCOM_ALTER_DB:
+    case SQLCOM_ALTER_PROCEDURE:
+    case SQLCOM_ALTER_FUNCTION:
+    case SQLCOM_ALTER_TABLESPACE:
+    case SQLCOM_ALTER_SERVER:
+    case SQLCOM_ALTER_EVENT:
+    case SQLCOM_ALTER_DB_UPGRADE:
+    case SQLCOM_ALTER_USER:
+    case SQLCOM_RENAME_TABLE:
+    case SQLCOM_RENAME_USER:
+      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_ALTER);
+
+    case SQLCOM_BEGIN:
+      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_BEGIN);
+
+    case SQLCOM_COMMIT:
+      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_COMMIT);
+
+    case SQLCOM_CREATE_TABLE:
+    case SQLCOM_CREATE_INDEX:
+    case SQLCOM_CREATE_DB:
+    case SQLCOM_CREATE_FUNCTION:
+    case SQLCOM_CREATE_USER:
+    case SQLCOM_CREATE_PROCEDURE:
+    case SQLCOM_CREATE_SPFUNCTION:
+    case SQLCOM_CREATE_VIEW:
+    case SQLCOM_CREATE_TRIGGER:
+    case SQLCOM_CREATE_SERVER:
+    case SQLCOM_CREATE_EVENT:
+      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_CREATE);
+
+    case SQLCOM_DELETE:
+    case SQLCOM_DELETE_MULTI:
+      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_DELETE);
+
+    case SQLCOM_DROP_TABLE:
+    case SQLCOM_DROP_INDEX:
+    case SQLCOM_DROP_DB:
+    case SQLCOM_DROP_FUNCTION:
+    case SQLCOM_DROP_USER:
+    case SQLCOM_DROP_PROCEDURE:
+    case SQLCOM_DROP_VIEW:
+    case SQLCOM_DROP_TRIGGER:
+    case SQLCOM_DROP_SERVER:
+    case SQLCOM_DROP_EVENT:
+      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_DROP);
+
+    case SQLCOM_INSERT:
+    case SQLCOM_INSERT_SELECT:
+      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_INSERT);
+
+    case SQLCOM_LOAD:
+      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_LOAD);
+
+    case SQLCOM_SELECT:
+      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_SELECT);
+
+    case SQLCOM_SET_OPTION:
+      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_SET);
+
+    case SQLCOM_REPLACE:
+    case SQLCOM_REPLACE_SELECT:
+      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_REPLACE);
+
+    case SQLCOM_ROLLBACK:
+      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_ROLLBACK);
+
+    case SQLCOM_TRUNCATE:
+      return IS_BIT_SET(admission_control_filter,  ADMISSION_CONTROL_TRUNCATE);
+
+    case SQLCOM_UPDATE:
+    case SQLCOM_UPDATE_MULTI:
+      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_UPDATE);
+
+    case SQLCOM_SHOW_DATABASES:
+    case SQLCOM_SHOW_TABLES:
+    case SQLCOM_SHOW_FIELDS:
+    case SQLCOM_SHOW_KEYS:
+    case SQLCOM_SHOW_VARIABLES:
+    case SQLCOM_SHOW_STATUS:
+    case SQLCOM_SHOW_ENGINE_LOGS:
+    case SQLCOM_SHOW_ENGINE_STATUS:
+    case SQLCOM_SHOW_ENGINE_MUTEX:
+    case SQLCOM_SHOW_PROCESSLIST:
+    case SQLCOM_SHOW_TRANSACTION_LIST:
+    case SQLCOM_SHOW_MASTER_STAT:
+    case SQLCOM_SHOW_SLAVE_STAT:
+    case SQLCOM_SHOW_GRANTS:
+    case SQLCOM_SHOW_CREATE:
+    case SQLCOM_SHOW_CHARSETS:
+    case SQLCOM_SHOW_COLLATIONS:
+    case SQLCOM_SHOW_CREATE_DB:
+    case SQLCOM_SHOW_TABLE_STATUS:
+    case SQLCOM_SHOW_TRIGGERS:
+    case SQLCOM_SHOW_BINLOGS:
+    case SQLCOM_SHOW_OPEN_TABLES:
+    case SQLCOM_SHOW_SLAVE_HOSTS:
+    case SQLCOM_SHOW_BINLOG_EVENTS:
+    case SQLCOM_SHOW_BINLOG_CACHE:
+    case SQLCOM_SHOW_WARNS:
+    case SQLCOM_SHOW_ERRORS:
+    case SQLCOM_SHOW_STORAGE_ENGINES:
+    case SQLCOM_SHOW_PRIVILEGES:
+    case SQLCOM_SHOW_CREATE_PROC:
+    case SQLCOM_SHOW_CREATE_FUNC:
+    case SQLCOM_SHOW_STATUS_PROC:
+    case SQLCOM_SHOW_STATUS_FUNC:
+    case SQLCOM_SHOW_PROC_CODE:
+    case SQLCOM_SHOW_FUNC_CODE:
+    case SQLCOM_SHOW_PLUGINS:
+    case SQLCOM_SHOW_CREATE_EVENT:
+    case SQLCOM_SHOW_EVENTS:
+    case SQLCOM_SHOW_CREATE_TRIGGER:
+    case SQLCOM_SHOW_PROFILE:
+    case SQLCOM_SHOW_PROFILES:
+    case SQLCOM_SHOW_RELAYLOG_EVENTS:
+    case SQLCOM_SHOW_ENGINE_TRX:
+    case SQLCOM_SHOW_MEMORY_STATUS:
+    case SQLCOM_SHOW_CONNECTION_ATTRIBUTES:
+      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_SHOW);
+
+    default:
+      return false;
+  }
+}
+
+
+/*
+ * Add a connection in multi-tenancy plugin
+ *
+ * @param thd THD structure
+ * @param attr_map connection attribute map
+ *
+ * @return 0 if the connection is added, 1 if rejected
+ */
+int multi_tenancy_add_connection(THD *thd, ATTRS_MAP_T &attr_map)
+{
+  int ret = 0;
+  st_mysql_multi_tenancy *data= NULL;
+
+  if (thd->variables.multi_tenancy_plugin)
+  {
+    mysql_mutex_lock(&thd->LOCK_thd_data);
+    data = plugin_data(thd->variables.multi_tenancy_plugin,
+                       struct st_mysql_multi_tenancy *);
+    ret = (int) data->
+      request_resource(
+        thd,
+        MT_RESOURCE_TYPE::MULTI_TENANCY_RESOURCE_CONNECTION,
+        &attr_map);
+    mysql_mutex_unlock(&thd->LOCK_thd_data);
+
+    // plugin is turned off
+    if (ret == (int) MT_RETURN_TYPE::MULTI_TENANCY_RET_FALLBACK)
+      ret = 0;
+  }
+
+  return ret;
+}
+
+
+/*
+ * Release a connection in multi-tenancy plugin
+ *
+ * @param thd THD structure
+ * @param attr_map connection attribute map
+ *
+ * @return 0 if successful, 1 if otherwise
+ */
+int multi_tenancy_close_connection(THD *thd, ATTRS_MAP_T &attr_map)
+{
+  st_mysql_multi_tenancy *data= NULL;
+  if (thd->variables.multi_tenancy_plugin)
+  {
+    mysql_mutex_lock(&thd->LOCK_thd_data);
+    data = plugin_data(thd->variables.multi_tenancy_plugin,
+                       struct st_mysql_multi_tenancy *);
+    data->release_resource(
+        thd,
+        MT_RESOURCE_TYPE::MULTI_TENANCY_RESOURCE_CONNECTION,
+        &attr_map);
+    mysql_mutex_unlock(&thd->LOCK_thd_data);
+  }
+
+  return 0;
+}
+
+
+/*
+ * Admit a query based on database entity
+ *
+ * @param thd THD structure
+ * @param attr_map Query attribute map for the query
+ *
+ * @return 0 if the query is admitted, 1 if otherwise
+ */
+int multi_tenancy_admit_query(THD *thd, ATTRS_MAP_T &attr_map)
+{
+  bool admission_check= false;
+
+  auto entity_iter = attr_map.find(multi_tenancy_entity_db);
+  if (entity_iter == attr_map.end())
+    return 0; // no limiting
+
+  /**
+    Admission control checks are skipped in the following
+    scenarios.
+    1. The query is run by super user
+    2. The THD is a replication thread
+    3. If this is a multi query packet, or is part of a transaction (controlled
+       by global var opt_admission_control_by_trx), and the THD already entered
+       admission control
+    4. No database is set for this session
+    5. Admission control checks are turned off by setting
+       max_running_queries=0
+    6. If the command is filtered from admission checks
+  */
+  if (!(thd->security_ctx->master_access & SUPER_ACL) && /* 1 */
+      !thd->rli_slave && /* 2 */
+      ((!opt_admission_control_by_trx || thd->is_real_trans) &&
+       !thd->is_in_ac) && /* 3 */
+      !entity_iter->second.empty() && /* 4 */
+      db_ac->get_max_running_queries() && /* 5 */
+      !filter_command(thd->lex->sql_command) /* 6 */
+     ) {
+    admission_check= true;
+  }
+
+  if (admission_check && db_ac->admission_control_enter(thd, attr_map))
+    return 1;
+
+  if (admission_check)
+    thd->is_in_ac = true;
+
+  return 0;
+}
+
+
+/*
+ * Exit a query based on database entity
+ *
+ * @param thd THD structure
+ * @param attr_map Query attribute map for the query
+ *
+ * @return 0 if successful, 1 if otherwise
+ */
+int multi_tenancy_exit_query(THD *thd, ATTRS_MAP_T &attr_map)
+{
+  if (attr_map.find(multi_tenancy_entity_db) == attr_map.end())
+    return 0; // no limiting
+
+  db_ac->admission_control_exit(thd, attr_map);
+  return 0;
+}
+
+
+int initialize_multi_tenancy_plugin(st_plugin_int *plugin_int)
+{
+  if (plugin_int->plugin->init && plugin_int->plugin->init(plugin_int))
+  {
+    sql_print_error("Plugin '%s' init function returned error.",
+                    plugin_int->name.str);
+    return 1;
+  }
+
+  /* Make the interface info more easily accessible */
+  plugin_int->data= plugin_int->plugin->info;
+
+  /* release the ref count of the previous multi-tenancy plugin */
+  if (global_system_variables.multi_tenancy_plugin)
+    plugin_unlock(NULL, global_system_variables.multi_tenancy_plugin);
+
+  /* Add the global var referencing the plugin */
+  plugin_ref plugin_r= plugin_int_to_ref(plugin_int);
+  global_system_variables.multi_tenancy_plugin=
+    my_plugin_lock(NULL, &plugin_r);
+
+  return 0;
+}
+
+
+int finalize_multi_tenancy_plugin(st_plugin_int *plugin_int)
+{
+  /* release the ref count of the previous multi-tenancy plugin */
+  if (global_system_variables.multi_tenancy_plugin)
+  {
+    plugin_unlock(NULL, global_system_variables.multi_tenancy_plugin);
+    global_system_variables.multi_tenancy_plugin= NULL;
+  }
+
+  if (plugin_int->plugin->deinit && plugin_int->plugin->deinit(NULL))
+  {
+    DBUG_PRINT("warning", ("Plugin '%s' deinit function returned error.",
+                            plugin_int->name.str));
+    DBUG_EXECUTE("finalize_audit_plugin", return 1; );
+  }
+
+  plugin_int->data= NULL;
+  return 0;
+}
+
+
+#else /* EMBEDDED_LIBRARY */
+
+
+int multi_tenancy_add_connection(THD *thd, ATTRS_MAP_T &attr_map)
+{
+  return 1;
+}
+
+int multi_tenancy_close_connection(THD *thd, ATTRS_MAP_T &attr_map)
+{
+  return 1;
+}
+
+int multi_tenancy_admit_query(THD *thd, ATTRS_MAP_T &attr_map)
+{
+  return 1;
+}
+
+int multi_tenancy_exit_query(THD *thd, ATTRS_MAP_T &attr_map)
+{
+  return 1;
+}
+
+
+int initialize_multi_tenancy_plugin(st_plugin_int *plugin)
+{
+  return 1;
+}
+
+
+int finalize_multi_tenancy_plugin(st_plugin_int *plugin)
+{
+  return 1;
+}
+
+
+#endif /* EMBEDDED_LIBRARY */
+
+
+AC *db_ac; // admission control object
+
+/**
+   @param thd THD structure.
+   @param entity current session's entity.
+
+   Applies admission control checks for the entity. Outline of
+   the steps in this function:
+   1. Error out if we crossed the max waiting limit.
+   2. Put the thd in a queue.
+   3. If we crossed the max running limit then wait for signal from threads
+      that completed their query execution.
+
+   @return False Run this query.
+           True  maximum waiting queries limit reached. Error out this query.
+*/
+bool AC::admission_control_enter(THD* thd, ATTRS_MAP_T &attr_map) {
+  bool error = false;
+  DBUG_ASSERT(attr_map.find(multi_tenancy_entity_db) != attr_map.end());
+  const std::string &entity = attr_map.at(multi_tenancy_entity_db);
+  const char* prev_proc_info = thd->proc_info;
+  THD_STAGE_INFO(thd, stage_admission_control_enter);
+  bool release_lock_ac = true;
+  // Unlock this before waiting.
+  mysql_rwlock_rdlock(&LOCK_ac);
+  if (max_running_queries) {
+    auto it = ac_map.find(entity);
+    if (it == ac_map.end()) {
+      // New DB.
+      mysql_rwlock_unlock(&LOCK_ac);
+      insert(entity);
+      mysql_rwlock_rdlock(&LOCK_ac);
+      it = ac_map.find(entity);
+    }
+
+    if (!thd->ac_node) {
+      // Both THD and the admission control queue will share the object
+      // created here.
+      thd->ac_node = std::make_shared<st_ac_node>();
+    }
+    auto ac_info = it->second;
+    MT_RETURN_TYPE ret = MT_RETURN_TYPE::MULTI_TENANCY_RET_FALLBACK;
+    st_mysql_multi_tenancy *data= NULL;
+    mysql_mutex_lock(&ac_info->lock);
+    // If a multi_tenancy plugin exists, check plugin for per-entity limit
+    if (thd->variables.multi_tenancy_plugin)
+    {
+      data = plugin_data(thd->variables.multi_tenancy_plugin,
+                         struct st_mysql_multi_tenancy *);
+      ret = data->request_resource(
+          thd,
+          MT_RESOURCE_TYPE::MULTI_TENANCY_RESOURCE_QUERY,
+          &attr_map);
+    }
+    // if plugin is disabled, fallback to check global query limit
+    if (ret == MT_RETURN_TYPE::MULTI_TENANCY_RET_FALLBACK)
+    {
+      if (ac_info->queue.size() < max_running_queries)
+        ret = MT_RETURN_TYPE::MULTI_TENANCY_RET_ACCEPT;
+      else
+      {
+        if (max_waiting_queries &&
+            ac_info->queue.size() >= max_running_queries + max_waiting_queries)
+          ret = MT_RETURN_TYPE::MULTI_TENANCY_RET_REJECT;
+        else
+          ret = MT_RETURN_TYPE::MULTI_TENANCY_RET_WAIT;
+      }
+    }
+
+    switch (ret)
+    {
+      case MT_RETURN_TYPE::MULTI_TENANCY_RET_REJECT:
+        ++total_aborted_queries;
+        // We reached max waiting limit. Error out
+        mysql_mutex_unlock(&ac_info->lock);
+        error = true;
+        break;
+
+      case MT_RETURN_TYPE::MULTI_TENANCY_RET_WAIT:
+        ac_info->queue.push_back(thd->ac_node);
+        ++ac_info->waiting_queries;
+        /**
+          Inserting or deleting in std::map will not invalidate existing
+          iterators except of course if the current iterator is erased. If the
+          db corresponding to this iterator is getting dropped, these waiting
+          queries are given signal to abort before the iterator
+          is erased. See AC::remove().
+          So, we don't need LOCK_ac here. The motivation to unlock the read lock
+          is that waiting queries here shouldn't block other operations
+          modifying ac_map or max_running_queries/max_waiting_queries.
+        */
+        mysql_rwlock_unlock(&LOCK_ac);
+        release_lock_ac = false;
+        wait_for_signal(thd, thd->ac_node, ac_info);
+        --ac_info->waiting_queries;
+        break;
+
+      case MT_RETURN_TYPE::MULTI_TENANCY_RET_ACCEPT:
+        // We are below the max running limit.
+        ac_info->queue.push_back(thd->ac_node);
+        mysql_mutex_unlock(&ac_info->lock);
+        break;
+
+      default:
+        // unreachable branch
+        DBUG_ASSERT(0);
+    }
+  }
+  if (release_lock_ac) {
+    mysql_rwlock_unlock(&LOCK_ac);
+  }
+  thd->proc_info = prev_proc_info;
+  return error;
+}
+
+void AC::wait_for_signal(THD* thd, std::shared_ptr<st_ac_node>& ac_node,
+                         std::shared_ptr<Ac_info> ac_info) {
+  PSI_stage_info old_stage;
+  mysql_mutex_lock(&ac_node->lock);
+  /**
+    The locking order followed during admission_control_enter() is
+    lock ac_info
+    lock ac_node
+    unlock ac_info
+    unlock ac_node
+    The locks are interleaved to avoid possible races which makes
+    this waiting thread miss the signal from admission_control_exit().
+  */
+  mysql_mutex_unlock(&ac_info->lock);
+  thd->ENTER_COND(&ac_node->cond, &ac_node->lock,
+                  &stage_waiting_for_admission,
+                  &old_stage);
+  // Spurious wake-ups are rare and fine in this design.
+  mysql_cond_wait(&ac_node->cond, &ac_node->lock);
+  thd->EXIT_COND(&old_stage);
+}
+
+/**
+  @param thd THD structure
+  @param entity current session's entity
+
+  Signals one waiting thread. Pops out the first THD in the queue.
+*/
+void AC::admission_control_exit(THD* thd, ATTRS_MAP_T &attr_map) {
+  DBUG_ASSERT(attr_map.find(multi_tenancy_entity_db) != attr_map.end());
+  const std::string &entity = attr_map.at(multi_tenancy_entity_db);
+  const char* prev_proc_info = thd->proc_info;
+  THD_STAGE_INFO(thd, stage_admission_control_exit);
+  mysql_rwlock_rdlock(&LOCK_ac);
+  auto it = ac_map.find(entity);
+  if (it != ac_map.end()) {
+    auto ac_info = it->second.get();
+    st_mysql_multi_tenancy *data= NULL;
+    mysql_mutex_lock(&ac_info->lock);
+    // If a multi_tenancy plugin exists, check plugin for per-entity limit
+    if (thd->variables.multi_tenancy_plugin)
+    {
+      data = plugin_data(thd->variables.multi_tenancy_plugin,
+                         struct st_mysql_multi_tenancy *);
+      data->release_resource(
+          thd,
+          MT_RESOURCE_TYPE::MULTI_TENANCY_RESOURCE_QUERY,
+          &attr_map);
+    }
+    if (max_running_queries &&
+        ac_info->queue.size() > max_running_queries) {
+      signal(ac_info->queue[max_running_queries]);
+    }
+    // The queue is empty if max_running_queries is toggled to 0
+    // when this THD is inside admission_control_enter().
+    if (ac_info->queue.size())
+    {
+      /**
+        The popped value here doesn't necessarily give the ac_node of the
+        current THD. It is better if the popped value is not accessed at all.
+      */
+      ac_info->queue.pop_front();
+    }
+    mysql_mutex_unlock(&ac_info->lock);
+  }
+  mysql_rwlock_unlock(&LOCK_ac);
+  thd->proc_info = prev_proc_info;
+}

--- a/sql/sql_multi_tenancy.h
+++ b/sql/sql_multi_tenancy.h
@@ -1,0 +1,294 @@
+/* Copyright (c) 2016, Facebook. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+
+#ifndef _sql_multi_tenancy_h
+#define _sql_multi_tenancy_h
+
+#include <my_global.h>
+
+#include <mysql/plugin_multi_tenancy.h>
+#include "sql_class.h"
+
+
+/*
+ * sql_multi_tenancy.h/cc
+ *
+ * This module handles multi-tenancy resource allocation on the server side.
+ * Functions will call into multi-tenancy plugin interfaces (if installed) to
+ * make a decision of whether or not a resource can be allocated. Connections
+ * and query limits are among the resources multi-tenancy plugin allocates.
+ * Note that admission control is now part of the multi-tenancy module to
+ * hanlde query throttling.
+ *
+ * The isolation level is defined by an entity. The entity could be a database,
+ * a user, or any thing that multi-tenancy plugin defines to isolate the
+ * resource allocation.
+ *
+ * See sql_multi_tenancy.cc for implementation.
+ */
+
+#define multi_tenancy_entity_str "entity"
+#define multi_tenancy_entity_db "db"
+
+extern int multi_tenancy_add_connection(THD *thd, ATTRS_MAP_T &attr_map);
+extern int multi_tenancy_close_connection(THD *thd, ATTRS_MAP_T &attr_map);
+extern int multi_tenancy_admit_query(THD *thd, ATTRS_MAP_T &attr_map);
+extern int multi_tenancy_exit_query(THD *thd, ATTRS_MAP_T &attr_map);
+
+
+/**
+  Per-thread information used in admission control.
+*/
+struct st_ac_node {
+#ifdef HAVE_PSI_INTERFACE
+  PSI_mutex_key key_lock;
+  PSI_cond_key key_cond;
+  PSI_mutex_info key_lock_info[1]=
+  {
+    {&key_lock, "st_ac_node::lock", 0}
+  };
+  PSI_cond_info key_cond_info[1]=
+  {
+    {&key_cond, "st_ac_node::cond", 0}
+  };
+#endif
+  mysql_mutex_t lock;
+  mysql_cond_t cond;
+  st_ac_node() {
+#ifdef HAVE_PSI_INTERFACE
+    mysql_mutex_register("sql", key_lock_info,
+                         array_elements(key_lock_info));
+    mysql_cond_register("sql", key_cond_info,
+                        array_elements(key_cond_info));
+#endif
+    mysql_mutex_init(key_lock, &lock, MY_MUTEX_INIT_FAST);
+    mysql_cond_init(key_cond, &cond, NULL);
+  }
+
+  ~st_ac_node () {
+    mysql_mutex_destroy(&lock);
+    mysql_cond_destroy(&cond);
+  }
+};
+
+
+/**
+  Class used in admission control.
+
+  Every entity (database or table or user name) will have this
+  object created and stored in the global map AC::ac_map.
+
+*/
+class Ac_info {
+  friend class AC;
+#ifdef HAVE_PSI_INTERFACE
+  PSI_mutex_key key_lock;
+  PSI_mutex_info key_lock_info[1]=
+  {
+    {&key_lock, "Ac_info::lock", 0}
+  };
+#endif
+  // Queue to track the running and waiting threads.
+  std::deque<std::shared_ptr<st_ac_node>> queue;
+  std::atomic<unsigned long> waiting_queries;
+  // Protects the queue.
+  mysql_mutex_t lock;
+public:
+  Ac_info() {
+#ifdef HAVE_PSI_INTERFACE
+    mysql_mutex_register("sql", key_lock_info,
+                         array_elements(key_lock_info));
+#endif
+    mysql_mutex_init(key_lock, &lock, MY_MUTEX_INIT_FAST);
+    waiting_queries = 0;
+  }
+  ~Ac_info() {
+    mysql_mutex_destroy(&lock);
+  }
+  // Disable copy constructor.
+  Ac_info(const Ac_info&) = delete;
+  Ac_info& operator=(const Ac_info&) = delete;
+};
+
+/**
+  Global class used to enforce per admission control limits.
+*/
+class AC {
+  // This map is protected by the rwlock LOCK_ac.
+  std::unordered_map<std::string, std::shared_ptr<Ac_info>> ac_map;
+  // Variables to track global limits
+  ulong max_running_queries, max_waiting_queries;
+  /**
+    Protects ac_map and max_running_queries/max_waiting_queries.
+
+    Locking order followed is LOCK_ac, Ac_info::lock, st_ac_node::lock.
+  */
+  mysql_rwlock_t LOCK_ac;
+#ifdef HAVE_PSI_INTERFACE
+  PSI_rwlock_key key_rwlock_LOCK_ac;
+  PSI_rwlock_info key_rwlock_LOCK_ac_info[1]=
+  {
+    {&key_rwlock_LOCK_ac, "AC::rwlock", 0}
+  };
+#endif
+
+  std::atomic<ulonglong> total_aborted_queries;
+
+public:
+  AC() {
+#ifdef HAVE_PSI_INTERFACE
+    mysql_rwlock_register("sql", key_rwlock_LOCK_ac_info,
+                          array_elements(key_rwlock_LOCK_ac_info));
+#endif
+    mysql_rwlock_init(key_rwlock_LOCK_ac, &LOCK_ac);
+    max_running_queries = 0;
+    max_waiting_queries = 0;
+    total_aborted_queries = 0;
+  }
+
+  ~AC() {
+    mysql_rwlock_destroy(&LOCK_ac);
+  }
+  // Disable copy constructor.
+  AC(const AC&) = delete;
+  AC& operator=(const AC&) = delete;
+
+  inline void signal(std::shared_ptr<st_ac_node>& ac_node) {
+    DBUG_ASSERT(ac_node && ac_node.get());
+    mysql_mutex_lock(&ac_node->lock);
+    mysql_cond_signal(&ac_node->cond);
+    mysql_mutex_unlock(&ac_node->lock);
+  }
+
+  /*
+   * Removes a dropped entity info from the global map.
+   */
+  void remove(const char* entity) {
+    std::string str(entity);
+    // First take a read lock to unblock any waiting queries.
+    mysql_rwlock_rdlock(&LOCK_ac);
+    auto it = ac_map.find(str);
+    if (it != ac_map.end()) {
+      auto ac_info  = it->second;
+      mysql_mutex_lock(&ac_info->lock);
+      while (ac_info->waiting_queries) {
+        for (uint i = max_running_queries; i < ac_info->queue.size(); ++i) {
+          signal(ac_info->queue[i]);
+        }
+      }
+      mysql_mutex_unlock(&ac_info->lock);
+    }
+    mysql_rwlock_unlock(&LOCK_ac);
+    mysql_rwlock_wrlock(&LOCK_ac);
+    it = ac_map.find(std::string(str));
+    if (it != ac_map.end()) {
+      ac_map.erase(it);
+    }
+    mysql_rwlock_unlock(&LOCK_ac);
+  }
+
+  void insert(const std::string &entity) {
+    mysql_rwlock_wrlock(&LOCK_ac);
+    if (ac_map.find(entity) == ac_map.end()) {
+      ac_map[entity] = std::make_shared<Ac_info>();
+    }
+    mysql_rwlock_unlock(&LOCK_ac);
+  }
+
+  void update_max_running_queries(ulong val) {
+    // lock to protect against erasing map iterators.
+    mysql_rwlock_wrlock(&LOCK_ac);
+    ulong old_val = max_running_queries;
+    max_running_queries = val;
+    // Signal any waiting threads which are below the new limit. Note 0 is a
+    // special case where every waiting thread needs to be signalled.
+    if (val > old_val || !val) {
+      for (auto &it: ac_map) {
+        auto &ac_info = it.second;
+        mysql_mutex_lock(&ac_info->lock);
+        for (uint i = old_val;
+             (!val || i < val) && i < ac_info->queue.size(); ++i) {
+          signal(ac_info->queue[i]);
+        }
+        mysql_mutex_unlock(&ac_info->lock);
+      }
+    }
+    mysql_rwlock_unlock(&LOCK_ac);
+  }
+
+  void update_max_waiting_queries(ulong val) {
+    mysql_rwlock_wrlock(&LOCK_ac);
+    max_waiting_queries = val;
+    mysql_rwlock_unlock(&LOCK_ac);
+  }
+
+  inline ulong get_max_running_queries() {
+    mysql_rwlock_rdlock(&LOCK_ac);
+    ulong res = max_running_queries;
+    mysql_rwlock_unlock(&LOCK_ac);
+    return res;
+  }
+
+  inline ulong get_max_waiting_queries() {
+    mysql_rwlock_rdlock(&LOCK_ac);
+    ulong res = max_waiting_queries;
+    mysql_rwlock_unlock(&LOCK_ac);
+    return res;
+  }
+
+  bool admission_control_enter(THD*, ATTRS_MAP_T&);
+  void admission_control_exit(THD*, ATTRS_MAP_T&);
+  void wait_for_signal(THD*, std::shared_ptr<st_ac_node>&,
+                       std::shared_ptr<Ac_info> ac_info);
+
+  ulonglong get_total_aborted_queries() const {
+    return total_aborted_queries;
+  }
+  ulong get_total_running_queries() {
+    ulonglong res= 0;
+    mysql_rwlock_rdlock(&LOCK_ac);
+    for (auto it : ac_map)
+    {
+      auto &ac_info = it.second;
+      mysql_mutex_lock(&ac_info->lock);
+      res += ac_info->queue.size() < max_running_queries ?
+        ac_info->queue.size() : max_running_queries;
+      mysql_mutex_unlock(&ac_info->lock);
+    }
+    mysql_rwlock_unlock(&LOCK_ac);
+    return res;
+  }
+  ulong get_total_waiting_queries() {
+    ulonglong res= 0;
+    mysql_rwlock_rdlock(&LOCK_ac);
+    for (auto it : ac_map)
+    {
+      auto &ac_info = it.second;
+      mysql_mutex_lock(&ac_info->lock);
+      if (ac_info->queue.size() > max_running_queries)
+        res += ac_info->queue.size() - max_running_queries;
+      mysql_mutex_unlock(&ac_info->lock);
+    }
+    mysql_rwlock_unlock(&LOCK_ac);
+    return res;
+  }
+};
+
+
+extern AC *db_ac;
+
+#endif /* _sql_multi_tenancy_h */

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -110,6 +110,7 @@
 
 #include "sql_db.h"      // init_thd_db_read_only
                          // is_thd_db_read_only_by_name
+#include "sql_multi_tenancy.h"
 
 #ifdef HAVE_JEMALLOC
 #ifndef EMBEDDED_LIBRARY
@@ -1532,6 +1533,7 @@ bool dispatch_command(enum enum_server_command command, THD *thd,
     status_var_increment(thd->status_var.com_stat[SQLCOM_CHANGE_DB]);
     thd->convert_string(&tmp, system_charset_info,
 			packet, packet_length, thd->charset());
+
     if (!mysql_change_db(thd, &tmp, FALSE))
     {
       general_log_write(thd, command, thd->db, thd->db_length);
@@ -1672,11 +1674,11 @@ bool dispatch_command(enum enum_server_command command, THD *thd,
     if (parser_state.init(thd, thd->query(), thd->query_length()))
       break;
 
-    my_bool exit_admission_control = FALSE;
-    // thd->db can be changed. So make a copy here.
-    std::string db = thd->db ? std::string(thd->db) : "";
+    // This is for admission control backward compatibility. Eventually this
+    // will be set in in the query attributes.
+    thd->query_attrs_map[multi_tenancy_entity_db] = thd->db ? thd->db : "";
     mysql_parse(thd, thd->query(), thd->query_length(), &parser_state,
-                &last_timer, &async_commit, db, &exit_admission_control);
+                &last_timer, &async_commit);
 
     while (!thd->killed && (parser_state.m_lip.found_semicolon != NULL) &&
            ! thd->is_error())
@@ -1760,10 +1762,13 @@ bool dispatch_command(enum enum_server_command command, THD *thd,
       parser_state.reset(beginning_of_next_stmt, length);
       /* TODO: set thd->lex->sql_command to SQLCOM_END here */
       mysql_parse(thd, beginning_of_next_stmt, length, &parser_state,
-                  &last_timer, &async_commit, db, &exit_admission_control);
+                  &last_timer, &async_commit);
     }
-    if (exit_admission_control)
-      db_ac->admission_control_exit(thd, db);
+    if (thd->is_in_ac && (!opt_admission_control_by_trx || thd->is_real_trans))
+    {
+      multi_tenancy_exit_query(thd, thd->query_attrs_map);
+      thd->is_in_ac = false;
+    }
 
     DBUG_PRINT("info",("query ready"));
     break;
@@ -4470,9 +4475,45 @@ end_with_restore_list:
   case SQLCOM_CHANGE_DB:
   {
     LEX_STRING db_str= { (char *) select_lex->db, strlen(select_lex->db) };
+    bool add_conn = false, release_conn = false;
+    // use a new map before we actually change the db successfully
+    std::unordered_map<std::string, std::string> attrs_map;
+    std::string old_db;
+    if (!thd->db || strcmp(thd->db, select_lex->db))
+    {
+      add_conn = true;
+      attrs_map[multi_tenancy_entity_db] = select_lex->db;
+      if (thd->db)
+      {
+        release_conn = true;
+        old_db = thd->db;
+      }
+    }
+
+    // check resource if we can switch the connection to another database
+    if (add_conn && multi_tenancy_add_connection(thd, attrs_map))
+    {
+      my_error(ER_MULTI_TENANCY_MAX_CONNECTION, MYF(0), select_lex->db);
+      goto error;
+    }
 
     if (!mysql_change_db(thd, &db_str, FALSE))
+    {
+      // release old connection resource in multi-tenancy plugin
+      if (release_conn)
+      {
+        attrs_map[multi_tenancy_entity_db] = old_db;
+        multi_tenancy_close_connection(thd, attrs_map);
+      }
+      // now update the connection attributes to reflect the new entity
+      thd->update_connection_attrs(attrs_map);
       my_ok(thd);
+    }
+    else if (add_conn)
+    {
+      // release connection resource in multi-tenancy plugin
+      multi_tenancy_close_connection(thd, attrs_map);
+    }
 
     break;
   }
@@ -7258,274 +7299,6 @@ static bool throttle_query_if_needed(THD* thd)
   DBUG_RETURN(false);
 }
 
-/**
-   @param thd THD structure.
-   @param entity current session's entity.
-
-   Applies admission control checks for the entity. Outline of
-   the steps in this function:
-   1. Error out if we crossed the max waiting limit.
-   2. Put the thd in a queue.
-   3. If we crossed the max running limit then wait for signal from threads
-      that completed their query execution.
-
-   @return False Run this query.
-           True  maximum waiting queries limit reached. Error out this query.
-*/
-bool AC::admission_control_enter(THD* thd, const std::string& entity) {
-  bool error = false;
-  const char* prev_proc_info = thd->proc_info;
-  THD_STAGE_INFO(thd, stage_admission_control_enter);
-  bool release_lock_ac = true;
-  // Unlock this before waiting.
-  mysql_rwlock_rdlock(&LOCK_ac);
-  if (max_running_queries) {
-    auto it = ac_map.find(entity);
-    if (it == ac_map.end()) {
-      // New DB.
-      mysql_rwlock_unlock(&LOCK_ac);
-      insert(entity);
-      mysql_rwlock_rdlock(&LOCK_ac);
-      it = ac_map.find(entity);
-    }
-
-    if (!thd->ac_node) {
-      // Both THD and the admission control queue will share the object
-      // created here.
-      thd->ac_node = std::make_shared<st_ac_node>();
-    }
-    auto ac_info = it->second;
-    mysql_mutex_lock(&ac_info->lock);
-    if (ac_info->queue.size() >= max_running_queries) {
-      if (max_waiting_queries &&
-          ac_info->queue.size() >= max_running_queries + max_waiting_queries) {
-        ++total_aborted_queries;
-        // We reached max waiting limit. Error out
-        mysql_mutex_unlock(&ac_info->lock);
-        error = true;
-      } else {
-        ac_info->queue.push_back(thd->ac_node);
-        ++ac_info->waiting_queries;
-        /**
-          Inserting or deleting in std::map will not invalidate existing
-          iterators except of course if the current iterator is erased. If the
-          db corresponding to this iterator is getting dropped, these waiting
-          queries are given signal to abort before the iterator
-          is erased. See AC::remove().
-          So, we don't need LOCK_ac here. The motivation to unlock the read lock
-          is that waiting queries here shouldn't block other operations
-          modifying ac_map or max_running_queries/max_waiting_queries.
-        */
-        mysql_rwlock_unlock(&LOCK_ac);
-        release_lock_ac = false;
-        wait_for_signal(thd, thd->ac_node, ac_info);
-        --ac_info->waiting_queries;
-      }
-    } else {
-      // We are below the max running limit.
-      ac_info->queue.push_back(thd->ac_node);
-      mysql_mutex_unlock(&ac_info->lock);
-    }
-  }
-  if (release_lock_ac) {
-    mysql_rwlock_unlock(&LOCK_ac);
-  }
-  thd->proc_info = prev_proc_info;
-  return error;
-}
-
-void AC::wait_for_signal(THD* thd, std::shared_ptr<st_ac_node>& ac_node,
-                         std::shared_ptr<Ac_info> ac_info) {
-  PSI_stage_info old_stage;
-  mysql_mutex_lock(&ac_node->lock);
-  /**
-    The locking order followed during admission_control_enter() is
-    lock ac_info
-    lock ac_node
-    unlock ac_info
-    unlock ac_node
-    The locks are interleaved to avoid possible races which makes
-    this waiting thread miss the signal from admission_control_exit().
-  */
-  mysql_mutex_unlock(&ac_info->lock);
-  thd->ENTER_COND(&ac_node->cond, &ac_node->lock,
-                  &stage_waiting_for_admission,
-                  &old_stage);
-  // Spurious wake-ups are rare and fine in this design.
-  mysql_cond_wait(&ac_node->cond, &ac_node->lock);
-  thd->EXIT_COND(&old_stage);
-}
-
-/**
-  @param thd THD structure
-  @param entity current session's entity
-
-  Signals one waiting thread. Pops out the first THD in the queue.
-*/
-void AC::admission_control_exit(THD* thd, const std::string& entity) {
-  const char* prev_proc_info = thd->proc_info;
-  THD_STAGE_INFO(thd, stage_admission_control_exit);
-  mysql_rwlock_rdlock(&LOCK_ac);
-  auto it = ac_map.find(entity);
-  if (it != ac_map.end()) {
-    auto ac_info = it->second.get();
-    mysql_mutex_lock(&ac_info->lock);
-    if (max_running_queries &&
-        ac_info->queue.size() > max_running_queries) {
-      signal(ac_info->queue[max_running_queries]);
-    }
-    // The queue is empty if max_running_queries is toggled to 0
-    // when this THD is inside admission_control_enter().
-    if (ac_info->queue.size())
-    {
-      /**
-        The popped value here doesn't necessarily give the ac_node of the
-        current THD. It is better if the popped value is not accessed at all.
-      */
-      ac_info->queue.pop_front();
-    }
-    mysql_mutex_unlock(&ac_info->lock);
-  }
-  mysql_rwlock_unlock(&LOCK_ac);
-  thd->proc_info = prev_proc_info;
-}
-
-/*
-  @param sql_command command the thread is currently executing
-
-  @return true Skips the current query in admission control
-          false Admission control checks are applied for this query
-*/
-static bool filter_command(enum_sql_command sql_command)
-{
-  switch (sql_command) {
-    case SQLCOM_ALTER_TABLE:
-    case SQLCOM_ALTER_DB:
-    case SQLCOM_ALTER_PROCEDURE:
-    case SQLCOM_ALTER_FUNCTION:
-    case SQLCOM_ALTER_TABLESPACE:
-    case SQLCOM_ALTER_SERVER:
-    case SQLCOM_ALTER_EVENT:
-    case SQLCOM_ALTER_DB_UPGRADE:
-    case SQLCOM_ALTER_USER:
-    case SQLCOM_RENAME_TABLE:
-    case SQLCOM_RENAME_USER:
-      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_ALTER);
-
-    case SQLCOM_BEGIN:
-      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_BEGIN);
-
-    case SQLCOM_COMMIT:
-      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_COMMIT);
-
-    case SQLCOM_CREATE_TABLE:
-    case SQLCOM_CREATE_INDEX:
-    case SQLCOM_CREATE_DB:
-    case SQLCOM_CREATE_FUNCTION:
-    case SQLCOM_CREATE_USER:
-    case SQLCOM_CREATE_PROCEDURE:
-    case SQLCOM_CREATE_SPFUNCTION:
-    case SQLCOM_CREATE_VIEW:
-    case SQLCOM_CREATE_TRIGGER:
-    case SQLCOM_CREATE_SERVER:
-    case SQLCOM_CREATE_EVENT:
-      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_CREATE);
-
-    case SQLCOM_DELETE:
-    case SQLCOM_DELETE_MULTI:
-      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_DELETE);
-
-    case SQLCOM_DROP_TABLE:
-    case SQLCOM_DROP_INDEX:
-    case SQLCOM_DROP_DB:
-    case SQLCOM_DROP_FUNCTION:
-    case SQLCOM_DROP_USER:
-    case SQLCOM_DROP_PROCEDURE:
-    case SQLCOM_DROP_VIEW:
-    case SQLCOM_DROP_TRIGGER:
-    case SQLCOM_DROP_SERVER:
-    case SQLCOM_DROP_EVENT:
-      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_DROP);
-
-    case SQLCOM_INSERT:
-    case SQLCOM_INSERT_SELECT:
-      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_INSERT);
-
-    case SQLCOM_LOAD:
-      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_LOAD);
-
-    case SQLCOM_SELECT:
-      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_SELECT);
-
-    case SQLCOM_SET_OPTION:
-      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_SET);
-
-    case SQLCOM_REPLACE:
-    case SQLCOM_REPLACE_SELECT:
-      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_REPLACE);
-
-    case SQLCOM_ROLLBACK:
-      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_ROLLBACK);
-
-    case SQLCOM_TRUNCATE:
-      return IS_BIT_SET(admission_control_filter,  ADMISSION_CONTROL_TRUNCATE);
-
-    case SQLCOM_UPDATE:
-    case SQLCOM_UPDATE_MULTI:
-      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_UPDATE);
-
-    case SQLCOM_SHOW_DATABASES:
-    case SQLCOM_SHOW_TABLES:
-    case SQLCOM_SHOW_FIELDS:
-    case SQLCOM_SHOW_KEYS:
-    case SQLCOM_SHOW_VARIABLES:
-    case SQLCOM_SHOW_STATUS:
-    case SQLCOM_SHOW_ENGINE_LOGS:
-    case SQLCOM_SHOW_ENGINE_STATUS:
-    case SQLCOM_SHOW_ENGINE_MUTEX:
-    case SQLCOM_SHOW_PROCESSLIST:
-    case SQLCOM_SHOW_TRANSACTION_LIST:
-    case SQLCOM_SHOW_MASTER_STAT:
-    case SQLCOM_SHOW_SLAVE_STAT:
-    case SQLCOM_SHOW_GRANTS:
-    case SQLCOM_SHOW_CREATE:
-    case SQLCOM_SHOW_CHARSETS:
-    case SQLCOM_SHOW_COLLATIONS:
-    case SQLCOM_SHOW_CREATE_DB:
-    case SQLCOM_SHOW_TABLE_STATUS:
-    case SQLCOM_SHOW_TRIGGERS:
-    case SQLCOM_SHOW_BINLOGS:
-    case SQLCOM_SHOW_OPEN_TABLES:
-    case SQLCOM_SHOW_SLAVE_HOSTS:
-    case SQLCOM_SHOW_BINLOG_EVENTS:
-    case SQLCOM_SHOW_BINLOG_CACHE:
-    case SQLCOM_SHOW_WARNS:
-    case SQLCOM_SHOW_ERRORS:
-    case SQLCOM_SHOW_STORAGE_ENGINES:
-    case SQLCOM_SHOW_PRIVILEGES:
-    case SQLCOM_SHOW_CREATE_PROC:
-    case SQLCOM_SHOW_CREATE_FUNC:
-    case SQLCOM_SHOW_STATUS_PROC:
-    case SQLCOM_SHOW_STATUS_FUNC:
-    case SQLCOM_SHOW_PROC_CODE:
-    case SQLCOM_SHOW_FUNC_CODE:
-    case SQLCOM_SHOW_PLUGINS:
-    case SQLCOM_SHOW_CREATE_EVENT:
-    case SQLCOM_SHOW_EVENTS:
-    case SQLCOM_SHOW_CREATE_TRIGGER:
-    case SQLCOM_SHOW_PROFILE:
-    case SQLCOM_SHOW_PROFILES:
-    case SQLCOM_SHOW_RELAYLOG_EVENTS:
-    case SQLCOM_SHOW_ENGINE_TRX:
-    case SQLCOM_SHOW_MEMORY_STATUS:
-    case SQLCOM_SHOW_CONNECTION_ATTRIBUTES:
-      return IS_BIT_SET(admission_control_filter, ADMISSION_CONTROL_SHOW);
-
-    default:
-      return false;
-  }
-}
-
 /*
   When you modify mysql_parse(), you may need to mofify
   mysql_test_parse_for_slave() in this same file.
@@ -7539,8 +7312,6 @@ static bool filter_command(enum_sql_command sql_command)
   @param       length  Length of the query text
   @param[out]  found_semicolon For multi queries, position of the character of
                                the next query in the query text.
-  @param[in]  db
-              database name used for admission control checks
   @param[in, out] exit_admission_control
               Set to TRUE when admission control limits are applied and
               query is allowed to run. This flag is TRUE if the THD entered
@@ -7550,9 +7321,7 @@ static bool filter_command(enum_sql_command sql_command)
 
 void mysql_parse(THD *thd, char *rawbuf, uint length,
                  Parser_state *parser_state, ulonglong *last_timer,
-                 my_bool* async_commit,
-                 const std::string &db,
-                 my_bool* exit_admission_control)
+                 my_bool* async_commit)
 {
   int error __attribute__((unused));
   ulonglong statement_start_time;
@@ -7695,39 +7464,16 @@ void mysql_parse(THD *thd, char *rawbuf, uint length,
             error= 1;
           }
           else {
-            bool admission_check= false;
-            /**
-              Admission control checks are skipped in the following
-              scenarios.
-              1. The query is run by super user
-              2. The THD is a replication thread
-              3. If this is a multi query packet and the THD already entered
-                 admission control
-              4. No database is set for this session
-              5. Admission control checks are turned off by setting
-                 max_running_queries=0
-              6. If the command is filtered from admission checks
-            */
-            if (!(thd->security_ctx->master_access & SUPER_ACL) &&
-                !thd->rli_slave &&
-                exit_admission_control && !(*exit_admission_control) &&
-                !db.empty() &&
-                db_ac->get_max_running_queries() &&
-                !filter_command(thd->lex->sql_command)) {
-              admission_check= true;
-            }
-
-            if (admission_check &&
-                db_ac->admission_control_enter(thd, db)) {
+            if (multi_tenancy_admit_query(thd, thd->query_attrs_map))
+            {
               my_error(ER_DB_ADMISSION_CONTROL, MYF(0),
-                       db_ac->get_max_waiting_queries(), thd->db);
+                       db_ac->get_max_waiting_queries(),
+                       thd->query_attrs_map[multi_tenancy_entity_db].c_str());
               error= 1;
-            } else {
+            }
+            else
               error = mysql_execute_command(thd, &statement_start_time,
                                             last_timer);
-              if (exit_admission_control && admission_check)
-                *exit_admission_control = TRUE;
-            }
           }
           if (error == 0 &&
               thd->variables.gtid_next.type == GTID_GROUP &&

--- a/sql/sql_parse.h
+++ b/sql/sql_parse.h
@@ -100,9 +100,7 @@ bool alloc_query(THD *thd, const char *packet, uint packet_length);
 void mysql_init_select(LEX *lex);
 void mysql_parse(THD *thd, char *rawbuf, uint length,
                  Parser_state *parser_state, ulonglong *last_timer,
-                 my_bool *async_commit,
-                 const std::string &db = std::string(""),
-                 my_bool *exit_admission_control = NULL);
+                 my_bool *async_commit);
 void mysql_reset_thd_for_next_command(THD *thd);
 bool mysql_new_select(LEX *lex, bool move_down);
 void create_select_for_variable(const char *var_name);

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -36,6 +36,7 @@
 #include <mysql/plugin_validate_password.h>
 #include "my_default.h"
 #include "debug_sync.h"
+#include <mysql/plugin_multi_tenancy.h>
 
 #include <algorithm>
 
@@ -78,7 +79,8 @@ const LEX_STRING plugin_type_names[MYSQL_MAX_PLUGIN_TYPE_NUM]=
   { C_STRING_WITH_LEN("AUDIT") },
   { C_STRING_WITH_LEN("REPLICATION") },
   { C_STRING_WITH_LEN("AUTHENTICATION") },
-  { C_STRING_WITH_LEN("VALIDATE PASSWORD") }
+  { C_STRING_WITH_LEN("VALIDATE PASSWORD") },
+  { C_STRING_WITH_LEN("MULTI TENANCY") }
 };
 
 extern int initialize_schema_table(st_plugin_int *plugin);
@@ -87,6 +89,9 @@ extern int finalize_schema_table(st_plugin_int *plugin);
 extern int initialize_audit_plugin(st_plugin_int *plugin);
 extern int finalize_audit_plugin(st_plugin_int *plugin);
 
+extern int initialize_multi_tenancy_plugin(st_plugin_int *plugin);
+extern int finalize_multi_tenancy_plugin(st_plugin_int *plugin);
+
 /*
   The number of elements in both plugin_type_initialize and
   plugin_type_deinitialize should equal to the number of plugins
@@ -94,14 +99,30 @@ extern int finalize_audit_plugin(st_plugin_int *plugin);
 */
 plugin_type_init plugin_type_initialize[MYSQL_MAX_PLUGIN_TYPE_NUM]=
 {
-  0,ha_initialize_handlerton,0,0,initialize_schema_table,
-  initialize_audit_plugin,0,0,0
+  0,
+  ha_initialize_handlerton,
+  0,
+  0,
+  initialize_schema_table,
+  initialize_audit_plugin,
+  0,
+  0,
+  0,
+  initialize_multi_tenancy_plugin
 };
 
 plugin_type_init plugin_type_deinitialize[MYSQL_MAX_PLUGIN_TYPE_NUM]=
 {
-  0,ha_finalize_handlerton,0,0,finalize_schema_table,
-  finalize_audit_plugin,0,0,0
+  0,
+  ha_finalize_handlerton,
+  0,
+  0,
+  finalize_schema_table,
+  finalize_audit_plugin,
+  0,
+  0,
+  0,
+  finalize_multi_tenancy_plugin
 };
 
 #ifdef HAVE_DLOPEN
@@ -128,7 +149,8 @@ static int min_plugin_info_interface_version[MYSQL_MAX_PLUGIN_TYPE_NUM]=
   MYSQL_AUDIT_INTERFACE_VERSION,
   MYSQL_REPLICATION_INTERFACE_VERSION,
   MYSQL_AUTHENTICATION_INTERFACE_VERSION,
-  MYSQL_VALIDATE_PASSWORD_INTERFACE_VERSION
+  MYSQL_VALIDATE_PASSWORD_INTERFACE_VERSION,
+	MYSQL_MULTI_TENANCY_INTERFACE_VERSION
 };
 static int cur_plugin_info_interface_version[MYSQL_MAX_PLUGIN_TYPE_NUM]=
 {
@@ -140,7 +162,8 @@ static int cur_plugin_info_interface_version[MYSQL_MAX_PLUGIN_TYPE_NUM]=
   MYSQL_AUDIT_INTERFACE_VERSION,
   MYSQL_REPLICATION_INTERFACE_VERSION,
   MYSQL_AUTHENTICATION_INTERFACE_VERSION,
-  MYSQL_VALIDATE_PASSWORD_INTERFACE_VERSION
+  MYSQL_VALIDATE_PASSWORD_INTERFACE_VERSION,
+	MYSQL_MULTI_TENANCY_INTERFACE_VERSION
 };
 
 /* support for Services */
@@ -2818,15 +2841,18 @@ void plugin_thdvar_init(THD *thd, bool enable_plugins)
 {
   plugin_ref old_table_plugin= thd->variables.table_plugin;
   plugin_ref old_temp_table_plugin= thd->variables.temp_table_plugin;
+  plugin_ref old_multi_tenancy_plugin= thd->variables.multi_tenancy_plugin;
   DBUG_ENTER("plugin_thdvar_init");
   
   thd->variables.table_plugin= NULL;
   thd->variables.temp_table_plugin= NULL;
+  thd->variables.multi_tenancy_plugin= NULL;
   cleanup_variables(thd, &thd->variables);
   
   thd->variables= global_system_variables;
   thd->variables.table_plugin= NULL;
   thd->variables.temp_table_plugin= NULL;
+  thd->variables.multi_tenancy_plugin= NULL;
 
   /* we are going to allocate these lazily */
   thd->variables.dynamic_variables_version= 0;
@@ -2842,6 +2868,10 @@ void plugin_thdvar_init(THD *thd, bool enable_plugins)
     thd->variables.temp_table_plugin=
       my_intern_plugin_lock(NULL, global_system_variables.temp_table_plugin);
     intern_plugin_unlock(NULL, old_temp_table_plugin);
+    if (global_system_variables.multi_tenancy_plugin)
+      thd->variables.multi_tenancy_plugin= my_intern_plugin_lock(NULL,
+          global_system_variables.multi_tenancy_plugin);
+    intern_plugin_unlock(NULL, old_multi_tenancy_plugin);
     mysql_mutex_unlock(&LOCK_plugin);
   }
   DBUG_VOID_RETURN;
@@ -2855,8 +2885,10 @@ static void unlock_variables(THD *thd, struct system_variables *vars)
 {
   intern_plugin_unlock(NULL, vars->table_plugin);
   intern_plugin_unlock(NULL, vars->temp_table_plugin);
+  intern_plugin_unlock(NULL, vars->multi_tenancy_plugin);
   vars->table_plugin= NULL;
   vars->temp_table_plugin= NULL;
+	vars->multi_tenancy_plugin= NULL;
 }
 
 
@@ -2873,6 +2905,7 @@ static void cleanup_variables(THD *thd, struct system_variables *vars)
 
   DBUG_ASSERT(vars->table_plugin == NULL);
   DBUG_ASSERT(vars->temp_table_plugin == NULL);
+  DBUG_ASSERT(vars->multi_tenancy_plugin == NULL);
 
   my_free(vars->dynamic_variables_ptr);
   vars->dynamic_variables_ptr= NULL;

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -60,6 +60,7 @@
 #include "sql_show.h"                           // opt_ignore_db_dirs
 #include "table_cache.h"                        // Table_cache_manager
 #include "my_aes.h" // my_aes_opmode_names
+#include "sql_multi_tenancy.h"
 
 #include "log_event.h"
 #include "binlog.h"
@@ -3223,6 +3224,12 @@ static Sys_var_set Admission_control_options(
        GLOBAL_VAR(admission_control_filter), CMD_LINE(REQUIRED_ARG),
        admission_control_filter_names,
        DEFAULT(0));
+
+static Sys_var_mybool Sys_admission_control_by_trx(
+       "admission_control_by_trx",
+       "Allow open transactions to go through admission control",
+       GLOBAL_VAR(opt_admission_control_by_trx), CMD_LINE(OPT_ARG),
+       DEFAULT(FALSE));
 
 static Sys_var_mybool Sys_slave_sql_verify_checksum(
        "slave_sql_verify_checksum",


### PR DESCRIPTION
Summary:
This patch adds a new plugin interface and a multi-tenancy module on server
side. In the first version of the plugin, the resource isolation is limited to
max connections and queries, while the APIs are generic to expand to other
resources in the future.

Main features:
  - plugin_multi_tenancy.h: defines the plugin interfaces to request and
    release resources.
  - multi-tenancy plugin will be installed and set as a global variable, so
    there will only be one multi-tenancy plugin in use on the server (similar
    to storage engine plugin). We could possible change to allow multiple
    multi-tenancy plugins in use at the same time if there is need.
  - sql_multi_tenancy.h/cc: unifies/refactors admission control into the
    multi-tenancy server module, and adds server side resource management
    interfaces.
  - resource isolation is based on connection attributes and query attributes,
    and is generic to handle per database or per user. admission control is
    modified to use query attributes.
  - connection resource management happens in two places: (1) when client
    initiates a connection, and (2) when client changes a database in the case
    of connection reuse.
  - mt_simple.h/cc: dummy multi-tenancy plugin example
  - Admission control can be set to be based on transactions (global var
    admission_control_by_trx), in addition to multi-statements.

Test Plan:
mtr and regression tests on admission control. manual test using mt_simple
plugin.