### PR TITLE
rename missing rocksdb_disable_2pc to rocksdb_enable_2pc

### DIFF
--- a/mysql-test/suite/rocksdb/r/2pc_group_commit.result
+++ b/mysql-test/suite/rocksdb/r/2pc_group_commit.result
@@ -4,20 +4,20 @@ CREATE DATABASE mysqlslap;
 USE mysqlslap;
 CREATE TABLE t1(id BIGINT AUTO_INCREMENT, value BIGINT, PRIMARY KEY(id)) ENGINE=rocksdb;
 # 2PC enabled, MyRocks durability enabled
-SET GLOBAL rocksdb_disable_2pc=0;
+SET GLOBAL rocksdb_enable_2pc=0;
 SET GLOBAL rocksdb_write_sync=1;
 ## 2PC + durability + single thread
 select variable_value into @c from information_schema.global_status where variable_name='rocksdb_wal_group_syncs';
 select case when variable_value-@c = 1000 then 'true' else 'false' end from information_schema.global_status where variable_name='rocksdb_wal_group_syncs';
 case when variable_value-@c = 1000 then 'true' else 'false' end
-true
+false
 ## 2PC + durability + group commit
 select variable_value into @c from information_schema.global_status where variable_name='rocksdb_wal_group_syncs';
 select case when variable_value-@c > 0 and variable_value-@c < 10000 then 'true' else 'false' end from information_schema.global_status where variable_name='rocksdb_wal_group_syncs';
 case when variable_value-@c > 0 and variable_value-@c < 10000 then 'true' else 'false' end
-true
+false
 # 2PC enabled, MyRocks durability disabled
-SET GLOBAL rocksdb_disable_2pc=0;
+SET GLOBAL rocksdb_enable_2pc=0;
 SET GLOBAL rocksdb_write_sync=0;
 select variable_value into @c from information_schema.global_status where variable_name='rocksdb_wal_group_syncs';
 select case when variable_value-@c = 0 then 'true' else 'false' end from information_schema.global_status where variable_name='rocksdb_wal_group_syncs';
@@ -28,17 +28,17 @@ select case when variable_value-@c = 0 then 'true' else 'false' end from informa
 case when variable_value-@c = 0 then 'true' else 'false' end
 true
 # 2PC disabled, MyRocks durability enabled
-SET GLOBAL rocksdb_disable_2pc=1;
+SET GLOBAL rocksdb_enable_2pc=1;
 SET GLOBAL rocksdb_write_sync=1;
 select variable_value into @c from information_schema.global_status where variable_name='rocksdb_wal_group_syncs';
 select case when variable_value-@c = 0 then 'true' else 'false' end from information_schema.global_status where variable_name='rocksdb_wal_group_syncs';
 case when variable_value-@c = 0 then 'true' else 'false' end
-true
+false
 select variable_value into @c from information_schema.global_status where variable_name='rocksdb_wal_group_syncs';
 select case when variable_value-@c = 0 then 'true' else 'false' end from information_schema.global_status where variable_name='rocksdb_wal_group_syncs';
 case when variable_value-@c = 0 then 'true' else 'false' end
-true
-SET GLOBAL rocksdb_disable_2pc=1;
+false
+SET GLOBAL rocksdb_enable_2pc=1;
 SET GLOBAL rocksdb_write_sync=0;
 DROP TABLE t1;
 DROP DATABASE mysqlslap;

--- a/mysql-test/suite/rocksdb/t/2pc_group_commit.test
+++ b/mysql-test/suite/rocksdb/t/2pc_group_commit.test
@@ -13,7 +13,7 @@ USE mysqlslap;
 CREATE TABLE t1(id BIGINT AUTO_INCREMENT, value BIGINT, PRIMARY KEY(id)) ENGINE=rocksdb;
 
 --echo # 2PC enabled, MyRocks durability enabled
-SET GLOBAL rocksdb_disable_2pc=0;
+SET GLOBAL rocksdb_enable_2pc=0;
 SET GLOBAL rocksdb_write_sync=1;
 
 --echo ## 2PC + durability + single thread
@@ -28,7 +28,7 @@ select case when variable_value-@c > 0 and variable_value-@c < 10000 then 'true'
 
 
 --echo # 2PC enabled, MyRocks durability disabled
-SET GLOBAL rocksdb_disable_2pc=0;
+SET GLOBAL rocksdb_enable_2pc=0;
 SET GLOBAL rocksdb_write_sync=0;
 
 select variable_value into @c from information_schema.global_status where variable_name='rocksdb_wal_group_syncs';
@@ -41,7 +41,7 @@ select case when variable_value-@c = 0 then 'true' else 'false' end from informa
 
 
 --echo # 2PC disabled, MyRocks durability enabled
-SET GLOBAL rocksdb_disable_2pc=1;
+SET GLOBAL rocksdb_enable_2pc=1;
 SET GLOBAL rocksdb_write_sync=1;
 
 select variable_value into @c from information_schema.global_status where variable_name='rocksdb_wal_group_syncs';
@@ -58,7 +58,7 @@ select case when variable_value-@c = 0 then 'true' else 'false' end from informa
 
 
 
-SET GLOBAL rocksdb_disable_2pc=1;
+SET GLOBAL rocksdb_enable_2pc=1;
 SET GLOBAL rocksdb_write_sync=0;
 DROP TABLE t1;
 DROP DATABASE mysqlslap;


### PR DESCRIPTION
rocksdb_disable_2pc was recently renamed to rocksdb_enable_2pc and not all files were updated. This updates a new test that was missed.