### PR TITLE
[MyRocks] Support --socket in myrocks_hotbackup

### DIFF
--- a/mysql-test/suite/rocksdb_hotbackup/include/stream_run.sh
+++ b/mysql-test/suite/rocksdb_hotbackup/include/stream_run.sh
@@ -39,6 +39,11 @@ elif [ "$STREAM_TYPE" == 'xbstream' ]; then
     --stream=xbstream --checkpoint_dir=$checkpoint_dir 2> \
     $COPY_LOG | xbstream -x \
     --directory=$backup_dir"
+elif [ "$STREAM_TYPE" == "xbstream_socket" ]; then
+  BACKUP_CMD="$MYSQL_MYROCKS_HOTBACKUP --user='root' --socket=${MASTER_MYSOCK} \
+    --stream=xbstream --checkpoint_dir=$checkpoint_dir 2> \
+    $COPY_LOG | xbstream -x \
+    --directory=$backup_dir"
 else
   BACKUP_CMD="$MYSQL_MYROCKS_HOTBACKUP --user='root' --stream=wdt \
     --port=${MASTER_MYPORT} --destination=localhost --backup_dir=$backup_dir \

--- a/mysql-test/suite/rocksdb_hotbackup/r/xbstream_socket.result
+++ b/mysql-test/suite/rocksdb_hotbackup/r/xbstream_socket.result
@@ -1,0 +1,20 @@
+include/rpl_init.inc [topology=none]
+include/rpl_default_connections.inc
+create database db1;
+create table db1.t1 (
+`id` int(10) not null auto_increment,
+`k` int(10),
+`data` varchar(2048),
+primary key (`id`),
+key (`k`)
+) engine=rocksdb;
+include/rpl_stop_server.inc [server_number=2]
+myrocks_hotbackup copy phase
+myrocks_hotbackup move-back phase
+include/rpl_start_server.inc [server_number=2]
+select count(*) from db1.t1;
+count(*)
+250000
+drop database db1;
+drop database db1;
+include/rpl_end.inc

--- a/mysql-test/suite/rocksdb_hotbackup/t/xbstream_socket.test
+++ b/mysql-test/suite/rocksdb_hotbackup/t/xbstream_socket.test
@@ -1,0 +1,22 @@
+
+source suite/rocksdb_hotbackup/include/setup.inc;
+
+--exec suite/rocksdb_hotbackup/include/load_data.sh 2>&1
+--let $rpl_server_number= 2
+--source include/rpl_stop_server.inc
+
+--exec STREAM_TYPE=xbstream_socket suite/rocksdb_hotbackup/include/stream_run.sh 2>&1
+
+--let $rpl_server_number= 2
+--source include/rpl_start_server.inc
+
+connection server_2;
+select count(*) from db1.t1;
+
+connection server_1;
+drop database db1;
+connection server_2;
+drop database db1;
+
+source suite/rocksdb_hotbackup/include/cleanup.inc;
+

--- a/scripts/myrocks_hotbackup
+++ b/scripts/myrocks_hotbackup
@@ -299,11 +299,16 @@ class RocksDBBackup():
 
 class MySQLUtil:
   @staticmethod
-  def connect(user, password, port):
-    dbh = MySQLdb.Connect(user=user,
-                          passwd=password,
-                          port=port,
-                          host="127.0.0.1")
+  def connect(user, password, port, socket=None):
+    if socket:
+      dbh = MySQLdb.Connect(user=user,
+                            passwd=password,
+                            unix_socket=socket)
+    else:
+      dbh = MySQLdb.Connect(user=user,
+                            passwd=password,
+                            port=port,
+                            host="127.0.0.1")
     return dbh
 
   @staticmethod
@@ -347,7 +352,10 @@ class BackupRunner:
         raise Exception("Currently only streaming backup is supported.")
 
       snapshot_dir = opts.checkpoint_directory + '/' + str(backup_round)
-      dbh= MySQLUtil.connect(opts.mysql_user, opts.mysql_password, opts.mysql_port)
+      dbh = MySQLUtil.connect(opts.mysql_user,
+                              opts.mysql_password,
+                              opts.mysql_port,
+                              opts.mysql_socket)
       if not self.datadir:
         self.datadir = MySQLUtil.get_datadir(dbh)
         logger.info("Set datadir: %s", self.datadir)
@@ -412,7 +420,8 @@ class WDTBackup:
       snapshot_dir = os.path.join(opts.checkpoint_directory, str(backup_round))
       dbh = MySQLUtil.connect(opts.mysql_user,
                               opts.mysql_password,
-                              opts.mysql_port)
+                              opts.mysql_port,
+                              opts.mysql_socket)
       logger.info("Creating checkpoint at %s", snapshot_dir)
       MySQLUtil.create_checkpoint(dbh, snapshot_dir)
       logger.info("Created checkpoint at %s", snapshot_dir)
@@ -559,6 +568,9 @@ def parse_options():
   parser.add_option('-P', '--port', type='int', dest='mysql_port',
                     default=3306,
                     help='MySQL port number')
+  parser.add_option('-S', '--socket', type='string', dest='mysql_socket',
+                    default=None,
+                    help='MySQL socket path. Takes precedence over --port.')
   parser.add_option('-m', '--move_back', action='store_true', dest='move_back',
                     default=False,
                     help='Moving MyRocks backup files to proper locations.')


### PR DESCRIPTION
Summary: This diff adds --socket argument in myrocks_hotbackup.
Since backups are taken locally, --socket makes more sense than --port

Test Plan: xbstream_socket