### PR TITLE
add bulk load sst file names to all error messages

### DIFF
--- a/storage/rocksdb/rdb_sst_info.h
+++ b/storage/rocksdb/rdb_sst_info.h
@@ -55,6 +55,7 @@ public:
   rocksdb::Status open();
   rocksdb::Status put(const rocksdb::Slice &key, const rocksdb::Slice &value);
   rocksdb::Status commit();
+  const std::string get_name() const { return m_name; }
 };
 
 class Rdb_sst_info {
@@ -83,7 +84,7 @@ private:
 
   int open_new_sst_file();
   void close_curr_sst_file();
-  void set_error_msg(const std::string &msg);
+  void set_error_msg(const std::string &sst_file_name, const std::string &msg);
 
 #if defined(RDB_SST_INFO_USE_THREAD)
   void run_thread();


### PR DESCRIPTION
This makes it easier to debug issues with bulk load by prefixing any/all error messages with the name of the sst file.

Squash with: D4504654