### PR TITLE
Fix linters so arc lint can be run from any subdirectory

### DIFF
--- a/arcanist/arcanist/FacebookMySQLArcanistConfiguration.php
+++ b/arcanist/arcanist/FacebookMySQLArcanistConfiguration.php
@@ -27,10 +27,11 @@ class FacebookMySQLArcanistConfiguration extends ArcanistConfiguration {
       }
     }
 
+    $project_root = $working_copy->getProjectRoot();
     $configuration_manager->setRuntimeConfig("lint.engine",
       "FacebookMySQLLintEngine");
     $configuration_manager->setRuntimeConfig("lint.cpplint.prefix",
-      "rocksdb/arcanist_util/cpp_linter/");
+      $project_root . "/rocksdb/arcanist_util/cpp_linter/");
     $configuration_manager->setRuntimeConfig("lint.cpplint.options",
       "--filter=-build/include_order,-whitespace/braces,-whitespace/newline");
     $console->writeOut("Linters are enabled.\n");


### PR DESCRIPTION
Summary: Attempting to run the linters from anywhere aside from the project root used to fail.  Update the prefix for cpplint to include the full path to solve this problem.

Test Plan: N/A