### PR TITLE
Const fix for storage/rocksdb #2

### DIFF
--- a/storage/rocksdb/rdb_mutex_wrapper.cc
+++ b/storage/rocksdb/rdb_mutex_wrapper.cc
@@ -49,7 +49,7 @@ Rdb_cond_var::~Rdb_cond_var() {
   mysql_cond_destroy(&m_cond);
 }
 
-Status Rdb_cond_var::Wait(std::shared_ptr<TransactionDBMutex> mutex_arg) {
+Status Rdb_cond_var::Wait(const std::shared_ptr<TransactionDBMutex> mutex_arg) {
   return WaitFor(mutex_arg, BIG_TIMEOUT);
 }
 
@@ -69,7 +69,7 @@ Status Rdb_cond_var::Wait(std::shared_ptr<TransactionDBMutex> mutex_arg) {
 */
 
 Status
-Rdb_cond_var::WaitFor(std::shared_ptr<TransactionDBMutex> mutex_arg,
+Rdb_cond_var::WaitFor(const std::shared_ptr<TransactionDBMutex> mutex_arg,
                       int64_t timeout_micros)
 {
   auto *mutex_obj= reinterpret_cast<Rdb_mutex*>(mutex_arg.get());
@@ -204,7 +204,7 @@ Status Rdb_mutex::TryLockFor(int64_t timeout_time __attribute__((__unused__)))
 
 
 #ifndef STANDALONE_UNITTEST
-void Rdb_mutex::set_unlock_action(PSI_stage_info *old_stage_arg)
+void Rdb_mutex::set_unlock_action(const PSI_stage_info* const old_stage_arg)
 {
   DBUG_ASSERT(old_stage_arg != nullptr);
 
@@ -221,7 +221,8 @@ void Rdb_mutex::UnLock() {
 #ifndef STANDALONE_UNITTEST
   if (m_old_stage_info.count(current_thd) > 0)
   {
-    std::shared_ptr<PSI_stage_info> old_stage = m_old_stage_info[current_thd];
+    const std::shared_ptr<PSI_stage_info> old_stage =
+      m_old_stage_info[current_thd];
     m_old_stage_info.erase(current_thd);
     /* The following will call mysql_mutex_unlock */
     my_core::thd_exit_cond(current_thd, old_stage.get());

--- a/storage/rocksdb/rdb_mutex_wrapper.h
+++ b/storage/rocksdb/rdb_mutex_wrapper.h
@@ -64,7 +64,7 @@ class Rdb_mutex: public rocksdb::TransactionDBMutex {
   friend class Rdb_cond_var;
 
 #ifndef STANDALONE_UNITTEST
-  void set_unlock_action(PSI_stage_info *old_stage_arg);
+  void set_unlock_action(const PSI_stage_info* const old_stage_arg);
   std::unordered_map<THD*, std::shared_ptr<PSI_stage_info>> m_old_stage_info;
 #endif
 };
@@ -87,7 +87,7 @@ class Rdb_cond_var: public rocksdb::TransactionDBCondVar {
   // Returns non-OK if TransactionDB should stop waiting and fail the operation.
   // May return OK spuriously even if not notified.
   virtual rocksdb::Status
-  Wait(std::shared_ptr<rocksdb::TransactionDBMutex> mutex) override;
+  Wait(const std::shared_ptr<rocksdb::TransactionDBMutex> mutex) override;
 
   // Block current thread until condition variable is notifiesd by a call to
   // Notify() or NotifyAll(), or if the timeout is reached.
@@ -102,7 +102,7 @@ class Rdb_cond_var: public rocksdb::TransactionDBCondVar {
   //  fail the operation.
   // May return OK spuriously even if not notified.
   virtual rocksdb::Status
-  WaitFor(std::shared_ptr<rocksdb::TransactionDBMutex> mutex,
+  WaitFor(const std::shared_ptr<rocksdb::TransactionDBMutex> mutex,
           int64_t timeout_time) override;
 
   // If any threads are waiting on *this, unblock at least one of the

--- a/storage/rocksdb/rdb_perf_context.cc
+++ b/storage/rocksdb/rdb_perf_context.cc
@@ -96,7 +96,7 @@ std::string rdb_pc_stat_types[]=
     idx++;                                                          \
   } while (0)
 
-static void harvest_diffs(Rdb_atomic_perf_counters *counters)
+static void harvest_diffs(Rdb_atomic_perf_counters * const counters)
 {
   // (C) These should be in the same order as the PC enum
   size_t idx= 0;
@@ -151,7 +151,7 @@ static void harvest_diffs(Rdb_atomic_perf_counters *counters)
 
 static Rdb_atomic_perf_counters rdb_global_perf_counters;
 
-void rdb_get_global_perf_counters(Rdb_perf_counters *counters)
+void rdb_get_global_perf_counters(Rdb_perf_counters* const counters)
 {
   DBUG_ASSERT(counters != nullptr);
 
@@ -165,9 +165,9 @@ void Rdb_perf_counters::load(const Rdb_atomic_perf_counters &atomic_counters)
   }
 }
 
-bool Rdb_io_perf::start(uint32_t perf_context_level)
+bool Rdb_io_perf::start(const uint32_t perf_context_level)
 {
-  rocksdb::PerfLevel perf_level=
+  const rocksdb::PerfLevel perf_level=
     static_cast<rocksdb::PerfLevel>(perf_context_level);
 
   if (rocksdb::GetPerfLevel() != perf_level)
@@ -185,9 +185,9 @@ bool Rdb_io_perf::start(uint32_t perf_context_level)
   return true;
 }
 
-void Rdb_io_perf::end_and_record(uint32_t perf_context_level)
+void Rdb_io_perf::end_and_record(const uint32_t perf_context_level)
 {
-  rocksdb::PerfLevel perf_level=
+  const rocksdb::PerfLevel perf_level=
     static_cast<rocksdb::PerfLevel>(perf_context_level);
 
   if (perf_level == rocksdb::kDisable)

--- a/storage/rocksdb/rdb_perf_context.h
+++ b/storage/rocksdb/rdb_perf_context.h
@@ -116,9 +116,9 @@ class Rdb_io_perf
   Rdb_io_perf(const Rdb_io_perf&) = delete;
   Rdb_io_perf& operator=(const Rdb_io_perf&) = delete;
 
-  void init(Rdb_atomic_perf_counters *atomic_counters,
-            my_io_perf_atomic_t *shared_io_perf_read,
-            ha_statistics *stats)
+  void init(Rdb_atomic_perf_counters* const atomic_counters,
+            my_io_perf_atomic_t* const shared_io_perf_read,
+            ha_statistics* const stats)
   {
     DBUG_ASSERT(atomic_counters != nullptr);
     DBUG_ASSERT(shared_io_perf_read != nullptr);
@@ -129,8 +129,8 @@ class Rdb_io_perf
     m_stats= stats;
   }
 
-  bool start(uint32_t perf_context_level);
-  void end_and_record(uint32_t perf_context_level);
+  bool start(const uint32_t perf_context_level);
+  void end_and_record(const uint32_t perf_context_level);
 
   explicit Rdb_io_perf() : m_atomic_counters(nullptr),
                            m_shared_io_perf_read(nullptr),

--- a/storage/rocksdb/rdb_sst_info.h
+++ b/storage/rocksdb/rdb_sst_info.h
@@ -37,19 +37,20 @@ class Rdb_sst_file {
   Rdb_sst_file(const Rdb_sst_file& p)= delete;
   Rdb_sst_file& operator=(const Rdb_sst_file& p)= delete;
 
-  rocksdb::DB*                 m_db;
-  rocksdb::ColumnFamilyHandle* m_cf;
-  const rocksdb::DBOptions&    m_db_options;
-  rocksdb::SstFileWriter*      m_sst_file_writer;
-  std::string                  m_name;
-  bool                         m_tracing;
+  rocksdb::DB* const                  m_db;
+  rocksdb::ColumnFamilyHandle* const  m_cf;
+  const rocksdb::DBOptions&           m_db_options;
+  rocksdb::SstFileWriter*             m_sst_file_writer;
+  const std::string                   m_name;
+  const bool                          m_tracing;
 
   std::string generateKey(const std::string& key);
 
  public:
-  Rdb_sst_file(rocksdb::DB* db, rocksdb::ColumnFamilyHandle* cf,
+  Rdb_sst_file(rocksdb::DB* const db,
+               rocksdb::ColumnFamilyHandle* const cf,
                const rocksdb::DBOptions& db_options, const std::string& name,
-               bool tracing);
+               const bool tracing);
   ~Rdb_sst_file();
 
   rocksdb::Status open();
@@ -62,24 +63,24 @@ class Rdb_sst_info {
   Rdb_sst_info(const Rdb_sst_info& p)= delete;
   Rdb_sst_info& operator=(const Rdb_sst_info& p)= delete;
 
-  rocksdb::DB*                 m_db;
-  rocksdb::ColumnFamilyHandle* m_cf;
-  const rocksdb::DBOptions&    m_db_options;
-  uint64_t                     m_curr_size;
-  uint64_t                     m_max_size;
-  uint                         m_sst_count;
-  std::string                  m_error_msg;
-  std::string                  m_prefix;
-  static std::string           m_suffix;
+  rocksdb::DB* const                  m_db;
+  rocksdb::ColumnFamilyHandle* const  m_cf;
+  const rocksdb::DBOptions&           m_db_options;
+  uint64_t                            m_curr_size;
+  uint64_t                            m_max_size;
+  uint                                m_sst_count;
+  std::string                         m_error_msg;
+  std::string                         m_prefix;
+  static std::string                  m_suffix;
 #if defined(RDB_SST_INFO_USE_THREAD)
-  std::queue<Rdb_sst_file*>    m_queue;
-  std::mutex                   m_mutex;
-  std::condition_variable      m_cond;
-  std::thread*                 m_thread;
-  bool                         m_finished;
+  std::queue<Rdb_sst_file*>           m_queue;
+  std::mutex                          m_mutex;
+  std::condition_variable             m_cond;
+  std::thread*                        m_thread;
+  bool                                m_finished;
 #endif
-  Rdb_sst_file*                m_sst_file;
-  bool                         m_tracing;
+  Rdb_sst_file*                       m_sst_file;
+  const bool                          m_tracing;
 
   int open_new_sst_file();
   void close_curr_sst_file();
@@ -92,9 +93,10 @@ class Rdb_sst_info {
 #endif
 
  public:
-  Rdb_sst_info(rocksdb::DB* db, const std::string& tablename,
-               const std::string& indexname, rocksdb::ColumnFamilyHandle* cf,
-               const rocksdb::DBOptions& db_options, bool tracing);
+  Rdb_sst_info(rocksdb::DB* const db, const std::string& tablename,
+               const std::string& indexname,
+               rocksdb::ColumnFamilyHandle* const cf,
+               const rocksdb::DBOptions& db_options, const bool &tracing);
   ~Rdb_sst_info();
 
   int put(const rocksdb::Slice& key, const rocksdb::Slice& value);
@@ -102,7 +104,7 @@ class Rdb_sst_info {
 
   const std::string& error_message() const { return m_error_msg; }
 
-  static void init(rocksdb::DB* db);
+  static void init(const rocksdb::DB* const db);
 };
 
 }  // namespace myrocks

--- a/storage/rocksdb/rdb_threads.cc
+++ b/storage/rocksdb/rdb_threads.cc
@@ -24,10 +24,10 @@
 
 namespace myrocks {
 
-void* Rdb_thread::thread_func(void* thread_ptr)
+void* Rdb_thread::thread_func(void* const thread_ptr)
 {
   DBUG_ASSERT(thread_ptr != nullptr);
-  Rdb_thread* thread= static_cast<Rdb_thread*>(thread_ptr);
+  Rdb_thread* const thread= static_cast<Rdb_thread* const>(thread_ptr);
   if (!thread->m_run_once.exchange(true))
   {
     thread->run();
@@ -68,7 +68,7 @@ int Rdb_thread::create_thread(
 }
 
 
-void Rdb_thread::signal(bool stop_thread)
+void Rdb_thread::signal(const bool &stop_thread)
 {
   mysql_mutex_lock(&m_signal_mutex);
   if (stop_thread) {

--- a/storage/rocksdb/rdb_threads.h
+++ b/storage/rocksdb/rdb_threads.h
@@ -58,7 +58,7 @@ class Rdb_thread
 
   virtual void run(void) = 0;
 
-  void signal(bool stop_thread= false);
+  void signal(const bool &stop_thread= false);
 
   int join()
   {
@@ -70,7 +70,7 @@ class Rdb_thread
   virtual ~Rdb_thread() {}
 
  private:
-  static void* thread_func(void* thread_ptr);
+  static void* thread_func(void* const thread_ptr);
 };
 
 

--- a/storage/rocksdb/rdb_utils.cc
+++ b/storage/rocksdb/rdb_utils.cc
@@ -32,7 +32,8 @@ namespace myrocks {
 /*
   Skip past any spaces in the input
 */
-const char* rdb_skip_spaces(struct charset_info_st* cs, const char *str)
+const char* rdb_skip_spaces(const struct charset_info_st* const cs,
+                            const char *str)
 {
   DBUG_ASSERT(cs != nullptr);
   DBUG_ASSERT(str != nullptr);
@@ -50,7 +51,7 @@ const char* rdb_skip_spaces(struct charset_info_st* cs, const char *str)
   Note that str1 can be longer but we only compare up to the number
   of characters in str2.
 */
-bool rdb_compare_strings_ic(const char *str1, const char *str2)
+bool rdb_compare_strings_ic(const char* const str1, const char* const str2)
 {
   DBUG_ASSERT(str1 != nullptr);
   DBUG_ASSERT(str2 != nullptr);
@@ -74,7 +75,7 @@ bool rdb_compare_strings_ic(const char *str1, const char *str2)
   and skipping all data enclosed in quotes.
 */
 const char* rdb_find_in_string(const char *str, const char *pattern,
-                               bool *succeeded)
+                               bool * const succeeded)
 {
   char        quote = '\0';
   bool        escape = false;
@@ -131,8 +132,9 @@ const char* rdb_find_in_string(const char *str, const char *pattern,
 /*
   See if the next valid token matches the specified string
 */
-const char* rdb_check_next_token(struct charset_info_st* cs, const char *str,
-                                 const char *pattern, bool *succeeded)
+const char* rdb_check_next_token(const struct charset_info_st* const cs,
+                                 const char *str, const char* const pattern,
+                                 bool* const succeeded)
 {
   DBUG_ASSERT(cs != nullptr);
   DBUG_ASSERT(str != nullptr);
@@ -156,8 +158,8 @@ const char* rdb_check_next_token(struct charset_info_st* cs, const char *str,
 /*
   Parse id
 */
-const char* rdb_parse_id(struct charset_info_st* cs, const char *str,
-                         std::string *id)
+const char* rdb_parse_id(const struct charset_info_st* const cs,
+                         const char *str, std::string * const id)
 {
   DBUG_ASSERT(cs != nullptr);
   DBUG_ASSERT(str != nullptr);
@@ -232,7 +234,7 @@ const char* rdb_parse_id(struct charset_info_st* cs, const char *str,
 /*
   Skip id
 */
-const char* rdb_skip_id(struct charset_info_st* cs, const char *str)
+const char* rdb_skip_id(const struct charset_info_st* const cs, const char *str)
 {
   DBUG_ASSERT(cs != nullptr);
   DBUG_ASSERT(str != nullptr);
@@ -251,8 +253,8 @@ static const std::array<char, 16> rdb_hexdigit =
   Convert data into a hex string with optional maximum length.
   If the data is larger than the maximum length trancate it and append "..".
 */
-std::string rdb_hexdump(const char *data, std::size_t data_len,
-                        std::size_t maxsize)
+std::string rdb_hexdump(const char *data, const std::size_t data_len,
+                        const std::size_t maxsize)
 {
   DBUG_ASSERT(data != nullptr);
 
@@ -296,8 +298,9 @@ std::string rdb_hexdump(const char *data, std::size_t data_len,
 */
 bool rdb_database_exists(const std::string& db_name)
 {
-  std::string dir = std::string(mysql_real_data_home) + FN_DIRSEP + db_name;
-  struct st_my_dir* dir_info = my_dir(dir.c_str(),
+  const std::string dir = std::string(mysql_real_data_home) + FN_DIRSEP
+                          + db_name;
+  struct st_my_dir* const dir_info = my_dir(dir.c_str(),
                                       MYF(MY_DONT_SORT | MY_WANT_STAT));
   if (dir_info == nullptr)
   {

--- a/storage/rocksdb/rdb_utils.h
+++ b/storage/rocksdb/rdb_utils.h
@@ -169,33 +169,35 @@ inline int purge_all_jemalloc_arenas()
   Helper functions to parse strings.
 */
 
-const char* rdb_skip_spaces(struct charset_info_st* cs, const char *str)
+const char* rdb_skip_spaces(const struct charset_info_st* const cs,
+                            const char *str)
   __attribute__((__nonnull__, __warn_unused_result__));
 
-bool rdb_compare_strings_ic(const char *str1, const char *str2)
+bool rdb_compare_strings_ic(const char* const str1, const char* const str2)
   __attribute__((__nonnull__, __warn_unused_result__));
 
 const char* rdb_find_in_string(const char *str, const char *pattern,
-                               bool *succeeded)
+                               bool * const succeeded)
   __attribute__((__nonnull__, __warn_unused_result__));
 
-const char* rdb_check_next_token(struct charset_info_st* cs, const char *str,
-                                 const char *pattern, bool *succeeded)
+const char* rdb_check_next_token(const struct charset_info_st* const cs,
+                                 const char *str, const char* const pattern,
+                                 bool * const succeeded)
   __attribute__((__nonnull__, __warn_unused_result__));
 
-const char* rdb_parse_id(struct charset_info_st* cs, const char *str,
-                         std::string *id)
+const char* rdb_parse_id(const struct charset_info_st* const cs,
+                         const char *str, std::string * const id)
   __attribute__((__nonnull__(1, 2), __warn_unused_result__));
 
-const char* rdb_skip_id(struct charset_info_st* cs, const char *str)
+const char* rdb_skip_id(const struct charset_info_st* const cs, const char *str)
   __attribute__((__nonnull__, __warn_unused_result__));
 
 /*
   Helper functions to populate strings.
 */
 
-std::string rdb_hexdump(const char *data, std::size_t data_len,
-                        std::size_t maxsize = 0)
+std::string rdb_hexdump(const char *data, const std::size_t data_len,
+                        const std::size_t maxsize = 0)
   __attribute__((__nonnull__));
 
 /*

--- a/storage/rocksdb/tools/mysql_ldb.cc
+++ b/storage/rocksdb/tools/mysql_ldb.cc
@@ -8,7 +8,7 @@
 
 int main(int argc, char** argv) {
   rocksdb::Options db_options;
-  myrocks::Rdb_pk_comparator pk_comparator;
+  const myrocks::Rdb_pk_comparator pk_comparator;
   db_options.comparator= &pk_comparator;
 
   rocksdb::LDBTool tool;


### PR DESCRIPTION
Const fix for rdb_mutex_wrapper, rdb_perf_context, rdb_sst_info, rdb_threads and rdb_utils.

This is the second pull request to add const correctness to all the files under storage/rocksdb.