### PR TITLE
Abort MyRocks on read io errors

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -1612,6 +1612,10 @@ public:
       return HA_ERR_ROCKSDB_TOO_MANY_LOCKS;
     }
 
+    if (s.IsIOError() || s.IsCorruption())
+    {
+      rdb_handle_io_error(s, RDB_IO_ERROR_GENERAL);
+    }
     my_error(ER_INTERNAL_ERROR, MYF(0), s.ToString().c_str());
     return HA_ERR_INTERNAL_ERROR;
   }
@@ -10880,6 +10884,14 @@ void rdb_handle_io_error(rocksdb::Status status, RDB_IO_ERROR_TYPE err_type)
                         status.ToString().c_str());
       break;
     }
+    case RDB_IO_ERROR_GENERAL:
+    {
+      sql_print_error("RocksDB: Failed on I/O - status %d, %s",
+                      status.code(), status.ToString().c_str());
+      sql_print_error("RocksDB: Aborting on I/O error.");
+      abort_with_stack_traces();
+      break;
+    }
     default:
       DBUG_ASSERT(0);
       break;
@@ -10907,7 +10919,7 @@ void rdb_handle_io_error(rocksdb::Status status, RDB_IO_ERROR_TYPE err_type)
       break;
     }
     default:
-      sql_print_warning("RocksDB: Failed to write to RocksDB "
+      sql_print_warning("RocksDB: Failed to read/write in RocksDB "
                         "- status %d, %s", status.code(),
                         status.ToString().c_str());
       break;

--- a/storage/rocksdb/ha_rocksdb_proto.h
+++ b/storage/rocksdb/ha_rocksdb_proto.h
@@ -31,7 +31,8 @@ namespace myrocks {
 enum RDB_IO_ERROR_TYPE {
   RDB_IO_ERROR_TX_COMMIT,
   RDB_IO_ERROR_DICT_COMMIT,
-  RDB_IO_ERROR_BG_THREAD
+  RDB_IO_ERROR_BG_THREAD,
+  RDB_IO_ERROR_GENERAL
 };
 
 void rdb_handle_io_error(rocksdb::Status status, RDB_IO_ERROR_TYPE err_type);


### PR DESCRIPTION
Summary: We had a logic to abort MyRocks instances on write io errors.
This diff covers on general io errors (including reads) too.