### PR TITLE
[rocksdb_hotbackup] ignore 'slockets' socket in data dir

### DIFF
--- a/mysql-test/suite/rocksdb_hotbackup/include/create_slocket_socket.sh
+++ b/mysql-test/suite/rocksdb_hotbackup/include/create_slocket_socket.sh
@@ -1,0 +1,2 @@
+src_data_dir="${MYSQLTEST_VARDIR}/mysqld.1/data/"
+python -c "import socket as s; sock = s.socket(s.AF_UNIX); sock.bind('${src_data_dir}/slocket')"

--- a/mysql-test/suite/rocksdb_hotbackup/include/load_data_slocket.sh
+++ b/mysql-test/suite/rocksdb_hotbackup/include/load_data_slocket.sh
@@ -1,0 +1,43 @@
+set -e
+
+# Insert 10 batches of 10 records each to a table with following schema:
+# create table slocket.t1 (
+#   `id` int(10) not null auto_increment,
+#   `k` int(10),
+#   `data` varchar(2048),
+#   primary key (`id`),
+#   key (`k`)
+# ) engine=innodb;
+
+MAX_INSERTS=10
+MAX_ROWS_PER_INSERT=10
+
+insertData() {
+  for ((i=1; i<=$MAX_INSERTS; i++));
+  do
+      stmt='INSERT INTO slocket.t1 values'
+      for ((j=1; j<=$MAX_ROWS_PER_INSERT; j++));
+      do
+          k=$RANDOM
+          data=$(head -c 2048 /dev/urandom|tr -cd 'a-zA-Z0-9')
+          stmt=$stmt' (NULL, '$k', "'$data'")'
+          if [ $j -lt $MAX_ROWS_PER_INSERT ]; then
+              stmt=$stmt','
+          fi
+      done
+      stmt=$stmt';'
+      $MYSQL --defaults-group-suffix=.1 -e "$stmt"
+  done
+}
+
+NUM_PARALLEL_INSERTS=25
+pids=()
+for ((k=1; k<=$NUM_PARALLEL_INSERTS; k++));
+do
+  insertData &
+  pids+=($!)
+done
+for ((k=1; k<=$NUM_PARALLEL_INSERTS; k++));
+do
+  wait ${pids[k]}
+done

--- a/mysql-test/suite/rocksdb_hotbackup/include/remove_slocket_socket.sh
+++ b/mysql-test/suite/rocksdb_hotbackup/include/remove_slocket_socket.sh
@@ -1,0 +1,2 @@
+src_data_dir="${MYSQLTEST_VARDIR}/mysqld.1/data/"
+rm "${src_data_dir}/slocket"

--- a/mysql-test/suite/rocksdb_hotbackup/include/setup_slocket.inc
+++ b/mysql-test/suite/rocksdb_hotbackup/include/setup_slocket.inc
@@ -1,0 +1,10 @@
+connection server_1;
+create database slocket;
+
+create table slocket.t1 (
+  `id` int(10) not null auto_increment,
+  `k` int(10),
+  `data` varchar(2048),
+  primary key (`id`),
+  key (`k`)
+) engine=rocksdb;

--- a/mysql-test/suite/rocksdb_hotbackup/r/slocket.result
+++ b/mysql-test/suite/rocksdb_hotbackup/r/slocket.result
@@ -1,0 +1,41 @@
+include/rpl_init.inc [topology=none]
+include/rpl_default_connections.inc
+create database db1;
+create table db1.t1 (
+`id` int(10) not null auto_increment,
+`k` int(10),
+`data` varchar(2048),
+primary key (`id`),
+key (`k`)
+) engine=rocksdb;
+create database slocket;
+create table slocket.t1 (
+`id` int(10) not null auto_increment,
+`k` int(10),
+`data` varchar(2048),
+primary key (`id`),
+key (`k`)
+) engine=rocksdb;
+include/rpl_stop_server.inc [server_number=2]
+myrocks_hotbackup copy phase
+myrocks_hotbackup move-back phase
+include/rpl_start_server.inc [server_number=2]
+select count(*) from db1.t1;
+count(*)
+250000
+select count(*) from slocket.t1;
+count(*)
+2500
+drop database slocket;
+drop database db1;
+drop database slocket;
+include/rpl_stop_server.inc [server_number=2]
+myrocks_hotbackup copy phase
+myrocks_hotbackup move-back phase
+include/rpl_start_server.inc [server_number=2]
+select count(*) from db1.t1;
+count(*)
+250000
+drop database db1;
+drop database db1;
+include/rpl_end.inc

