### PR TITLE
Refresh special commit_in_the_middle snapshot for fast secondary key creation

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -9983,7 +9983,15 @@ int ha_rocksdb::inplace_populate_sk(const TABLE* new_table_arg,
     {
       DBUG_RETURN(res);
     }
-    tx->commit();
+
+    if (commit_in_the_middle())
+    {
+      release_scan_iterator();
+    }
+    else
+    {
+      tx->commit();
+    }
   }
 
   ulonglong rdb_merge_buf_size= THDVAR(ha_thd(), merge_buf_size);


### PR DESCRIPTION
In 64db3fb, we had to refresh the snapshot by committing the transaction to ensure the last SST file for the primary key was committed. However, if commit_in_the_middle is set, the iterator is not based on the transaction, but is instead a standalone snapshot. We should refresh that snapshot instead if commit_in_the_middle is set.

Squash with: b927ffe Recreate iterator after committing in the middle
