### PR TITLE
Refactor persistent_cache_size from bytes to MB

### DIFF
--- a/mysql-test/r/mysqld--help-notwin-profiling.result
+++ b/mysql-test/r/mysqld--help-notwin-profiling.result
@@ -1253,7 +1253,7 @@ The following options may be given as the first argument:
  --rocksdb-persistent-cache-path=name 
  Path for BlockBasedTableOptions::persistent_cache for
  RocksDB
- --rocksdb-persistent-cache-size=# 
+ --rocksdb-persistent-cache-size-mb=# 
  Size of cache for
  BlockBasedTableOptions::persistent_cache for RocksDB
  --rocksdb-pin-l0-filter-and-index-blocks-in-cache 
@@ -2017,7 +2017,7 @@ rocksdb-perf-context ON
 rocksdb-perf-context-global ON
 rocksdb-perf-context-level 0
 rocksdb-persistent-cache-path 
-rocksdb-persistent-cache-size 0
+rocksdb-persistent-cache-size-mb 0
 rocksdb-pin-l0-filter-and-index-blocks-in-cache TRUE
 rocksdb-print-snapshot-conflict-queries FALSE
 rocksdb-rate-limiter-bytes-per-sec 0

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -1251,7 +1251,7 @@ The following options may be given as the first argument:
  --rocksdb-persistent-cache-path=name 
  Path for BlockBasedTableOptions::persistent_cache for
  RocksDB
- --rocksdb-persistent-cache-size=# 
+ --rocksdb-persistent-cache-size-mb=# 
  Size of cache for
  BlockBasedTableOptions::persistent_cache for RocksDB
  --rocksdb-pin-l0-filter-and-index-blocks-in-cache 
@@ -2014,7 +2014,7 @@ rocksdb-perf-context ON
 rocksdb-perf-context-global ON
 rocksdb-perf-context-level 0
 rocksdb-persistent-cache-path 
-rocksdb-persistent-cache-size 0
+rocksdb-persistent-cache-size-mb 0
 rocksdb-pin-l0-filter-and-index-blocks-in-cache TRUE
 rocksdb-print-snapshot-conflict-queries FALSE
 rocksdb-rate-limiter-bytes-per-sec 0

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -929,7 +929,7 @@ rocksdb_paranoid_checks	ON
 rocksdb_pause_background_work	ON
 rocksdb_perf_context_level	0
 rocksdb_persistent_cache_path	
-rocksdb_persistent_cache_size	0
+rocksdb_persistent_cache_size_mb	0
 rocksdb_pin_l0_filter_and_index_blocks_in_cache	ON
 rocksdb_print_snapshot_conflict_queries	OFF
 rocksdb_rate_limiter_bytes_per_sec	0

--- a/mysql-test/suite/rocksdb/t/persistent_cache.test
+++ b/mysql-test/suite/rocksdb/t/persistent_cache.test
@@ -11,7 +11,7 @@ DROP TABLE IF EXISTS t1;
 
 # restart server with correct parameters
 shutdown_server 10;
---exec echo "restart:--rocksdb_persistent_cache_path=$_cache_file_name --rocksdb_persistent_cache_size=1000000000" >$_expect_file_name
+--exec echo "restart:--rocksdb_persistent_cache_path=$_cache_file_name --rocksdb_persistent_cache_size_mb=100" >$_expect_file_name
 --sleep 5
 --enable_reconnect
 --source include/wait_until_connected_again.inc
@@ -29,7 +29,7 @@ select * from t1 where a = 1;
 # restart server to re-read cache
 --exec echo "wait" >$_expect_file_name
 shutdown_server 10;
---exec echo "restart:--rocksdb_persistent_cache_path=$_cache_file_name --rocksdb_persistent_cache_size=1000000000" >$_expect_file_name
+--exec echo "restart:--rocksdb_persistent_cache_path=$_cache_file_name --rocksdb_persistent_cache_size_mb=100" >$_expect_file_name
 --sleep 5
 --enable_reconnect
 --source include/wait_until_connected_again.inc

--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_persistent_cache_size_mb_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_persistent_cache_size_mb_basic.result
@@ -3,12 +3,12 @@ INSERT INTO valid_values VALUES(1);
 INSERT INTO valid_values VALUES(1024);
 CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
 INSERT INTO invalid_values VALUES('\'aaa\'');
-SET @start_global_value = @@global.ROCKSDB_PERSISTENT_CACHE_SIZE;
+SET @start_global_value = @@global.ROCKSDB_PERSISTENT_CACHE_SIZE_MB;
 SELECT @start_global_value;
 @start_global_value
 0
-"Trying to set variable @@global.ROCKSDB_PERSISTENT_CACHE_SIZE to 444. It should fail because it is readonly."
-SET @@global.ROCKSDB_PERSISTENT_CACHE_SIZE   = 444;
-ERROR HY000: Variable 'rocksdb_persistent_cache_size' is a read only variable
+"Trying to set variable @@global.ROCKSDB_PERSISTENT_CACHE_SIZE_MB to 444. It should fail because it is readonly."
+SET @@global.ROCKSDB_PERSISTENT_CACHE_SIZE_MB   = 444;
+ERROR HY000: Variable 'rocksdb_persistent_cache_size_mb' is a read only variable
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_persistent_cache_size_mb_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_persistent_cache_size_mb_basic.test
@@ -7,7 +7,7 @@ INSERT INTO valid_values VALUES(1024);
 CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
 INSERT INTO invalid_values VALUES('\'aaa\'');
 
