### PR TITLE
Change SET GLOBAL [super_]read_only to not acquire the global read lock

### DIFF
--- a/mysql-test/r/global_read_lock.result
+++ b/mysql-test/r/global_read_lock.result
@@ -1,0 +1,61 @@
+DROP TABLE IF EXISTS t1, t2, t3, t4;
+SET @save_read_only=@@global.read_only;
+SET @save_super_read_only=@@global.super_read_only;
+CREATE TABLE t1(a INT) Engine=InnoDB;
+CREATE TABLE t2(a INT) Engine=InnoDB;
+CREATE TABLE t3(a INT) Engine=InnoDB;
+CREATE TABLE t4(a INT) Engine=InnoDB;
+INSERT INTO t1 VALUES(1),(2),(3),(4),(5),(6),(7),(8);
+INSERT INTO t1 SELECT 8 + a FROM t1;
+INSERT INTO t1 SELECT 16 + a FROM t1;
+INSERT INTO t1 SELECT 32 + a FROM t1;
+INSERT INTO t2 SELECT a FROM t1;
+INSERT INTO t3 SELECT a FROM t1;
+BEGIN WORK;
+Issuing long running INSERT
+INSERT INTO t4 SELECT t1.a * 64 * 64 + t2.a * 64 + t3.a FROM t1, t2, t3;
+SELECT command, info FROM information_schema.processlist ORDER BY command, info;
+command	info
+Query	INSERT INTO t4 SELECT t1.a * 64 * 64 + t2.a * 64 + t3.a FROM t1, t2, t3
+Query	SELECT command, info FROM information_schema.processlist ORDER BY command, info
+Sleep	NULL
+SET GLOBAL super_read_only=1;
+SELECT command, info FROM information_schema.processlist ORDER BY command, info;
+command	info
+Query	INSERT INTO t4 SELECT t1.a * 64 * 64 + t2.a * 64 + t3.a FROM t1, t2, t3
+Query	SELECT command, info FROM information_schema.processlist ORDER BY command, info
+Sleep	NULL
+CREATE TABLE t5 (a INT) Engine=InnoDB;
+ERROR HY000: The MySQL server is running with the --read-only (super) option so it cannot execute this statement. 
+SELECT COUNT(*) FROM t4;
+COUNT(*)
+262144
+COMMIT;
+ERROR HY000: The MySQL server is running with the --read-only (super) option so it cannot execute this statement. 
+SELECT COUNT(*) FROM t4;
+COUNT(*)
+0
+SET @@global.super_read_only = @save_super_read_only;
+SET @@global.read_only = @save_read_only;
+Issuing long running INSERT
+INSERT INTO t4 SELECT t1.a * 64 * 64 + t2.a * 64 + t3.a FROM t1, t2, t3;
+SELECT command, info FROM information_schema.processlist ORDER BY command, info;
+command	info
+Query	INSERT INTO t4 SELECT t1.a * 64 * 64 + t2.a * 64 + t3.a FROM t1, t2, t3
+Query	SELECT command, info FROM information_schema.processlist ORDER BY command, info
+Sleep	NULL
+SET GLOBAL super_read_only=1;
+SELECT command, info FROM information_schema.processlist ORDER BY command, info;
+command	info
+Query	INSERT INTO t4 SELECT t1.a * 64 * 64 + t2.a * 64 + t3.a FROM t1, t2, t3
+Query	SELECT command, info FROM information_schema.processlist ORDER BY command, info
+Sleep	NULL
+CREATE TABLE t5 (a INT) Engine=InnoDB;
+ERROR HY000: The MySQL server is running with the --read-only (super) option so it cannot execute this statement. 
+ERROR HY000: The MySQL server is running with the --read-only (super) option so it cannot execute this statement. 
+SELECT COUNT(*) FROM t4;
+COUNT(*)
+0
+SET @@global.super_read_only = @save_super_read_only;
+SET @@global.read_only = @save_read_only;
+DROP TABLE t1, t2, t3, t4;

