### PR TITLE
Heartbeat event should carry the latest master timestamp

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_heartbeat_timestamp.result
+++ b/mysql-test/suite/rpl/r/rpl_heartbeat_timestamp.result
@@ -1,0 +1,41 @@
+include/rpl_init.inc [topology=1->2->3]
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+include/rpl_connect.inc [creating master]
+include/rpl_connect.inc [creating master1]
+include/rpl_connect.inc [creating slave]
+include/rpl_connect.inc [creating slave1]
+include/rpl_connect.inc [creating slave_2]
+STOP SLAVE;
+CHANGE MASTER TO MASTER_HEARTBEAT_PERIOD=2;
+START SLAVE;
+STOP SLAVE;
+CHANGE MASTER TO MASTER_HEARTBEAT_PERIOD=2;
+SET GLOBAL RESET_SECONDS_BEHIND_MASTER=0;
+START SLAVE;
+CREATE TABLE t1(a INT);
+INSERT INTO t1 VALUES(0);
+include/save_master_pos.inc
+include/sync_slave_sql.inc
+include/save_master_pos.inc
+include/sync_slave_sql.inc
+include/assert.inc [Seconds behind master should be between 0 and HB period]
+STOP SLAVE;
+include/assert.inc [Seconds behind master should keep increasing when intermidiate slave is stopped]
+START SLAVE;
+include/rpl_stop_server.inc [server_number=1]
+include/assert.inc [Seconds behind master should keep increasing when master is killed]
+include/rpl_start_server.inc [server_number=1]
+DROP TABLE t1;
+STOP SLAVE;
+CHANGE MASTER TO MASTER_HEARTBEAT_PERIOD=60.000;
+START SLAVE;
+STOP SLAVE;
+CHANGE MASTER TO MASTER_HEARTBEAT_PERIOD=60.000;
+SET GLOBAL RESET_SECONDS_BEHIND_MASTER=1;
+START SLAVE;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_heartbeat_timestamp.cnf
+++ b/mysql-test/suite/rpl/t/rpl_heartbeat_timestamp.cnf
@@ -1,0 +1,11 @@
+!include ../my.cnf
+
+[mysqld.1]
+log-slave-updates
+[mysqld.2]
+log-slave-updates
+[mysqld.3]
+log-slave-updates
+
+[ENV]
+SERVER_MYPORT_3= @mysqld.3.port

