### PR TITLE
Group purging of rows by table id

### DIFF
--- a/storage/innobase/include/mach0data.ic
+++ b/storage/innobase/include/mach0data.ic
@@ -549,6 +549,94 @@ mach_ull_parse_compressed(
 
 	return(ptr + 4);
 }
+
+/** Read a 32-bit integer in a compressed form.
+@param[in,out]	b	pointer to memory where to read;
+advanced by the number of bytes consumed
+@return unsigned value */
+UNIV_INLINE
+ib_uint32_t
+mach_read_next_compressed(
+	const byte**	b)
+{
+	ulint	val = mach_read_from_1(*b);
+
+	if (val < 0x80) {
+		/* 0nnnnnnn (7 bits) */
+		++*b;
+	} else if (val < 0xC0) {
+		/* 10nnnnnn nnnnnnnn (14 bits) */
+		val = mach_read_from_2(*b) & 0x3FFF;
+		ut_ad(val > 0x7F);
+		*b += 2;
+	} else if (val < 0xE0) {
+		/* 110nnnnn nnnnnnnn nnnnnnnn (21 bits) */
+		val = mach_read_from_3(*b) & 0x1FFFFF;
+		ut_ad(val > 0x3FFF);
+		*b += 3;
+	} else if (val < 0xF0) {
+		/* 1110nnnn nnnnnnnn nnnnnnnn nnnnnnnn (28 bits) */
+		val = mach_read_from_4(*b) & 0xFFFFFFF;
+		ut_ad(val > 0x1FFFFF);
+		*b += 4;
+	} else {
+		/* 11110000 nnnnnnnn nnnnnnnn nnnnnnnn nnnnnnnn (32 bits) */
+		ut_ad(val == 0xF0);
+		val = mach_read_from_4(*b + 1);
+		ut_ad(val > 0xFFFFFFF);
+		*b += 5;
+	}
+
+	return(static_cast<ib_uint32_t>(val));
+}
+
+/** Read a 64-bit integer in a compressed form.
+@param[in,out]	b	pointer to memory where to read;
+advanced by the number of bytes consumed
+@return unsigned value */
+UNIV_INLINE
+ib_uint64_t
+mach_read_next_much_compressed(
+	const byte**	b)
+{
+	ib_uint64_t	val = mach_read_from_1(*b);
+
+	if (val < 0x80) {
+		/* 0nnnnnnn (7 bits) */
+		++*b;
+	} else if (val < 0xC0) {
+		/* 10nnnnnn nnnnnnnn (14 bits) */
+		val = mach_read_from_2(*b) & 0x3FFF;
+		ut_ad(val > 0x7F);
+		*b += 2;
+	} else if (val < 0xE0) {
+		/* 110nnnnn nnnnnnnn nnnnnnnn (21 bits) */
+		val = mach_read_from_3(*b) & 0x1FFFFF;
+		ut_ad(val > 0x3FFF);
+		*b += 3;
+	} else if (val < 0xF0) {
+		/* 1110nnnn nnnnnnnn nnnnnnnn nnnnnnnn (28 bits) */
+		val = mach_read_from_4(*b) & 0xFFFFFFF;
+		ut_ad(val > 0x1FFFFF);
+		*b += 4;
+	} else if (val == 0xF0) {
+		/* 11110000 nnnnnnnn nnnnnnnn nnnnnnnn nnnnnnnn (32 bits) */
+		val = mach_read_from_4(*b + 1);
+		ut_ad(val > 0xFFFFFFF);
+		*b += 5;
+	} else {
+		/* 11111111 followed by up to 64 bits */
+		ut_ad(val == 0xFF);
+		++*b;
+		val = mach_read_next_compressed(b);
+		ut_ad(val > 0);
+		val <<= 32;
+		val |= mach_read_next_compressed(b);
+	}
+
+	return(val);
+}
+
 #ifndef UNIV_HOTBACKUP
 /*********************************************************//**
 Reads a double. It is stored in a little-endian format.

--- a/storage/innobase/include/trx0rec.h
+++ b/storage/innobase/include/trx0rec.h
@@ -127,6 +127,14 @@ trx_undo_rec_get_row_ref(
 	dtuple_t**	ref,	/*!< out, own: row reference */
 	mem_heap_t*	heap);	/*!< in: memory heap from which the memory
 				needed is allocated */
+
+/** Reads from an undo log record the table ID
+@param[in]	undo_rec	Undo log record
+@return the table ID */
+table_id_t
+trx_undo_rec_get_table_id(const trx_undo_rec_t* undo_rec)
+	__attribute__((nonnull, warn_unused_result));
+
 /*******************************************************************//**
 Skips a row reference from an undo log record.
 @return	pointer to remaining part of undo record */

--- a/storage/innobase/trx/trx0purge.cc
+++ b/storage/innobase/trx/trx0purge.cc
@@ -45,6 +45,8 @@ Created 3/26/1996 Heikki Tuuri
 #include "os0thread.h"
 #include "srv0mon.h"
 #include "mtr0log.h"
