### PR TITLE
Adding delayed_write_rate RocksDB option for MyRocks

### DIFF
--- a/mysql-test/r/mysqld--help-notwin-profiling.result
+++ b/mysql-test/r/mysqld--help-notwin-profiling.result
@@ -1121,6 +1121,8 @@ The following options may be given as the first argument:
  (Defaults to on; use --skip-rocksdb-debug-optimizer-no-zero-cardinality to disable.)
  --rocksdb-default-cf-options=name 
  default cf options for RocksDB
+ --rocksdb-delayed-write-rate=# 
+ DBOptions::delayed_write_rate
  --rocksdb-delete-obsolete-files-period-micros=# 
  DBOptions::delete_obsolete_files_period_micros for
  RocksDB
@@ -1952,6 +1954,7 @@ rocksdb-deadlock-detect FALSE
 rocksdb-debug-optimizer-n-rows 0
 rocksdb-debug-optimizer-no-zero-cardinality TRUE
 rocksdb-default-cf-options 
+rocksdb-delayed-write-rate 2097152
 rocksdb-delete-obsolete-files-period-micros 21600000000
 rocksdb-disabledatasync FALSE
 rocksdb-enable-2pc TRUE

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -1119,6 +1119,8 @@ The following options may be given as the first argument:
  (Defaults to on; use --skip-rocksdb-debug-optimizer-no-zero-cardinality to disable.)
  --rocksdb-default-cf-options=name 
  default cf options for RocksDB
+ --rocksdb-delayed-write-rate=# 
+ DBOptions::delayed_write_rate
  --rocksdb-delete-obsolete-files-period-micros=# 
  DBOptions::delete_obsolete_files_period_micros for
  RocksDB
@@ -1949,6 +1951,7 @@ rocksdb-deadlock-detect FALSE
 rocksdb-debug-optimizer-n-rows 0
 rocksdb-debug-optimizer-no-zero-cardinality TRUE
 rocksdb-default-cf-options 
+rocksdb-delayed-write-rate 2097152
 rocksdb-delete-obsolete-files-period-micros 21600000000
 rocksdb-disabledatasync FALSE
 rocksdb-enable-2pc TRUE

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -889,6 +889,7 @@ rocksdb_db_write_buffer_size	0
 rocksdb_deadlock_detect	OFF
 rocksdb_debug_optimizer_no_zero_cardinality	ON
 rocksdb_default_cf_options	
+rocksdb_delayed_write_rate	2097152
 rocksdb_delete_obsolete_files_period_micros	21600000000
 rocksdb_disabledatasync	OFF
 rocksdb_enable_2pc	ON