--- a/mysql-test/suite/rpl/t/rpl_heartbeat_timestamp.test
+++ b/mysql-test/suite/rpl/t/rpl_heartbeat_timestamp.test
@@ -1,0 +1,132 @@
+# Tests the behavior of heartbeat timestamps
+#
+# First we create a chain topology with two slaves i.e. master->slave->slave_2.
+# We disable RESET_SECONDS_BEHIND_MASTER in slave_2 so that
+# Seconds_Behind_Master depends on incoming events instead of difference between
+# IO and SQL thread. Then we check that when the master is running the lag on
+# slave_2 is between 0 and heartbeat period. We then kill the master and
+# check if the lag on slave_2 keeps increasing.
+
+let $rpl_server_count= 3;
+let $rpl_topology= 1->2->3;
+source include/rpl_init.inc;
+
+let $rpl_connection_name= master;
+let $rpl_server_number= 1;
+source include/rpl_connect.inc;
+
+let $rpl_connection_name= master1;
+let $rpl_server_number= 1;
+source include/rpl_connect.inc;
+
+let $rpl_connection_name= slave;
+let $rpl_server_number= 2;
+source include/rpl_connect.inc;
+
+let $rpl_connection_name= slave1;
+let $rpl_server_number= 2;
+source include/rpl_connect.inc;
+
+let $rpl_connection_name= slave_2;
+let $rpl_server_number= 3;
+source include/rpl_connect.inc;
+
+let $old_slave_heartbeat_period= query_get_value(SHOW GLOBAL STATUS LIKE 'slave_heartbeat_period', Value, 1);
+let $new_slave_heartbeat_period= 2;
+let $heartbeat_guarantee_sleep= `SELECT $new_slave_heartbeat_period + 1`;
+
+connection slave;
+STOP SLAVE;
+eval CHANGE MASTER TO MASTER_HEARTBEAT_PERIOD=$new_slave_heartbeat_period;
+START SLAVE;
+
+connection slave_2;
+STOP SLAVE;
+eval CHANGE MASTER TO MASTER_HEARTBEAT_PERIOD=$new_slave_heartbeat_period;
+SET GLOBAL RESET_SECONDS_BEHIND_MASTER=0;
+START SLAVE;
+
+# Send some binlog events so that last_master_timestamp > 0
+connection master;
+CREATE TABLE t1(a INT);
+INSERT INTO t1 VALUES(0);
+
+# Sync slave 1
+connection master;
+source include/save_master_pos.inc;
+connection slave;
+source include/sync_slave_sql.inc;
+
+# Sync slave 2
+connection slave;
+source include/save_master_pos.inc;
+connection slave_2;
+source include/sync_slave_sql.inc;
+
+# Check if seconds behind master is between 0 and heartbeat period
+connection slave_2;
+sleep $heartbeat_guarantee_sleep;
+let $first= query_get_value("SHOW SLAVE STATUS", Seconds_Behind_Master, 1);
+
+let $assert_cond= ($first <= $new_slave_heartbeat_period && $first >= 0);
+let $assert_text= Seconds behind master should be between 0 and HB period;
+source include/assert.inc;
+
+
+# Check if seconds behind master keeps increasing when intermediate slave is
+# stopped
+connection slave;
+STOP SLAVE;
+connection slave_2;
+sleep $heartbeat_guarantee_sleep;
+let $first= query_get_value("SHOW SLAVE STATUS", Seconds_Behind_Master, 1);
+sleep $heartbeat_guarantee_sleep;
+let $second= query_get_value("SHOW SLAVE STATUS", Seconds_Behind_Master, 1);
+
+let $assert_cond= $first < $second;
+let $assert_text= Seconds behind master should keep increasing when intermidiate slave is stopped;
+source include/assert.inc;
+
+connection slave;
+START SLAVE;
+
+
+# Kill the master
+let $rpl_server_number= 1;
+let $rpl_force_stop= 1;
+source include/rpl_stop_server.inc;
+
+
+# Check if seconds behind master keeps increasing
+connection slave_2;
+sleep $heartbeat_guarantee_sleep;
+let $first= query_get_value("SHOW SLAVE STATUS", Seconds_Behind_Master, 1);
+sleep $heartbeat_guarantee_sleep;
+let $second= query_get_value("SHOW SLAVE STATUS", Seconds_Behind_Master, 1);
+
+let $assert_cond= $first < $second;
+let $assert_text= Seconds behind master should keep increasing when master is killed;
+source include/assert.inc;
+
+let $rpl_server_number= 1;
+source include/rpl_start_server.inc;
+
+connection master;
+DROP TABLE t1;
+
+# Sync slaves
+sync_slave_with_master slave;
+sync_slave_with_master slave_2;
+
+connection slave;
+STOP SLAVE;
+eval CHANGE MASTER TO MASTER_HEARTBEAT_PERIOD=$old_slave_heartbeat_period;
+START SLAVE;
+
+connection slave_2;
+STOP SLAVE;
+eval CHANGE MASTER TO MASTER_HEARTBEAT_PERIOD=$old_slave_heartbeat_period;
+SET GLOBAL RESET_SECONDS_BEHIND_MASTER=1;
+START SLAVE;
+
+source include/rpl_end.inc;

--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -7210,6 +7210,18 @@ static int queue_event(Master_info* mi,const char* buf, ulong event_len)
     mi->received_heartbeats++;
     mi->last_heartbeat= my_time(0);
 
+    /*
+      Update the last_master_timestamp if the heartbeat from the master
+      has a greater timestamp value, this makes sure last_master_timestamp
+      is always monotonically increasing
+    */
+    mysql_mutex_lock(&mi->rli->data_lock);
+    if (hb.when.tv_sec > mi->rli->last_master_timestamp)
+    {
+      mi->rli->penultimate_master_timestamp= rli->last_master_timestamp;
+      mi->rli->last_master_timestamp= hb.when.tv_sec;
+    }
+    mysql_mutex_unlock(&mi->rli->data_lock);
 
     /*
       During GTID protocol, if the master skips transactions,


### PR DESCRIPTION
Summary: Heartbeat events should carry the now() timestamp from the master and
the last_master_timstamp from the slave. In other words, HB should always carry
the lastet master timestamp. This will help services connected to slaves know
if they are lagging even when no real events are flowing in the system. Also,
for this to work last_master_timestamp should be updated whenever a HB event is
received.

Test Plan: Added a new test to check this behavior.