### PR TITLE
Log error with bulk load using sql_print_error

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -7198,6 +7198,13 @@ int ha_rocksdb::finalize_bulk_load() {
   if (m_sst_info != nullptr) {
     rc = m_sst_info->commit();
     if (rc != 0) {
+      /*
+        Log the error immediately here in case the server crashes before
+        mysql prints via my_printf_error.
+      */
+      sql_print_error("Failed to commit bulk loaded sst file to the "
+                "data store (%s)", m_sst_info->error_message().c_str());
+
       my_printf_error(ER_UNKNOWN_ERROR,
                       "Failed to commit bulk loaded sst file to the "
                       "data store (%s)",


### PR DESCRIPTION
We record errors during finalizing bulk load via my_printf_error.  However, my_printf_error does not print the error immediately, and there are cases where the server will crash before we get a chance to see the error.   

To help debug issues with finalizing bulk load, add a call to sql_print_error as well so we can see the errors returned from RocksDB.