### PR TITLE
Fix handling of auto_increment_increment > 1

### DIFF
--- a/mysql-test/suite/rocksdb/r/autoinc_vars_thread.result
+++ b/mysql-test/suite/rocksdb/r/autoinc_vars_thread.result
@@ -1,0 +1,24 @@
+#---------------------------
+# two threads inserting simultaneously with increment > 1
+# Issue #390
+#---------------------------
+CREATE TABLE t1 (a INT AUTO_INCREMENT PRIMARY KEY) ENGINE=rocksdb;
+SET auto_increment_increment = 2;
+SET auto_increment_offset = 1;
+INSERT INTO t1 VALUES(NULL);
+SET auto_increment_increment = 2;
+SET auto_increment_offset = 1;
+SET debug_sync='rocksdb.autoinc_vars SIGNAL parked1 WAIT_FOR go NO_CLEAR_EVENT';
+INSERT INTO t1 VALUES(NULL);
+SET debug_sync='rocksdb.autoinc_vars SIGNAL parked2 WAIT_FOR go NO_CLEAR_EVENT';
+INSERT INTO t1 VALUES(NULL);
+SET debug_sync='now WAIT_FOR parked1';
+SET debug_sync='now WAIT_FOR parked2';
+SET debug_sync='now SIGNAL go';
+SET debug_sync='RESET';
+SELECT * FROM t1;
+a
+1
+3
+5
+DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/r/autoinc_vars_thread_2.result
+++ b/mysql-test/suite/rocksdb/r/autoinc_vars_thread_2.result
@@ -1,0 +1,53 @@
+#---------------------------
+# ten threads inserting simultaneously with increment > 1
+# Issue #390
+#---------------------------
+CREATE TABLE t1 (pk INT AUTO_INCREMENT PRIMARY KEY, thr INT) ENGINE=rocksdb;
+SET auto_increment_increment = 100;
+SET auto_increment_offset = 9 + 1;
+SET auto_increment_increment = 100;
+SET auto_increment_offset = 8 + 1;
+SET auto_increment_increment = 100;
+SET auto_increment_offset = 7 + 1;
+SET auto_increment_increment = 100;
+SET auto_increment_offset = 6 + 1;
+SET auto_increment_increment = 100;
+SET auto_increment_offset = 5 + 1;
+SET auto_increment_increment = 100;
+SET auto_increment_offset = 4 + 1;
+SET auto_increment_increment = 100;
+SET auto_increment_offset = 3 + 1;
+SET auto_increment_increment = 100;
+SET auto_increment_offset = 2 + 1;
+SET auto_increment_increment = 100;
+SET auto_increment_offset = 1 + 1;
+SET auto_increment_increment = 100;
+SET auto_increment_offset = 0 + 1;
+LOAD DATA INFILE <input_file> INTO TABLE t1;
+LOAD DATA INFILE <input_file> INTO TABLE t1;
+LOAD DATA INFILE <input_file> INTO TABLE t1;
+LOAD DATA INFILE <input_file> INTO TABLE t1;
+LOAD DATA INFILE <input_file> INTO TABLE t1;
+LOAD DATA INFILE <input_file> INTO TABLE t1;
+LOAD DATA INFILE <input_file> INTO TABLE t1;
+LOAD DATA INFILE <input_file> INTO TABLE t1;
+LOAD DATA INFILE <input_file> INTO TABLE t1;
+LOAD DATA INFILE <input_file> INTO TABLE t1;
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+1000000
+SELECT thr, COUNT(pk) FROM t1 GROUP BY thr;
+thr	COUNT(pk)
+0	100000
+1	100000
+2	100000
+3	100000
+4	100000
+5	100000
+6	100000
+7	100000
+8	100000
+9	100000
+SELECT * FROM t1 ORDER BY pk INTO OUTFILE <output_file>;
+All pk values matched their expected values
+DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/t/autoinc_vars_thread.test
+++ b/mysql-test/suite/rocksdb/t/autoinc_vars_thread.test
@@ -1,0 +1,53 @@
+--source include/have_rocksdb.inc
+--source include/have_debug_sync.inc
+
+--echo #---------------------------
+--echo # two threads inserting simultaneously with increment > 1
+--echo # Issue #390
+--echo #---------------------------
+
+CREATE TABLE t1 (a INT AUTO_INCREMENT PRIMARY KEY) ENGINE=rocksdb;
+
+# Set up connections
+connect (con1, localhost, root,,);
+SET auto_increment_increment = 2;
+SET auto_increment_offset = 1;
+# Insert one row to set up the conditions that caused the original failure
+INSERT INTO t1 VALUES(NULL);
+
+connect (con2, localhost, root,,);
+SET auto_increment_increment = 2;
+SET auto_increment_offset = 1;
+
+# Start each thread on an insert that will block waiting for a signal
+connection con1;
+SET debug_sync='rocksdb.autoinc_vars SIGNAL parked1 WAIT_FOR go NO_CLEAR_EVENT';
+send INSERT INTO t1 VALUES(NULL);
+
+connection con2;
+SET debug_sync='rocksdb.autoinc_vars SIGNAL parked2 WAIT_FOR go NO_CLEAR_EVENT';
+send INSERT INTO t1 VALUES(NULL);
+
+# Wait for both threads to be at debug_sync point
+connection default;
+SET debug_sync='now WAIT_FOR parked1';
+SET debug_sync='now WAIT_FOR parked2';
+
+# Signal both threads to continue
+SET debug_sync='now SIGNAL go';
+
+connection con1;
+reap;
+
+connection con2;
+reap;
+
+connection default;
+SET debug_sync='RESET';
+
+disconnect con1;
+disconnect con2;
+
+SELECT * FROM t1;
+DROP TABLE t1;
+

