### PR TITLE
rename rocksdb_disable_2pc to rocksdb_enable_2pc, default true

### DIFF
--- a/mysql-test/r/mysqld--help-notwin-profiling.result
+++ b/mysql-test/r/mysqld--help-notwin-profiling.result
@@ -1125,11 +1125,11 @@ The following options may be given as the first argument:
  --rocksdb-delete-obsolete-files-period-micros=# 
  DBOptions::delete_obsolete_files_period_micros for
  RocksDB
- --rocksdb-disable-2pc 
- Disable two phase commit for MyRocks
- (Defaults to on; use --skip-rocksdb-disable-2pc to disable.)
  --rocksdb-disabledatasync 
  DBOptions::disableDataSync for RocksDB
+ --rocksdb-enable-2pc 
+ Enable two phase commit for MyRocks
+ (Defaults to on; use --skip-rocksdb-enable-2pc to disable.)
  --rocksdb-enable-bulk-load-api 
  Enables using SstFileWriter for bulk loading
  (Defaults to on; use --skip-rocksdb-enable-bulk-load-api to disable.)
@@ -1948,8 +1948,8 @@ rocksdb-debug-optimizer-n-rows 0
 rocksdb-debug-optimizer-no-zero-cardinality TRUE
 rocksdb-default-cf-options 
 rocksdb-delete-obsolete-files-period-micros 21600000000
-rocksdb-disable-2pc TRUE
 rocksdb-disabledatasync FALSE
+rocksdb-enable-2pc TRUE
 rocksdb-enable-bulk-load-api TRUE
 rocksdb-enable-thread-tracking FALSE
 rocksdb-enable-write-thread-adaptive-yield TRUE

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -1123,11 +1123,11 @@ The following options may be given as the first argument:
  --rocksdb-delete-obsolete-files-period-micros=# 
  DBOptions::delete_obsolete_files_period_micros for
  RocksDB
- --rocksdb-disable-2pc 
- Disable two phase commit for MyRocks
- (Defaults to on; use --skip-rocksdb-disable-2pc to disable.)
  --rocksdb-disabledatasync 
  DBOptions::disableDataSync for RocksDB
+ --rocksdb-enable-2pc 
+ Enable two phase commit for MyRocks
+ (Defaults to on; use --skip-rocksdb-enable-2pc to disable.)
  --rocksdb-enable-bulk-load-api 
  Enables using SstFileWriter for bulk loading
  (Defaults to on; use --skip-rocksdb-enable-bulk-load-api to disable.)
@@ -1945,8 +1945,8 @@ rocksdb-debug-optimizer-n-rows 0
 rocksdb-debug-optimizer-no-zero-cardinality TRUE
 rocksdb-default-cf-options 
 rocksdb-delete-obsolete-files-period-micros 21600000000
-rocksdb-disable-2pc TRUE
 rocksdb-disabledatasync FALSE
+rocksdb-enable-2pc TRUE
 rocksdb-enable-bulk-load-api TRUE
 rocksdb-enable-thread-tracking FALSE
 rocksdb-enable-write-thread-adaptive-yield TRUE

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -891,8 +891,8 @@ rocksdb_deadlock_detect	OFF
 rocksdb_debug_optimizer_no_zero_cardinality	ON
 rocksdb_default_cf_options	
 rocksdb_delete_obsolete_files_period_micros	21600000000
-rocksdb_disable_2pc	ON
 rocksdb_disabledatasync	OFF
+rocksdb_enable_2pc	ON
 rocksdb_enable_bulk_load_api	ON
 rocksdb_enable_thread_tracking	OFF
 rocksdb_enable_write_thread_adaptive_yield	ON

--- a/mysql-test/suite/rocksdb_rpl/r/multiclient_2pc.result
+++ b/mysql-test/suite/rocksdb_rpl/r/multiclient_2pc.result
@@ -1,5 +1,5 @@
 DROP TABLE IF EXISTS t1;
