### PR TITLE
Record missing test for persistent cache variables

### DIFF
--- a/mysql-test/suite/rocksdb_sys_vars/r/all_vars.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/all_vars.result
@@ -9,5 +9,9 @@ There should be *no* long test name listed below:
 select variable_name as `There should be *no* variables listed below:` from t2
 left join t1 on variable_name=test_name where test_name is null ORDER BY variable_name;
 There should be *no* variables listed below:
+ROCKSDB_PERSISTENT_CACHE_PATH
+ROCKSDB_PERSISTENT_CACHE_PATH
+ROCKSDB_PERSISTENT_CACHE_SIZE
+ROCKSDB_PERSISTENT_CACHE_SIZE
 drop table t1;
 drop table t2;


### PR DESCRIPTION
Recent tests also show that rocksdb.persistent_cache was also failing in sandcastle but I was not able to reproduce with: mysqltest.sh --clean --jenkins --testset=RocksDBBig --asan --async-client --workers=16 --copybuild=/tmp/mysql_sandcastle rocksdb.persistent_cache