### PR TITLE
[MyRocks] Fixing a bug that ANALYZE TABLE did not always persist stats

### DIFF
--- a/mysql-test/suite/rocksdb/r/add_index_inplace.result
+++ b/mysql-test/suite/rocksdb/r/add_index_inplace.result
@@ -362,4 +362,35 @@ set global rocksdb_force_flush_memtable_now=1;
 ALTER TABLE t1 ADD INDEX kj(j), ALGORITHM=INPLACE;
 larger
 1
+larger
+1
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
+larger
+1
+larger
+1
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
+select 1300 < 1300 * 1.5 as "same";
+same
+1
 DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/t/add_index_inplace.test
+++ b/mysql-test/suite/rocksdb/t/add_index_inplace.test
@@ -301,6 +301,39 @@ ALTER TABLE t1 ADD INDEX kj(j), ALGORITHM=INPLACE;
 --let $data_length_new = query_get_value("select INDEX_LENGTH from information_schema.tables where table_schema=database() and table_name='t1'", INDEX_LENGTH, 1)
 --disable_query_log
 --eval select $data_length_old < $data_length_new as "larger"
+
+--source include/restart_mysqld.inc
+--source include/wait_until_connected_again.inc
+--let $data_length_new = query_get_value("select INDEX_LENGTH from information_schema.tables where table_schema=database() and table_name='t1'", INDEX_LENGTH, 1)
+--disable_query_log
+--eval select $data_length_old < $data_length_new as "larger"
+
+analyze table t1;
+--let $data_length_new = query_get_value("select INDEX_LENGTH from information_schema.tables where table_schema=database() and table_name='t1'", INDEX_LENGTH, 1)
+--disable_query_log
+--eval select $data_length_old < $data_length_new as "larger"
+
+--source include/restart_mysqld.inc
+--source include/wait_until_connected_again.inc
+--let $data_length_new = query_get_value("select INDEX_LENGTH from information_schema.tables where table_schema=database() and table_name='t1'", INDEX_LENGTH, 1)
+--disable_query_log
+--eval select $data_length_old < $data_length_new as "larger"
+
+# verifying multiple analyze table won't change stats
+--disable_query_log
+let $max = 10;
+let $i = 1;
+while ($i <= $max) {
+  let $analyze = ANALYZE TABLE t1;
+  inc $i;
+  eval $analyze;
+}
+--enable_query_log
+
+--let $data_length_new2 = query_get_value("select INDEX_LENGTH from information_schema.tables where table_schema=database() and table_name='t1'", INDEX_LENGTH, 1)
+--eval select $data_length_new2 < $data_length_new * 1.5 as "same"
+
+
 --enable_query_log
 
 ## uncomment to see the actual values

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -3473,6 +3473,7 @@ void Rdb_ddl_manager::set_stats(
     const auto& keydef = find(src.second.m_gl_index_id);
     if (keydef) {
       keydef->m_stats = src.second;
+      m_stats2store[keydef->m_stats.m_gl_index_id] = keydef->m_stats;
     }
   }
   mysql_rwlock_unlock(&m_rwlock);


### PR DESCRIPTION
Summary:
There was a bug that ANALYZE TABLE did not always persist
statistics, so stats were lost after restarting mysqld.
This diff fixes the problem.

Test Plan: mtr