### PR TITLE
Copy and move index file only when there are changes

### DIFF
--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -2856,7 +2856,9 @@ int MYSQL_BIN_LOG::remove_deleted_logs_from_index(bool need_lock_index,
     ++no_of_log_files_purged;
   }
 
-  error= remove_logs_from_index(&log_info, need_update_threads);
+  if (no_of_log_files_purged)
+    error= remove_logs_from_index(&log_info, need_update_threads);
+
   DBUG_PRINT("info",("num binlogs deleted = %d",no_of_log_files_purged));
 
 err:
@@ -4577,8 +4579,7 @@ int MYSQL_BIN_LOG::purge_logs(const char *to_log,
 {
   int error= 0, error_index= 0,
       no_of_log_files_to_purge= 0,
-      no_of_log_files_purged= 0;
-  int no_of_threads_locking_log= 0;
+      no_of_threads_locking_log= 0;
   bool exit_loop= 0;
   LOG_INFO log_info;
   THD *thd= current_thd;
@@ -4626,10 +4627,9 @@ int MYSQL_BIN_LOG::purge_logs(const char *to_log,
                             ER_WARN_PURGE_LOG_IN_USE,
                             ER(ER_WARN_PURGE_LOG_IN_USE),
                             log_info.log_file_name,  no_of_threads_locking_log,
-                            no_of_log_files_purged, no_of_log_files_to_purge);
+                            delete_list.size(), no_of_log_files_to_purge);
       break;
     }
-    no_of_log_files_purged++;
 
     delete_list.push_back(std::string(log_info.log_file_name));
 
@@ -4647,12 +4647,15 @@ int MYSQL_BIN_LOG::purge_logs(const char *to_log,
 
   DBUG_EXECUTE_IF("crash_purge_critical_before_update_index", DBUG_SUICIDE(););
 
-  /* We know how many files to delete. Update index file. */
-  if ((error=remove_logs_from_index(&log_info, need_update_threads)))
+  if (delete_list.size())
   {
-    sql_print_error("MYSQL_BIN_LOG::purge_logs"
-                    " failed to update the index file");
-    goto err;
+    /* We know how many files to delete. Update index file. */
+    if ((error=remove_logs_from_index(&log_info, need_update_threads)))
+    {
+      sql_print_error("MYSQL_BIN_LOG::purge_logs"
+          " failed to update the index file");
+      goto err;
+    }
   }
 
   DBUG_EXECUTE_IF("crash_purge_non_critical_after_update_index", DBUG_SUICIDE(););


### PR DESCRIPTION
Summary: When index file is updated, it is first copied to a crash safe index
file, updates are made to the crash safe file and finally the crash safe file is
renamed. During purge, all this should happen only when at least one log is
being removed.

Test Plan: Checked if all existing test cases pass