### PR TITLE
Log legacy user connections in slow log

### DIFF
--- a/mysql-test/r/mysqld--help-notwin-profiling.result
+++ b/mysql-test/r/mysqld--help-notwin-profiling.result
@@ -406,6 +406,8 @@ The following options may be given as the first argument:
  --lc-time-names=name 
  Set the language used for the month names and the days of
  the week.
+ --legacy-user-name-pattern[=name] 
+ Regex pattern string of a legacy user name
  --local-infile      Enable LOAD DATA LOCAL INFILE
  (Defaults to on; use --skip-local-infile to disable.)
  --lock-wait-timeout=# 
@@ -445,6 +447,7 @@ The following options may be given as the first argument:
  error log
  (Defaults to on; use --skip-log-gtid-unsafe-statements to disable.)
  --log-isam[=name]   Log all MyISAM changes to file.
+ --log-legacy-user   Log legacy user names in slow query log.
  --log-only-query-comments 
  Writes only the comments part at the beginning of the
  query in Rows_query_log_events.
@@ -1705,6 +1708,7 @@ large-pages FALSE
 lc-messages en_US
 lc-messages-dir MYSQL_SHAREDIR/
 lc-time-names en_US
+legacy-user-name-pattern (No default value)
 local-infile TRUE
 lock-wait-timeout 604800
 log-bin (No default value)
@@ -1718,6 +1722,7 @@ log-error
 log-global-var-changes FALSE
 log-gtid-unsafe-statements TRUE
 log-isam myisam.log
+log-legacy-user FALSE
 log-only-query-comments TRUE
 log-output FILE
 log-queries-not-using-indexes FALSE

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -406,6 +406,8 @@ The following options may be given as the first argument:
  --lc-time-names=name 
  Set the language used for the month names and the days of
  the week.
+ --legacy-user-name-pattern[=name] 
+ Regex pattern string of a legacy user name
  --local-infile      Enable LOAD DATA LOCAL INFILE
  (Defaults to on; use --skip-local-infile to disable.)
  --lock-wait-timeout=# 
@@ -445,6 +447,7 @@ The following options may be given as the first argument:
  error log
  (Defaults to on; use --skip-log-gtid-unsafe-statements to disable.)
  --log-isam[=name]   Log all MyISAM changes to file.
+ --log-legacy-user   Log legacy user names in slow query log.
  --log-only-query-comments 
  Writes only the comments part at the beginning of the
  query in Rows_query_log_events.
@@ -1703,6 +1706,7 @@ large-pages FALSE
 lc-messages en_US
 lc-messages-dir MYSQL_SHAREDIR/
 lc-time-names en_US
+legacy-user-name-pattern (No default value)
 local-infile TRUE
 lock-wait-timeout 604800
 log-bin (No default value)
@@ -1716,6 +1720,7 @@ log-error
 log-global-var-changes FALSE
 log-gtid-unsafe-statements TRUE
 log-isam myisam.log
+log-legacy-user FALSE
 log-only-query-comments TRUE
 log-output FILE
 log-queries-not-using-indexes FALSE

--- a/mysql-test/r/slow_log_legacy_user.result
+++ b/mysql-test/r/slow_log_legacy_user.result
@@ -1,0 +1,27 @@
+set @my_slow_logname = @@global.slow_query_log_file;
+set global slow_query_log_file = "slow_log_legacy_user-slow.log";
+set @my_log_legacy_user = @@global.log_legacy_user;
+set global log_legacy_user = TRUE;
+set @my_legacy_user_name_pattern = @@global.legacy_user_name_pattern;
+set global legacy_user_name_pattern = '^[^:]+$';
+# legacy_user1
+create user legacy_user1@localhost;
+# connection conn1
+# connection default
+# change legacy_user_name_pattern
+set global legacy_user_name_pattern = '^[^%]+$';
+# legacy%user2
+create user `legacy_user2`@localhost;
+# connection conn2
+# connection default
+
+# Check the slow log result.
+LEGACY_USER: legacy_user1@localhost on test;
+LEGACY_USER: legacy_user2@localhost on test;
+
+# clean up
+drop user `legacy_user1`@localhost;
+drop user `legacy_user2`@localhost;
+set @@global.slow_query_log_file = @my_slow_logname;
+set @@global.legacy_user_name_pattern = @my_legacy_user_name_pattern;
+set @@global.log_legacy_user = @my_log_legacy_user;

