### PR TITLE
rerecord mysqld--help-notwin

### DIFF
--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -2034,7 +2034,6 @@ rpl-skip-tx-api FALSE
 rpl-stop-slave-timeout 604800
 safe-user-create FALSE
 secure-auth TRUE
-secure-file-priv (No default value)
 select-into-file-fsync-size 0
 select-into-file-fsync-timeout 0
 send-error-before-closing-timed-out-connection TRUE


### PR DESCRIPTION
We missed rerecording this test in 04a32957d785e4546535c754cef9f9768e5c9d0f.

Squash with D4519761. 