### PR TITLE
Another attempt at fixing the flakiness in rocksdb.type_decimal

### DIFF
--- a/mysql-test/suite/rocksdb/r/type_decimal.result
+++ b/mysql-test/suite/rocksdb/r/type_decimal.result
@@ -99,9 +99,7 @@ insert into t1 select pk+200, 9.0, 9.0, 'extra-data' from t1;
 insert into t1 select pk+1000, 9.0, 9.0, 'extra-data' from t1;
 insert into t1 select pk+10000, 9.0, 9.0, 'extra-data' from t1;
 insert into t1 select pk+100000, 9.0, 9.0, 'extra-data' from t1;
-analyze table t1;
-Table	Op	Msg_type	Msg_text
-test.t1	analyze	status	OK
+set global rocksdb_force_flush_memtable_now=true;
 # The following can't use index-only:
 explain select * from t1 where col1 between -8 and 8;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra

--- a/mysql-test/suite/rocksdb/t/type_decimal.test
+++ b/mysql-test/suite/rocksdb/t/type_decimal.test
@@ -105,7 +105,7 @@ insert into t1 select pk+200, 9.0, 9.0, 'extra-data' from t1;
 insert into t1 select pk+1000, 9.0, 9.0, 'extra-data' from t1;
 insert into t1 select pk+10000, 9.0, 9.0, 'extra-data' from t1;
 insert into t1 select pk+100000, 9.0, 9.0, 'extra-data' from t1;
-analyze table t1;
+set global rocksdb_force_flush_memtable_now=true;
 
 --echo # The following can't use index-only:
 --replace_column 9 #


### PR DESCRIPTION
Summary: The rocksdb.type_decimal test is still failing.  I thought running ANYLIZE TABLE would solve it but was still getting problems.  I'm now trying to force a memtable flush to see if that solves it.

Test Plan: MTR

Reviewers: gunnarku, mung

Subscribers:

Tasks: D13556119

Blame Revision: