### PR TITLE
Recreate iterator after committing in the middle

### DIFF
--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -2468,7 +2468,10 @@ id2 bigint(20),
 PRIMARY KEY (id1, id2))
 DEFAULT CHARSET=latin1;
 set rocksdb_commit_in_the_middle=1;
+SET @save_rocksdb_bulk_load_size= @@rocksdb_bulk_load_size;
 set rocksdb_bulk_load_size = 100;
 DELETE t2, t1 FROM t2 LEFT JOIN t1 ON t2.id2 = t1.id2 AND t2.id1 = t1.id1 WHERE t2.id1 = 0;
+SET rocksdb_bulk_load_size= @save_rocksdb_bulk_load_size;
+SET rocksdb_commit_in_the_middle=0;
 DROP TABLE t1, t2;
 SET GLOBAL ROCKSDB_PAUSE_BACKGROUND_WORK = @ORIG_PAUSE_BACKGROUND_WORK;

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -2454,4 +2454,21 @@ a
 10
 11
 DROP TABLE t1;
+#
+# Issue #411: Setting rocksdb_commit_in_the_middle commits transaction
+# without releasing iterator
+#
+CREATE TABLE t1 (id1 bigint(20),
+id2 bigint(20),
+id3 bigint(20),
+PRIMARY KEY (id1, id2, id3))
+DEFAULT CHARSET=latin1;
+CREATE TABLE t2 (id1 bigint(20),
+id2 bigint(20),
+PRIMARY KEY (id1, id2))
+DEFAULT CHARSET=latin1;
+set rocksdb_commit_in_the_middle=1;
+set rocksdb_bulk_load_size = 100;
+DELETE t2, t1 FROM t2 LEFT JOIN t1 ON t2.id2 = t1.id2 AND t2.id1 = t1.id1 WHERE t2.id1 = 0;
+DROP TABLE t1, t2;
 SET GLOBAL ROCKSDB_PAUSE_BACKGROUND_WORK = @ORIG_PAUSE_BACKGROUND_WORK;

--- a/mysql-test/suite/rocksdb/t/rocksdb.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb.test
@@ -1924,4 +1924,39 @@ SHOW TABLE STATUS LIKE 't1';
 SELECT * FROM t1;
 DROP TABLE t1;
 
+--echo #
+--echo # Issue #411: Setting rocksdb_commit_in_the_middle commits transaction
+--echo # without releasing iterator
+--echo #
+
+CREATE TABLE t1 (id1 bigint(20),
+                 id2 bigint(20),
+                 id3 bigint(20),
+                 PRIMARY KEY (id1, id2, id3))
+                 DEFAULT CHARSET=latin1;
+
+CREATE TABLE t2 (id1 bigint(20),
+                 id2 bigint(20),
+                 PRIMARY KEY (id1, id2))
+                 DEFAULT CHARSET=latin1;
+
+
+set rocksdb_commit_in_the_middle=1;
+set rocksdb_bulk_load_size = 100;
+
+--disable_query_log
+let $j = 10000;
+while ($j)
+{
+  --eval insert into t1 (id1, id2, id3) values (0, $j, 0);
+  --eval insert into t2 (id1, id2) values (0, $j);
+  dec $j;
+}
+--enable_query_log
+
+DELETE t2, t1 FROM t2 LEFT JOIN t1 ON t2.id2 = t1.id2 AND t2.id1 = t1.id1 WHERE t2.id1 = 0;
+
+DROP TABLE t1, t2;
+
+
 SET GLOBAL ROCKSDB_PAUSE_BACKGROUND_WORK = @ORIG_PAUSE_BACKGROUND_WORK;

--- a/mysql-test/suite/rocksdb/t/rocksdb.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb.test
@@ -1942,6 +1942,7 @@ CREATE TABLE t2 (id1 bigint(20),
 
 
 set rocksdb_commit_in_the_middle=1;
+SET @save_rocksdb_bulk_load_size= @@rocksdb_bulk_load_size;
 set rocksdb_bulk_load_size = 100;
 
 --disable_query_log
@@ -1956,6 +1957,8 @@ while ($j)
 
 DELETE t2, t1 FROM t2 LEFT JOIN t1 ON t2.id2 = t1.id2 AND t2.id1 = t1.id1 WHERE t2.id1 = 0;
 
+SET rocksdb_bulk_load_size= @save_rocksdb_bulk_load_size;
+SET rocksdb_commit_in_the_middle=0;
 DROP TABLE t1, t2;
 
 

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -7331,9 +7331,26 @@ bool ha_rocksdb::commit_in_the_middle()
 bool ha_rocksdb::do_bulk_commit(Rdb_transaction *tx)
 {
   DBUG_ASSERT(tx != nullptr);
-  return commit_in_the_middle() &&
-         tx->get_write_count() >= THDVAR(table->in_use, bulk_load_size) &&
-         tx->flush_batch();
+  bool ret= false;
+
+  if (commit_in_the_middle() &&
+      tx->get_write_count() >= THDVAR(table->in_use, bulk_load_size))
+  {
+    String prev_key;
+    if (m_scan_it) {
+      prev_key.copy(m_scan_it->key().data(), m_scan_it->key().size(), &my_charset_bin);
+    }
+    rocksdb::Slice prev_slice = { prev_key.ptr(), prev_key.length() };
+
+    ret= tx->flush_batch();
+    if (m_scan_it) {
+      release_scan_iterator();
+      setup_scan_iterator(*m_key_descr_arr[m_scan_it_kd],
+                          &prev_slice, m_scan_it_skips_bloom);
+    }
+  }
+
+  return ret;
 }
 
 /*
@@ -8106,18 +8123,22 @@ void ha_rocksdb::setup_scan_iterator(
     const bool is_ascending,
     const uint eq_cond_len)
 {
-  DBUG_ASSERT(slice != nullptr);
   DBUG_ASSERT(slice->size() >= eq_cond_len);
 
-  Rdb_transaction *tx= get_or_create_tx(table->in_use);
-
-  bool skip_bloom= true;
-
   rocksdb::Slice eq_cond(slice->data(), eq_cond_len);
-  if (can_use_bloom_filter(ha_thd(), kd, eq_cond, use_all_keys, is_ascending))
-  {
-    skip_bloom= false;
-  }
+  setup_scan_iterator(kd, slice, !can_use_bloom_filter(ha_thd(), kd, eq_cond,
+                                                       use_all_keys,
+                                                       is_ascending));
+}
+
+void ha_rocksdb::setup_scan_iterator(
+    const Rdb_key_def& kd,
+    rocksdb::Slice *slice,
+    bool skip_bloom)
+{
+  DBUG_ASSERT(slice != nullptr);
+
+  Rdb_transaction *tx= get_or_create_tx(table->in_use);
 
   /*
     In some cases, setup_scan_iterator() is called multiple times from
@@ -8145,14 +8166,25 @@ void ha_rocksdb::setup_scan_iterator(
     bool fill_cache= !THDVAR(ha_thd(), skip_fill_cache);
     m_scan_it= tx->get_iterator(kd.get_cf(), skip_bloom, fill_cache);
     m_scan_it_skips_bloom= skip_bloom;
-  }
-  /*
-    Seek() will "Position at the first key in the source that at or past target".
-    The operation cannot fail.
-  */
-  m_scan_it->Seek(*slice);
-}
 
+    for (uint i= 0; i < m_tbl_def->m_key_count; i++)
+    {
+      if (&kd == m_key_descr_arr[i].get())
+      {
+        m_scan_it_kd= i;
+
+        /*
+          Seek() will "Position at the first key in the source that at or past target".
+          The operation cannot fail.
+        */
+        m_scan_it->Seek(*slice);
+        return;
+      }
+    }
+    // The kd passed in must be in m_key_descr_arr.
+    SHIP_ASSERT(0);
+  }
+}
 
 void ha_rocksdb::setup_iterator_for_rnd_scan()
 {

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -325,6 +325,9 @@ class ha_rocksdb: public my_core::handler
   /* Whether m_scan_it was created with skip_bloom=true */
   bool m_scan_it_skips_bloom;
 
+  /* The key index into m_key_descr_arr that m_scan_it used */
+  uint m_scan_it_kd;
+
   Rdb_tbl_def *m_tbl_def;
 
   /* Primary Key encoder from KeyTupleFormat to StorageFormat */
@@ -457,6 +460,8 @@ class ha_rocksdb: public my_core::handler
   {
     setup_scan_iterator(kd, slice, false, false, 0);
   }
+  void setup_scan_iterator(const Rdb_key_def& kd, rocksdb::Slice *slice,
+                           bool skip_bloom) __attribute__((__nonnull__));
   bool is_ascending(const Rdb_key_def& keydef,
                     enum ha_rkey_function find_flag) const
     __attribute__((__nonnull__, __warn_unused_result__));

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -325,8 +325,7 @@ class ha_rocksdb: public my_core::handler
   /* Whether m_scan_it was created with skip_bloom=true */
   bool m_scan_it_skips_bloom;
 
-  /* The key index into m_key_descr_arr that m_scan_it used */
-  uint m_scan_it_kd;
+  const rocksdb::Snapshot *m_scan_it_snapshot;
 
   Rdb_tbl_def *m_tbl_def;
 
@@ -460,8 +459,6 @@ class ha_rocksdb: public my_core::handler
   {
     setup_scan_iterator(kd, slice, false, false, 0);
   }
-  void setup_scan_iterator(const Rdb_key_def& kd, rocksdb::Slice *slice,
-                           bool skip_bloom) __attribute__((__nonnull__));
   bool is_ascending(const Rdb_key_def& keydef,
                     enum ha_rkey_function find_flag) const
     __attribute__((__nonnull__, __warn_unused_result__));
@@ -469,11 +466,7 @@ class ha_rocksdb: public my_core::handler
                            rocksdb::Slice *slice, const bool use_all_keys,
                            const bool is_ascending, const uint eq_cond_len)
     __attribute__((__nonnull__));
-  void release_scan_iterator(void)
-  {
-    delete m_scan_it;
-    m_scan_it= nullptr;
-  }
+  void release_scan_iterator(void);
 
   rocksdb::Status get_for_update(Rdb_transaction* tx,
                                  rocksdb::ColumnFamilyHandle* column_family,


### PR DESCRIPTION
It is not safe to keep using an iterator after the associated transaction has committed. This happens when rocksdb_commit_in_the_middle is set. To fix, we recreate an iterator from the new transaction and seek to the last key we were at.

Closes #411 