### PR TITLE
Making default to 1 shard when sharding is off, so that no change in …

### DIFF
--- a/mysql-test/suite/sys_vars/r/num_sharded_locks_basic.result
+++ b/mysql-test/suite/sys_vars/r/num_sharded_locks_basic.result
@@ -1,14 +1,14 @@
 SELECT @@GLOBAL.num_sharded_locks;
 @@GLOBAL.num_sharded_locks
-4
-4 Expected
+1
+1 Expected
 SET @@GLOBAL.num_sharded_locks=2;
 ERROR HY000: Variable 'num_sharded_locks' is a read only variable
 Expected error 'Read only variable'
 SELECT @@GLOBAL.num_sharded_locks;
 @@GLOBAL.num_sharded_locks
-4
-4 Expected
+1
+1 Expected
 SELECT @@num_sharded_locks = @@GLOBAL.num_sharded_locks;
 @@num_sharded_locks = @@GLOBAL.num_sharded_locks
 1
@@ -21,5 +21,5 @@ ERROR HY000: Variable 'num_sharded_locks' is a GLOBAL variable
 Expected error 'Variable is a GLOBAL variable'
 SELECT @@GLOBAL.num_sharded_locks;
 @@GLOBAL.num_sharded_locks
-4
-4 Expected
+1
+1 Expected

--- a/mysql-test/suite/sys_vars/t/num_sharded_locks_basic.test
+++ b/mysql-test/suite/sys_vars/t/num_sharded_locks_basic.test
@@ -1,10 +1,10 @@
 SELECT @@GLOBAL.num_sharded_locks;
---echo 4 Expected
+--echo 1 Expected
 --error ER_INCORRECT_GLOBAL_LOCAL_VAR
 SET @@GLOBAL.num_sharded_locks=2;
 --echo Expected error 'Read only variable'
 SELECT @@GLOBAL.num_sharded_locks;
---echo 4 Expected
+--echo 1 Expected
 SELECT @@num_sharded_locks = @@GLOBAL.num_sharded_locks;
 --echo 1 Expected
 --Error ER_INCORRECT_GLOBAL_LOCAL_VAR
@@ -14,4 +14,4 @@ SELECT COUNT(@@local.num_sharded_locks);
 SELECT COUNT(@@SESSION.num_sharded_locks);
 --echo Expected error 'Variable is a GLOBAL variable'
 SELECT @@GLOBAL.num_sharded_locks;
---echo 4 Expected
+--echo 1 Expected

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -10481,6 +10481,12 @@ To see what values a running MySQL server is using, type\n\
 static void init_sharding_variables()
 {
 #ifdef SHARDED_LOCKING
+  if (!gl_lock_sharding && num_sharded_locks != 1) {
+    //NO_LINT_DEBUG
+    sql_print_information("Setting num_sharded_locks=1 as sharding is OFF");
+    num_sharded_locks = 1;
+  }
+
   LOCK_thread_count_sharded.resize(num_sharded_locks);
   LOCK_thd_remove_sharded.resize(num_sharded_locks);
   for (uint ii = 0; ii < num_sharded_locks; ii++) {


### PR DESCRIPTION
…behavior.

Summary: In the default case, where use_lock_sharding is off,
we want no change in behavior and #shards = 1

Test Plan: Sandcastle

Reviewers: jkedgar