--- a/mysql-test/suite/rocksdb_hotbackup/t/slocket.test
+++ b/mysql-test/suite/rocksdb_hotbackup/t/slocket.test
@@ -1,0 +1,46 @@
+source suite/rocksdb_hotbackup/include/setup.inc;
+source suite/rocksdb_hotbackup/include/setup_slocket.inc;
+
+--exec suite/rocksdb_hotbackup/include/load_data.sh 2>&1
+--exec suite/rocksdb_hotbackup/include/load_data_slocket.sh 2>&1
+
+--let $rpl_server_number= 2
+--source include/rpl_stop_server.inc
+
+--exec suite/rocksdb_hotbackup/include/stream_run.sh 2>&1
+
+--let $rpl_server_number= 2
+--source include/rpl_start_server.inc
+
+connection server_2;
+select count(*) from db1.t1;
+select count(*) from slocket.t1;
+
+connection server_1;
+drop database slocket;
+connection server_2;
+drop database db1;
+drop database slocket;
+
+--exec sleep 2
+--exec suite/rocksdb_hotbackup/include/create_slocket_socket.sh 2>&1
+
+--let $rpl_server_number= 2
+--source include/rpl_stop_server.inc
+
+--exec suite/rocksdb_hotbackup/include/stream_run.sh 2>&1
+
+--let $rpl_server_number= 2
+--source include/rpl_start_server.inc
+
+connection server_2;
+select count(*) from db1.t1;
+
+connection server_1;
+drop database db1;
+connection server_2;
+drop database db1;
+
+--exec suite/rocksdb_hotbackup/include/remove_slocket_socket.sh 2>&1
+
+source suite/rocksdb_hotbackup/include/cleanup.inc;

--- a/scripts/myrocks_hotbackup
+++ b/scripts/myrocks_hotbackup
@@ -5,6 +5,7 @@ from optparse import OptionParser
 import collections
 import signal
 import os
+import stat
 import sys
 import re
 import commands
@@ -28,6 +29,7 @@ rocksdb_data_suffix = '.sst'
 rocksdb_wal_suffix = '.log'
 exclude_files = ['master.info', 'relay-log.info', 'worker-relay-log.info',
                  'auto.cnf', 'gaplock.log', 'ibdata', 'ib_logfile']
+exclude_logs = ['slocket']
 wdt_bin = 'wdt'
 
 def is_manifest(fname):
@@ -107,7 +109,7 @@ class MiscFilesProcessor():
     dirs = [ d for d in os.listdir(self.datadir) \
             if not os.path.isfile(os.path.join(self.datadir,d))]
     for db in dirs:
-      if not db.startswith('.'):
+      if not db.startswith('.') and not self._is_log_socket(db):
         dbs.append(db)
     return dbs
 
@@ -115,6 +117,12 @@ class MiscFilesProcessor():
     dbdir = self.datadir + "/" + db
     return [ f for f in os.listdir(dbdir) \
             if os.path.isfile(os.path.join(dbdir,f))]
+
+  def _is_log_socket(self, item):
+      mode = os.stat(os.path.join(self.datadir, item)).st_mode
+      if item in exclude_logs and stat.S_ISSOCK(mode):
+        return True
+      return False
 
 
 class MySQLBackup(MiscFilesProcessor):


### PR DESCRIPTION
Summary: Facebook uses a general log tool called `slocket_stats` which
creates a temporary socket at `f"{data_dir}/slocket"` which is picked up
by `MiscFilesProcessor#get_databases`. We now skip if it is a socket and
continue doing our work otherwise (a database named slocket would still
be copied)

Test plan: mtr. implemented a new test case on the rocksdb_hotbackup
suite