### PR TITLE
Making rocksdb_max_background_compactions dynamic

### DIFF
--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_max_background_compactions_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_max_background_compactions_basic.result
@@ -1,7 +1,46 @@
+CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(1);
+INSERT INTO valid_values VALUES(64);
+CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO invalid_values VALUES('\'abc\'');
 SET @start_global_value = @@global.ROCKSDB_MAX_BACKGROUND_COMPACTIONS;
 SELECT @start_global_value;
 @start_global_value
 1
-"Trying to set variable @@global.ROCKSDB_MAX_BACKGROUND_COMPACTIONS to 444. It should fail because it is readonly."
-SET @@global.ROCKSDB_MAX_BACKGROUND_COMPACTIONS   = 444;
-ERROR HY000: Variable 'rocksdb_max_background_compactions' is a read only variable
+'# Setting to valid values in global scope#'
+"Trying to set variable @@global.ROCKSDB_MAX_BACKGROUND_COMPACTIONS to 1"
+SET @@global.ROCKSDB_MAX_BACKGROUND_COMPACTIONS   = 1;
+SELECT @@global.ROCKSDB_MAX_BACKGROUND_COMPACTIONS;
+@@global.ROCKSDB_MAX_BACKGROUND_COMPACTIONS
+1
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_MAX_BACKGROUND_COMPACTIONS = DEFAULT;
+SELECT @@global.ROCKSDB_MAX_BACKGROUND_COMPACTIONS;
+@@global.ROCKSDB_MAX_BACKGROUND_COMPACTIONS
+1
+"Trying to set variable @@global.ROCKSDB_MAX_BACKGROUND_COMPACTIONS to 64"
+SET @@global.ROCKSDB_MAX_BACKGROUND_COMPACTIONS   = 64;
+SELECT @@global.ROCKSDB_MAX_BACKGROUND_COMPACTIONS;
+@@global.ROCKSDB_MAX_BACKGROUND_COMPACTIONS
+64
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_MAX_BACKGROUND_COMPACTIONS = DEFAULT;
+SELECT @@global.ROCKSDB_MAX_BACKGROUND_COMPACTIONS;
+@@global.ROCKSDB_MAX_BACKGROUND_COMPACTIONS
+1
+"Trying to set variable @@session.ROCKSDB_MAX_BACKGROUND_COMPACTIONS to 444. It should fail because it is not session."
+SET @@session.ROCKSDB_MAX_BACKGROUND_COMPACTIONS   = 444;
+ERROR HY000: Variable 'rocksdb_max_background_compactions' is a GLOBAL variable and should be set with SET GLOBAL
+'# Testing with invalid values in global scope #'
+"Trying to set variable @@global.ROCKSDB_MAX_BACKGROUND_COMPACTIONS to 'abc'"
+SET @@global.ROCKSDB_MAX_BACKGROUND_COMPACTIONS   = 'abc';
+Got one of the listed errors
+SELECT @@global.ROCKSDB_MAX_BACKGROUND_COMPACTIONS;
+@@global.ROCKSDB_MAX_BACKGROUND_COMPACTIONS
+1
+SET @@global.ROCKSDB_MAX_BACKGROUND_COMPACTIONS = @start_global_value;
+SELECT @@global.ROCKSDB_MAX_BACKGROUND_COMPACTIONS;
+@@global.ROCKSDB_MAX_BACKGROUND_COMPACTIONS
+1
+DROP TABLE valid_values;
+DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_max_background_compactions_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_max_background_compactions_basic.test
@@ -1,7 +1,16 @@
 --source include/have_rocksdb.inc
 
+CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(1);
+INSERT INTO valid_values VALUES(64);
+
+CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO invalid_values VALUES('\'abc\'');
+
 --let $sys_var=ROCKSDB_MAX_BACKGROUND_COMPACTIONS
---let $read_only=1
+--let $read_only=0
 --let $session=0
 --source suite/sys_vars/inc/rocksdb_sys_var.inc
 
+DROP TABLE valid_values;
+DROP TABLE invalid_values;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -382,6 +382,12 @@ rocksdb_set_bulk_load(THD*                     thd,
                       struct st_mysql_sys_var* var __attribute__((__unused__)),
                       void*                    var_ptr,
                       const void*              save);
+
+static void
+rocksdb_set_max_background_compactions(THD* thd,
+                                       struct st_mysql_sys_var* const var,
+                                       void* const var_ptr,
+                                       const void* const save);
 //////////////////////////////////////////////////////////////////////////////
 // Options definitions
 //////////////////////////////////////////////////////////////////////////////
@@ -740,9 +746,10 @@ static MYSQL_SYSVAR_INT(base_background_compactions,
 
 static MYSQL_SYSVAR_INT(max_background_compactions,
   rocksdb_db_options.max_background_compactions,
-  PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
+  PLUGIN_VAR_RQCMDARG,
   "DBOptions::max_background_compactions for RocksDB",
-  nullptr, nullptr, rocksdb_db_options.max_background_compactions,
+  nullptr, rocksdb_set_max_background_compactions,
+  rocksdb_db_options.max_background_compactions,
   /* min */ 1, /* max */ MAX_BACKGROUND_COMPACTIONS, 0);
 
 static MYSQL_SYSVAR_INT(max_background_flushes,
@@ -11206,6 +11213,23 @@ rocksdb_set_bulk_load(THD* const thd,
   }
 
   *static_cast<bool*>(var_ptr) = *static_cast<const bool*>(save);
+}
+
+static void
+rocksdb_set_max_background_compactions(THD* thd,
+                                       struct st_mysql_sys_var* const var,
+                                       void* const var_ptr,
+                                       const void* const save)
+{
+  DBUG_ASSERT(save != nullptr);
+
+  mysql_mutex_lock(&rdb_sysvars_mutex);
+  rocksdb_db_options.max_background_compactions=
+    *static_cast<const int*>(save);
+  rocksdb_db_options.env->SetBackgroundThreads(
+      rocksdb_db_options.max_background_compactions,
+      rocksdb::Env::Priority::LOW);
+  mysql_mutex_unlock(&rdb_sysvars_mutex);
 }
 
 void rdb_queue_save_stats_request()


### PR DESCRIPTION
Summary:
`max_background_compactions` is a mutable option in RocksDB. Making it dynamic
in MyRocks as well.