-SET GLOBAL ROCKSDB_DISABLE_2PC = OFF;
+SET GLOBAL ROCKSDB_ENABLE_2PC = ON;
 create table t1 (a int primary key, b int, c varchar(255)) engine=rocksdb;
 'con1'
 SET SESSION debug="d,crash_commit_after_log";
@@ -7,11 +7,11 @@ SET DEBUG_SYNC='rocksdb.prepared SIGNAL parked WAIT_FOR go';
 insert into t1 values (1, 1, "iamtheogthealphaandomega");;
 'con2'
 insert into t1 values (2, 1, "i_am_just_here_to_trigger_a_flush");
-SET GLOBAL ROCKSDB_DISABLE_2PC = ON;
+SET GLOBAL ROCKSDB_ENABLE_2PC = OFF;
 SET GLOBAL ROCKSDB_WRITE_SYNC = OFF;
 SET GLOBAL SYNC_BINLOG = 0;
 SET DEBUG_SYNC='now WAIT_FOR parked';
-SET GLOBAL ROCKSDB_DISABLE_2PC = OFF;
+SET GLOBAL ROCKSDB_ENABLE_2PC = ON;
 SET GLOBAL ROCKSDB_WRITE_SYNC = ON;
 SET GLOBAL SYNC_BINLOG = 1;
 insert into t1 values (1000000, 1, "i_am_just_here_to_trigger_a_flush");

--- a/mysql-test/suite/rocksdb_rpl/r/rpl_rocksdb_2pc_crash_recover.result
+++ b/mysql-test/suite/rocksdb_rpl/r/rpl_rocksdb_2pc_crash_recover.result
@@ -1,18 +1,18 @@
 DROP TABLE IF EXISTS t1;
 create table t1 (a int primary key, msg varchar(255)) engine=rocksdb;
-SET GLOBAL ROCKSDB_DISABLE_2PC = OFF;
+SET GLOBAL ROCKSDB_ENABLE_2PC = ON;
 SET SESSION debug="d,crash_commit_after_prepare";
 insert into t1 values (1, 'dogz');
 select * from t1;
 a	msg
-SET GLOBAL ROCKSDB_DISABLE_2PC = OFF;
+SET GLOBAL ROCKSDB_ENABLE_2PC = ON;
 SET SESSION debug="d,crash_commit_after_log";
 insert into t1 values (2, 'catz'), (3, 'men');
 select * from t1;
 a	msg
 2	catz
 3	men
-SET GLOBAL ROCKSDB_DISABLE_2PC = OFF;
+SET GLOBAL ROCKSDB_ENABLE_2PC = ON;
 SET SESSION debug="d,crash_commit_after";
 insert into t1 values (4, 'cars'), (5, 'foo');
 select * from t1;
@@ -21,7 +21,7 @@ a	msg
 3	men
 4	cars
 5	foo
-SET GLOBAL ROCKSDB_DISABLE_2PC = ON;
+SET GLOBAL ROCKSDB_ENABLE_2PC = OFF;
 SET SESSION debug="d,crash_commit_after_log";
 insert into t1 values (6, 'shipz'), (7, 'tankz');
 select * from t1;
@@ -30,7 +30,7 @@ a	msg
 3	men
 4	cars
 5	foo
-SET GLOBAL ROCKSDB_DISABLE_2PC = ON;
+SET GLOBAL ROCKSDB_ENABLE_2PC = OFF;
 SET SESSION debug="d,crash_commit_after";
 insert into t1 values (8, 'space'), (9, 'time');
 select * from t1;

--- a/mysql-test/suite/rocksdb_rpl/t/multiclient_2pc.test
+++ b/mysql-test/suite/rocksdb_rpl/t/multiclient_2pc.test
@@ -10,7 +10,7 @@
 DROP TABLE IF EXISTS t1;
 --enable_warnings
 
