### PR TITLE
Improve error handling by using named constants

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -196,7 +196,7 @@ rocksdb_compact_column_family(THD* const thd,
       rdb->CompactRange(rocksdb::CompactRangeOptions(), cfh, nullptr, nullptr);
     }
   }
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 ///////////////////////////////////////////////////////////
@@ -321,7 +321,7 @@ rocksdb_force_flush_memtable_now(THD* const thd,
 {
   sql_print_information("RocksDB: Manual memtable flush\n");
   rocksdb_flush_all_memtables();
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 static void rocksdb_drop_index_wakeup_thread(
@@ -1952,9 +1952,9 @@ public:
                       "SAVEPOINT if modifying rows.",
                       MYF(0));
       m_rollback_only= true;
-      return 1;
+      return HA_EXIT_FAILURE;
     }
-    return 0;
+    return HA_EXIT_SUCCESS;
   }
 
   /*
@@ -2625,7 +2625,7 @@ static int rocksdb_close_connection(handlerton* const hton, THD* const thd)
     delete tx;
     tx= nullptr;
   }
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 /*
@@ -2669,9 +2669,9 @@ static bool rocksdb_flush_wal(
   rocksdb_wal_group_syncs++;
   const rocksdb::Status s= rdb->SyncWAL();
   if (!s.ok()) {
-    return 1;
+    return HA_EXIT_FAILURE;
   }
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 /**
@@ -2684,7 +2684,7 @@ static int rocksdb_prepare(handlerton* const hton, THD* const thd,
   Rdb_transaction*& tx= get_tx_from_thd(thd);
   if (!tx->can_prepare())
   {
-    return 1;
+    return HA_EXIT_FAILURE;
   }
   if (prepare_tx ||
       (!my_core::thd_test_options(thd, OPTION_NOT_AUTOCOMMIT | OPTION_BEGIN))) {
@@ -2704,7 +2704,7 @@ static int rocksdb_prepare(handlerton* const hton, THD* const thd,
       XID xid;
       thd_get_xid(thd, reinterpret_cast<MYSQL_XID*>(&xid));
       if (!tx->prepare(rdb_xid_to_string(xid))) {
-        return 1;
+        return HA_EXIT_FAILURE;
       }
       if (thd->durability_property == HA_IGNORE_DURABILITY
           && THDVAR(thd, write_sync)) {
@@ -2718,7 +2718,7 @@ static int rocksdb_prepare(handlerton* const hton, THD* const thd,
     DEBUG_SYNC(thd, "rocksdb.prepared");
   }
 
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 /**
@@ -2730,14 +2730,14 @@ static int rocksdb_commit_by_xid(handlerton* const hton,	XID* const xid)
   const auto name= rdb_xid_to_string(*xid);
   rocksdb::Transaction* const trx= rdb->GetTransactionByName(name);
   if (trx == nullptr) {
-    return 1;
+    return HA_EXIT_FAILURE;
   }
   const rocksdb::Status s= trx->Commit();
   if (!s.ok()) {
-    return 1;
+    return HA_EXIT_FAILURE;
   }
   delete trx;
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 static int rocksdb_rollback_by_xid(
@@ -2747,14 +2747,14 @@ static int rocksdb_rollback_by_xid(
   const auto name= rdb_xid_to_string(*xid);
   rocksdb::Transaction* const trx= rdb->GetTransactionByName(name);
   if (trx == nullptr) {
-    return 1;
+    return HA_EXIT_FAILURE;
   }
   const rocksdb::Status s= trx->Rollback();
   if (!s.ok()) {
-    return 1;
+    return HA_EXIT_FAILURE;
   }
   delete trx;
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 /**
@@ -2815,7 +2815,7 @@ static int rocksdb_recover(handlerton* const hton, XID* const xid_list,
 
   if (len == 0 || xid_list == nullptr)
   {
-    return 0;
+    return HA_EXIT_SUCCESS;
   }
 
   std::vector<rocksdb::Transaction*> trans_list;
@@ -2881,7 +2881,7 @@ static int rocksdb_commit(handlerton* const hton, THD* const thd,
     }
   }
 
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
 
@@ -2923,7 +2923,7 @@ static int rocksdb_rollback(handlerton* const hton, THD* const thd,
       tx->release_snapshot();
     }
   }
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 static bool print_stats(THD* const thd,
@@ -3345,7 +3345,7 @@ static int rocksdb_start_tx_and_assign_read_view(
                     "Only REPEATABLE READ isolation level is supported "
                     "for START TRANSACTION WITH CONSISTENT SNAPSHOT "
                     "in RocksDB Storage Engine.", MYF(0));
-    return 1;
+    return HA_EXIT_FAILURE;
   }
 
   if (binlog_file)
@@ -3353,7 +3353,7 @@ static int rocksdb_start_tx_and_assign_read_view(
     if (binlog_pos && mysql_bin_log_is_open())
       mysql_bin_log_lock_commits();
     else
-      return 1;
+      return HA_EXIT_FAILURE;
   }
 
   Rdb_transaction* const tx= get_or_create_tx(thd);
@@ -3366,7 +3366,7 @@ static int rocksdb_start_tx_and_assign_read_view(
     mysql_bin_log_unlock_commits(binlog_file, binlog_pos, gtid_executed,
                                  gtid_executed_length);
 
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 /* Dummy SAVEPOINT support. This is needed for long running transactions
@@ -3377,7 +3377,7 @@ static int rocksdb_start_tx_and_assign_read_view(
 static int rocksdb_savepoint(handlerton* const hton, THD* const thd,
                              void* const savepoint)
 {
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 static int rocksdb_rollback_to_savepoint(handlerton* const hton, THD* const thd,
@@ -3647,7 +3647,7 @@ static int rocksdb_init_func(void* const p)
     sql_print_error("RocksDB: Can't enable both use_direct_reads "
                     "and allow_mmap_reads\n");
     rdb_open_tables.free_hash();
-    DBUG_RETURN(1);
+    DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
   if (rocksdb_db_options.allow_mmap_writes &&
@@ -3657,7 +3657,7 @@ static int rocksdb_init_func(void* const p)
     sql_print_error("RocksDB: Can't enable both use_direct_writes "
                     "and allow_mmap_writes\n");
     rdb_open_tables.free_hash();
-    DBUG_RETURN(1);
+    DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
   std::vector<std::string> cf_names;
@@ -3681,7 +3681,7 @@ static int rocksdb_init_func(void* const p)
       std::string err_text= status.ToString();
       sql_print_error("RocksDB: Error listing column families: %s", err_text.c_str());
       rdb_open_tables.free_hash();
-      DBUG_RETURN(1);
+      DBUG_RETURN(HA_EXIT_FAILURE);
     }
   }
   else
@@ -3741,7 +3741,7 @@ static int rocksdb_init_func(void* const p)
     // NO_LINT_DEBUG
     sql_print_error("RocksDB: Failed to initialize CF options map.");
     rdb_open_tables.free_hash();
-    DBUG_RETURN(1);
+    DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
   /*
@@ -3796,7 +3796,7 @@ static int rocksdb_init_func(void* const p)
     sql_print_error("RocksDB: compatibility check against existing database " \
                     "options failed. %s", status.ToString().c_str());
     rdb_open_tables.free_hash();
-    DBUG_RETURN(1);
+    DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
   status= rocksdb::TransactionDB::Open(main_opts, tx_db_options,
@@ -3808,7 +3808,7 @@ static int rocksdb_init_func(void* const p)
     std::string err_text= status.ToString();
     sql_print_error("RocksDB: Error opening instance: %s", err_text.c_str());
     rdb_open_tables.free_hash();
-    DBUG_RETURN(1);
+    DBUG_RETURN(HA_EXIT_FAILURE);
   }
   cf_manager.init(&rocksdb_cf_options_map, &cf_handles);
 
@@ -3817,7 +3817,7 @@ static int rocksdb_init_func(void* const p)
     // NO_LINT_DEBUG
     sql_print_error("RocksDB: Failed to initialize data dictionary.");
     rdb_open_tables.free_hash();
-    DBUG_RETURN(1);
+    DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
   if (binlog_manager.init(&dict_manager))
@@ -3825,7 +3825,7 @@ static int rocksdb_init_func(void* const p)
     // NO_LINT_DEBUG
     sql_print_error("RocksDB: Failed to initialize binlog manager.");
     rdb_open_tables.free_hash();
-    DBUG_RETURN(1);
+    DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
   if (ddl_manager.init(&dict_manager, &cf_manager, rocksdb_validate_tables))
@@ -3833,7 +3833,7 @@ static int rocksdb_init_func(void* const p)
     // NO_LINT_DEBUG
     sql_print_error("RocksDB: Failed to initialize DDL manager.");
     rdb_open_tables.free_hash();
-    DBUG_RETURN(1);
+    DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
   Rdb_sst_info::init(rdb);
@@ -3857,7 +3857,7 @@ static int rocksdb_init_func(void* const p)
     // NO_LINT_DEBUG
     sql_print_error("RocksDB: Error enabling compaction: %s", err_text.c_str());
     rdb_open_tables.free_hash();
-    DBUG_RETURN(1);
+    DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
   auto err= rdb_bg_thread.create_thread(
@@ -3869,7 +3869,7 @@ static int rocksdb_init_func(void* const p)
     sql_print_error("RocksDB: Couldn't start the background thread: (errno=%d)",
                     err);
     rdb_open_tables.free_hash();
-    DBUG_RETURN(1);
+    DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
   err= rdb_drop_idx_thread.create_thread(
@@ -3881,7 +3881,7 @@ static int rocksdb_init_func(void* const p)
     sql_print_error("RocksDB: Couldn't start the drop index thread: (errno=%d)",
                     err);
     rdb_open_tables.free_hash();
-    DBUG_RETURN(1);
+    DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
   rdb_set_collation_exception_list(rocksdb_strict_collation_exceptions);
@@ -3903,7 +3903,7 @@ static int rocksdb_init_func(void* const p)
 #endif
 
   sql_print_information("RocksDB instance opened");
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
 /*
@@ -4195,7 +4195,7 @@ int ha_rocksdb::load_hidden_pk_value()
 
   release_scan_iterator();
 
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 /* Get PK value from m_tbl_def->m_hidden_pk_info. */
@@ -4218,17 +4218,17 @@ int ha_rocksdb::read_hidden_pk_id_from_rowkey(longlong* const hidden_pk_id)
   // Get hidden primary key from old key slice
   Rdb_string_reader reader(&rowkey_slice);
   if ((!reader.read(Rdb_key_def::INDEX_NUMBER_SIZE)))
