### PR TITLE
Ignore all socket files not just log sockets

### DIFF
--- a/scripts/myrocks_hotbackup
+++ b/scripts/myrocks_hotbackup
@@ -29,7 +29,6 @@ rocksdb_data_suffix = '.sst'
 rocksdb_wal_suffix = '.log'
 exclude_files = ['master.info', 'relay-log.info', 'worker-relay-log.info',
                  'auto.cnf', 'gaplock.log', 'ibdata', 'ib_logfile']
-exclude_logs = ['slocket']
 wdt_bin = 'wdt'
 
 def is_manifest(fname):
@@ -109,7 +108,7 @@ class MiscFilesProcessor():
     dirs = [ d for d in os.listdir(self.datadir) \
             if not os.path.isfile(os.path.join(self.datadir,d))]
     for db in dirs:
-      if not db.startswith('.') and not self._is_log_socket(db):
+      if not db.startswith('.') and not self._is_socket(db):
         dbs.append(db)
     return dbs
 
@@ -118,9 +117,9 @@ class MiscFilesProcessor():
     return [ f for f in os.listdir(dbdir) \
             if os.path.isfile(os.path.join(dbdir,f))]
 
-  def _is_log_socket(self, item):
+  def _is_socket(self, item):
       mode = os.stat(os.path.join(self.datadir, item)).st_mode
-      if item in exclude_logs and stat.S_ISSOCK(mode):
+      if stat.S_ISSOCK(mode):
         return True
       return False
 


### PR DESCRIPTION
Summary: A change was added recently to ignore specific socket files in the data directory, but other users may create socket files there as well.  We don't need to specify which socket files to ignore as attempting to access any socket file will generate an error.  We simply need to skip all socket files.

Test Plan: TBD

Reviewers: hermanlee4

Subscribers: