### PR TITLE
Fixing how to get Iterator with commit_in_the_middle()

### DIFF
--- a/mysql-test/suite/rocksdb/r/commit_in_the_middle_ddl.result
+++ b/mysql-test/suite/rocksdb/r/commit_in_the_middle_ddl.result
@@ -1,0 +1,14 @@
+DROP TABLE IF EXISTS a;
+create table a (id int, value int,  primary key (id) comment 'cf_a') engine=rocksdb;
+set rocksdb_bulk_load=1;
+set rocksdb_commit_in_the_middle=1;
+alter table a add index v (value) COMMENT 'cf_a';
+set rocksdb_bulk_load=0;
+set rocksdb_commit_in_the_middle=0;
+select count(*) from a force index(primary);
+count(*)
+100000
+select count(*) from a force index(v);
+count(*)
+100000
+DROP TABLE a;

--- a/mysql-test/suite/rocksdb/t/commit_in_the_middle_ddl.test
+++ b/mysql-test/suite/rocksdb/t/commit_in_the_middle_ddl.test
@@ -1,0 +1,27 @@
+--source include/have_rocksdb.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS a;
+--enable_warnings
+
+create table a (id int, value int,  primary key (id) comment 'cf_a') engine=rocksdb;
+
+--disable_query_log
+let $i = 1;
+while ($i <= 100000) {
+  let $insert = INSERT INTO a VALUES($i, $i);
+  inc $i;
+  eval $insert;
+}
+--enable_query_log
+
+set rocksdb_bulk_load=1;
+set rocksdb_commit_in_the_middle=1;
+alter table a add index v (value) COMMENT 'cf_a';
+set rocksdb_bulk_load=0;
+set rocksdb_commit_in_the_middle=0;
+select count(*) from a force index(primary);
+select count(*) from a force index(v);
+
+DROP TABLE a;
+

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -8149,8 +8149,9 @@ void ha_rocksdb::setup_scan_iterator(
       m_scan_it_snapshot= rdb->GetSnapshot();
 
       auto read_opts = rocksdb::ReadOptions();
+      read_opts.total_order_seek = true; // TODO: set based on WHERE conditions
       read_opts.snapshot= m_scan_it_snapshot;
-      m_scan_it= rdb->NewIterator(read_opts);
+      m_scan_it= rdb->NewIterator(read_opts, kd.get_cf());
     }
     else
     {


### PR DESCRIPTION
Summary: NewIterator() needs CF handle, otherwise it returns
an iterator for default column family, which doesn't return
expected rows.

Squash with: https://phabricator.intern.facebook.com/D4159222

Test Plan: mtr