--- a/mysql-test/suite/perfschema/r/dml_setup_instruments.result
+++ b/mysql-test/suite/perfschema/r/dml_setup_instruments.result
@@ -27,8 +27,8 @@ wait/synch/rwlock/sql/gtid_commit_rollback	YES	YES
 wait/synch/rwlock/sql/LOCK_dboptions	YES	YES
 wait/synch/rwlock/sql/LOCK_gap_lock_exceptions	YES	YES
 wait/synch/rwlock/sql/LOCK_grant	YES	YES
+wait/synch/rwlock/sql/LOCK_legacy_user_name_pattern	YES	YES
 wait/synch/rwlock/sql/LOCK_system_variables_hash	YES	YES
-wait/synch/rwlock/sql/LOCK_sys_init_connect	YES	YES
 select * from performance_schema.setup_instruments
 where name like 'Wait/Synch/Cond/sql/%'
   and name not in (

--- a/mysql-test/suite/sys_vars/r/legacy_user_name_pattern_basic.result
+++ b/mysql-test/suite/sys_vars/r/legacy_user_name_pattern_basic.result
@@ -1,0 +1,14 @@
+set @saved_legacy_user_name_pattern = @@global.legacy_user_name_pattern;
+set @@global.legacy_user_name_pattern = default;
+select @@global.legacy_user_name_pattern;
+@@global.legacy_user_name_pattern
+NULL
+set @@global.legacy_user_name_pattern='%';
+set @@global.legacy_user_name_pattern='^[^:]+$';
+set @@global.legacy_user_name_pattern=1;
+ERROR 42000: Incorrect argument type to variable 'legacy_user_name_pattern'
+select @@session.legacy_user_name_pattern;
+ERROR HY000: Variable 'legacy_user_name_pattern' is a GLOBAL variable
+set @@session.legacy_user_name_pattern=':';
+ERROR HY000: Variable 'legacy_user_name_pattern' is a GLOBAL variable and should be set with SET GLOBAL
+set global legacy_user_name_pattern = @saved_legacy_user_name_pattern;

--- a/mysql-test/suite/sys_vars/r/log_legacy_user_basic.result
+++ b/mysql-test/suite/sys_vars/r/log_legacy_user_basic.result
@@ -1,0 +1,42 @@
+SET @start_log_legacy_user = @@global.log_legacy_user;
+SELECT @start_log_legacy_user;
+@start_log_legacy_user
+0
+SET @@global.log_legacy_user = DEFAULT;
+SELECT @@global.log_legacy_user;
+@@global.log_legacy_user
+0
+SET @@global.log_legacy_user = false;
+SELECT @@global.log_legacy_user;
+@@global.log_legacy_user
+0
+SET @@global.log_legacy_user = true;
+SELECT @@global.log_legacy_user;
+@@global.log_legacy_user
+1
+SET @@global.log_legacy_user = 1;
+SELECT @@global.log_legacy_user;
+@@global.log_legacy_user
+1
+SET @@global.log_legacy_user = 0;
+SELECT @@global.log_legacy_user;
+@@global.log_legacy_user
+0
+SET @@global.log_legacy_user = -1;
+ERROR 42000: Variable 'log_legacy_user' can't be set to the value of '-1'
+SELECT @@global.log_legacy_user;
+@@global.log_legacy_user
+0
+SET @@global.log_legacy_user = 100;
+ERROR 42000: Variable 'log_legacy_user' can't be set to the value of '100'
+SELECT @@global.log_legacy_user;
+@@global.log_legacy_user
+0
+SET @@session.log_legacy_user = 10;
+ERROR HY000: Variable 'log_legacy_user' is a GLOBAL variable and should be set with SET GLOBAL
+SELECT @@session.log_legacy_user;
+ERROR HY000: Variable 'log_legacy_user' is a GLOBAL variable
+SET @@global.log_legacy_user = @start_log_legacy_user;
+SELECT @@global.log_legacy_user;
+@@global.log_legacy_user
+0

--- a/mysql-test/suite/sys_vars/t/legacy_user_name_pattern_basic.test
+++ b/mysql-test/suite/sys_vars/t/legacy_user_name_pattern_basic.test
@@ -1,0 +1,20 @@
+--source include/not_embedded.inc
+--source include/load_sysvars.inc
+--source include/have_fullregex.inc
+
+set @saved_legacy_user_name_pattern = @@global.legacy_user_name_pattern;
+set @@global.legacy_user_name_pattern = default;
+select @@global.legacy_user_name_pattern;
+
+set @@global.legacy_user_name_pattern='%';
+set @@global.legacy_user_name_pattern='^[^:]+$';
+
+--error ER_WRONG_TYPE_FOR_VAR
+set @@global.legacy_user_name_pattern=1;
+
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+select @@session.legacy_user_name_pattern;
+--error ER_GLOBAL_VARIABLE
+set @@session.legacy_user_name_pattern=':';
+
+set global legacy_user_name_pattern = @saved_legacy_user_name_pattern;

--- a/mysql-test/suite/sys_vars/t/log_legacy_user_basic.test
+++ b/mysql-test/suite/sys_vars/t/log_legacy_user_basic.test
@@ -1,0 +1,34 @@
+--source include/not_embedded.inc
+
+SET @start_log_legacy_user = @@global.log_legacy_user;
+SELECT @start_log_legacy_user;
+
+SET @@global.log_legacy_user = DEFAULT;
+SELECT @@global.log_legacy_user;
+
+SET @@global.log_legacy_user = false;
+SELECT @@global.log_legacy_user;
+
+SET @@global.log_legacy_user = true;
+SELECT @@global.log_legacy_user;
+
+SET @@global.log_legacy_user = 1;
+SELECT @@global.log_legacy_user;
+
+SET @@global.log_legacy_user = 0;
+SELECT @@global.log_legacy_user;
+
+--Error ER_WRONG_VALUE_FOR_VAR
+SET @@global.log_legacy_user = -1;
+SELECT @@global.log_legacy_user;
+--Error ER_WRONG_VALUE_FOR_VAR
+SET @@global.log_legacy_user = 100;
+SELECT @@global.log_legacy_user;
+
+--ERROR ER_GLOBAL_VARIABLE
+SET @@session.log_legacy_user = 10;
+--ERROR ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.log_legacy_user;
+
+SET @@global.log_legacy_user = @start_log_legacy_user;
+SELECT @@global.log_legacy_user;

--- a/mysql-test/t/slow_log_legacy_user.test
+++ b/mysql-test/t/slow_log_legacy_user.test
@@ -1,0 +1,72 @@
+#
+# Test log_legacy_user
+#
+
+--source include/have_fullregex.inc
+--source include/have_innodb.inc
+
+# Just in case slow_log_wait_time-slow.log already exists, delete it first.
+--remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.1/data slow_log_legacy_user-slow.log
+
+set @my_slow_logname = @@global.slow_query_log_file;
+set global slow_query_log_file = "slow_log_legacy_user-slow.log";
+
+set @my_log_legacy_user = @@global.log_legacy_user;
+set global log_legacy_user = TRUE;
+set @my_legacy_user_name_pattern = @@global.legacy_user_name_pattern;
+
+# set the name pattern to indicate the name doesn't contain ':'
+set global legacy_user_name_pattern = '^[^:]+$';
+
+--echo # legacy_user1
+create user legacy_user1@localhost;
+--echo # connection conn1
+connect (conn1, localhost, legacy_user1,,);
+
+--echo # connection default
+connection default;
+
+# set the name pattern to indicate the name doesn't contain '%'
+--echo # change legacy_user_name_pattern
+set global legacy_user_name_pattern = '^[^%]+$';
+--echo # legacy%user2
+create user `legacy_user2`@localhost;
+--echo # connection conn2
+connect (conn2, localhost, legacy_user2,,);
+
+--echo # connection default
+connection default;
+
+--echo
+--echo # Check the slow log result.
+--perl
+my $found = 0;
+open FILE, "$ENV{'MYSQLTEST_VARDIR'}/mysqld.1/data/slow_log_legacy_user-slow.log" or die;
+my @lines = <FILE>;
+foreach $line (@lines) {
+  if ($line =~ /^LEGACY_USER:/) {
+    $found = 1;
+    print $line
+  }
+}
+# (test failure) print the log if we didn't find any legacy user
+if (!$found) {
+  print "**Legacy user not found in slow log**\n";
+  seek FILE, 0, 0;
+  while (<FILE>) {
+    print $_;
+  }
+}
+close FILE
+EOF
+
+--echo
+--echo # clean up
+disconnect conn1;
+drop user `legacy_user1`@localhost;
+disconnect conn2;
+drop user `legacy_user2`@localhost;
+
+set @@global.slow_query_log_file = @my_slow_logname;
+set @@global.legacy_user_name_pattern = @my_legacy_user_name_pattern;
+set @@global.log_legacy_user = @my_log_legacy_user;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -474,6 +474,10 @@ ulong log_warnings;
 uint host_cache_size;
 ulonglong tmp_table_rpl_max_file_size;
 
+my_bool log_legacy_user;
+const char *opt_legacy_user_name_pattern;
+Regex_list_handler *legacy_user_name_pattern;
+
 #if defined(_WIN32) && !defined(EMBEDDED_LIBRARY)
 ulong slow_start_timeout;
 #endif
@@ -2282,6 +2286,7 @@ void clean_up(bool print_message)
   free_list(opt_plugin_load_list_ptr);
 
   delete gap_lock_exceptions;
+  delete legacy_user_name_pattern;
 
   if (THR_THD)
     (void) pthread_key_delete(THR_THD);
@@ -5259,8 +5264,13 @@ static int init_thread_environment()
 #if defined(HAVE_PSI_INTERFACE)
   gap_lock_exceptions = new Regex_list_handler(
       key_rwlock_LOCK_gap_lock_exceptions);
+  // use the normalized delimiter as legacy_user_name only has one pattern
+  legacy_user_name_pattern = new Regex_list_handler(
+      key_rwlock_LOCK_legacy_user_name_pattern, '|');
 #else
   gap_lock_exceptions = new Regex_list_handler();
+  // use the normalized delimiter as legacy_user_name only has one pattern
+  legacy_user_name_pattern = new Regex_list_handler('|');
 #endif
   mysql_rwlock_init(key_rwlock_LOCK_grant, &LOCK_grant);
   mysql_cond_init(key_COND_thread_count, &COND_thread_count, NULL);
@@ -11352,6 +11362,7 @@ static int get_options(int *argc_ptr, char ***argv_ptr, my_bool logging)
   fix_delay_key_write(0, 0, OPT_GLOBAL);
 
   set_gap_lock_exception_list(0, 0, OPT_GLOBAL);
+  set_legacy_user_name_pattern(0, 0, OPT_GLOBAL);
 
 #ifndef EMBEDDED_LIBRARY
   if (mysqld_chroot)
@@ -11958,7 +11969,8 @@ static PSI_mutex_info all_server_mutexes[]=
 PSI_rwlock_key key_rwlock_LOCK_grant, key_rwlock_LOCK_logger,
   key_rwlock_LOCK_sys_init_connect, key_rwlock_LOCK_sys_init_slave,
   key_rwlock_LOCK_system_variables_hash, key_rwlock_query_cache_query_lock,
-  key_rwlock_global_sid_lock, key_rwlock_LOCK_gap_lock_exceptions;
+  key_rwlock_global_sid_lock, key_rwlock_LOCK_gap_lock_exceptions,
+  key_rwlock_LOCK_legacy_user_name_pattern;
 
 PSI_rwlock_key key_rwlock_Trans_delegate_lock;
 PSI_rwlock_key key_rwlock_Binlog_storage_delegate_lock;
@@ -11984,6 +11996,7 @@ static PSI_rwlock_info all_server_rwlocks[]=
   { &key_rwlock_LOCK_sys_init_connect, "LOCK_sys_init_connect", PSI_FLAG_GLOBAL},
   { &key_rwlock_LOCK_sys_init_slave, "LOCK_sys_init_slave", PSI_FLAG_GLOBAL},
   { &key_rwlock_LOCK_gap_lock_exceptions, "LOCK_gap_lock_exceptions", PSI_FLAG_GLOBAL},
+  { &key_rwlock_LOCK_legacy_user_name_pattern, "LOCK_legacy_user_name_pattern", PSI_FLAG_GLOBAL},
   { &key_rwlock_LOCK_system_variables_hash, "LOCK_system_variables_hash", PSI_FLAG_GLOBAL},
   { &key_rwlock_query_cache_query_lock, "Query_cache_query::lock", 0},
   { &key_rwlock_global_sid_lock, "gtid_commit_rollback", PSI_FLAG_GLOBAL},

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -363,6 +363,9 @@ extern char default_logfile_name[FN_REFLEN];
 extern char log_error_file[FN_REFLEN], *opt_tc_log_file;
 extern char *opt_gap_lock_exception_list;
 
+extern my_bool log_legacy_user;
+extern const char *opt_legacy_user_name_pattern;
+
 extern int32 thread_binlog_client;
 
 extern my_bool opt_log_slow_extra;
@@ -1138,7 +1141,8 @@ extern PSI_mutex_key key_LOCK_thread_created;
 extern PSI_rwlock_key key_rwlock_LOCK_grant, key_rwlock_LOCK_logger,
   key_rwlock_LOCK_sys_init_connect, key_rwlock_LOCK_sys_init_slave,
   key_rwlock_LOCK_system_variables_hash, key_rwlock_query_cache_query_lock,
-  key_rwlock_global_sid_lock, key_rwlock_LOCK_gap_lock_exceptions;
+  key_rwlock_global_sid_lock, key_rwlock_LOCK_gap_lock_exceptions,
+  key_rwlock_LOCK_legacy_user_name_pattern;
 
 #ifdef HAVE_MMAP
 extern PSI_cond_key key_PAGE_cond, key_COND_active, key_COND_pool;

--- a/sql/set_var.h
+++ b/sql/set_var.h
@@ -347,6 +347,7 @@ int sql_set_variables(THD *thd, List<set_var_base> *var_list);
 
 bool fix_delay_key_write(sys_var *self, THD *thd, enum_var_type type);
 bool set_gap_lock_exception_list(sys_var *, THD *, enum_var_type);
+bool set_legacy_user_name_pattern(sys_var *, THD *, enum_var_type);
 
 sql_mode_t expand_sql_mode(sql_mode_t sql_mode);
 bool sql_mode_string_representation(THD *thd, sql_mode_t sql_mode, LEX_STRING *ls);

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -11166,6 +11166,23 @@ acl_authenticate(THD *thd, uint com_change_user_pkt_len)
       general_log_print(thd, command, (char*) "%s@%s on %s",
                         mpvio.auth_info.user_name, mpvio.auth_info.host_or_ip,
                         mpvio.db.str ? mpvio.db.str : (char*) "");
+
+    if (log_legacy_user && opt_legacy_user_name_pattern)
+    {
+      if (legacy_user_name_pattern->matches(mpvio.auth_info.user_name))
+      {
+        /* Log the legacy user */
+        std::string output= std::string("LEGACY_USER: ") +
+          mpvio.auth_info.user_name + "@" + mpvio.auth_info.host_or_ip;
+        if (mpvio.db.str != nullptr)
+          output += std::string(" on ") + mpvio.db.str;
+
+        bool save_enable_slow_log = thd->enable_slow_log;
+        thd->enable_slow_log = true;
+        slow_log_print(thd, output.c_str(), output.size(), &(thd->status_var));
+        thd->enable_slow_log = save_enable_slow_log;
+      }
+    }
   }
 
   if (res == CR_OK && !mpvio.can_authenticate())

