### PR TITLE
Name MyRocks threads correctly to enhance debugging

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -3861,7 +3861,9 @@ static int rocksdb_init_func(void* const p)
   }
 
   auto err= rdb_bg_thread.create_thread(
+    BG_THREAD_NAME
 #ifdef HAVE_PSI_INTERFACE
+    ,
     rdb_background_psi_thread_key
 #endif
   );
@@ -3873,7 +3875,9 @@ static int rocksdb_init_func(void* const p)
   }
 
   err= rdb_drop_idx_thread.create_thread(
+    INDEX_THREAD_NAME
 #ifdef HAVE_PSI_INTERFACE
+    ,
     rdb_drop_idx_psi_thread_key
 #endif
   );

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -112,6 +112,16 @@ const char * const HIDDEN_PK_NAME= "HIDDEN_PK_ID";
 const char * const PER_INDEX_CF_NAME = "$per_index_cf";
 
 /*
+  Name for the background thread.
+*/
+const char* const BG_THREAD_NAME = "myrocks-bg";
+
+/*
+  Name for the drop index thread.
+*/
+const char* const INDEX_THREAD_NAME = "myrocks-index";
+
+/*
   Default, minimal valid, and maximum valid sampling rate values when collecting
   statistics about table.
 */

--- a/storage/rocksdb/rdb_threads.h
+++ b/storage/rocksdb/rdb_threads.h
@@ -16,6 +16,9 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 #pragma once
 
+/* C++ standard header files */
+#include <string>
+
 /* MySQL includes */
 #include "./my_global.h"
 #include <mysql/psi/mysql_table.h>
@@ -50,10 +53,11 @@ class Rdb_thread
   void init(my_core::PSI_mutex_key  stop_bg_psi_mutex_key,
             my_core::PSI_cond_key   stop_bg_psi_cond_key);
   int create_thread(
+            const std::string& thread_name,
             my_core::PSI_thread_key background_psi_thread_key);
 #else
   void init();
-  int create_thread();
+  int create_thread(const std::string& thread_name);
 #endif
 
   virtual void run(void) = 0;


### PR DESCRIPTION
Currently in `gdb` the MyRocks threads show up as "my-func". That's
because how setting thread names is implemented in MySQL (using the
substring of a callback function name).

Given how `Rdb_thread` class creates threads, the names all end up the
same. Therefore we need to reset them ourselves.