### PR TITLE
avoid calling GetOptions() destructor per query

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -10778,8 +10778,8 @@ bool can_use_bloom_filter(THD *thd,
     return can_use;
   }
 
-  rocksdb::Options opt = rdb->GetOptions(kd.get_cf());
-  if (opt.prefix_extractor)
+  const rocksdb::SliceTransform* prefix_extractor= kd.get_extractor();
+  if (prefix_extractor)
   {
     /*
       This is an optimized use case for CappedPrefixTransform.
@@ -10799,11 +10799,11 @@ bool can_use_bloom_filter(THD *thd,
       shorter require all parts of the key to be available
       for the short key match.
     */
-    if (use_all_keys && opt.prefix_extractor->InRange(eq_cond))
+    if (use_all_keys && prefix_extractor->InRange(eq_cond))
       can_use= true;
     else if (!is_ascending)
       can_use= false;
-    else if (opt.prefix_extractor->SameResultWhenAppended(eq_cond))
+    else if (prefix_extractor->SameResultWhenAppended(eq_cond))
       can_use= true;
     else
       can_use= false;

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -75,6 +75,7 @@ Rdb_key_def::Rdb_key_def(
     m_pack_info(nullptr),
     m_keyno(keyno_arg),
     m_key_parts(0),
+    m_prefix_extractor(nullptr),
     m_maxlength(0)  // means 'not intialized'
 {
   mysql_mutex_init(0, &m_mutex, MY_MUTEX_INIT_FAST);
@@ -93,6 +94,7 @@ Rdb_key_def::Rdb_key_def(const Rdb_key_def& k) :
     m_pack_info(k.m_pack_info),
     m_keyno(k.m_keyno),
     m_key_parts(k.m_key_parts),
+    m_prefix_extractor(k.m_prefix_extractor),
     m_maxlength(k.m_maxlength)
 {
   mysql_mutex_init(0, &m_mutex, MY_MUTEX_INIT_FAST);
@@ -312,6 +314,10 @@ void Rdb_key_def::setup(const TABLE* const tbl,
 
     /* Initialize the memory needed by the stats structure */
     m_stats.m_distinct_keys_per_prefix.resize(get_key_parts());
+
+    /* Cache prefix extractor for bloom filter usage later */
+    rocksdb::Options opt = rdb_get_rocksdb_db()->GetOptions(get_cf());
+    m_prefix_extractor= opt.prefix_extractor;
 
     /*
       This should be the last member variable set before releasing the mutex

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -298,6 +298,10 @@ public:
     return m_name;
   }
 
+  const rocksdb::SliceTransform* get_extractor() const {
+    return m_prefix_extractor.get();
+  }
+
   Rdb_key_def& operator=(const Rdb_key_def&) = delete;
   Rdb_key_def(const Rdb_key_def& k);
   Rdb_key_def(uint indexnr_arg, uint keyno_arg,
@@ -460,6 +464,9 @@ private:
     many elements are in the m_pack_info array.
   */
   uint m_key_parts;
+
+  /* Prefix extractor for the column family of the key definiton */
+  std::shared_ptr<const rocksdb::SliceTransform> m_prefix_extractor;
 
   /* Maximum length of the mem-comparable form. */
   uint m_maxlength;


### PR DESCRIPTION
We currently call GetOptions() for every query by MyRocks, to determine if we can use a bloom filter. GetOptions() constructs an object, which we can avoid doing if we cache the prefix_extractor (which is immutable for the lifetime of the db) when setting up key descriptors.