### PR TITLE
Fix rocksdb.collation test

### DIFF
--- a/mysql-test/suite/rocksdb/t/collation.test
+++ b/mysql-test/suite/rocksdb/t/collation.test
@@ -155,7 +155,7 @@ DROP TABLE t2;
 # test invalid regex (missing end bracket)
 --exec echo "" >$MYSQLTEST_VARDIR/log/mysqld.1.err
 SET GLOBAL rocksdb_strict_collation_exceptions="[a-b";
---exec grep -A 1 "Invalid pattern" $MYSQLTEST_VARDIR/log/mysqld.1.err | cut -d] -f2
+--exec grep "Invalid pattern" $MYSQLTEST_VARDIR/log/mysqld.1.err | cut -d] -f2
 --error ER_UNKNOWN_ERROR
 CREATE TABLE a (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
 SET GLOBAL rocksdb_strict_collation_exceptions="[a-b]";
@@ -168,7 +168,7 @@ DROP TABLE a, b;
 # test invalid regex (trailing escape)
 --exec echo "" >$MYSQLTEST_VARDIR/log/mysqld.1.err
 SET GLOBAL rocksdb_strict_collation_exceptions="abc\\";
---exec grep -A 1 "Invalid pattern" $MYSQLTEST_VARDIR/log/mysqld.1.err | cut -d] -f2
+--exec grep "Invalid pattern" $MYSQLTEST_VARDIR/log/mysqld.1.err | cut -d] -f2
 --error ER_UNKNOWN_ERROR
 CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
 SET GLOBAL rocksdb_strict_collation_exceptions="abc";


### PR DESCRIPTION
Summary: The test used grep to look for an expected line in the log file.  Somehow (maybe because of debugging) the "-A 1" was included that told grep to output the found line plus one more line.  Normally the found line would be the last line in the file, but if an index was being dropped, sometimes the "index dropped" message would get in after the "Invalid pattern" message and would get outputted as well.  This will fix the arguments to grep so that the extra line will no longer be printed.

Squash with: https://reviews.facebook.net/D64515

Test Plan: MTR