--- a/mysql-test/suite/rocksdb/t/autoinc_vars_thread_2.test
+++ b/mysql-test/suite/rocksdb/t/autoinc_vars_thread_2.test
@@ -1,0 +1,141 @@
+--source include/have_rocksdb.inc
+
+--echo #---------------------------
+--echo # ten threads inserting simultaneously with increment > 1
+--echo # Issue #390
+--echo #---------------------------
+
+# Run 10 simulatenous threads each inserting 10,000 rows
+let $num_threads = 10;
+let $num_rows_per_thread = 100000;
+
+# Create the table with an AUTO_INCREMENT primary key and a separate colum
+# to store which thread created the row
+CREATE TABLE t1 (pk INT AUTO_INCREMENT PRIMARY KEY, thr INT) ENGINE=rocksdb;
+
+# For each thread...
+# 1) set up a connection
+# 2) create a file that can be used for LOAD DATA INFILE ...
+let $i = `SELECT $num_threads`;
+while ($i > 0)
+{
+  dec $i;
+
+  # Set up connection
+  connect (con$i, localhost, root,,);
+
+  # Set up the auto_increment_* variables for each thread
+  eval SET auto_increment_increment = 100;
+  eval SET auto_increment_offset = $i + 1;
+  let $file = `SELECT CONCAT(@@datadir, "test_insert_", $i, ".txt")`;
+
+  # Pass variables into perl
+  let ROCKSDB_INFILE = $file;
+  let ROCKSDB_THREAD = `SELECT $i`;
+  let ROCKSDB_ROWS_PER_THREAD = `SELECT $num_rows_per_thread`;
+
+  # Create a file to load
+  perl;
+  my $fn = $ENV{'ROCKSDB_INFILE'};
+  my $thr = $ENV{'ROCKSDB_THREAD'};
+  my $num = $ENV{'ROCKSDB_ROWS_PER_THREAD'};
+  open(my $fh, '>>', $fn) || die "perl open($fn): $!";
+  for (my $ii = 0; $ii < $num; $ii++)
+  {
+    print $fh "\\N\t$thr\n"
+  }
+  close($fh);
+  EOF
+}
+
+# For each connection start the LOAD DATA INFILE in the background
+connection default;
+let $i = `SELECT $num_threads`;
+while ($i > 0)
+{
+  dec $i;
+
+  connection con$i;
+  let $file = `SELECT CONCAT(@@datadir, "test_insert_", $i, ".txt")`;
+  --disable_query_log
+  --echo LOAD DATA INFILE <input_file> INTO TABLE t1;
+  send_eval LOAD DATA INFILE '$file' INTO TABLE t1;
+  --enable_query_log
+}
+
+# Reap each connection's background result
+connection default;
+let $i = `SELECT $num_threads`;
+while ($i > 0)
+{
+  dec $i;
+
+  connection con$i;
+  reap;
+}
+
+# Make sure we have the required number of rows
+connection default;
+SELECT COUNT(*) FROM t1;
+SELECT thr, COUNT(pk) FROM t1 GROUP BY thr;
+
+# Cleanup the connection and file used for LOAD DATA INFILE
+let $i = `SELECT $num_threads`;
+while ($i > 0)
+{
+  dec $i;
+
+  disconnect con$i;
+  let $file = `SELECT CONCAT(@@datadir, "test_insert_", "$i", ".txt")`;
+  remove_file $file;
+}
+
+# Validate each row.  For each row, the created 'thr' column shows which
+# thread created the row.  The pk that was automatically generated should
+# therefore match a certain pattern.  For thread 0, the pk should be in
+# the sequence [1, 101, 201, 301, ...]; for thread 1, it should be in the
+# sequence [2, 102, 202, 302, ...], etc.  The pk for each row should be
+# smallest value in the sequence for thread 'thr' that is greater than
+# the pk in the previous row.
+let $file = `SELECT CONCAT(@@datadir, "test_export.txt")`;
+--disable_query_log
+--echo SELECT * FROM t1 ORDER BY pk INTO OUTFILE <output_file>;
+eval SELECT * FROM t1 ORDER BY pk INTO OUTFILE "$file";
+--enable_query_log
+
+let ROCKSDB_OUTFILE = $file;
+
+perl;
+my $fn = $ENV{'ROCKSDB_OUTFILE'};
+my $last_pk = 0;
+open(my $fh, '<', $fn) || die "perl open($fn): $!";
+while (<$fh>)
+{
+  if ($_ =~ m/^(.*)\t(.*)$/)
+  {
+    my $pk = $1;
+    my $thr = $2;
+
+    my $expected_pk = int($last_pk / 100) * 100 + ($thr + 1);
+    $expected_pk += 100 if $expected_pk <= $last_pk;
+
+    if ($expected_pk != $pk)
+    {
+      die "Incorrect next pk ($pk); expected $expected_pk (previous: $last_pk)"
+    }
+
+    $last_pk = $pk;
+  }
+  else
+  {
+    die "output file has incorrect format: $_";
+  }
+}
+print stdout "All pk values matched their expected values\n";
+EOF
+
+remove_file $file;
+
+# Drop the table to finally clean up
+DROP TABLE t1;
+

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -9572,7 +9572,7 @@ int ha_rocksdb::analyze(THD* thd, HA_CHECK_OPT* check_opt)
   DBUG_RETURN(0);
 }
 
