### PR TITLE
Remove an incorrect assertion

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -10628,7 +10628,6 @@ void Rdb_background_thread::run()
       // If we're here then that's because condition variable was signaled by
       // another thread and we're shutting down. Break out the loop to make
       // sure that shutdown thread can proceed.
-      DBUG_ASSERT(ret == 0);
       break;
     }
 


### PR DESCRIPTION
The invariant is incorrect when it comes to `pthread_cond_timedwait`
behavior. See documentation at
http://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_cond_timedwait.html
for more context.

Squash with: D4294886