### PR TITLE
Have the created thread set its own name

### DIFF
--- a/storage/rocksdb/rdb_threads.cc
+++ b/storage/rocksdb/rdb_threads.cc
@@ -28,6 +28,7 @@ void *Rdb_thread::thread_func(void *const thread_ptr) {
   DBUG_ASSERT(thread_ptr != nullptr);
   Rdb_thread *const thread = static_cast<Rdb_thread *const>(thread_ptr);
   if (!thread->m_run_once.exchange(true)) {
+    thread->setname();
     thread->run();
     thread->uninit();
   }
@@ -56,23 +57,12 @@ int Rdb_thread::create_thread(const std::string &thread_name
                               PSI_thread_key background_psi_thread_key
 #endif
                               ) {
-  DBUG_ASSERT(!thread_name.empty());
+  // Make a copy of the name so we can return without worrying that the
+  // caller will free the memory
+  m_name = thread_name;
 
-  int err = mysql_thread_create(background_psi_thread_key, &m_handle, nullptr,
-                                thread_func, this);
-
-  if (!err) {
-    /*
-      mysql_thread_create() ends up doing some work underneath and setting the
-      thread name as "my-func". This isn't what we want. Our intent is to name
-      the threads according to their purpose so that when displayed under the
-      debugger then they'll be more easily identifiable. Therefore we'll reset
-      the name if thread was successfully created.
-    */
-    err = pthread_setname_np(m_handle, thread_name.c_str());
-  }
-
-  return err;
+  return mysql_thread_create(background_psi_thread_key, &m_handle, nullptr,
+                             thread_func, this);
 }
 
 void Rdb_thread::signal(const bool &stop_thread) {

--- a/storage/rocksdb/rdb_threads.h
+++ b/storage/rocksdb/rdb_threads.h
@@ -40,6 +40,8 @@ private:
 
   pthread_t m_handle;
 
+  std::string m_name;
+
 protected:
   mysql_mutex_t m_signal_mutex;
   mysql_cond_t m_signal_cond;
@@ -63,6 +65,31 @@ public:
   void signal(const bool &stop_thread = false);
 
   int join() { return pthread_join(m_handle, nullptr); }
+
+  void setname() {
+    /*
+      mysql_thread_create() ends up doing some work underneath and setting the
+      thread name as "my-func". This isn't what we want. Our intent is to name
+      the threads according to their purpose so that when displayed under the
+      debugger then they'll be more easily identifiable. Therefore we'll reset
+      the name if thread was successfully created.
+    */
+
+    /*
+      We originally had the creator also set the thread name, but that seems to
+      not work correctly in all situations.  Having the created thread do the
+      pthread_setname_np resolves the issue.
+    */
+    DBUG_ASSERT(!m_name.empty());
+    int err = pthread_setname_np(m_handle, m_name.c_str());
+    if (err)
+    {
+      // NO_LINT_DEBUG
+      sql_print_warning(
+          "MyRocks: Failed to set name (%s) for current thread, errno=%d",
+          m_name.c_str(), errno);
+    }
+  }
 
   void uninit();
 


### PR DESCRIPTION
Summary: On some scenarios, having the creating thread set the created thread's name gets an errno 13 (EACCES).  Change the code so that the created thread sets its own name solves the problem.

Test Plan:  MTR