### PR TITLE
Fix the rocksdb.type_decimal test.

### DIFF
--- a/mysql-test/suite/rocksdb/t/type_decimal-master.opt
+++ b/mysql-test/suite/rocksdb/t/type_decimal-master.opt
@@ -1,0 +1,1 @@
+--rocksdb_debug_optimizer_n_rows=10


### PR DESCRIPTION
Summary: Many of the other rocksdb.type_* tests specify the rocksdb_debug_optimizer_n_rows to avoid issues with the optimizer getting different results depending on how the test is run.  This test needed this flag set.

Test Plan: MTR

Reviewers: gunnarku mung

Subscribers:

Tasks: D13556119

Blame Revision: