### PR TITLE
Issue #376: MyRocks: ORDER BY optimizer is unable to use the index ex…

### DIFF
--- a/mysql-test/suite/rocksdb/r/index.result
+++ b/mysql-test/suite/rocksdb/r/index.result
@@ -40,3 +40,23 @@ t1	0	PRIMARY	1	pk	A	#	NULL	NULL		LSMTREE
 t1	1	a	1	a	A	#	NULL	NULL	YES	LSMTREE		simple index on a
 ALTER TABLE t1 DROP KEY a;
 DROP TABLE t1;
+#
+# Issue #376: MyRocks: ORDER BY optimizer is unable to use the index extension
+#
+create table t0 (a int);
+insert into t0 values (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+create table t1(a int);
+insert into t1 select A.a + B.a* 10 + C.a * 100 from t0 A, t0 B, t0 C;
+create table t2 (
+pk int not null,
+a  int not null,
+b  int not null,
+primary key(pk),
+key(a) 
+) engine=rocksdb;
+insert into t2 select A.a, FLOOR(A.a/10), A.a from t1 A;
+# This must have type=range, index=a, and must not have 'Using filesort':
+explain select * from t2 force index (a) where a=0 and pk>=3 order by pk;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	range	a	a	8	NULL	#	Using index condition
+drop table t0,t1,t2;

--- a/mysql-test/suite/rocksdb/t/index.test
+++ b/mysql-test/suite/rocksdb/t/index.test
@@ -20,4 +20,25 @@
 
 --source index.inc
 
+--echo #
+--echo # Issue #376: MyRocks: ORDER BY optimizer is unable to use the index extension
+--echo #
+create table t0 (a int);
+insert into t0 values (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+create table t1(a int);
+insert into t1 select A.a + B.a* 10 + C.a * 100 from t0 A, t0 B, t0 C;
+create table t2 (
+  pk int not null,
+  a  int not null,
+  b  int not null,
+  primary key(pk),
+  key(a) 
+) engine=rocksdb;
+insert into t2 select A.a, FLOOR(A.a/10), A.a from t1 A;
+
+--echo # This must have type=range, index=a, and must not have 'Using filesort':
+--replace_column 9 #
+explain select * from t2 force index (a) where a=0 and pk>=3 order by pk;
+
+drop table t0,t1,t2;
 

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -4972,6 +4972,18 @@ int ha_rocksdb::open(const char *name, int mode, uint test_if_locked)
     DBUG_RETURN(err);
   }
 
+  /*
+    init_with_fields() is used to initialize table flags based on the field
+    definitions in table->field[].
+    It is called by open_binary_frm(), but that function calls the method for
+    a temporary ha_rocksdb object which is later destroyed.
+
+    If we are here in ::open(), then init_with_fields() has not been called
+    for this object. Call it ourselves, we want all member variables to be
+    properly initialized.
+  */
+  init_with_fields();
+
   setup_field_converters();
 
   info(HA_STATUS_NO_LOCK | HA_STATUS_VARIABLE | HA_STATUS_CONST);


### PR DESCRIPTION
…tension

Make ha_rocksdb::open() call ha_rocksdb::init_with_fields.

ha_rocksdb::init_with_fields() is normally called by open_binary_frm()
when TABLE object has table->fields[] set up. This allows ha_rocksdb
to set proper table flags.

However, ha_rocksdb objects that are used for reading/writing rows are
not created by open_binary_frm, so nobody calls init_with_fields() for
them.
This trivial fix just adds init_with_fields() call which is made before
ha_rocksdb object is used.