-void ha_rocksdb::get_auto_increment(ulonglong offset, ulonglong increment,
+void ha_rocksdb::get_auto_increment(ulonglong off, ulonglong inc,
                                     ulonglong nb_desired_values,
                                     ulonglong *first_value,
                                     ulonglong *nb_reserved_values)
@@ -9592,7 +9592,49 @@ void ha_rocksdb::get_auto_increment(ulonglong offset, ulonglong increment,
     m_auto_incr_val this should be safe - if we had to grab a mutex, doing
     an actual reserve of some values might be a better solution.
    */
-  *first_value= m_tbl_def->m_auto_incr_val++;
+  DEBUG_SYNC(ha_thd(), "rocksdb.autoinc_vars");
+
+  if (off > inc)
+  {
+    off= 1;
+  }
+
+  // Local variable reference to simplify code below
+  std::atomic<longlong>& auto_incr= m_tbl_def->m_auto_incr_val;
+
+  if (inc == 1 && off == 1)
+  {
+    // Optimization for the standard case where we are always simply
+    // incrementing from the last position
+    *first_value= auto_incr++;
+  }
+  else
+  {
+    // The next value can be more complicated if either `inc` or 'off' is not 1
+    longlong new_val;
+    longlong last_val= auto_incr;
+
+    // Loop until we can correctly update the atomic value
+    do
+    {
+      // Calculate the next value in the auto increment series:
+      //   offset + N * increment
+      // where N is 0, 1, 2, ...
+      //
+      // For further information please visit:
+      // http://dev.mysql.com/doc/refman/5.7/en/replication-options-master.html
+      new_val= ((last_val + (inc - off) - 1) / inc) * inc + off;
+
+      // Attempt to store the new value (plus 1 since m_auto_incr_val contains
+      // the next available value) into the atomic value.  If the current
+      // value no longer matches what we have in 'last_val' this will fail and
+      // we will repeat the loop (`last_val` will automatically get updated
+      // with the current value).
+    } while (!auto_incr.compare_exchange_weak(last_val, new_val + 1));
+
+    *first_value= new_val;
+  }
+
   *nb_reserved_values= 1;
 }
 


### PR DESCRIPTION
Summary: Our implementation of auto increment ignored the values set in auto_increment_increment and auto_increment_offset which caused problems when two or more threads attempted to create rows (with auto increment primary keys) at the same time when auto_increment_increment was greater than 1.

Test Plan: MTR (new test that reproduces the problem with old code)