-    return 1;
+    return HA_EXIT_FAILURE;
 
   const int length= Field_longlong::PACK_LENGTH;
   const uchar* from= reinterpret_cast<const uchar*>(reader.read(length));
   if (from == nullptr)
   {
-    return 1; /* Mem-comparable image doesn't have enough bytes */
+    return HA_EXIT_FAILURE; /* Mem-comparable image doesn't have enough bytes */
   }
 
   *hidden_pk_id= rdb_netbuf_read_uint64(&from);
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 
@@ -4793,7 +4793,7 @@ int ha_rocksdb::convert_record_from_storage_format(
       return HA_ERR_INTERNAL_ERROR;
   }
 
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 
@@ -4967,7 +4967,7 @@ int ha_rocksdb::alloc_key_buffers(const TABLE* const table_arg,
     goto error;
   }
 
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 
 error:
   // If we're here then this means that at some point above an allocation may
@@ -5137,7 +5137,7 @@ int ha_rocksdb::open(const char* const name, int mode, uint test_if_locked)
   /* Determine at open whether we should skip unique checks for this table */
   set_skip_unique_check_tables(THDVAR(ha_thd(), skip_unique_check_tables));
 
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
 
@@ -5159,7 +5159,7 @@ int ha_rocksdb::close(void)
     m_table_handler= nullptr;
   }
 
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
 bool ha_rocksdb::get_error_message(const int error, String* const buf)
@@ -5195,7 +5195,8 @@ bool ha_rocksdb::get_error_message(const int error, String* const buf)
       break;
     default:
       // We can be called with the values which are < HA_ERR_FIRST because most
-      // MySQL internal functions will just return 1 in case of an error.
+      // MySQL internal functions will just return HA_EXIT_FAILURE in case of
+      // an error.
       break;
   }
 
