### PR TITLE
Remove bashism in t/slocket_listen.sh

### DIFF
--- a/mysql-test/t/slocket_listen.sh
+++ b/mysql-test/t/slocket_listen.sh
@@ -14,7 +14,7 @@ dirname=`dirname "$0"`
 
 ###########################################################################
 
-function log_debug {
+log_debug() {
   echo $1 >> $log_file
 }
 


### PR DESCRIPTION
cases a test failure when sh isn't bash.