--- a/mysql-test/t/global_read_lock.test
+++ b/mysql-test/t/global_read_lock.test
@@ -1,0 +1,135 @@
+# Attempting to set read_only or super_read_only on would occassionally block
+# if there was a long running modifycation statement (INSERT, UPDATE, DELETE,
+# REPLACE, etc.).  This was because of contention on the global read lock.
+# The code to handle setting the read_only flags has been modified to not
+# acquire the global read lock
+
+--disable_warnings
+DROP TABLE IF EXISTS t1, t2, t3, t4;
+--enable_warnings
+
+# Save the current settings for read_only and super_read_only
+SET @save_read_only=@@global.read_only;
+SET @save_super_read_only=@@global.super_read_only;
+
+# Create the tables we need
+CREATE TABLE t1(a INT) Engine=InnoDB;
+CREATE TABLE t2(a INT) Engine=InnoDB;
+CREATE TABLE t3(a INT) Engine=InnoDB;
+CREATE TABLE t4(a INT) Engine=InnoDB;
+
+# Insert a bunch of data into t1, t2, and t3
+INSERT INTO t1 VALUES(1),(2),(3),(4),(5),(6),(7),(8);
+INSERT INTO t1 SELECT 8 + a FROM t1;
+INSERT INTO t1 SELECT 16 + a FROM t1;
+INSERT INTO t1 SELECT 32 + a FROM t1;
+INSERT INTO t2 SELECT a FROM t1;
+INSERT INTO t3 SELECT a FROM t1;
+
+connect(con1,localhost,root,,);
+connect(con2,localhost,root,,);
+connection con1;
+
+# In another thread start a statement that takes a bunch of time
+BEGIN WORK;
+echo Issuing long running INSERT;
+send INSERT INTO t4 SELECT t1.a * 64 * 64 + t2.a * 64 + t3.a FROM t1, t2, t3;
+
+# Back on the original thread show the process list
+connection default;
+real_sleep 2;
+SELECT command, info FROM information_schema.processlist ORDER BY command, info;
+
+# In a new thread set super_read_only on.  Setting this used to block on the
+# long running statement above.  Now it should succeed and the statement
+# should fail when it tries to commit
+connection con2;
+send SET GLOBAL super_read_only=1;
+
+# Back on the original thread show the process list again and show that
+# SET GLOBAL super_read_only is not waiting
+connection default;
+real_sleep 5;
+SELECT command, info FROM information_schema.processlist ORDER BY command, info;
+
+# Also try to create a table - this should fail because READ ONLY is on
+--error ER_OPTION_PREVENTS_STATEMENT
+CREATE TABLE t5 (a INT) Engine=InnoDB;
+
+# Wait for the SET GLOBAL super_read_only statement to finish
+connection con2;
+reap;
+
+# Wait for the long running statement to finish
+connection con1;
+reap;
+
+# The changes should be visible to the current connection
+SELECT COUNT(*) FROM t4;
+
+# But should fail when the transaction is committed (read_only mode is on)
+--error ER_OPTION_PREVENTS_STATEMENT
+COMMIT;
+SELECT COUNT(*) FROM t4;
+
+# Now do it without the BEGIN statement - make sure the statement fails
+# (instead of the COMMIT following the statement)
+connection default;
+SET @@global.super_read_only = @save_super_read_only;
+SET @@global.read_only = @save_read_only;
+
+# Start a statement that takes a bunch of time
+connection con1;
+echo Issuing long running INSERT;
+send INSERT INTO t4 SELECT t1.a * 64 * 64 + t2.a * 64 + t3.a FROM t1, t2, t3;
+
+# Back on the original thread show the process list
+connection default;
+real_sleep 2;
+SELECT command, info FROM information_schema.processlist ORDER BY command, info;
+
+# In a new thread set super_read_only on.  Setting this used to block on the
+# long running statement above.  Now it should succeed and the statement
+# should fail when it tries to commit
+connection con2;
+send SET GLOBAL super_read_only=1;
+
+# Back on the original thread show the process list again and show that
+# SET GLOBAL super_read_only is not waiting
+connection default;
+real_sleep 5;
+SELECT command, info FROM information_schema.processlist ORDER BY command, info;
+
+# Also try to create a table - this should fail because READ ONLY is on
+--error ER_OPTION_PREVENTS_STATEMENT
+CREATE TABLE t5 (a INT) Engine=InnoDB;
+
+# Wait for the SET GLOBAL super_read_only statement to finish
+connection con2;
+reap;
+
+# Wait for the long running statement to finish
+connection con1;
+--error ER_OPTION_PREVENTS_STATEMENT
+reap;
+
+# The changes should not exist
+SELECT COUNT(*) FROM t4;
+
+## But should fail when the transaction is committed (read_only mode is on)
+#--error ER_OPTION_PREVENTS_STATEMENT
+#COMMIT;
+#SELECT COUNT(*) FROM t4;
+
+# Cleanup connections
+connection default;
+disconnect con1;
+disconnect con2;
+
+# Reset the super_read_only and read_only variables
+SET @@global.super_read_only = @save_super_read_only;
+SET @@global.read_only = @save_read_only;
+
+# Get rid of the databases
+DROP TABLE t1, t2, t3, t4;
+