@@ -5263,7 +5264,7 @@ int ha_rocksdb::create_key_defs(const TABLE* const table_arg,
   */
   if (create_cfs(table_arg, tbl_def_arg, &cfs))
   {
-    DBUG_RETURN(1);
+    DBUG_RETURN(HA_EXIT_FAILURE);
   };
 
   if (!old_tbl_def_arg)
@@ -5280,7 +5281,7 @@ int ha_rocksdb::create_key_defs(const TABLE* const table_arg,
       if (create_key_def(table_arg, i, tbl_def_arg,
                          &m_key_descr_arr[i], cfs[i]))
       {
-        DBUG_RETURN(1);
+        DBUG_RETURN(HA_EXIT_FAILURE);
       }
     }
   }
@@ -5294,11 +5295,11 @@ int ha_rocksdb::create_key_defs(const TABLE* const table_arg,
     if (create_inplace_key_defs(table_arg, tbl_def_arg, old_table_arg,
                                 old_tbl_def_arg, cfs))
     {
-      DBUG_RETURN(1);
+      DBUG_RETURN(HA_EXIT_FAILURE);
     }
   }
 
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
 /*
@@ -5364,7 +5365,7 @@ int ha_rocksdb::create_cfs(const TABLE* const table_arg,
                           tbl_def_arg->full_tablename().c_str(),
                           table_arg->key_info[i].key_part[part].field->field_name,
                           collation_err.c_str());
-          DBUG_RETURN(1);
+          DBUG_RETURN(HA_EXIT_FAILURE);
         }
       }
     }
@@ -5380,21 +5381,21 @@ int ha_rocksdb::create_cfs(const TABLE* const table_arg,
     {
       my_error(ER_NOT_SUPPORTED_YET, MYF(0),
                "column family name looks like a typo of $per_index_cf");
-      DBUG_RETURN(1);
+      DBUG_RETURN(HA_EXIT_FAILURE);
     }
     /* Prevent create from using the system column family */
     if (comment && strcmp(DEFAULT_SYSTEM_CF_NAME, comment) == 0)
     {
       my_error(ER_WRONG_ARGUMENTS, MYF(0),
                "column family not valid for storing index data");
-      DBUG_RETURN(1);
+      DBUG_RETURN(HA_EXIT_FAILURE);
     }
     bool is_auto_cf_flag;
     cf_handle = cf_manager.get_or_create_cf(rdb, comment,
                                             tbl_def_arg->full_tablename(),
                                             key_name, &is_auto_cf_flag);
     if (!cf_handle)
-      DBUG_RETURN(1);
+      DBUG_RETURN(HA_EXIT_FAILURE);
 
     auto& cf = (*cfs)[i];
     cf.cf_handle = cf_handle;
