### PR TITLE
Fix deadlock detection tests

### DIFF
--- a/mysql-test/suite/rocksdb/r/rocksdb_deadlock_detect_rc.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_deadlock_detect_rc.result
@@ -44,6 +44,11 @@ ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 select * from t;
 i
 3
+rollback;
+i
+rollback;
+i
+rollback;
 set global rocksdb_lock_wait_timeout = @prior_rocksdb_lock_wait_timeout;
 set global rocksdb_deadlock_detect = @prior_rocksdb_deadlock_detect;
 drop table t,r1,r2;

--- a/mysql-test/suite/rocksdb/r/rocksdb_deadlock_detect_rr.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_deadlock_detect_rr.result
@@ -44,6 +44,11 @@ ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 select * from t;
 i
 3
+rollback;
+i
+rollback;
+i
+rollback;
 set global rocksdb_lock_wait_timeout = @prior_rocksdb_lock_wait_timeout;
 set global rocksdb_deadlock_detect = @prior_rocksdb_deadlock_detect;
 drop table t,r1,r2;

--- a/mysql-test/suite/rocksdb/t/rocksdb_deadlock_detect.inc
+++ b/mysql-test/suite/rocksdb/t/rocksdb_deadlock_detect.inc
@@ -25,10 +25,11 @@ update r1 set value=100 where id=8;
 --send select * from r2 for update;
 
 connection con1;
+# TODO(mung): Rewrite the wait conditions to use rocksdb_trx once we have that
+# available instead of counting locks.
 let $wait_condition =
-select count(*) = 1 as c from information_schema.processlist where
-state = "Waiting for row lock" and
-info = "select * from r2 for update";
+select count(*) = 10 from information_schema.rocksdb_locks;
+--source include/wait_condition.inc
 --error ER_LOCK_DEADLOCK
 select * from r1 for update;
 rollback;
@@ -73,6 +74,15 @@ select * from t;
 insert into t values (4), (1);
 --echo # Statement should be rolled back
 select * from t;
+rollback;
+
+connection con2;
+--reap
+rollback;
+
+connection con1;
+--reap
+rollback;
 
 connection default;
 disconnect con1;


### PR DESCRIPTION
Checking "Waiting for row locks" is not reliable because that message will display even if the thread is not blocked. One way to work around this is to use the newly created rocksdb_locks table to see if all the locks we expect the transaction to take has been taken. The better way is to use rocksdb_trx once we have that.

Test Plan: ./mtr --parallel=16 --repeat=16 ...