### PR TITLE
Issue #444: compression_zstd test fails when the server is compiled w…

### DIFF
--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -855,7 +855,10 @@ ERROR 42S02: Unknown table 'test.t45'
 # Now it fails if there is data overlap with what
 # already exists
 #
-show variables like 'rocksdb%';
+show variables
+where
+variable_name like 'rocksdb%' and
+variable_name not like 'rocksdb_supported_compression_types';
 Variable_name	Value
 rocksdb_access_hint_on_compaction_start	1
 rocksdb_advise_random_on_open	ON

--- a/mysql-test/suite/rocksdb/t/compression_zstd-master.opt
+++ b/mysql-test/suite/rocksdb/t/compression_zstd-master.opt
@@ -1,1 +1,0 @@
---rocksdb_default_cf_options=compression_per_level=kZSTDNotFinalCompression;compression_opts=-14:4:0

--- a/mysql-test/suite/rocksdb/t/compression_zstd.test
+++ b/mysql-test/suite/rocksdb/t/compression_zstd.test
@@ -1,4 +1,14 @@
 --source include/have_rocksdb.inc
 
+let $no_zstd=`select @@rocksdb_supported_compression_types NOT LIKE '%ZSTD%'`;
+
+if ($no_zstd)
+{
+  -- Skip Requires RocksDB to be built with ZStandard Compression support
+}
+
+--let $_mysqld_option=--rocksdb_default_cf_options=compression_per_level=kZSTDNotFinalCompression;compression_opts=-14:4:0;
+--source include/restart_mysqld_with_option.inc
+
 create table t (id int primary key) engine=rocksdb;
 drop table t;

--- a/mysql-test/suite/rocksdb/t/rocksdb.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb.test
@@ -785,7 +785,11 @@ drop table t45;
 --echo # Now it fails if there is data overlap with what
 --echo # already exists
 --echo #
-show variables like 'rocksdb%';
+show variables
+where
+  variable_name like 'rocksdb%' and
+  variable_name not like 'rocksdb_supported_compression_types';
+
 create table t47 (pk int primary key, col1 varchar(12)) engine=rocksdb;
 insert into t47 values (1, 'row1');
 insert into t47 values (2, 'row2');

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -415,6 +415,9 @@ static my_bool rocksdb_enable_bulk_load_api= 1;
 static my_bool rpl_skip_tx_api_var= 0;
 static my_bool rocksdb_print_snapshot_conflict_queries= 0;
 
+char *compression_types_val=
+  const_cast<char*>(get_rocksdb_supported_compression_types());
+
 std::atomic<uint64_t> rocksdb_snapshot_conflict_errors(0);
 
 static rocksdb::DBOptions rdb_init_rocksdb_db_options(void)
@@ -1116,6 +1119,13 @@ static MYSQL_SYSVAR_STR(datadir,
   "RocksDB data directory",
   nullptr, nullptr, "./.rocksdb");
 
+static MYSQL_SYSVAR_STR(supported_compression_types,
+  compression_types_val,
+  PLUGIN_VAR_NOCMDOPT | PLUGIN_VAR_READONLY,
+  "Compression algorithms supported by RocksDB",
+  nullptr, nullptr,
+  compression_types_val);
+
 static MYSQL_SYSVAR_UINT(
   table_stats_sampling_pct,
   rocksdb_table_stats_sampling_pct,
@@ -1240,6 +1250,7 @@ static struct st_mysql_sys_var* rocksdb_system_variables[]= {
   MYSQL_SYSVAR(print_snapshot_conflict_queries),
 
   MYSQL_SYSVAR(datadir),
+  MYSQL_SYSVAR(supported_compression_types),
   MYSQL_SYSVAR(create_checkpoint),
 
   MYSQL_SYSVAR(checksums_pct),

--- a/storage/rocksdb/rdb_utils.cc
+++ b/storage/rocksdb/rdb_utils.cc
@@ -27,6 +27,17 @@
 /* MyRocks header files */
 #include "./ha_rocksdb.h"
 
+/*
+  Both innobase/include/ut0counter.h and rocksdb/port/port_posix.h define
+  CACHE_LINE_SIZE.
+*/
+#ifdef CACHE_LINE_SIZE
+#  undef CACHE_LINE_SIZE
+#endif
+
+/* RocksDB header files */
+#include "util/compression.h"
+
 namespace myrocks {
 
 /*
@@ -306,6 +317,43 @@ bool rdb_database_exists(const std::string& db_name)
 
   my_dirend(dir_info);
   return true;
+}
+
+
+/*
+  @brief
+     Return a comma-separated string with compiled-in compression types.
+     Not thread-safe.
+*/
+const char *get_rocksdb_supported_compression_types()
+{
+  static std::string compression_methods_buf;
+  static bool inited=false;
+  if (!inited)
+  {
+    inited= true;
+    std::vector<rocksdb::CompressionType> known_types=
+    {
+      rocksdb::kSnappyCompression,
+      rocksdb::kZlibCompression,
+      rocksdb::kBZip2Compression,
+      rocksdb::kLZ4Compression,
+      rocksdb::kLZ4HCCompression,
+      rocksdb::kXpressCompression,
+      rocksdb::kZSTDNotFinalCompression
+    };
+
+    for (auto typ : known_types)
+    {
+      if (CompressionTypeSupported(typ))
+      {
+        if (compression_methods_buf.size())
+          compression_methods_buf.append(",");
+        compression_methods_buf.append(CompressionTypeToString(typ));
+      }
+    }
+  }
+  return compression_methods_buf.c_str();
 }
 
 }  // namespace myrocks

--- a/storage/rocksdb/rdb_utils.h
+++ b/storage/rocksdb/rdb_utils.h
@@ -203,4 +203,6 @@ std::string rdb_hexdump(const char *data, std::size_t data_len,
  */
 bool rdb_database_exists(const std::string& db_name);
 
+const char *get_rocksdb_supported_compression_types();
+
 }  // namespace myrocks


### PR DESCRIPTION
…ithout ZStandard

- Introduce @@rocksdb_supported_compression_types read-only variable.
  It has a comma-separated list of compiled-in compression algorithms.

- Make rocksdb.compression_zstd test skip itself when ZSTD support
  is not compiled in