### PR TITLE
Fixes 2 race conditions based on results from nightly contrun

### DIFF
--- a/mysql-test/r/mysqld--help-notwin-profiling.result
+++ b/mysql-test/r/mysqld--help-notwin-profiling.result
@@ -1777,7 +1777,7 @@ net-write-timeout 60
 new FALSE
 num-conn-handling-threads 1
 num-sharded-listen-sockets 1
-num-sharded-locks 4
+num-sharded-locks 1
 old FALSE
 old-alter-table FALSE
 old-passwords 0

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -1775,7 +1775,7 @@ net-write-timeout 60
 new FALSE
 num-conn-handling-threads 1
 num-sharded-listen-sockets 1
-num-sharded-locks 4
+num-sharded-locks 1
 old FALSE
 old-alter-table FALSE
 old-passwords 0

--- a/mysql-test/suite/perfschema/r/server_init.result
+++ b/mysql-test/suite/perfschema/r/server_init.result
@@ -38,7 +38,7 @@ count(name)
 select count(name) from mutex_instances
 where name like "wait/synch/mutex/sql/LOCK_thread_count";
 count(name)
-5
+2
 select count(name) from mutex_instances
 where name like "wait/synch/mutex/sql/LOCK_log_throttle_qni";
 count(name)

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1083,8 +1083,7 @@ void add_global_thread(THD *thd)
 {
   DBUG_PRINT("info", ("add_global_thread %p", thd));
   mutex_assert_owner_shard(SHARDED(&LOCK_thread_count), thd);
-  const bool have_thread=
-    global_thread_list->find(thd) != global_thread_list->end();
+  bool have_thread= global_thread_list->find_bool(thd);
   if (!have_thread)
   {
     ++global_thread_count;
@@ -7880,6 +7879,12 @@ void create_thread_to_handle_connection(THD *thd)
     thread_created++;
     DBUG_PRINT("info",(("creating thread %u"), thd->thread_id()));
     thd->prior_thr_create_utime= thd->start_utime= my_micro_time();
+
+    // hold the sharded lock before creating the thread and release
+    // it after adding the thread to global thread list, otherwise
+    // remove_global_thread can get called before the thread
+    // has been added to global list.
+    mutex_lock_shard(SHARDED(&LOCK_thread_count), thd);
     if ((error= mysql_thread_create(key_thread_one_connection,
                                     &thd->real_id, &connection_attrib,
                                     handle_one_connection,
@@ -7906,7 +7911,6 @@ void create_thread_to_handle_connection(THD *thd)
       return;
       /* purecov: end */
     }
-    mutex_lock_shard(SHARDED(&LOCK_thread_count), thd);
     add_global_thread(thd);
     mutex_unlock_shard(SHARDED(&LOCK_thread_count), thd);
   }

--- a/sql/thread_iterator.h
+++ b/sql/thread_iterator.h
@@ -59,6 +59,8 @@ class ShardedThreads {
 
    Thread_iterator find(THD *thd);
 
+   bool find_bool(THD *thd);
+
    Thread_iterator begin() {
       return Thread_iterator(this, 0, m_thread_list[0].begin());
    }
@@ -66,6 +68,8 @@ class ShardedThreads {
    Thread_iterator end() {
      return Thread_iterator(this, m_size - 1, m_thread_list[m_size-1].end());
    }
+
+   Thread_iterator shardend(THD *thd);
 };
 #else
 typedef std::set<THD*>::iterator Thread_iterator;


### PR DESCRIPTION
Summary: 1. we have to create a connection thread, holding
the sharded lock, otherwise disconnect of connection might
trigger thread removal, before thread addition.

2. when we do a find on global sharded thread list, we cannot
return the global iterator end, because that would access
the end from a different shard, while not holding its lock.

Test Plan: Sandcastle and connection rate benchmarks ran again.

Put a sleep after thread creation to consistently trigger race
condition. Checked it to be fixed after change.

Connection rate benchmarks didn't show any significant reduction
in conn rate, although the critical section increased.

Reviewers: jkedgar