--- a/sql/sql_acl.h
+++ b/sql/sql_acl.h
@@ -447,4 +447,6 @@ int set_default_auth_plugin(char *, int);
 /** controls the extra checks on plugin availability for mysql.user records */
 extern my_bool validate_user_plugins;
 
+extern Regex_list_handler *legacy_user_name_pattern;
+
 #endif /* SQL_ACL_INCLUDED */

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -1648,21 +1648,28 @@ static Sys_var_mybool Sys_gap_lock_write_log(
        SESSION_VAR(gap_lock_write_log), CMD_LINE(OPT_ARG),
        DEFAULT(false));
 
-bool set_gap_lock_exception_list(sys_var *, THD *, enum_var_type)
+static bool set_regex_list_handler(Regex_list_handler *rlh,
+                                   const char *regex_pattern,
+                                   const char *list_name)
 {
-  const char* str = opt_gap_lock_exception_list;
-
-  if (str == nullptr)
+  if (regex_pattern == nullptr)
   {
-    str = "";
+    regex_pattern = "";
   }
 
-  if (!gap_lock_exceptions->set_patterns(str))
+  if (!rlh->set_patterns(regex_pattern))
   {
-    warn_about_bad_patterns(gap_lock_exceptions, "gap_lock_exceptions");
+    warn_about_bad_patterns(rlh, list_name);
   }
 
   return false;
+}
+
+bool set_gap_lock_exception_list(sys_var *, THD *, enum_var_type)
+{
+  return set_regex_list_handler(gap_lock_exceptions,
+                                opt_gap_lock_exception_list,
+                                "gap_lock_exceptions");
 }
 static Sys_var_charptr Sys_gap_lock_exceptions(
        "gap_lock_exceptions",
@@ -5649,3 +5656,23 @@ static Sys_var_uint Sys_num_lock_shards(
        READ_ONLY GLOBAL_VAR(num_sharded_locks), CMD_LINE(OPT_ARG),
        VALID_RANGE(1, 16), DEFAULT(4), BLOCK_SIZE(1));
 #endif
+
+static Sys_var_mybool Sys_log_legacy_user(
+       "log_legacy_user",
+       "Log legacy user names in slow query log.",
+       GLOBAL_VAR(log_legacy_user),
+       CMD_LINE(OPT_ARG), DEFAULT(FALSE));
+
+bool set_legacy_user_name_pattern(sys_var *, THD *, enum_var_type)
+{
+  return set_regex_list_handler(legacy_user_name_pattern,
+                                opt_legacy_user_name_pattern,
+                                "legacy_user_name_pattern");
+}
+static Sys_var_charptr Sys_legacy_user_name_pattern(
+       "legacy_user_name_pattern",
+       "Regex pattern string of a legacy user name",
+       GLOBAL_VAR(opt_legacy_user_name_pattern), CMD_LINE(OPT_ARG),
+       IN_SYSTEM_CHARSET, DEFAULT(0), nullptr,
+       NOT_IN_BINLOG, ON_CHECK(nullptr),
+       ON_UPDATE(set_legacy_user_name_pattern));


### PR DESCRIPTION
Summary:
Introduced two global system variables for legacy user logging:
  - log_legacy_user: log legacy user connections. default is turned off.
  - legacy_user_name_pattern: regex pattern of a legacy user name.

If log_legacy_user is turned on, a legacy user connection will be logged in the
slow log, which is prefixed with `LEGACY_USER: `.

Test Plan: Added new mtr tests.