@@ -5402,7 +5403,7 @@ int ha_rocksdb::create_cfs(const TABLE* const table_arg,
     cf.is_auto_cf = is_auto_cf_flag;
   }
 
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
 /*
@@ -5463,7 +5464,7 @@ int ha_rocksdb::create_inplace_key_defs(const TABLE* const table_arg,
                         "for Index Number (%u,%u), table %s",
                         gl_index_id.cf_id, gl_index_id.index_id,
                         old_tbl_def_arg->full_tablename().c_str());
-        DBUG_RETURN(1);
+        DBUG_RETURN(HA_EXIT_FAILURE);
       }
 
       /*
@@ -5486,14 +5487,14 @@ int ha_rocksdb::create_inplace_key_defs(const TABLE* const table_arg,
     else if (create_key_def(table_arg, i, tbl_def_arg,
                             &new_key_descr[i], cfs[i]))
     {
-      DBUG_RETURN(1);
+      DBUG_RETURN(HA_EXIT_FAILURE);
     }
 
     DBUG_ASSERT(new_key_descr[i] != nullptr);
     new_key_descr[i]->setup(table_arg, tbl_def_arg);
   }
 
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
 std::unordered_map<std::string, uint> ha_rocksdb::get_old_key_positions(
@@ -5567,7 +5568,7 @@ int ha_rocksdb::compare_key_parts(const KEY* const old_key,
   /* Skip if key parts do not match, as it is a different key */
   if (new_key->user_defined_key_parts != old_key->user_defined_key_parts)
   {
-    DBUG_RETURN(1);
+    DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
   /* Check to see that key parts themselves match */
@@ -5576,11 +5577,11 @@ int ha_rocksdb::compare_key_parts(const KEY* const old_key,
     if (strcmp(old_key->key_part[i].field->field_name,
                new_key->key_part[i].field->field_name) != 0)
     {
-      DBUG_RETURN(1);
+      DBUG_RETURN(HA_EXIT_FAILURE);
     }
   }
 
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
 /*
@@ -5638,7 +5639,7 @@ int ha_rocksdb::create_key_def(const TABLE* const table_arg, const uint &i,
       index_id, i, cf_info.cf_handle, index_dict_version, index_type,
       kv_version, cf_info.is_reverse_cf, cf_info.is_auto_cf, key_name);
 
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
 int rdb_normalize_tablename(const std::string& tablename,
@@ -5661,7 +5662,7 @@ int rdb_normalize_tablename(const std::string& tablename,
 
   *strbuf = tablename.substr(2, pos - 2) + "." + tablename.substr(pos + 1);
 
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 /*
@@ -5728,7 +5729,7 @@ bool ha_rocksdb::contains_foreign_key(THD* const thd)
   @param dbbuf returns database name/table_schema
   @param tablebuf returns tablename
   @param partitionbuf returns partition suffix if there is one
-  @return 0 on success, non-zero on failure to split
+  @return HA_EXIT_SUCCESS on success, non-zero on failure to split
 */
 int rdb_split_normalized_tablename(const std::string& fullname,
                                    std::string* const db,
@@ -5780,7 +5781,7 @@ int rdb_split_normalized_tablename(const std::string& fullname,
     *table = fullname.substr(dotpos);
   }
 
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 
@@ -5920,7 +5921,7 @@ int ha_rocksdb::create(const char* const name, TABLE* const table_arg,
       DBUG_RETURN(HA_ERR_INTERNAL_ERROR);
   }
   */
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 
 error:
   /* Delete what we have allocated so far */
@@ -6008,7 +6009,7 @@ int ha_rocksdb::read_key_exact(const Rdb_key_def& kd,
     */
     return HA_ERR_KEY_NOT_FOUND;
   }
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 int ha_rocksdb::read_before_key(const Rdb_key_def& kd,
@@ -6036,7 +6037,7 @@ int ha_rocksdb::read_before_key(const Rdb_key_def& kd,
       m_scan_it->SeekToLast();
   }
 
-  return m_scan_it->Valid() ? 0 : HA_ERR_KEY_NOT_FOUND;
+  return m_scan_it->Valid() ? HA_EXIT_SUCCESS : HA_ERR_KEY_NOT_FOUND;
 }
 
 int ha_rocksdb::read_after_key(const Rdb_key_def& kd,
@@ -6072,7 +6073,7 @@ int ha_rocksdb::read_after_key(const Rdb_key_def& kd,
     }
   }
 
-  return m_scan_it->Valid() ? 0 : HA_ERR_KEY_NOT_FOUND;
+  return m_scan_it->Valid() ? HA_EXIT_SUCCESS : HA_ERR_KEY_NOT_FOUND;
 }
 
 int ha_rocksdb::position_to_correct_key(
@@ -6492,7 +6493,7 @@ int ha_rocksdb::read_range_first(const key_range* const start_key,
 
   if (compare_key(end_range) <= 0)
   {
-    DBUG_RETURN(0);
+    DBUG_RETURN(HA_EXIT_SUCCESS);
   }
   else
   {
@@ -6788,7 +6789,7 @@ int ha_rocksdb::find_icp_matching_index_rec(const bool &move_forward,
       */
     }
   }
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 
@@ -7694,7 +7695,7 @@ int ha_rocksdb::get_pk_for_update(struct update_row_info* const row_info)
 
   row_info->new_pk_slice= rocksdb::Slice((const char*)m_pk_packed_tuple, size);
 
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 int ha_rocksdb::check_and_lock_unique_pk(const uint &key_id,
@@ -7720,7 +7721,7 @@ int ha_rocksdb::check_and_lock_unique_pk(const uint &key_id,
                                              row_info.old_pk_slice))
     {
       *found= false;
-      return 0;
+      return HA_EXIT_SUCCESS;
     }
 
     *pk_changed= true;
@@ -7754,7 +7755,7 @@ int ha_rocksdb::check_and_lock_unique_pk(const uint &key_id,
   }
 
   *found= !s.IsNotFound();
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 int ha_rocksdb::check_and_lock_sk(const uint &key_id,
@@ -7769,7 +7770,7 @@ int ha_rocksdb::check_and_lock_sk(const uint &key_id,
   */
   if (row_info.old_data != nullptr && !m_update_scope.is_set(key_id))
   {
-    return 0;
+    return HA_EXIT_SUCCESS;
   }
 
   KEY* key_info= nullptr;
@@ -7784,7 +7785,7 @@ int ha_rocksdb::check_and_lock_sk(const uint &key_id,
   */
   if (!(key_info->flags & HA_NOSAME))
   {
-    return 0;
+    return HA_EXIT_SUCCESS;
   }
 
   const Rdb_key_def& kd= *m_key_descr_arr[key_id];
@@ -7804,7 +7805,7 @@ int ha_rocksdb::check_and_lock_sk(const uint &key_id,
       If any fields are marked as NULL this will never match another row as
       to NULL never matches anything else including another NULL.
      */
-    return 0;
+    return HA_EXIT_SUCCESS;
   }
 
   const rocksdb::Slice new_slice= rocksdb::Slice((const char*)m_sk_packed_tuple,
@@ -7832,7 +7833,7 @@ int ha_rocksdb::check_and_lock_sk(const uint &key_id,
     */
     if (!Rdb_pk_comparator::bytewise_compare(new_slice, old_slice))
     {
-      return 0;
+      return HA_EXIT_SUCCESS;
     }
   }
 
@@ -7888,7 +7889,7 @@ int ha_rocksdb::check_and_lock_sk(const uint &key_id,
   *found= !read_key_exact(kd, iter, all_parts_used, new_slice);
   delete iter;
 
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 int ha_rocksdb::check_uniqueness_and_lock(
@@ -7929,7 +7930,7 @@ int ha_rocksdb::check_uniqueness_and_lock(
     }
   }
 
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 int ha_rocksdb::bulk_load_key(Rdb_transaction* const tx,
@@ -8100,7 +8101,7 @@ int ha_rocksdb::update_sk(const TABLE* const table_arg,
   */
   if (row_info.old_data != nullptr && !m_update_scope.is_set(key_id))
   {
-    return 0;
+    return HA_EXIT_SUCCESS;
   }
 
   const bool store_row_debug_checksums= should_store_row_debug_checksums();
@@ -8140,7 +8141,7 @@ int ha_rocksdb::update_sk(const TABLE* const table_arg,
         memcmp(m_sk_tails_old.ptr(), m_sk_tails.ptr(),
                m_sk_tails.get_current_pos()) == 0)
     {
-      return 0;
+      return HA_EXIT_SUCCESS;
     }
 
     /*
@@ -8185,7 +8186,7 @@ int ha_rocksdb::update_sk(const TABLE* const table_arg,
 
   write_batch->Put(kd.get_cf(), new_key_slice, new_value_slice);
 
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 int ha_rocksdb::update_indexes(const struct update_row_info& row_info,
@@ -8211,7 +8212,7 @@ int ha_rocksdb::update_indexes(const struct update_row_info& row_info,
     }
   }
 
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 int ha_rocksdb::update_write_row(const uchar* const old_data,
@@ -8282,7 +8283,7 @@ int ha_rocksdb::update_write_row(const uchar* const old_data,
     DBUG_RETURN(HA_ERR_INTERNAL_ERROR);
   }
 
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
 
@@ -8407,7 +8408,7 @@ int ha_rocksdb::rnd_init(bool scan)
   // the snapshot immediately.
   tx->acquire_snapshot(m_lock_rows == RDB_LOCK_NONE);
 
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
 int ha_rocksdb::rnd_next(uchar* const buf)
@@ -8553,7 +8554,7 @@ int ha_rocksdb::rnd_end()
 
   release_scan_iterator();
 
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
 int ha_rocksdb::index_init(uint idx, bool sorted)
@@ -8572,7 +8573,7 @@ int ha_rocksdb::index_init(uint idx, bool sorted)
 
   active_index= idx;
 
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
 int ha_rocksdb::index_end()
@@ -8584,7 +8585,7 @@ int ha_rocksdb::index_end()
   active_index= MAX_KEY;
   in_range_check_pushed_down= FALSE;
 
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
 int ha_rocksdb::truncate()
@@ -8598,7 +8599,7 @@ int ha_rocksdb::truncate()
 
   remove_rows(m_tbl_def);
 
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
 
@@ -8660,7 +8661,7 @@ int ha_rocksdb::delete_row(const uchar* const buf)
   stats.rows_deleted++;
   update_row_stats(ROWS_DELETED);
 
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
 
@@ -8706,7 +8707,7 @@ int ha_rocksdb::info(uint flag)
   DBUG_ENTER_FUNC();
 
   if (!table)
-    return 1;
+    return HA_EXIT_FAILURE;
 
   if (flag & HA_STATUS_VARIABLE)
   {
@@ -8728,7 +8729,7 @@ int ha_rocksdb::info(uint flag)
         static_cast<longlong>(stats.records) < 0)
     {
       if (analyze(nullptr, nullptr)) {
-        DBUG_RETURN(1);
+        DBUG_RETURN(HA_EXIT_FAILURE);
       }
 
       update_stats();
@@ -8805,7 +8806,7 @@ int ha_rocksdb::info(uint flag)
     stats.auto_increment_value= m_tbl_def->m_auto_incr_val;
   }
 
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
 void ha_rocksdb::position(const uchar* const record)
@@ -9190,7 +9191,7 @@ int ha_rocksdb::start_stmt(THD* const thd, thr_lock_type lock_type)
   rocksdb_register_tx(ht, thd, tx);
   tx->io_perf_start(&m_io_perf);
 
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
 rocksdb::Range get_range(
@@ -9410,7 +9411,7 @@ int ha_rocksdb::delete_table(const char* const tablename)
 
   rdb_drop_idx_thread.signal();
 
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
 
@@ -9571,7 +9572,7 @@ int ha_rocksdb::extra(enum ha_extra_function operation)
     break;
   }
 
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
 /*
@@ -9635,7 +9636,7 @@ ha_rows ha_rocksdb::records_in_range(uint inx, key_range* const min_key,
   // slice1 >= slice2 means no row will match
   if (slice1.compare(slice2) >= 0)
   {
-    DBUG_RETURN(0);
+    DBUG_RETURN(HA_EXIT_SUCCESS);
   }
 
   rocksdb::Range r(
@@ -9820,7 +9821,7 @@ int ha_rocksdb::calculate_stats(const TABLE* const table_arg, THD* const thd,
   ddl_manager.set_stats(stats);
   ddl_manager.persist_stats(true);
 
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
 int ha_rocksdb::analyze(THD* const thd, HA_CHECK_OPT* const check_opt)
@@ -9828,7 +9829,7 @@ int ha_rocksdb::analyze(THD* const thd, HA_CHECK_OPT* const check_opt)
   DBUG_ENTER_FUNC();
 
   if (!table) {
-    DBUG_RETURN(1);
+    DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
   DBUG_RETURN(calculate_stats(table, thd, check_opt));
@@ -10136,7 +10137,7 @@ bool ha_rocksdb::prepare_inplace_alter_table(
     */
     new_tdef->m_key_descr_arr= nullptr;
     delete new_tdef;
-    DBUG_RETURN(1);
+    DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
   std::unordered_set<std::shared_ptr<Rdb_key_def>> added_indexes;
@@ -10183,7 +10184,7 @@ bool ha_rocksdb::prepare_inplace_alter_table(
     new_tdef, old_key_descr, new_key_descr, old_n_keys, new_n_keys,
     added_indexes, dropped_index_ids, n_added_keys, n_dropped_keys);
 
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
 /**
@@ -10239,13 +10240,14 @@ bool ha_rocksdb::inplace_alter_table(TABLE* const altered_table,
     if (inplace_populate_sk(altered_table, ctx->m_added_indexes))
     {
       free_key_buffers();
-      DBUG_RETURN(1);
+      DBUG_RETURN(HA_EXIT_FAILURE);
     }
   }
 
-  DBUG_EXECUTE_IF("myrocks_simulate_index_create_rollback", DBUG_RETURN(1););
+  DBUG_EXECUTE_IF("myrocks_simulate_index_create_rollback",
+    DBUG_RETURN(HA_EXIT_FAILURE););
 
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
 /**
@@ -10489,7 +10491,7 @@ bool ha_rocksdb::commit_inplace_alter_table(
     /* If ctx has not been created yet, nothing to do here */
     if (!ctx0)
     {
-      DBUG_RETURN(0);
+      DBUG_RETURN(HA_EXIT_SUCCESS);
     }
 
     /*
@@ -10512,7 +10514,7 @@ bool ha_rocksdb::commit_inplace_alter_table(
       delete ctx0->m_new_tdef;
     }
 
-    DBUG_RETURN(0);
+    DBUG_RETURN(HA_EXIT_SUCCESS);
   }
 
   DBUG_ASSERT(ctx0);
@@ -10607,7 +10609,7 @@ bool ha_rocksdb::commit_inplace_alter_table(
     rdb_drop_idx_thread.signal();
   }
 
-  DBUG_RETURN(0);
+  DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
 #define SHOW_FNAME(name) rocksdb_show_##name
@@ -10619,7 +10621,7 @@ bool ha_rocksdb::commit_inplace_alter_table(
       rocksdb_stats->getTickerCount(rocksdb::key);                       \
     var->type = SHOW_LONGLONG;                                           \
     var->value = (char *)&rocksdb_status_counters.name;                  \
-    return 0;                                                            \
+    return HA_EXIT_SUCCESS;                                              \
   }
 
 #define DEF_STATUS_VAR(name) \
@@ -11030,7 +11032,7 @@ int rdb_get_table_perf_counters(const char* const tablename,
   counters->load(table_handler->m_table_perf_context);
 
   rdb_open_tables.release_table_handler(table_handler);
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -1036,7 +1036,7 @@ public:
     /* Free blob data */
     m_retrieved_record.clear();
 
-    DBUG_RETURN(0);
+    DBUG_RETURN(HA_EXIT_SUCCESS);
   }
 
   int check(THD* const thd, HA_CHECK_OPT* const check_opt) override

--- a/storage/rocksdb/properties_collector.cc
+++ b/storage/rocksdb/properties_collector.cc
@@ -428,8 +428,8 @@ std::string Rdb_index_stats::materialize(
 /**
   @brief
   Reads an array of Rdb_index_stats from a string.
-  @return 1 if it detects any inconsistency in the input
-  @return 0 if completes successfully
+  @return HA_EXIT_FAILURE if it detects any inconsistency in the input
+  @return HA_EXIT_SUCCESS if completes successfully
 */
 int Rdb_index_stats::unmaterialize(
   const std::string& s, std::vector<Rdb_index_stats>* const ret)
@@ -441,7 +441,7 @@ int Rdb_index_stats::unmaterialize(
 
   if (p+2 > p2)
   {
-    return 1;
+    return HA_EXIT_FAILURE;
   }
 
   const int version= rdb_netbuf_read_uint16(&p);
@@ -474,7 +474,7 @@ int Rdb_index_stats::unmaterialize(
   {
     if (p+needed > p2)
     {
-      return 1;
+      return HA_EXIT_FAILURE;
     }
     rdb_netbuf_read_gl_index(&p, &stats.m_gl_index_id);
     stats.m_data_size=            rdb_netbuf_read_uint64(&p);
@@ -491,7 +491,7 @@ int Rdb_index_stats::unmaterialize(
     if (p+stats.m_distinct_keys_per_prefix.size()
         *sizeof(stats.m_distinct_keys_per_prefix[0]) > p2)
     {
-      return 1;
+      return HA_EXIT_FAILURE;
     }
     for (std::size_t i= 0; i < stats.m_distinct_keys_per_prefix.size(); i++)
     {
@@ -499,7 +499,7 @@ int Rdb_index_stats::unmaterialize(
     }
     ret->push_back(stats);
   }
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 /*

--- a/storage/rocksdb/rdb_comparator.h
+++ b/storage/rocksdb/rdb_comparator.h
@@ -24,6 +24,9 @@
 /* RocksDB header files */
 #include "rocksdb/comparator.h"
 
+/* MyRocks header files */
+#include "./rdb_utils.h"
+
 namespace myrocks {
 
 /*
@@ -54,7 +57,7 @@ class Rdb_pk_comparator : public rocksdb::Comparator
     {
       return a_size < b_size? -1 : 1;
     }
-    return 0;
+    return HA_EXIT_SUCCESS;
   }
 
   /* Override virtual methods of interest */

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -776,10 +776,10 @@ int Rdb_key_def::compare_keys(
 
   // Skip the index number
   if ((!reader1.read(INDEX_NUMBER_SIZE)))
-    return 1;
+    return HA_EXIT_FAILURE;
 
   if ((!reader2.read(INDEX_NUMBER_SIZE)))
-    return 1;
+    return HA_EXIT_FAILURE;
 
   for (uint i= 0; i < m_key_parts ; i++)
   {
@@ -788,13 +788,16 @@ int Rdb_key_def::compare_keys(
     {
       const auto nullp1= reader1.read(1);
       const auto nullp2= reader2.read(1);
+
       if (nullp1 == nullptr || nullp2 == nullptr)
-        return 1; //error
+      {
+        return HA_EXIT_FAILURE;
+      }
 
       if (*nullp1 != *nullp2)
       {
         *column_index = i;
-        return 0;
+        return HA_EXIT_SUCCESS;
       }
 
       if (*nullp1 == 0)
@@ -808,25 +811,25 @@ int Rdb_key_def::compare_keys(
     const auto before_skip2 = reader2.get_current_ptr();
     DBUG_ASSERT(fpi->m_skip_func);
     if (fpi->m_skip_func(fpi, nullptr, &reader1))
-      return 1;
+      return HA_EXIT_FAILURE;
     if (fpi->m_skip_func(fpi, nullptr, &reader2))
-      return 1;
+      return HA_EXIT_FAILURE;
     const auto size1 = reader1.get_current_ptr() - before_skip1;
     const auto size2 = reader2.get_current_ptr() - before_skip2;
     if (size1 != size2)
     {
       *column_index = i;
-      return 0;
+      return HA_EXIT_SUCCESS;
     }
 
     if (memcmp(before_skip1, before_skip2, size1) != 0) {
       *column_index = i;
-      return 0;
+      return HA_EXIT_SUCCESS;
     }
   }
 
   *column_index = m_key_parts;
-  return 0;
+  return HA_EXIT_SUCCESS;
 
 }
 
@@ -899,7 +902,7 @@ int Rdb_key_def::unpack_record(TABLE* const table, uchar* const buf,
   // Skip the index number
   if ((!reader.read(INDEX_NUMBER_SIZE)))
   {
-    return 1;
+    return HA_EXIT_FAILURE;
   }
 
   // For secondary keys, we expect the value field to contain unpack data and
@@ -909,7 +912,7 @@ int Rdb_key_def::unpack_record(TABLE* const table, uchar* const buf,
     *unp_reader.get_current_ptr() == RDB_UNPACK_DATA_TAG;
   if (has_unpack_info && !unp_reader.read(RDB_UNPACK_HEADER_SIZE))
   {
-    return 1;
+    return HA_EXIT_FAILURE;
   }
 
   for (uint i= 0; i < m_key_parts ; i++)
@@ -926,7 +929,7 @@ int Rdb_key_def::unpack_record(TABLE* const table, uchar* const buf,
       DBUG_ASSERT(fpi->m_unpack_func);
       if (fpi->m_skip_func(fpi, nullptr, &reader))
       {
-        return 1;
+        return HA_EXIT_FAILURE;
       }
       continue;
     }
@@ -941,7 +944,7 @@ int Rdb_key_def::unpack_record(TABLE* const table, uchar* const buf,
       {
         const char* nullp;
         if (!(nullp= reader.read(1)))
-          return 1;
+          return HA_EXIT_FAILURE;
         if (*nullp == 0)
         {
           /* Set the NULL-bit of this field */
@@ -956,7 +959,7 @@ int Rdb_key_def::unpack_record(TABLE* const table, uchar* const buf,
         else if (*nullp == 1)
           field->set_notnull(ptr_diff);
         else
-          return 1;
+          return HA_EXIT_FAILURE;
       }
 
       // If we need unpack info, but there is none, tell the unpack function
@@ -978,7 +981,7 @@ int Rdb_key_def::unpack_record(TABLE* const table, uchar* const buf,
       {
         const char* nullp;
         if (!(nullp= reader.read(1)))
-          return 1;
+          return HA_EXIT_FAILURE;
         if (*nullp == 0)
         {
           /* This is a NULL value */
@@ -986,10 +989,10 @@ int Rdb_key_def::unpack_record(TABLE* const table, uchar* const buf,
         }
         /* If NULL marker is not '0', it can be only '1'  */
         if (*nullp != 1)
-          return 1;
+          return HA_EXIT_FAILURE;
       }
       if (fpi->m_skip_func(fpi, field, &reader))
-        return 1;
+        return HA_EXIT_FAILURE;
     }
   }
 
@@ -1019,7 +1022,7 @@ int Rdb_key_def::unpack_record(TABLE* const table, uchar* const buf,
       {
         report_checksum_mismatch(true, packed_key->data(),
                                  packed_key->size());
-        return 1;
+        return HA_EXIT_FAILURE;
       }
 
       if (stored_val_chksum != computed_val_chksum)
@@ -1027,7 +1030,7 @@ int Rdb_key_def::unpack_record(TABLE* const table, uchar* const buf,
         report_checksum_mismatch(
             false, unpack_info->data(),
             unpack_info->size() - RDB_CHECKSUM_CHUNK_SIZE);
-        return 1;
+        return HA_EXIT_FAILURE;
       }
     }
     else
@@ -1037,9 +1040,9 @@ int Rdb_key_def::unpack_record(TABLE* const table, uchar* const buf,
   }
 
   if (reader.remaining_bytes())
-    return 1;
+    return HA_EXIT_FAILURE;
 
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 bool Rdb_key_def::table_has_hidden_pk(const TABLE* const table)
@@ -1092,8 +1095,8 @@ int rdb_skip_max_length(const Rdb_field_packing* const fpi,
                         Rdb_string_reader* const reader)
 {
   if (!reader->read(fpi->m_max_image_len))
-    return 1;
-  return 0;
+    return HA_EXIT_FAILURE;
+  return HA_EXIT_SUCCESS;
 }
 
 /*
@@ -1138,7 +1141,7 @@ static int rdb_skip_variable_length(
 
     if (used_bytes > RDB_ESCAPE_LENGTH - 1 || used_bytes > dst_len)
     {
-      return 1; /* cannot store that much, invalid data */
+      return HA_EXIT_FAILURE; /* cannot store that much, invalid data */
     }
 
     if (used_bytes < RDB_ESCAPE_LENGTH - 1)
@@ -1151,10 +1154,10 @@ static int rdb_skip_variable_length(
 
   if (!finished)
   {
-    return 1;
+    return HA_EXIT_FAILURE;
   }
 
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 const int VARCHAR_CMP_LESS_THAN_SPACES = 1;
@@ -1200,7 +1203,7 @@ static int rdb_skip_variable_space_pad(
       {
         // The segment is full of data but the table field can't hold that
         // much! This must be data corruption.
-        return 1;
+        return HA_EXIT_FAILURE;
       }
       dst_len -= (fpi->m_segment_size-1);
     }
@@ -1208,10 +1211,10 @@ static int rdb_skip_variable_space_pad(
     {
       // Encountered a value that's none of the VARCHAR_CMP* constants
       // It's data corruption.
-      return 1;
+      return HA_EXIT_FAILURE;
     }
   }
-  return finished? 0: 1;
+  return finished ? HA_EXIT_SUCCESS : HA_EXIT_FAILURE;
 }
 
 
@@ -3017,7 +3020,7 @@ int Rdb_validate_tbls::add_table(Rdb_tbl_def* tdef)
   m_list[tdef->base_dbname()].insert(
       tbl_info_t(tdef->base_tablename(), is_partition));
 
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 /*
@@ -3540,7 +3543,7 @@ int Rdb_ddl_manager::put_and_write(Rdb_tbl_def* const tbl,
   {
     return res;
   }
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 
@@ -3991,7 +3994,7 @@ int Rdb_dict_manager::commit(rocksdb::WriteBatch* const batch, const bool &sync)
 const
 {
   if (!batch)
-    return 1;
+    return HA_EXIT_FAILURE;
   int res= 0;
   rocksdb::WriteOptions options;
   options.sync= sync;

--- a/storage/rocksdb/rdb_i_s.cc
+++ b/storage/rocksdb/rdb_i_s.cc
@@ -1021,7 +1021,7 @@ int Rdb_ddl_scanner::add_table(Rdb_tbl_def *tdef)
     if (ret)
       return ret;
   }
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 static int rdb_i_s_ddl_fill_table(my_core::THD* const thd,

--- a/storage/rocksdb/rdb_index_merge.cc
+++ b/storage/rocksdb/rdb_index_merge.cc
@@ -76,7 +76,7 @@ int Rdb_index_merge::init()
   m_output_buf= std::shared_ptr<merge_buf_info>(
       new merge_buf_info(m_merge_buf_size));
 
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 /**
@@ -105,7 +105,7 @@ int Rdb_index_merge::merge_file_create()
   m_merge_file.fd = fd;
   m_merge_file.num_sort_buffers = 0;
 
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 /**
@@ -163,7 +163,7 @@ int Rdb_index_merge::add(const rocksdb::Slice& key,
   m_offset_tree.emplace(m_rec_buf_unsorted->block.get() + rec_offset,
                         m_comparator);
 
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 /**
@@ -234,7 +234,7 @@ int Rdb_index_merge::merge_buf_write()
   /* Reset everything for next run */
   merge_reset();
 
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 /**
@@ -301,7 +301,7 @@ int Rdb_index_merge::merge_heap_prepare()
     m_merge_min_heap.push(std::move(entry));
   }
 
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 /**
@@ -330,7 +330,7 @@ int Rdb_index_merge::next(rocksdb::Slice* const key, rocksdb::Slice* const val)
     merge_read_rec(rec->block, key, val);
 
     m_offset_tree.erase(rec);
-    return 0;
+    return HA_EXIT_SUCCESS;
   }
 
   int res;
@@ -354,7 +354,7 @@ int Rdb_index_merge::next(rocksdb::Slice* const key, rocksdb::Slice* const val)
       inside the SST file yet.
     */
     merge_heap_top(key, val);
-    return 0;
+    return HA_EXIT_SUCCESS;
   }
 
   DBUG_ASSERT(!m_merge_min_heap.empty());
@@ -405,7 +405,7 @@ int Rdb_index_merge::merge_heap_pop_and_get_next(rocksdb::Slice* const key,
     }
 
     merge_heap_top(key, val);
-    return 0;
+    return HA_EXIT_SUCCESS;
   }
 
   /*
@@ -436,18 +436,18 @@ int Rdb_index_merge::merge_heap_pop_and_get_next(rocksdb::Slice* const key,
 
   /* Return the current top record on heap */
   merge_heap_top(key, val);
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 int Rdb_index_merge::merge_heap_entry::read_next_chunk_from_disk(File fd)
 {
   if (chunk_info->read_next_chunk_from_disk(fd))
   {
-    return 1;
+    return HA_EXIT_FAILURE;
   }
 
   block= chunk_info->block.get();
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 int Rdb_index_merge::merge_buf_info::read_next_chunk_from_disk(File fd)
@@ -458,7 +458,7 @@ int Rdb_index_merge::merge_buf_info::read_next_chunk_from_disk(File fd)
   {
     // NO_LINT_DEBUG
     sql_print_error("Error seeking to location in merge file on disk.");
-    return 1;
+    return HA_EXIT_FAILURE;
   }
 
   /* Overwrite the old block */
@@ -467,11 +467,11 @@ int Rdb_index_merge::merge_buf_info::read_next_chunk_from_disk(File fd)
   {
     // NO_LINT_DEBUG
     sql_print_error("Error reading merge file from disk.");
-    return 1;
+    return HA_EXIT_FAILURE;
   }
 
   curr_offset= 0;
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 /**
@@ -516,7 +516,7 @@ int Rdb_index_merge::merge_heap_entry::read_rec(rocksdb::Slice* const key,
   /* Read key at block offset into key slice and the value into value slice*/
   if (read_slice(key, &block_ptr) != 0)
   {
-    return 1;
+    return HA_EXIT_FAILURE;
   }
 
   chunk_info->curr_offset += (uintptr_t) block_ptr - (uintptr_t) block;
@@ -526,13 +526,13 @@ int Rdb_index_merge::merge_heap_entry::read_rec(rocksdb::Slice* const key,
   {
     chunk_info->curr_offset= orig_offset;
     block= orig_block;
-    return 1;
+    return HA_EXIT_FAILURE;
   }
 
   chunk_info->curr_offset += (uintptr_t) block_ptr - (uintptr_t) block;
   block += (uintptr_t) block_ptr - (uintptr_t) block;
 
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 int Rdb_index_merge::merge_heap_entry::read_slice(rocksdb::Slice* const slice,
@@ -540,19 +540,19 @@ int Rdb_index_merge::merge_heap_entry::read_slice(rocksdb::Slice* const slice,
 {
   if (!chunk_info->has_space(RDB_MERGE_REC_DELIMITER))
   {
-    return 1;
+    return HA_EXIT_FAILURE;
   }
 
   uint64 slice_len;
   merge_read_uint64(block_ptr, &slice_len);
   if (!chunk_info->has_space(RDB_MERGE_REC_DELIMITER + slice_len))
   {
-    return 1;
+    return HA_EXIT_FAILURE;
   }
 
   *slice= rocksdb::Slice(reinterpret_cast<const char*>(*block_ptr), slice_len);
   *block_ptr += slice_len;
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 size_t Rdb_index_merge::merge_heap_entry::prepare(File fd, ulonglong f_offset,

--- a/storage/rocksdb/rdb_sst_info.cc
+++ b/storage/rocksdb/rdb_sst_info.cc
@@ -263,12 +263,12 @@ int Rdb_sst_info::open_new_sst_file()
     set_error_msg(s.ToString());
     delete m_sst_file;
     m_sst_file= nullptr;
-    return 1;
+    return HA_EXIT_FAILURE;
   }
 
   m_curr_size= 0;
 
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 void Rdb_sst_info::close_curr_sst_file()
@@ -322,7 +322,7 @@ int Rdb_sst_info::put(const rocksdb::Slice& key,
     // background thread - we don't want to wait for the end to report them
     if (!m_error_msg.empty())
     {
-      return 1;
+      return HA_EXIT_FAILURE;
     }
   }
 
@@ -343,12 +343,12 @@ int Rdb_sst_info::put(const rocksdb::Slice& key,
   if (!s.ok())
   {
     set_error_msg(s.ToString());
-    return 1;
+    return HA_EXIT_FAILURE;
   }
 
   m_curr_size += key.size() + value.size();
 
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 int Rdb_sst_info::commit()
@@ -376,10 +376,10 @@ int Rdb_sst_info::commit()
   // Did we get any errors?
   if (!m_error_msg.empty())
   {
-    return 1;
+    return HA_EXIT_FAILURE;
   }
 
-  return 0;
+  return HA_EXIT_SUCCESS;
 }
 
 void Rdb_sst_info::set_error_msg(const std::string& msg)

--- a/storage/rocksdb/rdb_utils.h
+++ b/storage/rocksdb/rdb_utils.h
@@ -114,6 +114,22 @@ namespace myrocks {
 #define DBUG_ENTER_FUNC() DBUG_ENTER(__PRETTY_FUNCTION__)
 
 /*
+  Error handling pattern used across MySQL abides by the following rules: "All
+  functions that can report an error (usually an allocation error), should
+  return 0/FALSE/false on success, 1/TRUE/true on failure."
+
+  https://dev.mysql.com/doc/internals/en/additional-suggestions.html has more
+  details.
+
+  To increase the comprehension and readability of MyRocks codebase we'll use
+  constants similar to ones from C standard (EXIT_SUCCESS and EXIT_FAILURE) to
+  make sure that both failure and success paths are clearly identifiable. The
+  definitions of FALSE and TRUE come from <my_global.h>.
+*/
+#define HA_EXIT_SUCCESS FALSE
+#define HA_EXIT_FAILURE TRUE
+
+/*
   Generic constant.
 */
 const size_t RDB_MAX_HEXDUMP_LEN= 1000;


### PR DESCRIPTION
To increase the comprehension and readability of MyRocks codebase we'll
use constants similar to ones from C standard (`EXIT_SUCCESS` and
`EXIT_FAILURE`) to make sure that both failure and success paths are
clearly identifiable. The definitions of FALSE and TRUE come from
`<my_global.h`>.

Error handling pattern used across MySQL abides by the following rules:
"All functions that can report an error (usually an allocation error),
should return `0/FALSE/false` on success, `1/TRUE/true` on failure."

https://dev.mysql.com/doc/internals/en/additional-suggestions.html has
more details.