+#include <vector>
+#include <unordered_map>
 
 /** Maximum allowable purge history length.  <=0 means 'infinite'. */
 UNIV_INTERN ulong		srv_max_purge_lag = 0;
@@ -971,6 +973,9 @@ trx_purge_attach_undo_recs(
 	ulint		i = 0;
 	ulint		n_pages_handled = 0;
 	ulint		n_thrs = UT_LIST_GET_LEN(purge_sys->query->thrs);
+	mem_heap_t*	heap = purge_sys->heap;
+	ulint		free_thr = 0;
+	std::vector<que_thr_t*> run_thrs;
 
 	ut_a(n_purge_threads > 0);
 
@@ -991,33 +996,26 @@ trx_purge_attach_undo_recs(
 		ut_a(node->done);
 
 		node->done = FALSE;
+		run_thrs.push_back(thr);
 	}
 
 	/* There should never be fewer nodes than threads, the inverse
 	however is allowed because we only use purge threads as needed. */
 	ut_a(i == n_purge_threads);
 
-	/* Fetch and parse the UNDO records. The UNDO records are added
-	to a per purge node vector. */
-	thr = UT_LIST_GET_FIRST(purge_sys->query->thrs);
-	ut_a(n_thrs > 0 && thr != NULL);
+	ut_a(n_thrs > 0);
 
 	ut_ad(trx_purge_check_limit());
 
-	i = 0;
+	std::unordered_map<table_id_t, que_thr_t*> table_thr;
 
 	for (;;) {
 		purge_node_t*		node;
 		trx_purge_rec_t*	purge_rec;
 
-		ut_a(!thr->is_active);
-
-		/* Get the purge node. */
-		node = (purge_node_t*) thr->child;
-		ut_a(que_node_get_type(node) == QUE_NODE_PURGE);
 
 		purge_rec = static_cast<trx_purge_rec_t*>(
-			mem_heap_zalloc(node->heap, sizeof(*purge_rec)));
+			mem_heap_zalloc(heap, sizeof(*purge_rec)));
 
 		/* Track the max {trx_id, undo_no} for truncating the
 		UNDO logs once we have purged the records. */
@@ -1031,9 +1029,25 @@ trx_purge_attach_undo_recs(
 
 		/* Fetch the next record, and advance the purge_sys->iter. */
 		purge_rec->undo_rec = trx_purge_fetch_next_rec(
-			&purge_rec->roll_ptr, &n_pages_handled, node->heap);
+			&purge_rec->roll_ptr, &n_pages_handled, heap);
 
 		if (purge_rec->undo_rec != NULL) {
+
+			table_id_t table_id =
+				trx_undo_rec_get_table_id(purge_rec->undo_rec);
+
+			auto it = table_thr.find(table_id);
+			if (it == table_thr.end()) {
+				thr = run_thrs[free_thr++ % n_purge_threads];
+				table_thr.emplace(table_id, thr);
+			} else {
+				thr = it->second;
+			}
+
+			ut_a(thr != NULL && !thr->is_active);
+			/* Get the purge node. */
+			node = (purge_node_t*) thr->child;
+			ut_a(que_node_get_type(node) == QUE_NODE_PURGE);
 
 			if (node->undo_recs == NULL) {
 				node->undo_recs = ib_vector_create(
@@ -1053,14 +1067,6 @@ trx_purge_attach_undo_recs(
 		} else {
 			break;
 		}
-
-		thr = UT_LIST_GET_NEXT(thrs, thr);
-
-		if (!(++i % n_purge_threads)) {
-			thr = UT_LIST_GET_FIRST(purge_sys->query->thrs);
-		}
-
-		ut_a(thr != NULL);
 	}
 
 	ut_ad(trx_purge_check_limit());

--- a/storage/innobase/trx/trx0rec.cc
+++ b/storage/innobase/trx/trx0rec.cc
@@ -416,6 +416,21 @@ trx_undo_rec_get_row_ref(
 	return(ptr);
 }
 
+/** Reads from an undo log record the table ID
+@param[in]	undo_rec	Undo log record
+@return the table ID */
+table_id_t
+trx_undo_rec_get_table_id(const trx_undo_rec_t* undo_rec)
+{
+	const byte*	ptr = undo_rec + 3;
+
+	/* Skip the UNDO number */
+	mach_read_next_much_compressed(&ptr);
+
+	/* Read the table ID */
+	return(mach_read_next_much_compressed(&ptr));
+}
+
 /*******************************************************************//**
 Skips a row reference from an undo log record.
 @return	pointer to remaining part of undo record */


### PR DESCRIPTION
Summary:
The current assignment of purge records to workers may lead to lock contention on dict_index_t::lock. Fix this by assigning record of same table to one purge thread.

This is a back-port from https://github.com/mysql/mysql-server/commit/7e43fd218aa1a63cc74d2d706e84adac93ac6905. I used simpler
logic to group records by table id. The refactoring in the upstream change is not ported here.

Test Plan: mtr