-SET GLOBAL ROCKSDB_DISABLE_2PC = OFF;
+SET GLOBAL ROCKSDB_ENABLE_2PC = ON;
 create table t1 (a int primary key, b int, c varchar(255)) engine=rocksdb;
 
 connect (con1, localhost, root,,);
@@ -35,7 +35,7 @@ insert into t1 values (2, 1, "i_am_just_here_to_trigger_a_flush");
 
 # Disable 2PC and syncing for faster inserting of dummy rows
 # These rows only purpose is to rotate the binlog
-SET GLOBAL ROCKSDB_DISABLE_2PC = ON;
+SET GLOBAL ROCKSDB_ENABLE_2PC = ON;
 SET GLOBAL ROCKSDB_WRITE_SYNC = OFF;
 SET GLOBAL SYNC_BINLOG = 0;
 
@@ -50,7 +50,7 @@ while ($pk < 1000000) {
 
 # re-enable 2PC an syncing then write to trigger a flush
 # before we trigger the crash to simulate full-durability
-SET GLOBAL ROCKSDB_DISABLE_2PC = OFF;
+SET GLOBAL ROCKSDB_ENABLE_2PC = ON;
 SET GLOBAL ROCKSDB_WRITE_SYNC = ON;
 SET GLOBAL SYNC_BINLOG = 1;
 

--- a/mysql-test/suite/rocksdb_rpl/t/rpl_crash_safe_wal_corrupt.cnf
+++ b/mysql-test/suite/rocksdb_rpl/t/rpl_crash_safe_wal_corrupt.cnf
@@ -2,8 +2,10 @@
 
 [mysqld.1]
 log_slave_updates
+rocksdb_enable_2pc=OFF
 
 [mysqld.2]
 relay_log_recovery=1
 relay_log_info_repository=TABLE
 log_slave_updates
+rocksdb_enable_2pc=OFF

--- a/mysql-test/suite/rocksdb_rpl/t/rpl_gtid_crash_safe_wal_corrupt.cnf
+++ b/mysql-test/suite/rocksdb_rpl/t/rpl_gtid_crash_safe_wal_corrupt.cnf
@@ -4,6 +4,7 @@
 log_slave_updates
 gtid_mode=ON
 enforce_gtid_consistency=ON
+rocksdb_enable_2pc=OFF
 
 [mysqld.2]
 sync_relay_log_info=100
@@ -12,3 +13,4 @@ relay_log_info_repository=FILE
 log_slave_updates
 gtid_mode=ON
 enforce_gtid_consistency=ON
+rocksdb_enable_2pc=OFF

--- a/mysql-test/suite/rocksdb_rpl/t/rpl_rocksdb_2pc_crash_recover.test
+++ b/mysql-test/suite/rocksdb_rpl/t/rpl_rocksdb_2pc_crash_recover.test
@@ -8,7 +8,7 @@ DROP TABLE IF EXISTS t1;
 
 create table t1 (a int primary key, msg varchar(255)) engine=rocksdb;
 
-SET GLOBAL ROCKSDB_DISABLE_2PC = OFF;
+SET GLOBAL ROCKSDB_ENABLE_2PC = ON;
 --exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 SET SESSION debug="d,crash_commit_after_prepare";
 --error 0,2013
@@ -17,7 +17,7 @@ insert into t1 values (1, 'dogz');
 --source include/wait_until_connected_again.inc
 select * from t1;
 
-SET GLOBAL ROCKSDB_DISABLE_2PC = OFF;
+SET GLOBAL ROCKSDB_ENABLE_2PC = ON;
 --exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 SET SESSION debug="d,crash_commit_after_log";
 --error 0,2013
@@ -26,7 +26,7 @@ insert into t1 values (2, 'catz'), (3, 'men');
 --source include/wait_until_connected_again.inc
 select * from t1;
 
-SET GLOBAL ROCKSDB_DISABLE_2PC = OFF;
+SET GLOBAL ROCKSDB_ENABLE_2PC = ON;
 --exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 SET SESSION debug="d,crash_commit_after";
 --error 0,2013
@@ -35,7 +35,7 @@ insert into t1 values (4, 'cars'), (5, 'foo');
 --source include/wait_until_connected_again.inc
 select * from t1;
 
-SET GLOBAL ROCKSDB_DISABLE_2PC = ON;
+SET GLOBAL ROCKSDB_ENABLE_2PC = OFF;
 --exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 SET SESSION debug="d,crash_commit_after_log";
 --error 0,2013
@@ -44,7 +44,7 @@ insert into t1 values (6, 'shipz'), (7, 'tankz');
 --source include/wait_until_connected_again.inc
 select * from t1;
 
-SET GLOBAL ROCKSDB_DISABLE_2PC = ON;
+SET GLOBAL ROCKSDB_ENABLE_2PC = OFF;
 --exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 SET SESSION debug="d,crash_commit_after";
 --error 0,2013

--- a/mysql-test/suite/rocksdb_sys_vars/r/all_vars.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/all_vars.result
@@ -9,5 +9,7 @@ There should be *no* long test name listed below:
 select variable_name as `There should be *no* variables listed below:` from t2
 left join t1 on variable_name=test_name where test_name is null ORDER BY variable_name;
 There should be *no* variables listed below:
+ROCKSDB_ENABLE_2PC
+ROCKSDB_ENABLE_2PC
 drop table t1;
 drop table t2;

--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_disable_2pc_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_disable_2pc_basic.result
@@ -6,70 +6,70 @@ INSERT INTO valid_values VALUES('off');
 CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
 INSERT INTO invalid_values VALUES('\'aaa\'');
 INSERT INTO invalid_values VALUES('\'bbb\'');
-SET @start_global_value = @@global.ROCKSDB_DISABLE_2PC;
+SET @start_global_value = @@global.ROCKSDB_ENABLE_2PC;
 SELECT @start_global_value;
 @start_global_value
 1
 '# Setting to valid values in global scope#'
-"Trying to set variable @@global.ROCKSDB_DISABLE_2PC to 1"
-SET @@global.ROCKSDB_DISABLE_2PC   = 1;
-SELECT @@global.ROCKSDB_DISABLE_2PC;
-@@global.ROCKSDB_DISABLE_2PC
+"Trying to set variable @@global.ROCKSDB_ENABLE_2PC to 1"
+SET @@global.ROCKSDB_ENABLE_2PC   = 1;
+SELECT @@global.ROCKSDB_ENABLE_2PC;
+@@global.ROCKSDB_ENABLE_2PC
 1
 "Setting the global scope variable back to default"
-SET @@global.ROCKSDB_DISABLE_2PC = DEFAULT;
-SELECT @@global.ROCKSDB_DISABLE_2PC;
-@@global.ROCKSDB_DISABLE_2PC
+SET @@global.ROCKSDB_ENABLE_2PC = DEFAULT;
+SELECT @@global.ROCKSDB_ENABLE_2PC;
+@@global.ROCKSDB_ENABLE_2PC
 1
-"Trying to set variable @@global.ROCKSDB_DISABLE_2PC to 0"
-SET @@global.ROCKSDB_DISABLE_2PC   = 0;
-SELECT @@global.ROCKSDB_DISABLE_2PC;
-@@global.ROCKSDB_DISABLE_2PC
+"Trying to set variable @@global.ROCKSDB_ENABLE_2PC to 0"
+SET @@global.ROCKSDB_ENABLE_2PC   = 0;
+SELECT @@global.ROCKSDB_ENABLE_2PC;
+@@global.ROCKSDB_ENABLE_2PC
 0
 "Setting the global scope variable back to default"
-SET @@global.ROCKSDB_DISABLE_2PC = DEFAULT;
-SELECT @@global.ROCKSDB_DISABLE_2PC;
-@@global.ROCKSDB_DISABLE_2PC
+SET @@global.ROCKSDB_ENABLE_2PC = DEFAULT;
+SELECT @@global.ROCKSDB_ENABLE_2PC;
+@@global.ROCKSDB_ENABLE_2PC
 1
-"Trying to set variable @@global.ROCKSDB_DISABLE_2PC to on"
-SET @@global.ROCKSDB_DISABLE_2PC   = on;
-SELECT @@global.ROCKSDB_DISABLE_2PC;
-@@global.ROCKSDB_DISABLE_2PC
+"Trying to set variable @@global.ROCKSDB_ENABLE_2PC to on"
+SET @@global.ROCKSDB_ENABLE_2PC   = on;
+SELECT @@global.ROCKSDB_ENABLE_2PC;
+@@global.ROCKSDB_ENABLE_2PC
 1
 "Setting the global scope variable back to default"
-SET @@global.ROCKSDB_DISABLE_2PC = DEFAULT;
-SELECT @@global.ROCKSDB_DISABLE_2PC;
-@@global.ROCKSDB_DISABLE_2PC
+SET @@global.ROCKSDB_ENABLE_2PC = DEFAULT;
+SELECT @@global.ROCKSDB_ENABLE_2PC;
+@@global.ROCKSDB_ENABLE_2PC
 1
-"Trying to set variable @@global.ROCKSDB_DISABLE_2PC to off"
-SET @@global.ROCKSDB_DISABLE_2PC   = off;
-SELECT @@global.ROCKSDB_DISABLE_2PC;
-@@global.ROCKSDB_DISABLE_2PC
+"Trying to set variable @@global.ROCKSDB_ENABLE_2PC to off"
+SET @@global.ROCKSDB_ENABLE_2PC   = off;
+SELECT @@global.ROCKSDB_ENABLE_2PC;
+@@global.ROCKSDB_ENABLE_2PC
 0
 "Setting the global scope variable back to default"
-SET @@global.ROCKSDB_DISABLE_2PC = DEFAULT;
-SELECT @@global.ROCKSDB_DISABLE_2PC;
-@@global.ROCKSDB_DISABLE_2PC
+SET @@global.ROCKSDB_ENABLE_2PC = DEFAULT;
+SELECT @@global.ROCKSDB_ENABLE_2PC;
+@@global.ROCKSDB_ENABLE_2PC
 1
-"Trying to set variable @@session.ROCKSDB_DISABLE_2PC to 444. It should fail because it is not session."
-SET @@session.ROCKSDB_DISABLE_2PC   = 444;
-ERROR HY000: Variable 'rocksdb_disable_2pc' is a GLOBAL variable and should be set with SET GLOBAL
+"Trying to set variable @@session.ROCKSDB_ENABLE_2PC to 444. It should fail because it is not session."
+SET @@session.ROCKSDB_ENABLE_2PC   = 444;
+ERROR HY000: Variable 'rocksdb_enable_2pc' is a GLOBAL variable and should be set with SET GLOBAL
 '# Testing with invalid values in global scope #'
-"Trying to set variable @@global.ROCKSDB_DISABLE_2PC to 'aaa'"
-SET @@global.ROCKSDB_DISABLE_2PC   = 'aaa';
+"Trying to set variable @@global.ROCKSDB_ENABLE_2PC to 'aaa'"
+SET @@global.ROCKSDB_ENABLE_2PC   = 'aaa';
 Got one of the listed errors
-SELECT @@global.ROCKSDB_DISABLE_2PC;
-@@global.ROCKSDB_DISABLE_2PC
+SELECT @@global.ROCKSDB_ENABLE_2PC;
+@@global.ROCKSDB_ENABLE_2PC
 1
-"Trying to set variable @@global.ROCKSDB_DISABLE_2PC to 'bbb'"
-SET @@global.ROCKSDB_DISABLE_2PC   = 'bbb';
+"Trying to set variable @@global.ROCKSDB_ENABLE_2PC to 'bbb'"
+SET @@global.ROCKSDB_ENABLE_2PC   = 'bbb';
 Got one of the listed errors
-SELECT @@global.ROCKSDB_DISABLE_2PC;
-@@global.ROCKSDB_DISABLE_2PC
+SELECT @@global.ROCKSDB_ENABLE_2PC;
+@@global.ROCKSDB_ENABLE_2PC
 1
-SET @@global.ROCKSDB_DISABLE_2PC = @start_global_value;
-SELECT @@global.ROCKSDB_DISABLE_2PC;
-@@global.ROCKSDB_DISABLE_2PC
+SET @@global.ROCKSDB_ENABLE_2PC = @start_global_value;
+SELECT @@global.ROCKSDB_ENABLE_2PC;
+@@global.ROCKSDB_ENABLE_2PC
 1
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_disable_2pc_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_disable_2pc_basic.test
@@ -10,7 +10,7 @@ CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
 INSERT INTO invalid_values VALUES('\'aaa\'');
 INSERT INTO invalid_values VALUES('\'bbb\'');
 
---let $sys_var=ROCKSDB_DISABLE_2PC
+--let $sys_var=ROCKSDB_ENABLE_2PC
 --let $read_only=0
 --let $session=0
 --let $sticky=1

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -395,7 +395,7 @@ static char * rocksdb_compact_cf_name;
 static char * rocksdb_checkpoint_name;
 static my_bool rocksdb_signal_drop_index_thread;
 static my_bool rocksdb_strict_collation_check= 1;
-static my_bool rocksdb_disable_2pc= 0;
+static my_bool rocksdb_enable_2pc= 0;
 static char * rocksdb_strict_collation_exceptions;
 static my_bool rocksdb_collect_sst_properties= 1;
 static my_bool rocksdb_force_flush_memtable_now_var= 0;
@@ -1002,10 +1002,10 @@ static MYSQL_SYSVAR_BOOL(pause_background_work,
   "Disable all rocksdb background operations",
   nullptr, rocksdb_set_pause_background_work, FALSE);
 
-static MYSQL_SYSVAR_BOOL(disable_2pc,
-  rocksdb_disable_2pc,
+static MYSQL_SYSVAR_BOOL(enable_2pc,
+  rocksdb_enable_2pc,
   PLUGIN_VAR_RQCMDARG,
-  "Disable two phase commit for MyRocks",
+  "Enable two phase commit for MyRocks",
   nullptr, nullptr, TRUE);
 
 static MYSQL_SYSVAR_BOOL(strict_collation_check,
@@ -1226,7 +1226,7 @@ static struct st_mysql_sys_var* rocksdb_system_variables[]= {
   MYSQL_SYSVAR(compact_cf),
   MYSQL_SYSVAR(signal_drop_index_thread),
   MYSQL_SYSVAR(pause_background_work),
-  MYSQL_SYSVAR(disable_2pc),
+  MYSQL_SYSVAR(enable_2pc),
   MYSQL_SYSVAR(strict_collation_check),
   MYSQL_SYSVAR(strict_collation_exceptions),
   MYSQL_SYSVAR(collect_sst_properties),
@@ -2173,7 +2173,7 @@ class Rdb_transaction_impl : public Rdb_transaction
     write_opts.disableWAL= THDVAR(m_thd, write_disable_wal);
     write_opts.ignore_missing_column_families=
       THDVAR(m_thd, write_ignore_missing_column_families);
-    m_is_two_phase= !rocksdb_disable_2pc;
+    m_is_two_phase= rocksdb_enable_2pc;
 
     /*
       If m_rocksdb_reuse_tx is null this will create a new transaction object.


### PR DESCRIPTION
This diff renames the flag rocksdb_disable_2pc to rocksdb_enable_2pc. The default for this value remains true, enabling 2pc by default.