### PR TITLE
add missing test for persistent cache support

### DIFF
--- a/mysql-test/suite/rocksdb_sys_vars/r/all_vars.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/all_vars.result
@@ -9,9 +9,5 @@ There should be *no* long test name listed below:
 select variable_name as `There should be *no* variables listed below:` from t2
 left join t1 on variable_name=test_name where test_name is null ORDER BY variable_name;
 There should be *no* variables listed below:
-ROCKSDB_PERSISTENT_CACHE_PATH
-ROCKSDB_PERSISTENT_CACHE_PATH
-ROCKSDB_PERSISTENT_CACHE_SIZE
-ROCKSDB_PERSISTENT_CACHE_SIZE
 drop table t1;
 drop table t2;

--- a/mysql-test/suite/rocksdb_sys_vars/r/all_vars.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/all_vars.result
@@ -9,5 +9,9 @@ There should be *no* long test name listed below:
 select variable_name as `There should be *no* variables listed below:` from t2
 left join t1 on variable_name=test_name where test_name is null ORDER BY variable_name;
 There should be *no* variables listed below:
+ROCKSDB_PERSISTENT_CACHE_PATH
+ROCKSDB_PERSISTENT_CACHE_PATH
+ROCKSDB_PERSISTENT_CACHE_SIZE
+ROCKSDB_PERSISTENT_CACHE_SIZE
 drop table t1;
 drop table t2;

--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_persistent_cache_path_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_persistent_cache_path_basic.result
@@ -1,0 +1,13 @@
+CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES('abc');
+INSERT INTO valid_values VALUES('def');
+CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
+SET @start_global_value = @@global.ROCKSDB_PERSISTENT_CACHE_PATH;
+SELECT @start_global_value;
+@start_global_value
+
+"Trying to set variable @@global.ROCKSDB_PERSISTENT_CACHE_PATH to 444. It should fail because it is readonly."
+SET @@global.ROCKSDB_PERSISTENT_CACHE_PATH   = 444;
+ERROR HY000: Variable 'rocksdb_persistent_cache_path' is a read only variable
+DROP TABLE valid_values;
+DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_persistent_cache_size_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_persistent_cache_size_basic.result
@@ -1,0 +1,14 @@
+CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(1);
+INSERT INTO valid_values VALUES(1024);
+CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO invalid_values VALUES('\'aaa\'');
+SET @start_global_value = @@global.ROCKSDB_PERSISTENT_CACHE_SIZE;
+SELECT @start_global_value;
+@start_global_value
+0
+"Trying to set variable @@global.ROCKSDB_PERSISTENT_CACHE_SIZE to 444. It should fail because it is readonly."
+SET @@global.ROCKSDB_PERSISTENT_CACHE_SIZE   = 444;
+ERROR HY000: Variable 'rocksdb_persistent_cache_size' is a read only variable
+DROP TABLE valid_values;
+DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_persistent_cache_path_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_persistent_cache_path_basic.test
@@ -1,0 +1,16 @@
+--source include/have_rocksdb.inc
+
+CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES('abc');
+INSERT INTO valid_values VALUES('def');
+
+CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
+
+--let $sys_var=ROCKSDB_PERSISTENT_CACHE_PATH
+--let $read_only=1
+--let $session=0
+--let $sticky=1
+--source suite/sys_vars/inc/rocksdb_sys_var.inc
+
+DROP TABLE valid_values;
+DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_persistent_cache_size_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_persistent_cache_size_basic.test
@@ -1,0 +1,16 @@
+--source include/have_rocksdb.inc
+
+CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(1);
+INSERT INTO valid_values VALUES(1024);
+
+CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO invalid_values VALUES('\'aaa\'');
+
+--let $sys_var=ROCKSDB_PERSISTENT_CACHE_SIZE
+--let $read_only=1
+--let $session=0
+--source suite/sys_vars/inc/rocksdb_sys_var.inc
+
+DROP TABLE valid_values;
+DROP TABLE invalid_values;


### PR DESCRIPTION
This diff adds tests so that sys_vars tests no longer fail. The persistent_cache test is still failing on sandcastle and is disabled.