### PR TITLE
Replace new/delete with std::unique_ptr

### DIFF
--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -8170,11 +8170,7 @@ bool Regex_list_handler::set_patterns(const std::string& pattern_str)
     // Note that this means the delimiter can not be part of a regular
     // expression.  This is currently not a problem as we are using the comma
     // character as a delimiter and commas are not valid in table names.
-    const std::regex* pattern= new std::regex(norm_pattern);
-
-    // Free any existing regex information and setup the new one
-    delete m_pattern;
-    m_pattern= pattern;
+    m_pattern.reset(new std::regex(norm_pattern));
   }
   catch (const std::regex_error& e)
   {

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -1846,7 +1846,7 @@ class Regex_list_handler
 
   char m_delimiter;
   std::string m_bad_pattern_str;
-  const std::regex* m_pattern;
+  std::unique_ptr<const std::regex> m_pattern;
 
   mutable mysql_rwlock_t m_rwlock;
 
@@ -1871,7 +1871,6 @@ class Regex_list_handler
   ~Regex_list_handler()
   {
     mysql_rwlock_destroy(&m_rwlock);
-    delete m_pattern;
   }
 
   // Set the list of patterns


### PR DESCRIPTION
Summary: Get rid of recent new/delete in Regex_list_handler by using std::unique_ptr.

Test Plan: MTR