### PR TITLE
avoid calling GetOptions() destructor per query

### DIFF
--- a/storage/rocksdb/rdb_cf_options.cc
+++ b/storage/rocksdb/rdb_cf_options.cc
@@ -337,6 +337,12 @@ void Rdb_cf_options::get_cf_options(const std::string &cf_name,
 
   // Set the comparator according to 'rev:'
   opts->comparator= get_cf_comparator(cf_name);
+
+  // Cache the prefix extractor so it can be referenced later
+  if (opts->prefix_extractor)
+  {
+    m_cf_to_prefix_extractor[cf_name]= opts->prefix_extractor.get();
+  }
 }
 
 }  // namespace myrocks

--- a/storage/rocksdb/rdb_cf_options.h
+++ b/storage/rocksdb/rdb_cf_options.h
@@ -23,6 +23,7 @@
 /* RocksDB header files */
 #include "rocksdb/table.h"
 #include "rocksdb/utilities/options_util.h"
+#include "rocksdb/slice_transform.h"
 
 /* MyRocks header files */
 #include "./rdb_comparator.h"
@@ -41,6 +42,10 @@ namespace myrocks {
 class Rdb_cf_options
 {
  public:
+  /* Cache the prefix extractor for each cf here since it is immutable */
+  std::unordered_map<std::string, const rocksdb::SliceTransform*>
+    m_cf_to_prefix_extractor;
+
   Rdb_cf_options(const Rdb_cf_options&) = delete;
   Rdb_cf_options& operator=(const Rdb_cf_options&) = delete;
   Rdb_cf_options() = default;


### PR DESCRIPTION
We currently call GetOptions() for every query by MyRocks, to determine if we can use a bloom filter.  GetOptions() constructs an object, which we can avoid doing if we cache the prefix_extractor (which is immutable for the lifetime of the db) on startup.