--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_delayed_write_rate_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_delayed_write_rate_basic.result
@@ -1,0 +1,85 @@
+CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(100);
+INSERT INTO valid_values VALUES(1);
+INSERT INTO valid_values VALUES(0);
+CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO invalid_values VALUES('\'aaa\'');
+INSERT INTO invalid_values VALUES('\'bbb\'');
+INSERT INTO invalid_values VALUES('\'-1\'');
+INSERT INTO invalid_values VALUES('\'101\'');
+INSERT INTO invalid_values VALUES('\'484436\'');
+SET @start_global_value = @@global.ROCKSDB_DELAYED_WRITE_RATE;
+SELECT @start_global_value;
+@start_global_value
+2097152
+'# Setting to valid values in global scope#'
+"Trying to set variable @@global.ROCKSDB_DELAYED_WRITE_RATE to 100"
+SET @@global.ROCKSDB_DELAYED_WRITE_RATE   = 100;
+SELECT @@global.ROCKSDB_DELAYED_WRITE_RATE;
+@@global.ROCKSDB_DELAYED_WRITE_RATE
+100
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_DELAYED_WRITE_RATE = DEFAULT;
+SELECT @@global.ROCKSDB_DELAYED_WRITE_RATE;
+@@global.ROCKSDB_DELAYED_WRITE_RATE
+2097152
+"Trying to set variable @@global.ROCKSDB_DELAYED_WRITE_RATE to 1"
+SET @@global.ROCKSDB_DELAYED_WRITE_RATE   = 1;
+SELECT @@global.ROCKSDB_DELAYED_WRITE_RATE;
+@@global.ROCKSDB_DELAYED_WRITE_RATE
+1
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_DELAYED_WRITE_RATE = DEFAULT;
+SELECT @@global.ROCKSDB_DELAYED_WRITE_RATE;
+@@global.ROCKSDB_DELAYED_WRITE_RATE
+2097152
+"Trying to set variable @@global.ROCKSDB_DELAYED_WRITE_RATE to 0"
+SET @@global.ROCKSDB_DELAYED_WRITE_RATE   = 0;
+SELECT @@global.ROCKSDB_DELAYED_WRITE_RATE;
+@@global.ROCKSDB_DELAYED_WRITE_RATE
+0
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_DELAYED_WRITE_RATE = DEFAULT;
+SELECT @@global.ROCKSDB_DELAYED_WRITE_RATE;
+@@global.ROCKSDB_DELAYED_WRITE_RATE
+2097152
+"Trying to set variable @@session.ROCKSDB_DELAYED_WRITE_RATE to 444. It should fail because it is not session."
+SET @@session.ROCKSDB_DELAYED_WRITE_RATE   = 444;
+ERROR HY000: Variable 'rocksdb_delayed_write_rate' is a GLOBAL variable and should be set with SET GLOBAL
+'# Testing with invalid values in global scope #'
+"Trying to set variable @@global.ROCKSDB_DELAYED_WRITE_RATE to 'aaa'"
+SET @@global.ROCKSDB_DELAYED_WRITE_RATE   = 'aaa';
+Got one of the listed errors
+SELECT @@global.ROCKSDB_DELAYED_WRITE_RATE;
+@@global.ROCKSDB_DELAYED_WRITE_RATE
+2097152
+"Trying to set variable @@global.ROCKSDB_DELAYED_WRITE_RATE to 'bbb'"
+SET @@global.ROCKSDB_DELAYED_WRITE_RATE   = 'bbb';
+Got one of the listed errors
+SELECT @@global.ROCKSDB_DELAYED_WRITE_RATE;
+@@global.ROCKSDB_DELAYED_WRITE_RATE
+2097152
+"Trying to set variable @@global.ROCKSDB_DELAYED_WRITE_RATE to '-1'"
+SET @@global.ROCKSDB_DELAYED_WRITE_RATE   = '-1';
+Got one of the listed errors
+SELECT @@global.ROCKSDB_DELAYED_WRITE_RATE;
+@@global.ROCKSDB_DELAYED_WRITE_RATE
+2097152
+"Trying to set variable @@global.ROCKSDB_DELAYED_WRITE_RATE to '101'"
+SET @@global.ROCKSDB_DELAYED_WRITE_RATE   = '101';
+Got one of the listed errors
+SELECT @@global.ROCKSDB_DELAYED_WRITE_RATE;
+@@global.ROCKSDB_DELAYED_WRITE_RATE
+2097152
+"Trying to set variable @@global.ROCKSDB_DELAYED_WRITE_RATE to '484436'"
+SET @@global.ROCKSDB_DELAYED_WRITE_RATE   = '484436';
+Got one of the listed errors
+SELECT @@global.ROCKSDB_DELAYED_WRITE_RATE;
+@@global.ROCKSDB_DELAYED_WRITE_RATE
+2097152
+SET @@global.ROCKSDB_DELAYED_WRITE_RATE = @start_global_value;
+SELECT @@global.ROCKSDB_DELAYED_WRITE_RATE;
+@@global.ROCKSDB_DELAYED_WRITE_RATE
+2097152
+DROP TABLE valid_values;
+DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_delayed_write_rate_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_delayed_write_rate_basic.test
@@ -1,0 +1,22 @@
+--source include/have_rocksdb.inc
+
+CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(100);
+INSERT INTO valid_values VALUES(1);
+INSERT INTO valid_values VALUES(0);
+
+CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO invalid_values VALUES('\'aaa\'');
+INSERT INTO invalid_values VALUES('\'bbb\'');
+INSERT INTO invalid_values VALUES('\'-1\'');
+INSERT INTO invalid_values VALUES('\'101\'');
+INSERT INTO invalid_values VALUES('\'484436\'');
+
+--let $sys_var=ROCKSDB_DELAYED_WRITE_RATE
+--let $read_only=0
+--let $session=0
+--source suite/sys_vars/inc/rocksdb_sys_var.inc
+
+DROP TABLE valid_values;
+DROP TABLE invalid_values;
+

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -331,6 +331,11 @@ static void rocksdb_set_rate_limiter_bytes_per_sec(THD *thd,
                                                    void *var_ptr,
                                                    const void *save);
 
