### PR TITLE
Yield the background thread when not necessary (#465)

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -10600,17 +10600,23 @@ static SHOW_VAR rocksdb_status_vars[]= {
 
 void Rdb_background_thread::run()
 {
+  // How many seconds to wait till flushing the WAL next time.
+  const int WAKE_UP_INTERVAL = 1;
+
   timespec ts_next_sync;
   clock_gettime(CLOCK_REALTIME, &ts_next_sync);
-  ts_next_sync.tv_sec++;
+  ts_next_sync.tv_sec += WAKE_UP_INTERVAL;
 
   for (;;)
   {
-    // wait for 1 second or until we received a condition to stop the thread
+    // Wait until the next timeout or until we receive a signal to stop the
+    // thread. Request to stop the thread should only be triggered when the
+    // storage engine is being unloaded.
     mysql_mutex_lock(&m_signal_mutex);
     auto ret __attribute__((__unused__)) = mysql_cond_timedwait(
-        &m_signal_cond, &m_signal_mutex, &ts_next_sync);
-    // make sure that no program error is returned
+      &m_signal_cond, &m_signal_mutex, &ts_next_sync);
+
+    // Check that we receive only the expected error codes.
     DBUG_ASSERT(ret == 0 || ret == ETIMEDOUT);
     bool local_stop= m_stop;
     bool local_save_stats= m_save_stats;
@@ -10619,29 +10625,37 @@ void Rdb_background_thread::run()
 
     if (local_stop)
     {
+      // If we're here then that's because condition variable was signaled by
+      // another thread and we're shutting down. Break out the loop to make
+      // sure that shutdown thread can proceed.
+      DBUG_ASSERT(ret == 0);
       break;
     }
+
+    // This path should be taken only when the timer expired.
+    DBUG_ASSERT(ret == ETIMEDOUT);
 
     if (local_save_stats)
     {
       ddl_manager.persist_stats();
     }
 
-    // Flush the WAL if need be but don't do it more frequent
-    // than once per second
     timespec ts;
     clock_gettime(CLOCK_REALTIME, &ts);
-    if (ts.tv_sec - ts_next_sync.tv_sec >= 1)
+
+    // Flush the WAL.
+    if (rdb && rocksdb_background_sync)
     {
-      if (rdb && rocksdb_background_sync)
-      {
-        DBUG_ASSERT(!rocksdb_db_options.allow_mmap_writes);
-        rocksdb::Status s= rdb->SyncWAL();
-        if (!s.ok())
-          rdb_handle_io_error(s, RDB_IO_ERROR_BG_THREAD);
+      DBUG_ASSERT(!rocksdb_db_options.allow_mmap_writes);
+      rocksdb::Status s= rdb->SyncWAL();
+      if (!s.ok()) {
+        rdb_handle_io_error(s, RDB_IO_ERROR_BG_THREAD);
       }
-      ts_next_sync.tv_sec= ts.tv_sec + 1;
     }
+
+    // Set the next timestamp for mysql_cond_timedwait() (which ends up calling
+    // pthread_cond_timedwait()) to wait on.
+    ts_next_sync.tv_sec= ts.tv_sec + WAKE_UP_INTERVAL;
   }
 
   // save remaining stats which might've left unsaved


### PR DESCRIPTION
These changes are the proposed fix for
https://github.com/facebook/mysql-5.6/issues/465. The intent of the
background thread is to wake up once per second and call SyncWAL() if
all the preconditions are met.

Previous implementation ended up constantly looping because of a logic
error. This solution removes the unnecessary checks and uses a call to
`mysql_cond_timedwait()` (ends up being `pthread_cond_timedwait()`) to
make sure that thread yields its quantum and OS scheduler can do its
thing while we're waiting for the timer to expire.

We still loop, but for the majority of the time we end up sleeping and
not using the CPU.

Basic testing:

  - Verify that function body is called once per second. If we need then
    we can tune it to be more precise and use what approximate amount of
    ms-s or ns-s we desire.
  - Before the fix the code path was executed hundreds of time per
    second and 25-49% of CPU was utilized. After the fix `htop` show
    marginal (0.0%) utilization.
  - `perf` records multiple orders of magnitude less events than before.

Fixes #465.