### PR TITLE
fix broken tests for rocksdb_trx table

### DIFF
--- a/mysql-test/suite/rocksdb/r/trx_info.result
+++ b/mysql-test/suite/rocksdb/r/trx_info.result
@@ -9,5 +9,5 @@ a
 2
 select * from information_schema.rocksdb_trx;
 TRANSACTION_ID	STATE	NAME	WRITE_COUNT	LOCK_COUNT	TIMEOUT_SEC	WAITING_TXN_ID	IS_REPLICATION	SKIP_TRX_API	READ_ONLY	HAS_DEADLOCK_DETECTION	NUM_ONGOING_BULKLOAD	THREAD_ID	QUERY
-_TRX_ID_	STARTED	_NAME_	0	2	1	_TIMEOUT_	0	0	0	0	0	2	select * from information_schema.rocksdb_trx
+_TRX_ID_	STARTED	_NAME_	0	2	1	_TIMEOUT_	0	0	0	0	0	_THREAD_ID_	select * from information_schema.rocksdb_trx
 DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/t/trx_info.test
+++ b/mysql-test/suite/rocksdb/t/trx_info.test
@@ -11,7 +11,7 @@ insert into t1 values (2);
 set autocommit=0;
 select * from t1 for update;
 
---replace_column 1 _TRX_ID_ 3 _NAME_ 7 _TIMEOUT_
+--replace_column 1 _TRX_ID_ 3 _NAME_ 7 _TIMEOUT_ 13 _THREAD_ID_
 select * from information_schema.rocksdb_trx;
 
 DROP TABLE t1;


### PR DESCRIPTION
Thread id is non-deterministic and needs to be mocked.