---let $sys_var=ROCKSDB_PERSISTENT_CACHE_SIZE
+--let $sys_var=ROCKSDB_PERSISTENT_CACHE_SIZE_MB
 --let $read_only=1
 --let $session=0
 --source suite/sys_vars/inc/rocksdb_sys_var.inc

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -356,7 +356,7 @@ static unsigned long long // NOLINT(runtime/int)
     rocksdb_rate_limiter_bytes_per_sec;
 static unsigned long long rocksdb_delayed_write_rate;
 static unsigned long // NOLINT(runtime/int)
-    rocksdb_persistent_cache_size;
+    rocksdb_persistent_cache_size_mb;
 static uint64_t rocksdb_info_log_level;
 static char *rocksdb_wal_dir;
 static char *rocksdb_persistent_cache_path;
@@ -675,10 +675,10 @@ static MYSQL_SYSVAR_STR(
     nullptr, "");
 
 static MYSQL_SYSVAR_ULONG(
-    persistent_cache_size, rocksdb_persistent_cache_size,
+    persistent_cache_size_mb, rocksdb_persistent_cache_size_mb,
     PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
     "Size of cache for BlockBasedTableOptions::persistent_cache for RocksDB",
-    nullptr, nullptr, rocksdb_persistent_cache_size,
+    nullptr, nullptr, rocksdb_persistent_cache_size_mb,
     /* min */ 0L, /* max */ ULONG_MAX, 0);
 
 static MYSQL_SYSVAR_ULONG(
@@ -1202,7 +1202,7 @@ static struct st_mysql_sys_var *rocksdb_system_variables[] = {
     MYSQL_SYSVAR(use_fsync),
     MYSQL_SYSVAR(wal_dir),
     MYSQL_SYSVAR(persistent_cache_path),
-    MYSQL_SYSVAR(persistent_cache_size),
+    MYSQL_SYSVAR(persistent_cache_size_mb),
     MYSQL_SYSVAR(delete_obsolete_files_period_micros),
     MYSQL_SYSVAR(base_background_compactions),
     MYSQL_SYSVAR(max_background_compactions),
@@ -3432,14 +3432,15 @@ static int rocksdb_init_func(void *const p) {
     RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
   }
 
-  if (rocksdb_persistent_cache_size > 0) {
+  if (rocksdb_persistent_cache_size_mb > 0) {
     std::shared_ptr<rocksdb::PersistentCache> pcache;
+    uint64_t cache_size_bytes = rocksdb_persistent_cache_size_mb * 1024 * 1024;
     rocksdb::NewPersistentCache(
         rocksdb::Env::Default(), std::string(rocksdb_persistent_cache_path),
-        rocksdb_persistent_cache_size, myrocks_logger, true, &pcache);
+        cache_size_bytes, myrocks_logger, true, &pcache);
     rocksdb_tbl_options.persistent_cache = pcache;
   } else if (strlen(rocksdb_persistent_cache_path)) {
-    sql_print_error("RocksDB: Must specify rocksdb_persistent_cache_size");
+    sql_print_error("RocksDB: Must specify rocksdb_persistent_cache_size_mb");
     DBUG_RETURN(1);
   }
 

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -677,8 +677,8 @@ static MYSQL_SYSVAR_STR(
 static MYSQL_SYSVAR_ULONG(
     persistent_cache_size_mb, rocksdb_persistent_cache_size_mb,
     PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
-    "Size of cache for BlockBasedTableOptions::persistent_cache for RocksDB",
-    nullptr, nullptr, rocksdb_persistent_cache_size_mb,
+    "Size of cache in MB for BlockBasedTableOptions::persistent_cache "
+    "for RocksDB", nullptr, nullptr, rocksdb_persistent_cache_size_mb,
     /* min */ 0L, /* max */ ULONG_MAX, 0);
 
 static MYSQL_SYSVAR_ULONG(
@@ -3434,7 +3434,7 @@ static int rocksdb_init_func(void *const p) {
 
   if (rocksdb_persistent_cache_size_mb > 0) {
     std::shared_ptr<rocksdb::PersistentCache> pcache;
-    uint64_t cache_size_bytes = rocksdb_persistent_cache_size_mb * 1024 * 1024;
+    uint64_t cache_size_bytes= rocksdb_persistent_cache_size_mb * 1024 * 1024;
     rocksdb::NewPersistentCache(
         rocksdb::Env::Default(), std::string(rocksdb_persistent_cache_path),
         cache_size_bytes, myrocks_logger, true, &pcache);


### PR DESCRIPTION
This diff refactors rocksdb_persistent_cache_size to rocksdb_persistent_cache_size_mb.