### PR TITLE
Increasing default RocksDB write buffer and block cache size

### DIFF
--- a/mysql-test/r/mysqld--help-notwin-profiling.result
+++ b/mysql-test/r/mysqld--help-notwin-profiling.result
@@ -1895,7 +1895,7 @@ rocksdb-allow-mmap-writes FALSE
 rocksdb-allow-os-buffer TRUE
 rocksdb-background-sync FALSE
 rocksdb-base-background-compactions 1
-rocksdb-block-cache-size 8388608
+rocksdb-block-cache-size 536870912
 rocksdb-block-restart-interval 16
 rocksdb-block-size 4096
 rocksdb-block-size-deviation 10

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -1892,7 +1892,7 @@ rocksdb-allow-mmap-writes FALSE
 rocksdb-allow-os-buffer TRUE
 rocksdb-background-sync FALSE
 rocksdb-base-background-compactions 1
-rocksdb-block-cache-size 8388608
+rocksdb-block-cache-size 536870912
 rocksdb-block-restart-interval 16
 rocksdb-block-size 4096
 rocksdb-block-size-deviation 10

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -865,7 +865,7 @@ rocksdb_allow_mmap_writes	OFF
 rocksdb_allow_os_buffer	ON
 rocksdb_background_sync	OFF
 rocksdb_base_background_compactions	1
-rocksdb_block_cache_size	8388608
+rocksdb_block_cache_size	536870912
 rocksdb_block_restart_interval	16
 rocksdb_block_size	4096
 rocksdb_block_size_deviation	10

--- a/mysql-test/suite/rocksdb/r/statistics.result
+++ b/mysql-test/suite/rocksdb/r/statistics.result
@@ -21,8 +21,8 @@ index t3_1(b) comment 'rev:cf_t4'
 ) engine=rocksdb;
 SELECT table_name, table_rows FROM information_schema.tables WHERE table_schema = DATABASE() and table_name <> 't1';
 table_name	table_rows
-t2	4999
-t3	4999
+t2	1000
+t3	1000
 SELECT CASE WHEN table_rows < 100000 then 'true' else 'false' end from information_schema.tables where table_name = 't1';
 CASE WHEN table_rows < 100000 then 'true' else 'false' end
 true

--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_block_cache_size_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_block_cache_size_basic.result
@@ -1,7 +1,7 @@
 SET @start_global_value = @@global.ROCKSDB_BLOCK_CACHE_SIZE;
 SELECT @start_global_value;
 @start_global_value
-8388608
+536870912
 "Trying to set variable @@global.ROCKSDB_BLOCK_CACHE_SIZE to 444. It should fail because it is readonly."
 SET @@global.ROCKSDB_BLOCK_CACHE_SIZE   = 444;
 ERROR HY000: Variable 'rocksdb_block_cache_size' is a read only variable

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -843,7 +843,7 @@ static MYSQL_SYSVAR_BOOL(enable_thread_tracking,
 static MYSQL_SYSVAR_LONGLONG(block_cache_size, rocksdb_block_cache_size,
   PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
   "block_cache size for RocksDB",
-  nullptr, nullptr, /* RocksDB's default is 8 MB: */ 8*1024*1024L,
+  nullptr, nullptr, 512*1024*1024L,
   /* min */ 1024L, /* max */ LONGLONG_MAX, /* Block size */1024L);
 
 static MYSQL_SYSVAR_BOOL(cache_index_and_filter_blocks,
@@ -1130,7 +1130,6 @@ static MYSQL_SYSVAR_UINT(
   RDB_DEFAULT_TBL_STATS_SAMPLE_PCT, /* everything */ 0,
   /* max */ RDB_TBL_STATS_SAMPLE_PCT_MAX, 0);
 
-static const longlong ROCKSDB_WRITE_BUFFER_SIZE_DEFAULT= 4194304;
 static const int ROCKSDB_ASSUMED_KEY_VALUE_DISK_SIZE= 100;
 
 static struct st_mysql_sys_var* rocksdb_system_variables[]= {
@@ -3569,7 +3568,7 @@ static int rocksdb_init_func(void *p)
     mysql_mutex_unlock(&rdb_sysvars_mutex);
   }
 
-  if (!rocksdb_cf_options_map.init(ROCKSDB_WRITE_BUFFER_SIZE_DEFAULT,
+  if (!rocksdb_cf_options_map.init(
                                    rocksdb_tbl_options,
                                    properties_collector_factory,
                                    rocksdb_default_cf_options,

--- a/storage/rocksdb/rdb_cf_options.cc
+++ b/storage/rocksdb/rdb_cf_options.cc
@@ -41,7 +41,6 @@ Rdb_pk_comparator Rdb_cf_options::s_pk_comparator;
 Rdb_rev_comparator Rdb_cf_options::s_rev_pk_comparator;
 
 bool Rdb_cf_options::init(
-  size_t default_write_buffer_size,
   const rocksdb::BlockBasedTableOptions& table_options,
   std::shared_ptr<rocksdb::TablePropertiesCollectorFactory> prop_coll_factory,
   const char * default_cf_options,
@@ -50,7 +49,6 @@ bool Rdb_cf_options::init(
   m_default_cf_opts.comparator = &s_pk_comparator;
   m_default_cf_opts.compaction_filter_factory.reset(
     new Rdb_compact_filter_factory);
-  m_default_cf_opts.write_buffer_size = default_write_buffer_size;
 
   m_default_cf_opts.table_factory.reset(
     rocksdb::NewBlockBasedTableFactory(table_options));

--- a/storage/rocksdb/rdb_cf_options.h
+++ b/storage/rocksdb/rdb_cf_options.h
@@ -44,7 +44,6 @@ class Rdb_cf_options
   void get(const std::string &cf_name, rocksdb::ColumnFamilyOptions *opts);
 
   bool init(
-    size_t default_write_buffer_size,
     const rocksdb::BlockBasedTableOptions& table_options,
     std::shared_ptr<rocksdb::TablePropertiesCollectorFactory> prop_coll_factory,
     const char * default_cf_options,


### PR DESCRIPTION
Summary: This diff increases RocksDB default write buffer size
from 4MB to 64MB, and block cache size from 8MB to 512MB.

Test Plan: mtr