+static void rocksdb_set_delayed_write_rate(THD *thd,
+                                           struct st_mysql_sys_var *var,
+                                           void *var_ptr,
+                                           const void *save);
+
 static void rdb_set_collation_exception_list(const char *exception_list);
 static void rocksdb_set_collation_exception_list(THD *thd,
                                                  struct st_mysql_sys_var *var,
@@ -352,6 +357,7 @@ static long long rocksdb_block_cache_size;
 /* Use unsigned long long instead of uint64_t because of MySQL compatibility */
 static unsigned long long // NOLINT(runtime/int)
     rocksdb_rate_limiter_bytes_per_sec;
+static unsigned long long rocksdb_delayed_write_rate;
 static unsigned long // NOLINT(runtime/int)
     rocksdb_persistent_cache_size;
 static uint64_t rocksdb_info_log_level;
@@ -564,6 +570,12 @@ static MYSQL_SYSVAR_ULONGLONG(
     PLUGIN_VAR_RQCMDARG, "DBOptions::rate_limiter bytes_per_sec for RocksDB",
     nullptr, rocksdb_set_rate_limiter_bytes_per_sec, /* default */ 0L,
     /* min */ 0L, /* max */ MAX_RATE_LIMITER_BYTES_PER_SEC, 0);
+
+static MYSQL_SYSVAR_ULONGLONG(
+    delayed_write_rate, rocksdb_delayed_write_rate,
+    PLUGIN_VAR_RQCMDARG, "DBOptions::delayed_write_rate", nullptr,
+    rocksdb_set_delayed_write_rate, rocksdb_db_options.delayed_write_rate,
+    0, UINT64_MAX, 0);
 
 static MYSQL_SYSVAR_ENUM(
     info_log_level, rocksdb_info_log_level, PLUGIN_VAR_RQCMDARG,
@@ -1171,6 +1183,7 @@ static struct st_mysql_sys_var *rocksdb_system_variables[] = {
     MYSQL_SYSVAR(error_if_exists),
     MYSQL_SYSVAR(paranoid_checks),
     MYSQL_SYSVAR(rate_limiter_bytes_per_sec),
+    MYSQL_SYSVAR(delayed_write_rate),
     MYSQL_SYSVAR(info_log_level),
     MYSQL_SYSVAR(max_open_files),
     MYSQL_SYSVAR(max_total_wal_size),
@@ -3307,6 +3320,8 @@ static int rocksdb_init_func(void *const p) {
         rocksdb::NewGenericRateLimiter(rocksdb_rate_limiter_bytes_per_sec));
     rocksdb_db_options.rate_limiter = rocksdb_rate_limiter;
   }
+
+  rocksdb_db_options.delayed_write_rate = rocksdb_delayed_write_rate;
 
   std::shared_ptr<Rdb_logger> myrocks_logger = std::make_shared<Rdb_logger>();
   rocksdb::Status s = rocksdb::CreateLoggerFromOptions(
@@ -10206,6 +10221,17 @@ void rocksdb_set_rate_limiter_bytes_per_sec(
     DBUG_ASSERT(rocksdb_rate_limiter != nullptr);
     rocksdb_rate_limiter_bytes_per_sec = new_val;
     rocksdb_rate_limiter->SetBytesPerSecond(new_val);
+  }
+}
+
+void rocksdb_set_delayed_write_rate(THD *thd,
+                                    struct st_mysql_sys_var *var,
+                                    void *var_ptr,
+                                    const void *save) {
+  const uint64_t new_val = *static_cast<const uint64_t *>(save);
+  if (rocksdb_delayed_write_rate != new_val) {
+    rocksdb_delayed_write_rate = new_val;
+    rocksdb_db_options.delayed_write_rate = new_val;
   }
 }
 


### PR DESCRIPTION
Summary: Currently delayed_write_rate is not configurable in MySQL. This
diff adds the configuration to MySQL so it can be configured in MySQL

Test Plan: ran rocksdb_sys_vars test suite

Reviewers: yoshinori

Subscribers:

Tasks: 15979933

Blame Revision:

Closes #517 