### PR TITLE
const fix for mysql_ldb

### DIFF
--- a/storage/rocksdb/tools/mysql_ldb.cc
+++ b/storage/rocksdb/tools/mysql_ldb.cc
@@ -8,7 +8,7 @@
 
 int main(int argc, char** argv) {
   rocksdb::Options db_options;
-  myrocks::Rdb_pk_comparator pk_comparator;
+  const myrocks::Rdb_pk_comparator pk_comparator;
   db_options.comparator= &pk_comparator;
 
   rocksdb::LDBTool tool;


### PR DESCRIPTION
Adding const key word for the file mysql_ldb.cc.

This is start of a series of changes to add constness for all the files under storage/rocksdb.