### PR TITLE
Fix prefixed unique secondary keys

### DIFF
--- a/mysql-test/suite/rocksdb/r/unique_sec.result
+++ b/mysql-test/suite/rocksdb/r/unique_sec.result
@@ -183,3 +183,24 @@ ERROR 23000: Duplicate entry '1-1' for key 'PRIMARY'
 INSERT INTO t2 VALUES (2,1);
 ERROR 23000: Duplicate entry '1' for key 'a'
 DROP TABLE t2;
+#
+# Issue #491 (https://github.com/facebook/mysql-5.6/issues/491)
+#
+CREATE TABLE t (a BLOB, PRIMARY KEY(a(2)), UNIQUE KEY (a(1))) engine=rocksdb;
+INSERT INTO t VALUES('a');
+CHECK TABLE t EXTENDED;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+DROP TABLE t;
+CREATE TABLE t (a VARCHAR(255), PRIMARY KEY(a), UNIQUE KEY (a(1))) engine=rocksdb;
+INSERT INTO t VALUES('a');
+CHECK TABLE t EXTENDED;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+DROP TABLE t;
+CREATE TABLE t (a VARCHAR(255), PRIMARY KEY(a(2)), UNIQUE KEY (a(1))) engine=rocksdb;
+INSERT INTO t VALUES('a');
+CHECK TABLE t EXTENDED;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+DROP TABLE t;

--- a/mysql-test/suite/rocksdb/t/unique_sec.test
+++ b/mysql-test/suite/rocksdb/t/unique_sec.test
@@ -31,3 +31,21 @@ INSERT INTO t2 VALUES (1,1);
 --error ER_DUP_ENTRY
 INSERT INTO t2 VALUES (2,1);
 DROP TABLE t2;
+
+--echo #
+--echo # Issue #491 (https://github.com/facebook/mysql-5.6/issues/491)
+--echo #
+CREATE TABLE t (a BLOB, PRIMARY KEY(a(2)), UNIQUE KEY (a(1))) engine=rocksdb;
+INSERT INTO t VALUES('a');
+CHECK TABLE t EXTENDED;
+DROP TABLE t;
+
+CREATE TABLE t (a VARCHAR(255), PRIMARY KEY(a), UNIQUE KEY (a(1))) engine=rocksdb;
+INSERT INTO t VALUES('a');
+CHECK TABLE t EXTENDED;
+DROP TABLE t;
+
+CREATE TABLE t (a VARCHAR(255), PRIMARY KEY(a(2)), UNIQUE KEY (a(1))) engine=rocksdb;
+INSERT INTO t VALUES('a');
+CHECK TABLE t EXTENDED;
+DROP TABLE t;

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -227,11 +227,13 @@ void Rdb_key_def::setup(const TABLE* const tbl,
 
         if (simulating_extkey && !hidden_pk_exists)
         {
+          DBUG_ASSERT(secondary_key);
           /* Check if this field is already present in the key definition */
           bool found= false;
           for (uint j= 0; j < key_info->actual_key_parts; j++)
           {
-            if (field->field_index == key_info->key_part[j].field->field_index)
+            if (field->field_index == key_info->key_part[j].field->field_index &&
+                key_part->length == key_info->key_part[j].length)
             {
               found= true;
               break;


### PR DESCRIPTION
Unique secondary keys with prefixes do not work with extended keys, because the check to see if a key part in the unique index is equivalent to a key part in the primary key only looks at the field index, and does not check if it is prefixed or not. If it is prefixed, then in general, you cannot use it as part of the rowid since the primary key part may be longer than the secondary key part.

The fix is to check for key part length.

Closes #491