--- a/sql/lock.cc
+++ b/sql/lock.cc
@@ -1068,16 +1068,21 @@ void Global_read_lock::unlock_global_read_lock(THD *thd)
 {
   DBUG_ENTER("unlock_global_read_lock");
 
-  DBUG_ASSERT(m_mdl_global_shared_lock && m_state);
+  DBUG_ASSERT(m_state);
 
   if (m_mdl_blocks_commits_lock)
   {
     thd->mdl_context.release_lock(m_mdl_blocks_commits_lock);
     m_mdl_blocks_commits_lock= NULL;
   }
-  thd->mdl_context.release_lock(m_mdl_global_shared_lock);
-  my_atomic_add32(&Global_read_lock::m_active_requests, -1);
-  m_mdl_global_shared_lock= NULL;
+
+  if (m_mdl_global_shared_lock)
+  {
+    thd->mdl_context.release_lock(m_mdl_global_shared_lock);
+    my_atomic_add32(&Global_read_lock::m_active_requests, -1);
+    m_mdl_global_shared_lock= NULL;
+  }
+
   m_state= GRL_NONE;
   DBUG_VOID_RETURN;
 }
@@ -1106,7 +1111,7 @@ bool Global_read_lock::make_global_read_lock_block_commit(THD *thd)
     If we didn't succeed lock_global_read_lock(), or if we already suceeded
     make_global_read_lock_block_commit(), do nothing.
   */
-  if (m_state != GRL_ACQUIRED)
+  if (m_state == GRL_ACQUIRED_AND_BLOCKS_COMMIT)
     DBUG_RETURN(0);
 
   mdl_request.init(MDL_key::COMMIT, "", "", MDL_SHARED, MDL_EXPLICIT);

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -2732,9 +2732,6 @@ static bool fix_read_only(sys_var *self, THD *thd, enum_var_type type)
   read_only= opt_readonly;
   mysql_mutex_unlock(&LOCK_global_system_variables);
 
-  if (thd->global_read_lock.lock_global_read_lock(thd))
-    goto end_with_mutex_unlock;
-
   if ((result= thd->global_read_lock.make_global_read_lock_block_commit(thd)))
     goto end_with_read_lock;
 
@@ -2746,7 +2743,6 @@ static bool fix_read_only(sys_var *self, THD *thd, enum_var_type type)
  end_with_read_lock:
   /* Release the lock */
   thd->global_read_lock.unlock_global_read_lock(thd);
- end_with_mutex_unlock:
   mysql_mutex_lock(&LOCK_global_system_variables);
  end:
   super_read_only= opt_super_readonly;


### PR DESCRIPTION
Summary: Currently calling SET GLOBAL [super_]read_only acquires the global read lock before setting the flag and this will block on a long running DML statement.  We think it is safe in our environment to not acquire this lock.

Test Plan: MTR