### PR TITLE
Fix build issues related to compression libraries

### DIFF
--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -56,32 +56,26 @@ ENDIF()
 SET(rocksdb_static_libs )
 IF (NOT "$ENV{WITH_SNAPPY}" STREQUAL "")
   SET(rocksdb_static_libs ${rocksdb_static_libs}
-  $ENV{WITH_SNAPPY}/lib/libsnappy${PIC_EXT}.a)
+  $ENV{WITH_SNAPPY}/libsnappy${PIC_EXT}.a)
   ADD_DEFINITIONS(-DSNAPPY)
-ELSE()
-  SET(rocksdb_static_libs ${rocksdb_static_libs} snappy)
 ENDIF()
 
 IF (NOT "$ENV{WITH_LZ4}" STREQUAL "")
   SET(rocksdb_static_libs ${rocksdb_static_libs}
-  $ENV{WITH_LZ4}/lib/liblz4${PIC_EXT}.a)
+  $ENV{WITH_LZ4}/liblz4${PIC_EXT}.a)
   ADD_DEFINITIONS(-DLZ4)
-ELSE()
-  SET(rocksdb_static_libs ${rocksdb_static_libs} lz4)
 ENDIF()
 
 IF (NOT "$ENV{WITH_BZ2}" STREQUAL "")
   SET(rocksdb_static_libs ${rocksdb_static_libs}
-  $ENV{WITH_BZ2}/lib/libbz2${PIC_EXT}.a)
+  $ENV{WITH_BZ2}/libbz2${PIC_EXT}.a)
   ADD_DEFINITIONS(-DBZIP2)
-ELSE()
-  SET(rocksdb_static_libs ${rocksdb_static_libs} bz2)
 ENDIF()
 
 # link ZSTD only if instructed
 IF (NOT "$ENV{WITH_ZSTD}" STREQUAL "")
   SET(rocksdb_static_libs ${rocksdb_static_libs}
-  $ENV{WITH_ZSTD}/lib/libzstd${PIC_EXT}.a)
+  $ENV{WITH_ZSTD}/libzstd${PIC_EXT}.a)
   ADD_DEFINITIONS(-DZSTD)
 ENDIF()
 


### PR DESCRIPTION
This set of changes is a fix for
https://github.com/facebook/mysql-5.6/issues/354 and
https://github.com/facebook/mysql-5.6/issues/351. It doesn't fix
https://github.com/facebook/mysql-5.6/issues/104 which is related to
`libz` usage and will be handled separately.

We're changing the way how the path for compression libraries is getting
specified. Before it was assumed that a library will be under whatever
prefix + `lib`. This isn't necessarily true. For example on Ubuntu
`libsnappy.a` can be found under `/usr/lib/x86_64-linux-gnu/` or one may
choose to use a privately built version of a library from some other
location.

Here's the sequence of changes needed to fix this for both external and
internal builds:

  - Push the current changes. This will break internal builds
    temporarily.
  - Push internal toolset related changes. This will fix internal
    builds.
  - Update the build instructions at
    https://github.com/facebook/mysql-5.6/wiki/Build-Steps to clarify
    that full path prefix for compression libraries needs to be
    specified.