### PR TITLE
Improved diagnostics to understand MyRocks execution

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -2819,7 +2819,10 @@ static int rocksdb_recover(handlerton* const hton, XID* const xid_list,
 static int rocksdb_commit(handlerton* const hton, THD* const thd,
                           bool commit_tx, bool)
 {
-  DBUG_ENTER("rocksdb_commit");
+  DBUG_ENTER_FUNC();
+
+  DBUG_ASSERT(hton != nullptr);
+  DBUG_ASSERT(thd != nullptr);
 
   /* this will trigger saving of perf_context information */
   Rdb_perf_context_guard guard(thd);
@@ -2858,6 +2861,7 @@ static int rocksdb_commit(handlerton* const hton, THD* const thd,
       tx->release_snapshot();
     }
   }
+
   DBUG_RETURN(0);
 }
 
@@ -3524,7 +3528,7 @@ static rocksdb::Status check_rocksdb_options_compatibility(
 
 static int rocksdb_init_func(void* const p)
 {
-  DBUG_ENTER("rocksdb_init_func");
+  DBUG_ENTER_FUNC();
 
   // Validate the assumption about the size of ROCKSDB_SIZEOF_HIDDEN_PK_COLUMN.
   static_assert(sizeof(longlong) == 8, "Assuming that longlong is 8 bytes.");
@@ -3877,8 +3881,9 @@ static int rocksdb_init_func(void* const p)
 
 static int rocksdb_done_func(void* const p)
 {
+  DBUG_ENTER_FUNC();
+
   int error= 0;
-  DBUG_ENTER("rocksdb_done_func");
 
   // signal the drop index thread to stop
   rdb_drop_idx_thread.signal(true);
@@ -4261,7 +4266,9 @@ static const char *ha_rocksdb_exts[] = {
 
 const char **ha_rocksdb::bas_ext() const
 {
-  return ha_rocksdb_exts;
+  DBUG_ENTER_FUNC();
+
+  DBUG_RETURN(ha_rocksdb_exts);
 }
 
 bool ha_rocksdb::same_table(const ha_rocksdb& other) const
@@ -4271,6 +4278,8 @@ bool ha_rocksdb::same_table(const ha_rocksdb& other) const
 
 bool ha_rocksdb::init_with_fields()
 {
+  DBUG_ENTER_FUNC();
+
   const uint pk= table_share->primary_key;
   if (pk != MAX_KEY)
   {
@@ -4281,7 +4290,8 @@ bool ha_rocksdb::init_with_fields()
     m_pk_can_be_decoded= false;
 
   cached_table_flags= table_flags();
-  return false; /* Ok */
+
+  DBUG_RETURN(false); /* Ok */
 }
 
 
@@ -4856,7 +4866,8 @@ void ha_rocksdb::setup_field_converters()
 int ha_rocksdb::alloc_key_buffers(const TABLE* const table_arg,
                                   const Rdb_tbl_def* const tbl_def_arg)
 {
-  DBUG_ENTER("ha_rocksdb::alloc_key_buffers");
+  DBUG_ENTER_FUNC();
+
   DBUG_ASSERT(m_pk_tuple == nullptr);
   DBUG_ASSERT(tbl_def_arg != nullptr);
 
@@ -4987,7 +4998,7 @@ void ha_rocksdb::set_skip_unique_check_tables(const char* const whitelist)
 
 int ha_rocksdb::open(const char* const name, int mode, uint test_if_locked)
 {
-  DBUG_ENTER("ha_rocksdb::open");
+  DBUG_ENTER_FUNC();
 
   if (m_table_handler != nullptr)
   {
@@ -5011,7 +5022,7 @@ int ha_rocksdb::open(const char* const name, int mode, uint test_if_locked)
   std::string fullname;
   if (rdb_normalize_tablename(name, &fullname))
   {
-    return HA_ERR_INTERNAL_ERROR;
+    DBUG_RETURN(HA_ERR_INTERNAL_ERROR);
   }
 
   m_tbl_def= ddl_manager.find(fullname);
@@ -5087,7 +5098,7 @@ int ha_rocksdb::open(const char* const name, int mode, uint test_if_locked)
 
 int ha_rocksdb::close(void)
 {
-  DBUG_ENTER("ha_rocksdb::close");
+  DBUG_ENTER_FUNC();
 
   m_pk_descr= nullptr;
   m_key_descr_arr= nullptr;
@@ -5105,6 +5116,8 @@ int ha_rocksdb::close(void)
 
 bool ha_rocksdb::get_error_message(const int error, String* const buf)
 {
+  DBUG_ENTER_FUNC();
+
   static_assert(HA_ERR_ROCKSDB_LAST > HA_ERR_FIRST,
     "HA_ERR_ROCKSDB_LAST > HA_ERR_FIRST");
   static_assert(HA_ERR_ROCKSDB_LAST > HA_ERR_LAST,
@@ -5138,7 +5151,7 @@ bool ha_rocksdb::get_error_message(const int error, String* const buf)
       break;
   }
 
-  return temp_error;
+  DBUG_RETURN(temp_error);
 }
 
 /* MyRocks supports only the following collations for indexed columns */
@@ -5181,10 +5194,10 @@ int ha_rocksdb::create_key_defs(const TABLE* const table_arg,
                                 const Rdb_tbl_def* const old_tbl_def_arg
                                 /* = nullptr */) const
 {
+  DBUG_ENTER_FUNC();
+
   DBUG_ASSERT(table_arg != nullptr);
   DBUG_ASSERT(table_arg->s != nullptr);
-
-  DBUG_ENTER("ha_rocksdb::create_key_defs");
 
   uint i;
 
@@ -5260,10 +5273,10 @@ int ha_rocksdb::create_cfs(const TABLE* const table_arg,
           Rdb_tbl_def* const tbl_def_arg,
           std::array<struct key_def_cf_info, MAX_INDEXES + 1>* const cfs) const
 {
+  DBUG_ENTER_FUNC();
+
   DBUG_ASSERT(table_arg != nullptr);
   DBUG_ASSERT(table_arg->s != nullptr);
-
-  DBUG_ENTER("ha_rocksdb::create_cfs");
 
   char tablename_sys[NAME_LEN + 1];
 
@@ -5364,11 +5377,11 @@ int ha_rocksdb::create_inplace_key_defs(const TABLE* const table_arg,
                   const Rdb_tbl_def* const old_tbl_def_arg,
                   const std::array<key_def_cf_info, MAX_INDEXES + 1>& cfs) const
 {
+  DBUG_ENTER_FUNC();
+
   DBUG_ASSERT(table_arg != nullptr);
   DBUG_ASSERT(tbl_def_arg != nullptr);
   DBUG_ASSERT(old_tbl_def_arg != nullptr);
-
-  DBUG_ENTER("create_key_def");
 
   std::shared_ptr<Rdb_key_def>* const old_key_descr=
       old_tbl_def_arg->m_key_descr_arr;
@@ -5441,12 +5454,12 @@ std::unordered_map<std::string, uint> ha_rocksdb::get_old_key_positions(
     const TABLE* const old_table_arg,
     const Rdb_tbl_def* const old_tbl_def_arg) const
 {
+  DBUG_ENTER_FUNC();
+
   DBUG_ASSERT(table_arg != nullptr);
   DBUG_ASSERT(old_table_arg != nullptr);
   DBUG_ASSERT(tbl_def_arg != nullptr);
   DBUG_ASSERT(old_tbl_def_arg != nullptr);
-
-  DBUG_ENTER("get_old_key_positions");
 
   std::shared_ptr<Rdb_key_def>* const old_key_descr=
       old_tbl_def_arg->m_key_descr_arr;
@@ -5498,10 +5511,10 @@ std::unordered_map<std::string, uint> ha_rocksdb::get_old_key_positions(
 int ha_rocksdb::compare_key_parts(const KEY* const old_key,
                                   const KEY* const new_key) const
 {
+  DBUG_ENTER_FUNC();
+
   DBUG_ASSERT(old_key != nullptr);
   DBUG_ASSERT(new_key != nullptr);
-
-  DBUG_ENTER("compare_key_parts");
 
   /* Skip if key parts do not match, as it is a different key */
   if (new_key->user_defined_key_parts != old_key->user_defined_key_parts)
@@ -5544,7 +5557,8 @@ int ha_rocksdb::create_key_def(const TABLE* const table_arg, const uint &i,
                                std::shared_ptr<Rdb_key_def>* const new_key_def,
                                const struct key_def_cf_info& cf_info) const
 {
-  DBUG_ENTER("create_key_def");
+  DBUG_ENTER_FUNC();
+
   DBUG_ASSERT(new_key_def != nullptr);
   DBUG_ASSERT(*new_key_def == nullptr);
 
@@ -5744,9 +5758,10 @@ int rdb_split_normalized_tablename(const std::string& fullname,
 int ha_rocksdb::create(const char* const name, TABLE* const table_arg,
                        HA_CREATE_INFO* const create_info)
 {
+  DBUG_ENTER_FUNC();
+
   int res;
   std::string str;
-  DBUG_ENTER("ha_rocksdb::create");
 
   THD* const thd = my_core::thd_get_current_thd();
 
@@ -6288,6 +6303,8 @@ int ha_rocksdb::try_keyonly_read_from_sk(uchar* buf,
 
 ulong ha_rocksdb::index_flags(uint inx, uint part, bool all_parts) const
 {
+  DBUG_ENTER_FUNC();
+
   ulong base_flags= HA_READ_NEXT  |   // doesn't seem to be used
                     HA_READ_ORDER |
                     HA_READ_RANGE |
@@ -6315,7 +6332,7 @@ ulong ha_rocksdb::index_flags(uint inx, uint part, bool all_parts) const
     base_flags |= HA_DO_INDEX_COND_PUSHDOWN;
   }
 
-  return base_flags;
+  DBUG_RETURN(base_flags);
 }
 
 
@@ -6391,8 +6408,9 @@ int ha_rocksdb::read_range_first(const key_range* const start_key,
                                  const key_range* const end_key,
                                  bool eq_range_arg, bool sorted)
 {
+  DBUG_ENTER_FUNC();
+
   int result;
-  DBUG_ENTER("ha_rocksdb::read_range_first");
 
   eq_range= eq_range_arg;
   set_end_range(end_key, RANGE_SCAN_ASC);
@@ -6444,7 +6462,9 @@ int ha_rocksdb::index_read_map(uchar* const buf, const uchar* const key,
                                key_part_map keypart_map,
                                enum ha_rkey_function find_flag)
 {
-  return index_read_map_impl(buf, key, keypart_map, find_flag, nullptr);
+  DBUG_ENTER_FUNC();
+
+  DBUG_RETURN(index_read_map_impl(buf, key, keypart_map, find_flag, nullptr));
 }
 
 /*
@@ -6464,8 +6484,9 @@ int ha_rocksdb::index_read_map_impl(uchar* const buf, const uchar* const key,
                                     enum ha_rkey_function find_flag,
                                     const key_range* end_key)
 {
+  DBUG_ENTER_FUNC();
+
   int rc= 0;
-  DBUG_ENTER("ha_rocksdb::index_read_map");
 
   ha_statistic_increment(&SSV::ha_read_key_count);
   const Rdb_key_def& kd= *m_key_descr_arr[active_index];
@@ -6623,6 +6644,7 @@ int ha_rocksdb::index_read_map_impl(uchar* const buf, const uchar* const key,
     stats.rows_index_first++;
     update_row_stats(ROWS_READ);
   }
+
   DBUG_RETURN(rc);
 }
 
@@ -6725,12 +6747,19 @@ int ha_rocksdb::find_icp_matching_index_rec(const bool &move_forward,
 int ha_rocksdb::index_read_last_map(uchar* const buf, const uchar* const key,
                                     key_part_map keypart_map)
 {
-  return index_read_map(buf, key, keypart_map, HA_READ_PREFIX_LAST);
+  DBUG_ENTER_FUNC();
+
+  DBUG_RETURN(index_read_map(buf, key, keypart_map, HA_READ_PREFIX_LAST));
 }
 
 
 int ha_rocksdb::check(THD* const thd, HA_CHECK_OPT* const check_opt)
 {
+  DBUG_ENTER_FUNC();
+
+  DBUG_ASSERT(thd != nullptr);
+  DBUG_ASSERT(check_opt != nullptr);
+
   const uint pk= pk_index(table, m_tbl_def);
   String rowkey_copy;
   String sec_key_copy;
@@ -6889,12 +6918,13 @@ print_and_error:
     For that, need to walk through the PK and check that every PK record has a
     proper counterpart in each secondary index.
   */
-  return HA_ADMIN_OK;
+  DBUG_RETURN(HA_ADMIN_OK);
 error:
   m_verify_row_debug_checksums= save_verify_row_debug_checksums;
   ha_index_or_rnd_end();
   extra(HA_EXTRA_NO_KEYREAD);
-  return HA_ADMIN_CORRUPT;
+
+  DBUG_RETURN(HA_ADMIN_CORRUPT);
 }
 
 
@@ -6974,12 +7004,13 @@ rocksdb::Status ha_rocksdb::get_for_update(
 int ha_rocksdb::get_row_by_rowid(uchar* const buf, const char* const rowid,
                                  const uint rowid_size)
 {
+  DBUG_ENTER_FUNC();
+
   DBUG_ASSERT(buf != nullptr);
   DBUG_ASSERT(rowid != nullptr);
   DBUG_ASSERT(table != nullptr);
 
   int rc;
-  DBUG_ENTER("ha_rocksdb::get_row_by_rowid");
 
   rocksdb::Slice key_slice(rowid, rowid_size);
 
@@ -7040,6 +7071,8 @@ int ha_rocksdb::get_row_by_rowid(uchar* const buf, const char* const rowid,
 
 int ha_rocksdb::index_next(uchar* const buf)
 {
+  DBUG_ENTER_FUNC();
+
   bool moves_forward= true;
   ha_statistic_increment(&SSV::ha_read_next_count);
   if (m_key_descr_arr[active_index]->m_is_reverse_cf)
@@ -7050,12 +7083,15 @@ int ha_rocksdb::index_next(uchar* const buf)
   int rc= index_next_with_direction(buf, moves_forward);
   if (rc == HA_ERR_KEY_NOT_FOUND)
     rc = HA_ERR_END_OF_FILE;
-  return rc;
+
+  DBUG_RETURN(rc);
 }
 
 
 int ha_rocksdb::index_prev(uchar* const buf)
 {
+  DBUG_ENTER_FUNC();
+
   bool moves_forward= false;
   ha_statistic_increment(&SSV::ha_read_prev_count);
   if (m_key_descr_arr[active_index]->m_is_reverse_cf)
@@ -7067,14 +7103,15 @@ int ha_rocksdb::index_prev(uchar* const buf)
   if (rc == HA_ERR_KEY_NOT_FOUND)
     rc = HA_ERR_END_OF_FILE;
 
-  return rc;
+  DBUG_RETURN(rc);
 }
 
 
 int ha_rocksdb::index_next_with_direction(uchar* const buf, bool move_forward)
 {
+  DBUG_ENTER_FUNC();
+
   int rc;
-  DBUG_ENTER("ha_rocksdb::index_next");
 
   if (active_index == pk_index(table, m_tbl_def))
   {
@@ -7104,25 +7141,31 @@ int ha_rocksdb::index_next_with_direction(uchar* const buf, bool move_forward)
 
 int ha_rocksdb::index_first(uchar* const buf)
 {
+  DBUG_ENTER_FUNC();
+
   m_sk_match_prefix= nullptr;
   ha_statistic_increment(&SSV::ha_read_first_count);
   int rc= m_key_descr_arr[active_index]->m_is_reverse_cf ?
       index_last_intern(buf) : index_first_intern(buf);
   if (rc == HA_ERR_KEY_NOT_FOUND)
     rc = HA_ERR_END_OF_FILE;
-  return rc;
+
+  DBUG_RETURN(rc);
 }
 
 
 int ha_rocksdb::index_last(uchar* const buf)
 {
+  DBUG_ENTER_FUNC();
+
   m_sk_match_prefix= nullptr;
   ha_statistic_increment(&SSV::ha_read_last_count);
   int rc= m_key_descr_arr[active_index]->m_is_reverse_cf ?
       index_first_intern(buf) : index_last_intern(buf);
   if (rc == HA_ERR_KEY_NOT_FOUND)
     rc = HA_ERR_END_OF_FILE;
-  return rc;
+
+  DBUG_RETURN(rc);
 }
 
 
@@ -7159,12 +7202,13 @@ int ha_rocksdb::index_last(uchar* const buf)
 
 int ha_rocksdb::index_first_intern(uchar* const buf)
 {
+  DBUG_ENTER_FUNC();
+
   DBUG_ASSERT(buf != nullptr);
 
   uchar *key;
   uint key_size;
   int rc;
-  DBUG_ENTER("ha_rocksdb::index_first");
 
   if (is_pk(active_index, table, m_tbl_def))
   {
@@ -7219,6 +7263,7 @@ int ha_rocksdb::index_first_intern(uchar* const buf)
     stats.rows_index_first++;
     stats.rows_index_next--;
   }
+
   DBUG_RETURN(rc);
 }
 
@@ -7262,12 +7307,13 @@ int ha_rocksdb::index_first_intern(uchar* const buf)
 
 int ha_rocksdb::index_last_intern(uchar* const buf)
 {
+  DBUG_ENTER_FUNC();
+
   DBUG_ASSERT(buf != nullptr);
 
   uchar *key;
   uint key_size;
   int rc;
-  DBUG_ENTER("ha_rocksdb::index_last");
 
   if (is_pk(active_index, table, m_tbl_def))
   {
@@ -7351,18 +7397,23 @@ int ha_rocksdb::index_last_intern(uchar* const buf)
     stats.rows_index_first++;
     stats.rows_index_next--;
   }
+
   DBUG_RETURN(rc);
 }
 
 
 void ha_rocksdb::unlock_row()
 {
+  DBUG_ENTER_FUNC();
+
   if (m_lock_rows != RDB_LOCK_NONE)
   {
     Rdb_transaction* const tx= get_or_create_tx(table->in_use);
     tx->release_lock(m_pk_descr->get_cf(), std::string(m_last_rowkey.ptr(),
                                                      m_last_rowkey.length()));
   }
+
+  DBUG_VOID_RETURN;
 }
 
 /*
@@ -7395,7 +7446,11 @@ bool ha_rocksdb::skip_unique_check() const
 
 void ha_rocksdb::set_force_skip_unique_check(bool skip)
 {
+  DBUG_ENTER_FUNC();
+
   m_force_skip_unique_check= skip;
+
+  DBUG_VOID_RETURN;
 }
 
 bool ha_rocksdb::commit_in_the_middle()
@@ -7499,9 +7554,12 @@ const char* ha_rocksdb::get_key_comment(const uint index,
 
 int ha_rocksdb::write_row(uchar* const buf)
 {
-  DBUG_ENTER("ha_rocksdb::write_row");
+  DBUG_ENTER_FUNC();
+
+  DBUG_ASSERT(buf != nullptr);
   DBUG_ASSERT(buf == table->record[0]);
   DBUG_ASSERT(m_lock_rows == RDB_LOCK_WRITE);
+
   ha_statistic_increment(&SSV::ha_write_count);
   /*
     Note: "buf == table->record[0]" is copied from innodb. I am not aware of
@@ -7523,6 +7581,7 @@ int ha_rocksdb::write_row(uchar* const buf)
     stats.rows_inserted++;
     update_row_stats(ROWS_INSERTED);
   }
+
   DBUG_RETURN(rv);
 }
 
@@ -8111,6 +8170,8 @@ int ha_rocksdb::update_write_row(const uchar* const old_data,
                                  const uchar* const new_data,
                                  const bool skip_unique_check)
 {
+  DBUG_ENTER_FUNC();
+
   bool                   pk_changed= false;
   struct update_row_info row_info;
 
@@ -8118,8 +8179,6 @@ int ha_rocksdb::update_write_row(const uchar* const old_data,
   row_info.new_data= new_data;
   row_info.skip_unique_check= skip_unique_check;
   row_info.new_pk_unpack_info= nullptr;
-
-  DBUG_ENTER("ha_rocksdb::write_row_common");
 
   set_last_rowkey(old_data);
 
@@ -8280,7 +8339,7 @@ void ha_rocksdb::setup_iterator_for_rnd_scan()
 
 int ha_rocksdb::rnd_init(bool scan)
 {
-  DBUG_ENTER("ha_rocksdb::rnd_init");
+  DBUG_ENTER_FUNC();
 
   Rdb_transaction* const tx= get_or_create_tx(table->in_use);
   setup_read_decoders();
@@ -8303,9 +8362,10 @@ int ha_rocksdb::rnd_init(bool scan)
   DBUG_RETURN(0);
 }
 
-
 int ha_rocksdb::rnd_next(uchar* const buf)
 {
+  DBUG_ENTER_FUNC();
+
   int rc;
   ha_statistic_increment(&SSV::ha_read_rnd_next_count);
   for (;;)
@@ -8325,7 +8385,8 @@ int ha_rocksdb::rnd_next(uchar* const buf)
 
   if (rc == HA_ERR_KEY_NOT_FOUND)
     rc = HA_ERR_END_OF_FILE;
-  return rc;
+
+  DBUG_RETURN(rc);
 }
 
 
@@ -8334,8 +8395,9 @@ int ha_rocksdb::rnd_next(uchar* const buf)
 */
 int ha_rocksdb::rnd_next_with_direction(uchar* const buf, bool move_forward)
 {
+  DBUG_ENTER_FUNC();
+
   int rc;
-  DBUG_ENTER("ha_rocksdb::rnd_next");
 
   table->status= STATUS_NOT_FOUND;
   stats.rows_requested++;
@@ -8439,7 +8501,7 @@ int ha_rocksdb::rnd_next_with_direction(uchar* const buf, bool move_forward)
 
 int ha_rocksdb::rnd_end()
 {
-  DBUG_ENTER("ha_rocksdb::rnd_end");
+  DBUG_ENTER_FUNC();
 
   release_scan_iterator();
 
@@ -8448,6 +8510,8 @@ int ha_rocksdb::rnd_end()
 
 int ha_rocksdb::index_init(uint idx, bool sorted)
 {
+  DBUG_ENTER_FUNC();
+
   Rdb_transaction* const tx= get_or_create_tx(table->in_use);
   DBUG_ASSERT(tx != nullptr);
 
@@ -8460,35 +8524,33 @@ int ha_rocksdb::index_init(uint idx, bool sorted)
 
   active_index= idx;
 
-  return 0;
+  DBUG_RETURN(0);
 }
 
 int ha_rocksdb::index_end()
 {
+  DBUG_ENTER_FUNC();
+
   release_scan_iterator();
 
   active_index= MAX_KEY;
   in_range_check_pushed_down= FALSE;
-  return 0;
-}
 
-
-int ha_rocksdb::delete_all_rows(ha_rows* const nrows)
-{
-  DBUG_ENTER("ha_rocksdb::delete_all_rows");
-  /*
-    We will have to delete records one-by-one anyway. Let the SQL layer do
-    it.
-  */
-  DBUG_RETURN(HA_ERR_WRONG_COMMAND);
+  DBUG_RETURN(0);
 }
 
 int ha_rocksdb::truncate()
 {
+  DBUG_ENTER_FUNC();
+
+  DBUG_ASSERT(m_tbl_def != nullptr);
+
   m_tbl_def->m_auto_incr_val= 1;
   m_tbl_def->m_hidden_pk_val= 1;
+
   remove_rows(m_tbl_def);
-  return 0;
+
+  DBUG_RETURN(0);
 }
 
 
@@ -8502,7 +8564,9 @@ int ha_rocksdb::truncate()
 */
 int ha_rocksdb::delete_row(const uchar* const buf)
 {
-  DBUG_ENTER("ha_rocksdb::delete_row");
+  DBUG_ENTER_FUNC();
+
+  DBUG_ASSERT(buf != nullptr);
 
   ha_statistic_increment(&SSV::ha_delete_count);
   set_last_rowkey(buf);
@@ -8566,12 +8630,13 @@ ha_rocksdb::delete_or_singledelete(uint index,
 
 void ha_rocksdb::update_stats(void)
 {
-  DBUG_ENTER("ha_rocksdb::update_stats");
+  DBUG_ENTER_FUNC();
 
   stats.records= 0;
   stats.index_file_length= 0ul;
   stats.data_file_length= 0ul;
   stats.mean_rec_length= 0;
+
   for (uint i= 0; i < m_tbl_def->m_key_count; i++)
   {
     if (is_pk(i, table, m_tbl_def))
@@ -8584,12 +8649,13 @@ void ha_rocksdb::update_stats(void)
       stats.index_file_length+= m_key_descr_arr[i]->m_stats.m_actual_disk_size;
     }
   }
+
   DBUG_VOID_RETURN;
 }
 
 int ha_rocksdb::info(uint flag)
 {
-  DBUG_ENTER("ha_rocksdb::info");
+  DBUG_ENTER_FUNC();
 
   if (!table)
     return 1;
@@ -8696,7 +8762,7 @@ int ha_rocksdb::info(uint flag)
 
 void ha_rocksdb::position(const uchar* const record)
 {
-  DBUG_ENTER("ha_rocksdb::position");
+  DBUG_ENTER_FUNC();
 
   longlong hidden_pk_id= 0;
   if (has_hidden_pk(table) && read_hidden_pk_id_from_rowkey(&hidden_pk_id))
@@ -8731,9 +8797,10 @@ void ha_rocksdb::position(const uchar* const record)
 
 int ha_rocksdb::rnd_pos(uchar* const buf, uchar* const pos)
 {
+  DBUG_ENTER_FUNC();
+
   int rc;
   size_t len;
-  DBUG_ENTER("ha_rocksdb::rnd_pos");
 
   ha_statistic_increment(&SSV::ha_read_rnd_count);
   stats.rows_requested++;
@@ -8797,7 +8864,10 @@ void ha_rocksdb::calc_updated_indexes()
 
 int ha_rocksdb::update_row(const uchar* const old_data, uchar* const new_data)
 {
-  DBUG_ENTER("ha_rocksdb::update_row");
+  DBUG_ENTER_FUNC();
+
+  DBUG_ASSERT(old_data != nullptr);
+  DBUG_ASSERT(new_data != nullptr);
   DBUG_ASSERT(m_lock_rows == RDB_LOCK_WRITE);
   /*
     old_data points to record we're updating. It is the same as the record
@@ -8814,6 +8884,7 @@ int ha_rocksdb::update_row(const uchar* const old_data, uchar* const new_data)
     stats.rows_updated++;
     update_row_stats(ROWS_UPDATED);
   }
+
   DBUG_RETURN(rv);
 }
 
@@ -8823,7 +8894,10 @@ THR_LOCK_DATA **ha_rocksdb::store_lock(THD* const thd,
                                        THR_LOCK_DATA **to,
                                        enum thr_lock_type lock_type)
 {
-  DBUG_ENTER("ha_rocksdb::store_lock");
+  DBUG_ENTER_FUNC();
+
+  DBUG_ASSERT(thd != nullptr);
+  DBUG_ASSERT(to != nullptr);
 
   bool in_lock_tables = my_core::thd_in_lock_tables(thd);
 
@@ -8901,7 +8975,9 @@ THR_LOCK_DATA **ha_rocksdb::store_lock(THD* const thd,
 
     m_db_lock.type= lock_type;
   }
+
   *to++= &m_db_lock;
+
   DBUG_RETURN(to);
 }
 
@@ -8929,9 +9005,11 @@ const char* ha_rocksdb::thd_rocksdb_tmpdir()
 
 int ha_rocksdb::external_lock(THD* const thd, int lock_type)
 {
-  int res= 0;
-  DBUG_ENTER("ha_rocksdb::external_lock");
+  DBUG_ENTER_FUNC();
 
+  DBUG_ASSERT(thd != nullptr);
+
+  int res= 0;
   int binlog_format= my_core::thd_binlog_format(thd);
   bool unsafe_for_binlog= THDVAR(ha_thd(), unsafe_for_binlog);
   if (lock_type == F_WRLCK && !thd->rli_slave &&
@@ -9055,11 +9133,16 @@ int ha_rocksdb::external_lock(THD* const thd, int lock_type)
 
 int ha_rocksdb::start_stmt(THD* const thd, thr_lock_type lock_type)
 {
+  DBUG_ENTER_FUNC();
+
+  DBUG_ASSERT(thd != nullptr);
+
   Rdb_transaction* const tx= get_or_create_tx(thd);
   read_thd_vars(thd);
   rocksdb_register_tx(ht, thd, tx);
   tx->io_perf_start(&m_io_perf);
-  return 0;
+
+  DBUG_RETURN(0);
 }
 
 rocksdb::Range get_range(
@@ -9256,7 +9339,10 @@ Rdb_tbl_def* ha_rocksdb::get_table_if_exists(const char* const tablename)
 
 int ha_rocksdb::delete_table(const char* const tablename)
 {
-  DBUG_ENTER("ha_rocksdb::delete_table");
+  DBUG_ENTER_FUNC();
+
+  DBUG_ASSERT(tablename != nullptr);
+
   const std::unique_ptr<rocksdb::WriteBatch> wb= dict_manager.begin();
   rocksdb::WriteBatch* const batch= wb.get();
 
@@ -9324,6 +9410,8 @@ void ha_rocksdb::remove_rows(Rdb_tbl_def* const tbl)
 
 int ha_rocksdb::rename_table(const char* const from, const char* const to)
 {
+  DBUG_ENTER_FUNC();
+
   DBUG_ASSERT(from != nullptr);
   DBUG_ASSERT(to != nullptr);
 
@@ -9336,20 +9424,20 @@ int ha_rocksdb::rename_table(const char* const from, const char* const to)
   if (rdb_normalize_tablename(from, &from_str) ||
       rdb_split_normalized_tablename(from_str, &from_db))
   {
-    return HA_ERR_INTERNAL_ERROR;
+    DBUG_RETURN(HA_ERR_INTERNAL_ERROR);
   }
 
   if (rdb_normalize_tablename(to, &to_str) ||
       rdb_split_normalized_tablename(to_str, &to_db))
   {
-    return HA_ERR_INTERNAL_ERROR;
+    DBUG_RETURN(HA_ERR_INTERNAL_ERROR);
   }
 
   // If the user changed the database part of the name then validate that the
   // 'to' database exists.
   if (from_db != to_db && !rdb_database_exists(to_db))
   {
-    return HA_ERR_INTERNAL_ERROR;
+    DBUG_RETURN(HA_ERR_INTERNAL_ERROR);
   }
 
   /* Check if any index has a per-index column family */
@@ -9365,7 +9453,7 @@ int ha_rocksdb::rename_table(const char* const from, const char* const to)
     */
     Rdb_tbl_def *tdef;
     if (!(tdef= ddl_manager.find(from_str)))
-      return HA_ERR_INTERNAL_ERROR;
+      DBUG_RETURN(HA_ERR_INTERNAL_ERROR);
 
     for (uint i= 0; i < tdef->m_key_count; i++)
     {
@@ -9375,7 +9463,7 @@ int ha_rocksdb::rename_table(const char* const from, const char* const to)
       {
         my_error(ER_NOT_SUPPORTED_YET, MYF(0),
                  "ALTER TABLE on table with per-index CF");
-        return HA_ERR_INTERNAL_ERROR;
+        DBUG_RETURN(HA_ERR_INTERNAL_ERROR);
       }
     }
   }
@@ -9387,7 +9475,7 @@ int ha_rocksdb::rename_table(const char* const from, const char* const to)
              || dict_manager.commit(batch);
   dict_manager.unlock();
 
-  return write_err ? HA_ERR_INTERNAL_ERROR : 0;
+  DBUG_RETURN(write_err ? HA_ERR_INTERNAL_ERROR : 0);
 }
 
 /**
@@ -9404,7 +9492,10 @@ int ha_rocksdb::rename_table(const char* const from, const char* const to)
 bool ha_rocksdb::check_if_incompatible_data(HA_CREATE_INFO* const info,
                                             uint table_changes)
 {
-  DBUG_ENTER("ha_rocksdb::check_if_incompatible_data");
+  DBUG_ENTER_FUNC();
+
+  DBUG_ASSERT(info != nullptr);
+
   // this function is needed only for online alter-table
   DBUG_RETURN(COMPATIBLE_DATA_NO);
 }
@@ -9412,7 +9503,7 @@ bool ha_rocksdb::check_if_incompatible_data(HA_CREATE_INFO* const info,
 
 int ha_rocksdb::extra(enum ha_extra_function operation)
 {
-  DBUG_ENTER("ha_rocksdb::extra");
+  DBUG_ENTER_FUNC();
 
   switch (operation) {
   case HA_EXTRA_KEYREAD:
@@ -9442,7 +9533,8 @@ int ha_rocksdb::extra(enum ha_extra_function operation)
 ha_rows ha_rocksdb::records_in_range(uint inx, key_range* const min_key,
                                      key_range* const max_key)
 {
-  DBUG_ENTER("ha_rocksdb::records_in_range");
+  DBUG_ENTER_FUNC();
+
   ha_rows ret = THDVAR(ha_thd(), records_in_range);
   if (ret) {
     DBUG_RETURN(ret);
@@ -9547,10 +9639,16 @@ ha_rows ha_rocksdb::records_in_range(uint inx, key_range* const min_key,
 
 void ha_rocksdb::update_create_info(HA_CREATE_INFO* const create_info)
 {
+  DBUG_ENTER_FUNC();
+
+  DBUG_ASSERT(create_info != nullptr);
+
   if (!(create_info->used_fields & HA_CREATE_USED_AUTO))
   {
     create_info->auto_increment_value= m_tbl_def->m_auto_incr_val;
   }
+
+  DBUG_VOID_RETURN;
 }
 
 /**
@@ -9569,6 +9667,11 @@ void ha_rocksdb::update_create_info(HA_CREATE_INFO* const create_info)
 */
 int ha_rocksdb::optimize(THD* const thd, HA_CHECK_OPT* const check_opt)
 {
+  DBUG_ENTER_FUNC();
+
+  DBUG_ASSERT(thd != nullptr);
+  DBUG_ASSERT(check_opt != nullptr);
+
   int rc= 0;
   for (uint i= 0; i < table->s->keys; i++)
   {
@@ -9582,13 +9685,14 @@ int ha_rocksdb::optimize(THD* const thd, HA_CHECK_OPT* const check_opt)
       break;
     }
   }
-  return rc;
+
+  DBUG_RETURN(rc);
 }
 
 int ha_rocksdb::calculate_stats(const TABLE* const table_arg, THD* const thd,
                                 HA_CHECK_OPT* const check_opt)
 {
-  DBUG_ENTER("ha_rocksdb::calculate_stats");
+  DBUG_ENTER_FUNC();
 
   // find per column family key ranges which need to be queried
   std::unordered_map<rocksdb::ColumnFamilyHandle*, std::vector<rocksdb::Range>>
@@ -9673,10 +9777,11 @@ int ha_rocksdb::calculate_stats(const TABLE* const table_arg, THD* const thd,
 
 int ha_rocksdb::analyze(THD* const thd, HA_CHECK_OPT* const check_opt)
 {
-  DBUG_ENTER("ha_rocksdb::analyze");
+  DBUG_ENTER_FUNC();
 
-  if (!table)
+  if (!table) {
     DBUG_RETURN(1);
+  }
 
   DBUG_RETURN(calculate_stats(table, thd, check_opt));
 }
@@ -9793,6 +9898,8 @@ const char *dbug_print_item(Item* const item)
 
 class Item* ha_rocksdb::idx_cond_push(uint keyno, class Item* const idx_cond)
 {
+  DBUG_ENTER_FUNC();
+
   DBUG_ASSERT(keyno != MAX_KEY);
   DBUG_ASSERT(idx_cond != nullptr);
 
@@ -9801,7 +9908,7 @@ class Item* ha_rocksdb::idx_cond_push(uint keyno, class Item* const idx_cond)
   in_range_check_pushed_down = TRUE;
 
   /* We will check the whole condition */
-  return nullptr;
+  DBUG_RETURN(nullptr);
 }
 
 
@@ -9892,7 +9999,9 @@ my_core::enum_alter_inplace_result ha_rocksdb::check_if_supported_inplace_alter(
   TABLE* /* altered_table */,
   my_core::Alter_inplace_info* const ha_alter_info)
 {
-  DBUG_ENTER("check_if_supported_alter");
+  DBUG_ENTER_FUNC();
+
+  DBUG_ASSERT(ha_alter_info != nullptr);
 
   if (ha_alter_info->handler_flags &
       ~(my_core::Alter_inplace_info::DROP_INDEX |
@@ -9937,11 +10046,16 @@ bool ha_rocksdb::prepare_inplace_alter_table(
     TABLE* const altered_table,
     my_core::Alter_inplace_info* const ha_alter_info)
 {
-  DBUG_ENTER("prepare_inplace_alter_table");
+  DBUG_ENTER_FUNC();
+
+  DBUG_ASSERT(altered_table != nullptr);
+  DBUG_ASSERT(ha_alter_info != nullptr);
+
   const uint n_dropped_keys= ha_alter_info->index_drop_count;
   const uint n_added_keys= ha_alter_info->index_add_count;
   const uint old_n_keys= m_tbl_def->m_key_count;
   uint new_n_keys= altered_table->s->keys;
+
   if (has_hidden_pk(altered_table))
   {
     new_n_keys += 1;
@@ -10047,9 +10161,11 @@ bool ha_rocksdb::prepare_inplace_alter_table(
 bool ha_rocksdb::inplace_alter_table(TABLE* const altered_table,
                               my_core::Alter_inplace_info* const ha_alter_info)
 {
-  /* Do nothing for now */
-  DBUG_ENTER("inplace_alter_table");
-  DBUG_ASSERT(ha_alter_info->handler_ctx);
+  DBUG_ENTER_FUNC();
+
+  DBUG_ASSERT(altered_table != nullptr);
+  DBUG_ASSERT(ha_alter_info != nullptr);
+  DBUG_ASSERT(ha_alter_info->handler_ctx != nullptr);
 
   Rdb_inplace_alter_ctx* const ctx=
     static_cast<Rdb_inplace_alter_ctx*> (ha_alter_info->handler_ctx);
@@ -10083,7 +10199,8 @@ bool ha_rocksdb::inplace_alter_table(TABLE* const altered_table,
 int ha_rocksdb::inplace_populate_sk(const TABLE* const new_table_arg,
       const std::unordered_set<std::shared_ptr<Rdb_key_def>>& indexes)
 {
-  DBUG_ENTER("ha_rocksdb::inplace_populate_sk");
+  DBUG_ENTER_FUNC();
+
   const std::unique_ptr<rocksdb::WriteBatch> wb= dict_manager.begin();
   rocksdb::WriteBatch* const batch= wb.get();
 
@@ -10294,10 +10411,13 @@ bool ha_rocksdb::commit_inplace_alter_table(
     my_core::Alter_inplace_info* const ha_alter_info,
     bool commit)
 {
+  DBUG_ENTER_FUNC();
+
+  DBUG_ASSERT(altered_table != nullptr);
+  DBUG_ASSERT(ha_alter_info != nullptr);
+
   Rdb_inplace_alter_ctx* const ctx0=
     static_cast<Rdb_inplace_alter_ctx*> (ha_alter_info->handler_ctx);
-
-  DBUG_ENTER("commit_inplace_alter_table");
 
   /*
     IMPORTANT: When rollback is requested, mysql will abort with
@@ -11073,22 +11193,38 @@ void rdb_queue_save_stats_request()
 
 void ha_rocksdb::rpl_before_delete_rows()
 {
+  DBUG_ENTER_FUNC();
+
   m_in_rpl_delete_rows= true;
+
+  DBUG_VOID_RETURN;
 }
 
 void ha_rocksdb::rpl_after_delete_rows()
 {
+  DBUG_ENTER_FUNC();
+
   m_in_rpl_delete_rows= false;
+
+  DBUG_VOID_RETURN;
 }
 
 void ha_rocksdb::rpl_before_update_rows()
 {
+  DBUG_ENTER_FUNC();
+
   m_in_rpl_update_rows= true;
+
+  DBUG_VOID_RETURN;
 }
 
 void ha_rocksdb::rpl_after_update_rows()
 {
+  DBUG_ENTER_FUNC();
+
   m_in_rpl_update_rows= false;
+
+  DBUG_VOID_RETURN;
 }
 
 /**
@@ -11100,17 +11236,22 @@ void ha_rocksdb::rpl_after_update_rows()
 */
 bool ha_rocksdb::use_read_free_rpl()
 {
-  return ((m_in_rpl_delete_rows || m_in_rpl_update_rows) &&
+  DBUG_ENTER_FUNC();
+
+  DBUG_RETURN((m_in_rpl_delete_rows || m_in_rpl_update_rows) &&
       !has_hidden_pk(table) && m_use_read_free_rpl);
 }
 
 double ha_rocksdb::read_time(uint index, uint ranges, ha_rows rows)
 {
+  DBUG_ENTER_FUNC();
+
   if (index != table->s->primary_key) {
     /* Non covering index range scan */
-    return(handler::read_time(index, ranges, rows));
+    DBUG_RETURN(handler::read_time(index, ranges, rows));
   }
-  return (rows/20.0) + 1;
+
+  DBUG_RETURN((rows/20.0) + 1);
 }
 
 }  // namespace myrocks

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -590,15 +590,25 @@ public:
   /** @brief
     The name that will be used for display purposes.
    */
-  const char *table_type() const { return rocksdb_hton_name; }
+  const char *table_type() const override
+  {
+    DBUG_ENTER_FUNC();
+
+    DBUG_RETURN(rocksdb_hton_name);
+  }
 
   /* The following is only used by SHOW KEYS: */
-  const char *index_type(uint inx) { return "LSMTREE"; }
+  const char *index_type(uint inx) override
+  {
+    DBUG_ENTER_FUNC();
+
+    DBUG_RETURN("LSMTREE");
+  }
 
   /** @brief
     The file extensions.
    */
-  const char **bas_ext() const;
+  const char **bas_ext() const override;
 
   /*
     See if this is the same base table - this should only be true for different
@@ -612,6 +622,8 @@ public:
   */
   ulonglong table_flags() const override
   {
+    DBUG_ENTER_FUNC();
+
     /*
       HA_BINLOG_STMT_CAPABLE
         We are saying that this engine is just statement capable to have
@@ -621,12 +633,12 @@ public:
         If we don't set it, filesort crashes, because it assumes rowids are
         1..8 byte numbers
     */
-    return HA_BINLOG_ROW_CAPABLE | HA_BINLOG_STMT_CAPABLE |
+    DBUG_RETURN(HA_BINLOG_ROW_CAPABLE | HA_BINLOG_STMT_CAPABLE |
            HA_REC_NOT_IN_SEQ | HA_CAN_INDEX_BLOBS |
            (m_pk_can_be_decoded? HA_PRIMARY_KEY_IN_READ_INDEX : 0) |
            HA_PRIMARY_KEY_REQUIRED_FOR_POSITION |
            HA_NULL_IN_KEY |
-           HA_PARTIAL_COLUMN_READ;
+           HA_PARTIAL_COLUMN_READ);
   }
 
   bool init_with_fields() override;
@@ -641,16 +653,20 @@ public:
     If all_parts is set, MySQL wants to know the flags for the combined
     index, up to and including 'part'.
   */
-  ulong index_flags(uint inx, uint part, bool all_parts) const;
+  ulong index_flags(uint inx, uint part, bool all_parts) const override;
 
-  const key_map * keys_to_use_for_scanning()
+  const key_map * keys_to_use_for_scanning() override
   {
-    return &key_map_full;
+    DBUG_ENTER_FUNC();
+
+    DBUG_RETURN(&key_map_full);
   }
 
-  bool primary_key_is_clustered()
+  bool primary_key_is_clustered() override
   {
-    return true;
+    DBUG_ENTER_FUNC();
+
+    DBUG_RETURN(true);
   }
 
   bool should_store_row_debug_checksums() const
@@ -658,7 +674,7 @@ public:
     return m_store_row_debug_checksums && (rand() % 100 < m_checksums_pct);
   }
 
-  int rename_table(const char* const from, const char* const to)
+  int rename_table(const char* const from, const char* const to) override
       __attribute__((__nonnull__, __warn_unused_result__));
 
   int convert_record_from_storage_format(const rocksdb::Slice* const key,
@@ -704,11 +720,34 @@ public:
     send. Return *real* limits of your storage engine here; MySQL will do
     min(your_limits, MySQL_limits) automatically.
    */
-  uint max_supported_record_length() const { return HA_MAX_REC_LENGTH; }
+  uint max_supported_record_length() const override
+  {
+    DBUG_ENTER_FUNC();
 
-  uint max_supported_keys()          const { return MAX_INDEXES; }
-  uint max_supported_key_parts()     const { return MAX_REF_PARTS; }
-  uint max_supported_key_part_length() const { return 2048; }
+    DBUG_RETURN(HA_MAX_REC_LENGTH);
+  }
+
+  uint max_supported_keys() const override
+  {
+    DBUG_ENTER_FUNC();
+
+    DBUG_RETURN(MAX_INDEXES);
+  }
+
+  uint max_supported_key_parts() const override
+  {
+    DBUG_ENTER_FUNC();
+
+    DBUG_RETURN(MAX_REF_PARTS);
+  }
+
+  uint max_supported_key_part_length() const override
+  {
+    DBUG_ENTER_FUNC();
+
+    DBUG_RETURN(2048);
+  }
+
   /** @brief
     unireg.cc will call this to make sure that the storage engine can handle
     the data it is about to send. Return *real* limits of your storage engine
@@ -718,47 +757,65 @@ public:
     There is no need to implement ..._key_... methods if your engine doesn't
     support indexes.
    */
-  uint max_supported_key_length()    const { return 16*1024; /* just to return something*/ }
+  uint max_supported_key_length() const override
+  {
+    DBUG_ENTER_FUNC();
+
+    DBUG_RETURN(16 * 1024); /* just to return something*/
+  }
 
   /**
     TODO: return actual upper bound of number of records in the table.
     (e.g. save number of records seen on full table scan and/or use file size
     as upper bound)
   */
-  ha_rows estimate_rows_upper_bound() { return HA_POS_ERROR; }
+  ha_rows estimate_rows_upper_bound() override
+  {
+    DBUG_ENTER_FUNC();
+
+    DBUG_RETURN(HA_POS_ERROR);
+  }
 
   /* At the moment, we're ok with default handler::index_init() implementation. */
   int index_read_map(uchar* const buf, const uchar* const key,
                      key_part_map keypart_map,
-                     enum ha_rkey_function find_flag);
+                     enum ha_rkey_function find_flag) override
     __attribute__((__warn_unused_result__));
 
   int index_read_map_impl(uchar* const buf, const uchar* const key,
                           key_part_map keypart_map,
                           enum ha_rkey_function find_flag,
                           const key_range* end_key)
-    __attribute__((__warn_unused_result__));;
+    __attribute__((__warn_unused_result__));
 
   int index_read_last_map(uchar* const buf, const uchar* const key,
-                          key_part_map keypart_map)
-    __attribute__((__warn_unused_result__));;
+                          key_part_map keypart_map) override
+    __attribute__((__warn_unused_result__));
 
   int read_range_first(const key_range* const start_key,
                        const key_range* const end_key,
-                       bool eq_range, bool sorted)
-    __attribute__((__warn_unused_result__));;
+                       bool eq_range, bool sorted) override
+    __attribute__((__warn_unused_result__));
 
-  virtual double scan_time() { return (double) (stats.records+stats.deleted) / 20.0+10; }
+  virtual double scan_time() override
+  {
+    DBUG_ENTER_FUNC();
+
+    DBUG_RETURN(static_cast<double>((stats.records + stats.deleted) / 20.0
+      + 10));
+  }
+
   virtual double read_time(uint, uint, ha_rows rows) override;
 
-  int open(const char* const name, int mode, uint test_if_locked)
+  int open(const char* const name, int mode, uint test_if_locked) override
     __attribute__((__warn_unused_result__));
-  int close(void) __attribute__((__warn_unused_result__));
+  int close(void) override __attribute__((__warn_unused_result__));
 
-  int write_row(uchar* const buf) __attribute__((__warn_unused_result__));
-  int update_row(const uchar* const old_data, uchar* const new_data)
+  int write_row(uchar* const buf) override
     __attribute__((__warn_unused_result__));
-  int delete_row(const uchar* const buf)
+  int update_row(const uchar* const old_data, uchar* const new_data) override
+    __attribute__((__warn_unused_result__));
+  int delete_row(const uchar* const buf) override
     __attribute__((__warn_unused_result__));
   rocksdb::Status delete_or_singledelete(uint index,
                                          Rdb_transaction* const tx,
@@ -766,15 +823,19 @@ public:
                                          const rocksdb::Slice& key)
     __attribute__((__warn_unused_result__));
 
-  int index_next(uchar* const buf) __attribute__((__warn_unused_result__));
+  int index_next(uchar* const buf) override
+    __attribute__((__warn_unused_result__));
   int index_next_with_direction(uchar* const buf, bool move_forward)
     __attribute__((__warn_unused_result__));
-  int index_prev(uchar* const buf) __attribute__((__warn_unused_result__));
+  int index_prev(uchar* const buf) override
+    __attribute__((__warn_unused_result__));
 
-  int index_first(uchar* const buf) __attribute__((__warn_unused_result__));
-  int index_last(uchar* const buf) __attribute__((__warn_unused_result__));
+  int index_first(uchar* const buf) override
+    __attribute__((__warn_unused_result__));
+  int index_last(uchar* const buf) override
+    __attribute__((__warn_unused_result__));
 
-  class Item* idx_cond_push(uint keyno, class Item* const idx_cond);
+  class Item* idx_cond_push(uint keyno, class Item* const idx_cond) override;
   /*
     Default implementation from cancel_pushed_idx_cond() suits us
   */
@@ -930,10 +991,11 @@ private:
       const std::unordered_set<std::shared_ptr<Rdb_key_def>>& indexes);
 
 public:
-  int index_init(uint idx, bool sorted) __attribute__((__warn_unused_result__));
-  int index_end() __attribute__((__warn_unused_result__));
+  int index_init(uint idx, bool sorted) override
+    __attribute__((__warn_unused_result__));
+  int index_end() override __attribute__((__warn_unused_result__));
 
-  void unlock_row();
+  void unlock_row() override;
 
   /** @brief
     Unlike index_init(), rnd_init() can be called two consecutive times
@@ -943,75 +1005,81 @@ public:
     cursor to the start of the table; no need to deallocate and allocate
     it again. This is a required method.
   */
-  int rnd_init(bool scan) __attribute__((__warn_unused_result__));
-  int rnd_end() __attribute__((__warn_unused_result__));
+  int rnd_init(bool scan) override __attribute__((__warn_unused_result__));
+  int rnd_end() override __attribute__((__warn_unused_result__));
 
-  int rnd_next(uchar* const buf) __attribute__((__warn_unused_result__));
+  int rnd_next(uchar* const buf) override
+    __attribute__((__warn_unused_result__));
   int rnd_next_with_direction(uchar* const buf, bool move_forward)
     __attribute__((__warn_unused_result__));
 
-  int rnd_pos(uchar* const buf, uchar* const pos)
+  int rnd_pos(uchar* const buf, uchar* const pos) override
     __attribute__((__warn_unused_result__));
-  void position(const uchar* const record);
+  void position(const uchar* const record) override;
   int info(uint) override;
 
   /* This function will always return success, therefore no annotation related
    * to checking the return value. Can't change the signature because it's
    * required by the interface. */
-  int extra(enum ha_extra_function operation);
+  int extra(enum ha_extra_function operation) override;
 
-  int start_stmt(THD* const thd, thr_lock_type lock_type)
+  int start_stmt(THD* const thd, thr_lock_type lock_type) override
     __attribute__((__warn_unused_result__));
-  int external_lock(THD* const thd, int lock_type)
+  int external_lock(THD* const thd, int lock_type) override
     __attribute__((__warn_unused_result__));
-  int delete_all_rows(ha_rows* const nrows) __attribute__((__warn_unused_result__));
-  int truncate() __attribute__((__warn_unused_result__));
+  int truncate() override __attribute__((__warn_unused_result__));
 
   int reset() override
   {
+    DBUG_ENTER_FUNC();
+
     /* Free blob data */
     m_retrieved_record.clear();
-    return 0;
+
+    DBUG_RETURN(0);
   }
 
-  int check(THD* const thd, HA_CHECK_OPT* const check_opt)
+  int check(THD* const thd, HA_CHECK_OPT* const check_opt) override
     __attribute__((__warn_unused_result__));
   void remove_rows(Rdb_tbl_def* const tbl);
   ha_rows records_in_range(uint inx, key_range* const min_key,
-                           key_range* const max_key)
+                           key_range* const max_key) override
     __attribute__((__warn_unused_result__));
-  int delete_table(const char* const from) __attribute__((__warn_unused_result__));
+  int delete_table(const char* const from) override
+    __attribute__((__warn_unused_result__));
   int create(const char* const name, TABLE* const form,
-             HA_CREATE_INFO* const create_info)
+             HA_CREATE_INFO* const create_info) override
     __attribute__((__warn_unused_result__));
   bool check_if_incompatible_data(HA_CREATE_INFO* const info,
-                                  uint table_changes)
+                                  uint table_changes) override
     __attribute__((__warn_unused_result__));
 
   THR_LOCK_DATA **store_lock(THD* const thd, THR_LOCK_DATA **to,
-                             enum thr_lock_type lock_type)
+                             enum thr_lock_type lock_type) override
     __attribute__((__warn_unused_result__));
 
   my_bool register_query_cache_table(THD* const thd, char* const table_key,
                                      uint key_length,
                                      qc_engine_callback* const engine_callback,
-                                     ulonglong* const engine_data)
+                                     ulonglong* const engine_data) override
   {
+    DBUG_ENTER_FUNC();
+
     /* Currently, we don't support query cache */
-    return FALSE;
+    DBUG_RETURN(FALSE);
   }
 
-  bool get_error_message(const int error, String* const buf)
+  bool get_error_message(const int error, String* const buf) override
     __attribute__((__nonnull__));
 
   void get_auto_increment(ulonglong offset, ulonglong increment,
                           ulonglong nb_desired_values,
                           ulonglong* const first_value,
-                          ulonglong* const nb_reserved_values);
-  void update_create_info(HA_CREATE_INFO* const create_info);
-  int optimize(THD* const thd, HA_CHECK_OPT* const check_opt)
+                          ulonglong* const nb_reserved_values) override;
+  void update_create_info(HA_CREATE_INFO* const create_info) override;
+  int optimize(THD* const thd, HA_CHECK_OPT* const check_opt) override
     __attribute__((__warn_unused_result__));
-  int analyze(THD* const thd, HA_CHECK_OPT* const check_opt)
+  int analyze(THD* const thd, HA_CHECK_OPT* const check_opt) override
     __attribute__((__warn_unused_result__));
   int calculate_stats(const TABLE* const table_arg, THD* const thd,
                       HA_CHECK_OPT* const check_opt)
@@ -1022,14 +1090,16 @@ public:
     my_core::Alter_inplace_info* const ha_alter_info) override;
 
   bool prepare_inplace_alter_table(TABLE* const altered_table,
-                              my_core::Alter_inplace_info* const ha_alter_info);
+                              my_core::Alter_inplace_info* const ha_alter_info)
+                              override;
 
   bool inplace_alter_table(TABLE* const altered_table,
-                           my_core::Alter_inplace_info* const ha_alter_info);
+                           my_core::Alter_inplace_info* const ha_alter_info)
+                           override;
 
   bool commit_inplace_alter_table(TABLE* const altered_table,
                               my_core::Alter_inplace_info* const ha_alter_info,
-                              bool commit);
+                              bool commit) override;
 
   int finalize_bulk_load() __attribute__((__warn_unused_result__));
 

--- a/storage/rocksdb/rdb_i_s.cc
+++ b/storage/rocksdb/rdb_i_s.cc
@@ -76,10 +76,10 @@ static int rdb_i_s_cfstats_fill_table(
     my_core::TABLE_LIST* const tables,
     my_core::Item* const cond __attribute__((__unused__)))
 {
+  DBUG_ENTER_FUNC();
+
   bool ret;
   uint64_t val;
-
-  DBUG_ENTER("rdb_i_s_cfstats_fill_table");
 
   const std::vector<std::pair<const std::string, std::string>> cf_properties = {
     {rocksdb::DB::Properties::kNumImmutableMemTable, "NUM_IMMUTABLE_MEM_TABLE"},
@@ -143,10 +143,11 @@ static int rdb_i_s_cfstats_fill_table(
 
 static int rdb_i_s_cfstats_init(void *p)
 {
-  my_core::ST_SCHEMA_TABLE *schema;
+  DBUG_ENTER_FUNC();
 
-  DBUG_ENTER("rdb_i_s_cfstats_init");
   DBUG_ASSERT(p != nullptr);
+
+  my_core::ST_SCHEMA_TABLE *schema;
 
   schema= (my_core::ST_SCHEMA_TABLE*) p;
 
@@ -180,10 +181,10 @@ static int rdb_i_s_dbstats_fill_table(
     my_core::TABLE_LIST* const tables,
     my_core::Item* const cond __attribute__((__unused__)))
 {
+  DBUG_ENTER_FUNC();
+
   bool ret;
   uint64_t val;
-
-  DBUG_ENTER("rdb_i_s_dbstats_fill_table");
 
   const std::vector<std::pair<std::string, std::string>> db_properties = {
     {rocksdb::DB::Properties::kBackgroundErrors, "DB_BACKGROUND_ERRORS"},
@@ -236,11 +237,11 @@ static int rdb_i_s_dbstats_fill_table(
 
 static int rdb_i_s_dbstats_init(void* const p)
 {
+  DBUG_ENTER_FUNC();
+
   DBUG_ASSERT(p != nullptr);
 
   my_core::ST_SCHEMA_TABLE *schema;
-
-  DBUG_ENTER("rdb_i_s_dbstats_init");
 
   schema= (my_core::ST_SCHEMA_TABLE*) p;
 
@@ -282,13 +283,13 @@ static int rdb_i_s_perf_context_fill_table(
     my_core::TABLE_LIST* const tables,
     my_core::Item* const cond __attribute__((__unused__)))
 {
+  DBUG_ENTER_FUNC();
+
   DBUG_ASSERT(thd != nullptr);
   DBUG_ASSERT(tables != nullptr);
 
   int ret= 0;
   Field** field= tables->table->field;
-
-  DBUG_ENTER("rdb_i_s_perf_context_fill_table");
 
   const std::vector<std::string> tablenames= rdb_get_open_table_names();
   for (const auto& it : tablenames)
@@ -346,11 +347,11 @@ static int rdb_i_s_perf_context_fill_table(
 
 static int rdb_i_s_perf_context_init(void* const p)
 {
+  DBUG_ENTER_FUNC();
+
   DBUG_ASSERT(p != nullptr);
 
   my_core::ST_SCHEMA_TABLE *schema;
-
-  DBUG_ENTER("rdb_i_s_perf_context_init");
 
   schema= (my_core::ST_SCHEMA_TABLE*) p;
 
@@ -384,11 +385,12 @@ static int rdb_i_s_perf_context_global_fill_table(
     my_core::TABLE_LIST* const tables,
     my_core::Item* const cond __attribute__((__unused__)))
 {
+  DBUG_ENTER_FUNC();
+
   DBUG_ASSERT(thd != nullptr);
   DBUG_ASSERT(tables != nullptr);
 
   int ret= 0;
-  DBUG_ENTER("rdb_i_s_perf_context_global_fill_table");
 
   // Get a copy of the global perf counters.
   Rdb_perf_counters global_counters;
@@ -415,11 +417,11 @@ static int rdb_i_s_perf_context_global_fill_table(
 
 static int rdb_i_s_perf_context_global_init(void* const p)
 {
+  DBUG_ENTER_FUNC();
+
   DBUG_ASSERT(p != nullptr);
 
   my_core::ST_SCHEMA_TABLE *schema;
-
-  DBUG_ENTER("rdb_i_s_perf_context_global_init");
 
   schema= (my_core::ST_SCHEMA_TABLE*) p;
 
@@ -455,12 +457,12 @@ static int rdb_i_s_cfoptions_fill_table(
     my_core::TABLE_LIST* const tables,
     my_core::Item* const cond __attribute__((__unused__)))
 {
+  DBUG_ENTER_FUNC();
+
   DBUG_ASSERT(thd != nullptr);
   DBUG_ASSERT(tables != nullptr);
 
   bool ret;
-
-  DBUG_ENTER("rdb_i_s_cfoptions_fill_table");
 
   Rdb_cf_manager& cf_manager= rdb_get_cf_manager();
 
@@ -776,10 +778,11 @@ static int rdb_i_s_global_info_fill_table(
     my_core::TABLE_LIST* const tables,
     my_core::Item* const cond __attribute__((__unused__)))
 {
+  DBUG_ENTER_FUNC();
+
   DBUG_ASSERT(thd != nullptr);
   DBUG_ASSERT(tables != nullptr);
 
-  DBUG_ENTER("rdb_i_s_global_info_fill_table");
   static const uint32_t INT_BUF_LEN = 21;
   static const uint32_t GTID_BUF_LEN = 60;
   static const uint32_t CF_ID_INDEX_BUF_LEN = 60;
@@ -1025,7 +1028,7 @@ static int rdb_i_s_ddl_fill_table(my_core::THD* const thd,
                                   my_core::TABLE_LIST* const tables,
                                   my_core::Item* const cond)
 {
-  DBUG_ENTER("rdb_i_s_ddl_fill_table");
+  DBUG_ENTER_FUNC();
 
   DBUG_ASSERT(thd != nullptr);
   DBUG_ASSERT(tables != nullptr);
@@ -1043,9 +1046,10 @@ static int rdb_i_s_ddl_fill_table(my_core::THD* const thd,
 
 static int rdb_i_s_ddl_init(void* const p)
 {
+  DBUG_ENTER_FUNC();
+
   my_core::ST_SCHEMA_TABLE *schema;
 
-  DBUG_ENTER("rdb_i_s_ddl_init");
   DBUG_ASSERT(p != nullptr);
 
   schema= (my_core::ST_SCHEMA_TABLE*) p;
@@ -1058,10 +1062,11 @@ static int rdb_i_s_ddl_init(void* const p)
 
 static int rdb_i_s_cfoptions_init(void* const p)
 {
-  my_core::ST_SCHEMA_TABLE *schema;
+  DBUG_ENTER_FUNC();
 
-  DBUG_ENTER("rdb_i_s_cfoptions_init");
   DBUG_ASSERT(p != nullptr);
+
+  my_core::ST_SCHEMA_TABLE *schema;
 
   schema= (my_core::ST_SCHEMA_TABLE*) p;
 
@@ -1073,10 +1078,11 @@ static int rdb_i_s_cfoptions_init(void* const p)
 
 static int rdb_i_s_global_info_init(void* const p)
 {
-  my_core::ST_SCHEMA_TABLE *schema;
+  DBUG_ENTER_FUNC();
 
-  DBUG_ENTER("rdb_i_s_global_info_init");
   DBUG_ASSERT(p != nullptr);
+
+  my_core::ST_SCHEMA_TABLE *schema;
 
   schema= reinterpret_cast<my_core::ST_SCHEMA_TABLE*>(p);
 
@@ -1164,6 +1170,8 @@ static int rdb_i_s_index_file_map_fill_table(
     my_core::TABLE_LIST* const tables,
     my_core::Item* const cond __attribute__((__unused__)))
 {
+  DBUG_ENTER_FUNC();
+
   DBUG_ASSERT(thd != nullptr);
   DBUG_ASSERT(tables != nullptr);
   DBUG_ASSERT(tables->table != nullptr);
@@ -1171,8 +1179,6 @@ static int rdb_i_s_index_file_map_fill_table(
   int     ret = 0;
   Field **field = tables->table->field;
   DBUG_ASSERT(field != nullptr);
-
-  DBUG_ENTER("rdb_i_s_index_file_map_fill_table");
 
   /* Iterate over all the column families */
   rocksdb::DB* const rdb= rdb_get_rocksdb_db();
@@ -1244,10 +1250,11 @@ static int rdb_i_s_index_file_map_fill_table(
 /* Initialize the information_schema.rocksdb_index_file_map virtual table */
 static int rdb_i_s_index_file_map_init(void* const p)
 {
-  my_core::ST_SCHEMA_TABLE *schema;
+  DBUG_ENTER_FUNC();
 
-  DBUG_ENTER("rdb_i_s_index_file_map_init");
   DBUG_ASSERT(p != nullptr);
+
+  my_core::ST_SCHEMA_TABLE *schema;
 
   schema= (my_core::ST_SCHEMA_TABLE*) p;
 
@@ -1286,13 +1293,13 @@ static int rdb_i_s_lock_info_fill_table(
     my_core::TABLE_LIST* const tables,
     my_core::Item* const cond __attribute__((__unused__)))
 {
+  DBUG_ENTER_FUNC();
+
   DBUG_ASSERT(thd != nullptr);
   DBUG_ASSERT(tables != nullptr);
   DBUG_ASSERT(tables->table != nullptr);
 
   int ret = 0;
-
-  DBUG_ENTER("rdb_i_s_lock_info_fill_table");
 
   rocksdb::TransactionDB* const rdb= rdb_get_rocksdb_db();
   DBUG_ASSERT(rdb != nullptr);
@@ -1332,10 +1339,11 @@ static int rdb_i_s_lock_info_fill_table(
 /* Initialize the information_schema.rocksdb_lock_info virtual table */
 static int rdb_i_s_lock_info_init(void* const p)
 {
-  my_core::ST_SCHEMA_TABLE *schema;
+  DBUG_ENTER_FUNC();
 
-  DBUG_ENTER("rdb_i_s_lock_info_init");
   DBUG_ASSERT(p != nullptr);
+
+  my_core::ST_SCHEMA_TABLE *schema;
 
   schema= (my_core::ST_SCHEMA_TABLE*) p;
 
@@ -1400,13 +1408,13 @@ static int rdb_i_s_trx_info_fill_table(
     my_core::TABLE_LIST* const tables,
     my_core::Item* const cond __attribute__((__unused__)))
 {
+  DBUG_ENTER_FUNC();
+
   DBUG_ASSERT(thd != nullptr);
   DBUG_ASSERT(tables != nullptr);
   DBUG_ASSERT(tables->table != nullptr);
 
   int ret = 0;
-
-  DBUG_ENTER("rdb_i_s_trx_info_fill_table");
 
   const std::vector<Rdb_trx_info> &all_trx_info = rdb_get_all_trx_info();
 
@@ -1459,10 +1467,11 @@ static int rdb_i_s_trx_info_fill_table(
 /* Initialize the information_schema.rocksdb_trx_info virtual table */
 static int rdb_i_s_trx_info_init(void* const p)
 {
-  my_core::ST_SCHEMA_TABLE *schema;
+  DBUG_ENTER_FUNC();
 
-  DBUG_ENTER("rdb_i_s_trx_info_init");
   DBUG_ASSERT(p != nullptr);
+
+  my_core::ST_SCHEMA_TABLE *schema;
 
   schema= (my_core::ST_SCHEMA_TABLE*) p;
 
@@ -1474,7 +1483,7 @@ static int rdb_i_s_trx_info_init(void* const p)
 
 static int rdb_i_s_deinit(void *p __attribute__((__unused__)))
 {
-  DBUG_ENTER("rdb_i_s_deinit");
+  DBUG_ENTER_FUNC();
   DBUG_RETURN(0);
 }
 

--- a/storage/rocksdb/rdb_utils.h
+++ b/storage/rocksdb/rdb_utils.h
@@ -102,6 +102,18 @@ namespace myrocks {
 #endif
 
 /*
+  Intent behind this macro is to avoid manually typing the function name every
+  time we want to add the debugging statement and use the compiler for this
+  work. This avoids typical refactoring problems when one renames a function,
+  but the tracing message doesn't get updated.
+
+  We could use __func__ or __FUNCTION__ macros, but __PRETTY_FUNCTION__
+  contains the signature of the function as well as its bare name and provides
+  therefore more context when interpreting the logs.
+*/
+#define DBUG_ENTER_FUNC() DBUG_ENTER(__PRETTY_FUNCTION__)
+
+/*
   Generic constant.
 */
 const size_t RDB_MAX_HEXDUMP_LEN= 1000;


### PR DESCRIPTION
Interface MySQL provides for implementing custom storage engines is
quite cumbersome. For the purposes of the debugging and understanding
the flow of execution we need to be able to clearly observe and trace
how MyRocks code is being called. Interface itself is described in
`sql\handler.h`.

As a standard solution, MySQL exposes DBUG package and various macros
associated with it.

This set of changes makes sure that every call to any of the functions
MyRocks implements will be tracked with a pair of `DBUG_FUNC_CALL` and
`DBUG_RETURN*` macros. We can now change DBUG settings during runtime
(`SET GLOBAL debug = '+d,enter,exit:L';` or something similar) and
observe the execution flow.

`DBUG_FUNC_CALL` is a simple customization based on `DBUG_ENTER` and it
uses `__PRETTY_FUNCTION__` to delegate the work of composing correct
function names to a compiler. Yes, this functionality is specific to
`Clang` or `GCC` and these are the only toolsets we care about now.

For future references: please use `DBUG_FUNC_CALL` always at the top of
the function as opposed to after variable declarations (which may cause
tons of code in some c'tor to be executed) to make sure that logs will
correctly reflect the reality.

As a bonus we also add some extra invariants :-)