### PR TITLE
[sync client ssl] Ensure socket is in NON BLOCKING mode when SSL is used

### DIFF
--- a/sql-common/client.c
+++ b/sql-common/client.c
@@ -3302,6 +3302,10 @@ static int run_ssl_connect(MCPVIO_EXT *mpvio, my_bool *error) {
   NET *net= &mysql->net;
   Vio *vio = net->vio;
 
+  // we need the ssl connection to be done in non blocking not to block
+  // indefinitelly if server is not reachable
+  vio_set_blocking(vio, FALSE);
+
   struct st_mysql_options *options= &mysql->options;
   // Init all the SSL parts, from FD to ssl pointer, this is the init phase
   // for both sync and async ssl connect.

--- a/vio/viossl.c
+++ b/vio/viossl.c
@@ -180,6 +180,9 @@ size_t vio_ssl_read(Vio *vio, uchar *buf, size_t size)
   {
     enum enum_vio_io_event event;
 
+    // Verify the socket is non blocking.
+    DBUG_ASSERT(!vio_is_blocking(vio));
+
 #ifndef HAVE_YASSL
     /*
       OpenSSL: check that the SSL thread's error queue is cleared. Otherwise
@@ -227,6 +230,9 @@ size_t vio_ssl_write(Vio *vio, const uchar *buf, size_t size)
   while (1)
   {
     enum enum_vio_io_event event;
+
+    // Verify the socket is non blocking.
+    DBUG_ASSERT(!vio_is_blocking(vio));
 
 #ifndef HAVE_YASSL
     /*
@@ -656,10 +662,11 @@ my_bool vio_ssl_has_data(Vio *vio)
 
 int vio_ssl_set_blocking(Vio *vio, my_bool status)
 {
+  DBUG_ENTER("vio_ssl_set_blocking");
   int ret;
-  ret = vio_set_blocking(vio, status);
+  ret = vio_set_blocking(vio, FALSE);
   vio->ssl_is_nonblocking = !status;
-  return ret;
+  DBUG_RETURN(ret);
 }
 
 #endif /* HAVE_OPENSSL */


### PR DESCRIPTION
Summary:
If the socket is in BLOCKING mode when ssl connect is performed, it can
block indifenitely if the server does not respond.

Force NON BLOCKING mode before sslconnect() is called.

Put back setting the socket to NON BLOCKING in vio_ssl_set_blocking().
It was changed in https://reviews.facebook.net/D51801. The reason stated
there is not very clear, but tests didn't show this is a problem.

Test Plan:
Run mysql client with debug logs:
   _build-5.6-Debug/client/mysql -h127.0.0.1 -P3306
   --ssl_ca=ca.pem
   --ssl_key=cert.pem
   --ssl_cert=cert.pem
   --debug='d:t:o,/tmp/mysql_client_test.trace' -e"select 1"
Observed mode transition to NON BLOCKING before connect:
  >vio_set_blocking
  | info: blocking: fd 4, 1 -> 0
Run mtr tests.