### PR TITLE
Setting some *histogram_step_size* variables to NULL crashed the server

### DIFF
--- a/mysql-test/suite/sys_vars/r/histogram_step_size_binlog_fsync_basic.result
+++ b/mysql-test/suite/sys_vars/r/histogram_step_size_binlog_fsync_basic.result
@@ -75,6 +75,11 @@ Expected error 'Variable cannot be set to this value';
 SET @@GLOBAL.histogram_step_size_binlog_fsync='s';
 ERROR 42000: Variable 'histogram_step_size_binlog_fsync' can't be set to the value of 's'
 Expected error 'Variable cannot be set to this value';
+SET @@GLOBAL.histogram_step_size_binlog_fsync=null;
+select @@GLOBAL.histogram_step_size_binlog_fsync;
+@@GLOBAL.histogram_step_size_binlog_fsync
+NULL
+NULL Expected
 SET @@GLOBAL.histogram_step_size_binlog_fsync='16.5us';
 select @@GLOBAL.histogram_step_size_binlog_fsync;
 @@GLOBAL.histogram_step_size_binlog_fsync

--- a/mysql-test/suite/sys_vars/r/histogram_step_size_connection_create_basic.result
+++ b/mysql-test/suite/sys_vars/r/histogram_step_size_connection_create_basic.result
@@ -63,6 +63,11 @@ Expected error 'Variable cannot be set to this value';
 SET @@GLOBAL.histogram_step_size_connection_create='s';
 ERROR 42000: Variable 'histogram_step_size_connection_create' can't be set to the value of 's'
 Expected error 'Variable cannot be set to this value';
+SET @@GLOBAL.histogram_step_size_connection_create=null;
+select @@GLOBAL.histogram_step_size_connection_create;
+@@GLOBAL.histogram_step_size_connection_create
+NULL
+NULL Expected
 SET @@GLOBAL.histogram_step_size_connection_create='16.5us';
 select @@GLOBAL.histogram_step_size_connection_create;
 @@GLOBAL.histogram_step_size_connection_create

--- a/mysql-test/suite/sys_vars/r/histogram_step_size_ddl_command_basic.result
+++ b/mysql-test/suite/sys_vars/r/histogram_step_size_ddl_command_basic.result
@@ -63,6 +63,11 @@ Expected error 'Variable cannot be set to this value';
 SET @@GLOBAL.histogram_step_size_ddl_command='s';
 ERROR 42000: Variable 'histogram_step_size_ddl_command' can't be set to the value of 's'
 Expected error 'Variable cannot be set to this value';
+SET @@GLOBAL.histogram_step_size_ddl_command=null;
+select @@GLOBAL.histogram_step_size_ddl_command;
+@@GLOBAL.histogram_step_size_ddl_command
+NULL
+NULL Expected
 SET @@GLOBAL.histogram_step_size_ddl_command='16.5us';
 select @@GLOBAL.histogram_step_size_ddl_command;
 @@GLOBAL.histogram_step_size_ddl_command

--- a/mysql-test/suite/sys_vars/r/histogram_step_size_delete_command_basic.result
+++ b/mysql-test/suite/sys_vars/r/histogram_step_size_delete_command_basic.result
@@ -63,6 +63,11 @@ Expected error 'Variable cannot be set to this value';
 SET @@GLOBAL.histogram_step_size_delete_command='s';
 ERROR 42000: Variable 'histogram_step_size_delete_command' can't be set to the value of 's'
 Expected error 'Variable cannot be set to this value';
+SET @@GLOBAL.histogram_step_size_delete_command=null;
+select @@GLOBAL.histogram_step_size_delete_command;
+@@GLOBAL.histogram_step_size_delete_command
+NULL
+NULL Expected
 SET @@GLOBAL.histogram_step_size_delete_command='16.5us';
 select @@GLOBAL.histogram_step_size_delete_command;
 @@GLOBAL.histogram_step_size_delete_command

--- a/mysql-test/suite/sys_vars/r/histogram_step_size_handler_command_basic.result
+++ b/mysql-test/suite/sys_vars/r/histogram_step_size_handler_command_basic.result
@@ -63,6 +63,11 @@ Expected error 'Variable cannot be set to this value';
 SET @@GLOBAL.histogram_step_size_handler_command='s';
 ERROR 42000: Variable 'histogram_step_size_handler_command' can't be set to the value of 's'
 Expected error 'Variable cannot be set to this value';
+SET @@GLOBAL.histogram_step_size_handler_command=null;
+select @@GLOBAL.histogram_step_size_handler_command;
+@@GLOBAL.histogram_step_size_handler_command
+NULL
+NULL Expected
 SET @@GLOBAL.histogram_step_size_handler_command='16.5us';
 select @@GLOBAL.histogram_step_size_handler_command;
 @@GLOBAL.histogram_step_size_handler_command

--- a/mysql-test/suite/sys_vars/r/histogram_step_size_insert_command_basic.result
+++ b/mysql-test/suite/sys_vars/r/histogram_step_size_insert_command_basic.result
@@ -63,6 +63,11 @@ Expected error 'Variable cannot be set to this value';
 SET @@GLOBAL.histogram_step_size_insert_command='s';
 ERROR 42000: Variable 'histogram_step_size_insert_command' can't be set to the value of 's'
 Expected error 'Variable cannot be set to this value';
+SET @@GLOBAL.histogram_step_size_insert_command=null;
+select @@GLOBAL.histogram_step_size_insert_command;
+@@GLOBAL.histogram_step_size_insert_command
+NULL
+NULL Expected
 SET @@GLOBAL.histogram_step_size_insert_command='16.5us';
 select @@GLOBAL.histogram_step_size_insert_command;
 @@GLOBAL.histogram_step_size_insert_command

--- a/mysql-test/suite/sys_vars/r/histogram_step_size_other_command_basic.result
+++ b/mysql-test/suite/sys_vars/r/histogram_step_size_other_command_basic.result
@@ -63,6 +63,11 @@ Expected error 'Variable cannot be set to this value';
 SET @@GLOBAL.histogram_step_size_other_command='s';
 ERROR 42000: Variable 'histogram_step_size_other_command' can't be set to the value of 's'
 Expected error 'Variable cannot be set to this value';
+SET @@GLOBAL.histogram_step_size_other_command=null;
+select @@GLOBAL.histogram_step_size_other_command;
+@@GLOBAL.histogram_step_size_other_command
+NULL
+NULL Expected
 SET @@GLOBAL.histogram_step_size_other_command='16.5us';
 select @@GLOBAL.histogram_step_size_other_command;
 @@GLOBAL.histogram_step_size_other_command

--- a/mysql-test/suite/sys_vars/r/histogram_step_size_select_command_basic.result
+++ b/mysql-test/suite/sys_vars/r/histogram_step_size_select_command_basic.result
@@ -63,6 +63,11 @@ Expected error 'Variable cannot be set to this value';
 SET @@GLOBAL.histogram_step_size_select_command='s';
 ERROR 42000: Variable 'histogram_step_size_select_command' can't be set to the value of 's'
 Expected error 'Variable cannot be set to this value';
+SET @@GLOBAL.histogram_step_size_select_command=null;
+select @@GLOBAL.histogram_step_size_select_command;
+@@GLOBAL.histogram_step_size_select_command
+NULL
+NULL Expected
 SET @@GLOBAL.histogram_step_size_select_command='16.5us';
 select @@GLOBAL.histogram_step_size_select_command;
 @@GLOBAL.histogram_step_size_select_command

--- a/mysql-test/suite/sys_vars/r/histogram_step_size_transaction_command_basic.result
+++ b/mysql-test/suite/sys_vars/r/histogram_step_size_transaction_command_basic.result
@@ -63,6 +63,11 @@ Expected error 'Variable cannot be set to this value';
 SET @@GLOBAL.histogram_step_size_transaction_command='s';
 ERROR 42000: Variable 'histogram_step_size_transaction_command' can't be set to the value of 's'
 Expected error 'Variable cannot be set to this value';
+SET @@GLOBAL.histogram_step_size_transaction_command=null;
+select @@GLOBAL.histogram_step_size_transaction_command;
+@@GLOBAL.histogram_step_size_transaction_command
+NULL
+NULL Expected
 SET @@GLOBAL.histogram_step_size_transaction_command='16.5us';
 select @@GLOBAL.histogram_step_size_transaction_command;
 @@GLOBAL.histogram_step_size_transaction_command

--- a/mysql-test/suite/sys_vars/r/histogram_step_size_update_command_basic.result
+++ b/mysql-test/suite/sys_vars/r/histogram_step_size_update_command_basic.result
@@ -63,6 +63,11 @@ Expected error 'Variable cannot be set to this value';
 SET @@GLOBAL.histogram_step_size_update_command='s';
 ERROR 42000: Variable 'histogram_step_size_update_command' can't be set to the value of 's'
 Expected error 'Variable cannot be set to this value';
+SET @@GLOBAL.histogram_step_size_update_command=null;
+select @@GLOBAL.histogram_step_size_update_command;
+@@GLOBAL.histogram_step_size_update_command
+NULL
+NULL Expected
 SET @@GLOBAL.histogram_step_size_update_command='16.5us';
 select @@GLOBAL.histogram_step_size_update_command;
 @@GLOBAL.histogram_step_size_update_command

--- a/mysql-test/suite/sys_vars/r/innodb_histogram_step_size_async_read_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_histogram_step_size_async_read_basic.result
@@ -63,6 +63,11 @@ Expected error 'Variable cannot be set to this value';
 SET @@GLOBAL.innodb_histogram_step_size_async_read='s';
 ERROR 42000: Variable 'innodb_histogram_step_size_async_read' can't be set to the value of 's'
 Expected error 'Variable cannot be set to this value';
+SET @@GLOBAL.innodb_histogram_step_size_async_read=null;
+select @@GLOBAL.innodb_histogram_step_size_async_read;
+@@GLOBAL.innodb_histogram_step_size_async_read
+NULL
+NULL Expected
 SET @@GLOBAL.innodb_histogram_step_size_async_read='16.5us';
 select @@GLOBAL.innodb_histogram_step_size_async_read;
 @@GLOBAL.innodb_histogram_step_size_async_read

--- a/mysql-test/suite/sys_vars/r/innodb_histogram_step_size_async_write_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_histogram_step_size_async_write_basic.result
@@ -63,6 +63,11 @@ Expected error 'Variable cannot be set to this value';
 SET @@GLOBAL.innodb_histogram_step_size_async_write='s';
 ERROR 42000: Variable 'innodb_histogram_step_size_async_write' can't be set to the value of 's'
 Expected error 'Variable cannot be set to this value';
+SET @@GLOBAL.innodb_histogram_step_size_async_write=null;
+select @@GLOBAL.innodb_histogram_step_size_async_write;
+@@GLOBAL.innodb_histogram_step_size_async_write
+NULL
+NULL Expected
 SET @@GLOBAL.innodb_histogram_step_size_async_write='16.5us';
 select @@GLOBAL.innodb_histogram_step_size_async_write;
 @@GLOBAL.innodb_histogram_step_size_async_write

--- a/mysql-test/suite/sys_vars/r/innodb_histogram_step_size_double_write_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_histogram_step_size_double_write_basic.result
@@ -63,6 +63,11 @@ Expected error 'Variable cannot be set to this value';
 SET @@GLOBAL.innodb_histogram_step_size_double_write='s';
 ERROR 42000: Variable 'innodb_histogram_step_size_double_write' can't be set to the value of 's'
 Expected error 'Variable cannot be set to this value';
+SET @@GLOBAL.innodb_histogram_step_size_double_write=null;
+select @@GLOBAL.innodb_histogram_step_size_double_write;
+@@GLOBAL.innodb_histogram_step_size_double_write
+NULL
+NULL Expected
 SET @@GLOBAL.innodb_histogram_step_size_double_write='16.5us';
 select @@GLOBAL.innodb_histogram_step_size_double_write;
 @@GLOBAL.innodb_histogram_step_size_double_write

--- a/mysql-test/suite/sys_vars/r/innodb_histogram_step_size_file_flush_time_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_histogram_step_size_file_flush_time_basic.result
@@ -63,6 +63,11 @@ Expected error 'Variable cannot be set to this value';
 SET @@GLOBAL.innodb_histogram_step_size_file_flush_time='s';
 ERROR 42000: Variable 'innodb_histogram_step_size_file_flush_time' can't be set to the value of 's'
 Expected error 'Variable cannot be set to this value';
+SET @@GLOBAL.innodb_histogram_step_size_file_flush_time=null;
+select @@GLOBAL.innodb_histogram_step_size_file_flush_time;
+@@GLOBAL.innodb_histogram_step_size_file_flush_time
+NULL
+NULL Expected
 SET @@GLOBAL.innodb_histogram_step_size_file_flush_time='16.5us';
 select @@GLOBAL.innodb_histogram_step_size_file_flush_time;
 @@GLOBAL.innodb_histogram_step_size_file_flush_time

--- a/mysql-test/suite/sys_vars/r/innodb_histogram_step_size_fsync_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_histogram_step_size_fsync_basic.result
@@ -63,6 +63,11 @@ Expected error 'Variable cannot be set to this value';
 SET @@GLOBAL.innodb_histogram_step_size_fsync='s';
 ERROR 42000: Variable 'innodb_histogram_step_size_fsync' can't be set to the value of 's'
 Expected error 'Variable cannot be set to this value';
+SET @@GLOBAL.innodb_histogram_step_size_fsync=null;
+select @@GLOBAL.innodb_histogram_step_size_fsync;
+@@GLOBAL.innodb_histogram_step_size_fsync
+NULL
+NULL Expected
 SET @@GLOBAL.innodb_histogram_step_size_fsync='16.5us';
 select @@GLOBAL.innodb_histogram_step_size_fsync;
 @@GLOBAL.innodb_histogram_step_size_fsync

--- a/mysql-test/suite/sys_vars/r/innodb_histogram_step_size_log_write_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_histogram_step_size_log_write_basic.result
@@ -63,6 +63,11 @@ Expected error 'Variable cannot be set to this value';
 SET @@GLOBAL.innodb_histogram_step_size_log_write='s';
 ERROR 42000: Variable 'innodb_histogram_step_size_log_write' can't be set to the value of 's'
 Expected error 'Variable cannot be set to this value';
+SET @@GLOBAL.innodb_histogram_step_size_log_write=null;
+select @@GLOBAL.innodb_histogram_step_size_log_write;
+@@GLOBAL.innodb_histogram_step_size_log_write
+NULL
+NULL Expected
 SET @@GLOBAL.innodb_histogram_step_size_log_write='16.5us';
 select @@GLOBAL.innodb_histogram_step_size_log_write;
 @@GLOBAL.innodb_histogram_step_size_log_write

--- a/mysql-test/suite/sys_vars/r/innodb_histogram_step_size_sync_read_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_histogram_step_size_sync_read_basic.result
@@ -63,6 +63,11 @@ Expected error 'Variable cannot be set to this value';
 SET @@GLOBAL.innodb_histogram_step_size_sync_read='s';
 ERROR 42000: Variable 'innodb_histogram_step_size_sync_read' can't be set to the value of 's'
 Expected error 'Variable cannot be set to this value';
+SET @@GLOBAL.innodb_histogram_step_size_sync_read=null;
+select @@GLOBAL.innodb_histogram_step_size_sync_read;
+@@GLOBAL.innodb_histogram_step_size_sync_read
+NULL
+NULL Expected
 SET @@GLOBAL.innodb_histogram_step_size_sync_read='16.5us';
 select @@GLOBAL.innodb_histogram_step_size_sync_read;
 @@GLOBAL.innodb_histogram_step_size_sync_read

--- a/mysql-test/suite/sys_vars/r/innodb_histogram_step_size_sync_write_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_histogram_step_size_sync_write_basic.result
@@ -63,6 +63,11 @@ Expected error 'Variable cannot be set to this value';
 SET @@GLOBAL.innodb_histogram_step_size_sync_write='s';
 ERROR 42000: Variable 'innodb_histogram_step_size_sync_write' can't be set to the value of 's'
 Expected error 'Variable cannot be set to this value';
+SET @@GLOBAL.innodb_histogram_step_size_sync_write=null;
+select @@GLOBAL.innodb_histogram_step_size_sync_write;
+@@GLOBAL.innodb_histogram_step_size_sync_write
+NULL
+NULL Expected
 SET @@GLOBAL.innodb_histogram_step_size_sync_write='16.5us';
 select @@GLOBAL.innodb_histogram_step_size_sync_write;
 @@GLOBAL.innodb_histogram_step_size_sync_write

--- a/mysql-test/suite/sys_vars/t/histogram_step_size_binlog_fsync_basic.test
+++ b/mysql-test/suite/sys_vars/t/histogram_step_size_binlog_fsync_basic.test
@@ -86,6 +86,10 @@ SET @@GLOBAL.histogram_step_size_binlog_fsync='32s.';
 SET @@GLOBAL.histogram_step_size_binlog_fsync='s';
 --echo Expected error 'Variable cannot be set to this value';
 
+SET @@GLOBAL.histogram_step_size_binlog_fsync=null;
+select @@GLOBAL.histogram_step_size_binlog_fsync;
+--echo NULL Expected
+
 SET @@GLOBAL.histogram_step_size_binlog_fsync='16.5us';
 select @@GLOBAL.histogram_step_size_binlog_fsync;
 --echo 16.5us Expected

--- a/mysql-test/suite/sys_vars/t/histogram_step_size_connection_create_basic.test
+++ b/mysql-test/suite/sys_vars/t/histogram_step_size_connection_create_basic.test
@@ -84,6 +84,10 @@ SET @@GLOBAL.histogram_step_size_connection_create='32s.';
 SET @@GLOBAL.histogram_step_size_connection_create='s';
 --echo Expected error 'Variable cannot be set to this value';
 
+SET @@GLOBAL.histogram_step_size_connection_create=null;
+select @@GLOBAL.histogram_step_size_connection_create;
+--echo NULL Expected
+
 SET @@GLOBAL.histogram_step_size_connection_create='16.5us';
 select @@GLOBAL.histogram_step_size_connection_create;
 --echo 16.5us Expected

--- a/mysql-test/suite/sys_vars/t/histogram_step_size_ddl_command_basic.test
+++ b/mysql-test/suite/sys_vars/t/histogram_step_size_ddl_command_basic.test
@@ -84,6 +84,10 @@ SET @@GLOBAL.histogram_step_size_ddl_command='32s.';
 SET @@GLOBAL.histogram_step_size_ddl_command='s';
 --echo Expected error 'Variable cannot be set to this value';
 
+SET @@GLOBAL.histogram_step_size_ddl_command=null;
+select @@GLOBAL.histogram_step_size_ddl_command;
+--echo NULL Expected
+
 SET @@GLOBAL.histogram_step_size_ddl_command='16.5us';
 select @@GLOBAL.histogram_step_size_ddl_command;
 --echo 16.5us Expected

--- a/mysql-test/suite/sys_vars/t/histogram_step_size_delete_command_basic.test
+++ b/mysql-test/suite/sys_vars/t/histogram_step_size_delete_command_basic.test
@@ -84,6 +84,10 @@ SET @@GLOBAL.histogram_step_size_delete_command='32s.';
 SET @@GLOBAL.histogram_step_size_delete_command='s';
 --echo Expected error 'Variable cannot be set to this value';
 
+SET @@GLOBAL.histogram_step_size_delete_command=null;
+select @@GLOBAL.histogram_step_size_delete_command;
+--echo NULL Expected
+
 SET @@GLOBAL.histogram_step_size_delete_command='16.5us';
 select @@GLOBAL.histogram_step_size_delete_command;
 --echo 16.5us Expected

--- a/mysql-test/suite/sys_vars/t/histogram_step_size_handler_command_basic.test
+++ b/mysql-test/suite/sys_vars/t/histogram_step_size_handler_command_basic.test
@@ -84,6 +84,10 @@ SET @@GLOBAL.histogram_step_size_handler_command='32s.';
 SET @@GLOBAL.histogram_step_size_handler_command='s';
 --echo Expected error 'Variable cannot be set to this value';
 
+SET @@GLOBAL.histogram_step_size_handler_command=null;
+select @@GLOBAL.histogram_step_size_handler_command;
+--echo NULL Expected
+
 SET @@GLOBAL.histogram_step_size_handler_command='16.5us';
 select @@GLOBAL.histogram_step_size_handler_command;
 --echo 16.5us Expected

--- a/mysql-test/suite/sys_vars/t/histogram_step_size_insert_command_basic.test
+++ b/mysql-test/suite/sys_vars/t/histogram_step_size_insert_command_basic.test
@@ -84,6 +84,10 @@ SET @@GLOBAL.histogram_step_size_insert_command='32s.';
 SET @@GLOBAL.histogram_step_size_insert_command='s';
 --echo Expected error 'Variable cannot be set to this value';
 
+SET @@GLOBAL.histogram_step_size_insert_command=null;
+select @@GLOBAL.histogram_step_size_insert_command;
+--echo NULL Expected
+
 SET @@GLOBAL.histogram_step_size_insert_command='16.5us';
 select @@GLOBAL.histogram_step_size_insert_command;
 --echo 16.5us Expected

--- a/mysql-test/suite/sys_vars/t/histogram_step_size_other_command_basic.test
+++ b/mysql-test/suite/sys_vars/t/histogram_step_size_other_command_basic.test
@@ -84,6 +84,10 @@ SET @@GLOBAL.histogram_step_size_other_command='32s.';
 SET @@GLOBAL.histogram_step_size_other_command='s';
 --echo Expected error 'Variable cannot be set to this value';
 
+SET @@GLOBAL.histogram_step_size_other_command=null;
+select @@GLOBAL.histogram_step_size_other_command;
+--echo NULL Expected
+
 SET @@GLOBAL.histogram_step_size_other_command='16.5us';
 select @@GLOBAL.histogram_step_size_other_command;
 --echo 16.5us Expected

--- a/mysql-test/suite/sys_vars/t/histogram_step_size_select_command_basic.test
+++ b/mysql-test/suite/sys_vars/t/histogram_step_size_select_command_basic.test
@@ -84,6 +84,10 @@ SET @@GLOBAL.histogram_step_size_select_command='32s.';
 SET @@GLOBAL.histogram_step_size_select_command='s';
 --echo Expected error 'Variable cannot be set to this value';
 
+SET @@GLOBAL.histogram_step_size_select_command=null;
+select @@GLOBAL.histogram_step_size_select_command;
+--echo NULL Expected
+
 SET @@GLOBAL.histogram_step_size_select_command='16.5us';
 select @@GLOBAL.histogram_step_size_select_command;
 --echo 16.5us Expected

--- a/mysql-test/suite/sys_vars/t/histogram_step_size_transaction_command_basic.test
+++ b/mysql-test/suite/sys_vars/t/histogram_step_size_transaction_command_basic.test
@@ -84,6 +84,10 @@ SET @@GLOBAL.histogram_step_size_transaction_command='32s.';
 SET @@GLOBAL.histogram_step_size_transaction_command='s';
 --echo Expected error 'Variable cannot be set to this value';
 
+SET @@GLOBAL.histogram_step_size_transaction_command=null;
+select @@GLOBAL.histogram_step_size_transaction_command;
+--echo NULL Expected
+
 SET @@GLOBAL.histogram_step_size_transaction_command='16.5us';
 select @@GLOBAL.histogram_step_size_transaction_command;
 --echo 16.5us Expected

--- a/mysql-test/suite/sys_vars/t/histogram_step_size_update_command_basic.test
+++ b/mysql-test/suite/sys_vars/t/histogram_step_size_update_command_basic.test
@@ -84,6 +84,10 @@ SET @@GLOBAL.histogram_step_size_update_command='32s.';
 SET @@GLOBAL.histogram_step_size_update_command='s';
 --echo Expected error 'Variable cannot be set to this value';
 
+SET @@GLOBAL.histogram_step_size_update_command=null;
+select @@GLOBAL.histogram_step_size_update_command;
+--echo NULL Expected
+
 SET @@GLOBAL.histogram_step_size_update_command='16.5us';
 select @@GLOBAL.histogram_step_size_update_command;
 --echo 16.5us Expected

--- a/mysql-test/suite/sys_vars/t/innodb_histogram_step_size_async_read_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_histogram_step_size_async_read_basic.test
@@ -84,6 +84,10 @@ SET @@GLOBAL.innodb_histogram_step_size_async_read='32s.';
 SET @@GLOBAL.innodb_histogram_step_size_async_read='s';
 --echo Expected error 'Variable cannot be set to this value';
 
+SET @@GLOBAL.innodb_histogram_step_size_async_read=null;
+select @@GLOBAL.innodb_histogram_step_size_async_read;
+--echo NULL Expected
+
 SET @@GLOBAL.innodb_histogram_step_size_async_read='16.5us';
 select @@GLOBAL.innodb_histogram_step_size_async_read;
 --echo 16.5us Expected

--- a/mysql-test/suite/sys_vars/t/innodb_histogram_step_size_async_write_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_histogram_step_size_async_write_basic.test
@@ -84,6 +84,10 @@ SET @@GLOBAL.innodb_histogram_step_size_async_write='32s.';
 SET @@GLOBAL.innodb_histogram_step_size_async_write='s';
 --echo Expected error 'Variable cannot be set to this value';
 
+SET @@GLOBAL.innodb_histogram_step_size_async_write=null;
+select @@GLOBAL.innodb_histogram_step_size_async_write;
+--echo NULL Expected
+
 SET @@GLOBAL.innodb_histogram_step_size_async_write='16.5us';
 select @@GLOBAL.innodb_histogram_step_size_async_write;
 --echo 16.5us Expected

--- a/mysql-test/suite/sys_vars/t/innodb_histogram_step_size_double_write_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_histogram_step_size_double_write_basic.test
@@ -84,6 +84,10 @@ SET @@GLOBAL.innodb_histogram_step_size_double_write='32s.';
 SET @@GLOBAL.innodb_histogram_step_size_double_write='s';
 --echo Expected error 'Variable cannot be set to this value';
 
+SET @@GLOBAL.innodb_histogram_step_size_double_write=null;
+select @@GLOBAL.innodb_histogram_step_size_double_write;
+--echo NULL Expected
+
 SET @@GLOBAL.innodb_histogram_step_size_double_write='16.5us';
 select @@GLOBAL.innodb_histogram_step_size_double_write;
 --echo 16.5us Expected

--- a/mysql-test/suite/sys_vars/t/innodb_histogram_step_size_file_flush_time_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_histogram_step_size_file_flush_time_basic.test
@@ -82,6 +82,10 @@ SET @@GLOBAL.innodb_histogram_step_size_file_flush_time='32s.';
 SET @@GLOBAL.innodb_histogram_step_size_file_flush_time='s';
 --echo Expected error 'Variable cannot be set to this value';
 
+SET @@GLOBAL.innodb_histogram_step_size_file_flush_time=null;
+select @@GLOBAL.innodb_histogram_step_size_file_flush_time;
+--echo NULL Expected
+
 SET @@GLOBAL.innodb_histogram_step_size_file_flush_time='16.5us';
 select @@GLOBAL.innodb_histogram_step_size_file_flush_time;
 --echo 16.5us Expected

--- a/mysql-test/suite/sys_vars/t/innodb_histogram_step_size_fsync_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_histogram_step_size_fsync_basic.test
@@ -82,6 +82,10 @@ SET @@GLOBAL.innodb_histogram_step_size_fsync='32s.';
 SET @@GLOBAL.innodb_histogram_step_size_fsync='s';
 --echo Expected error 'Variable cannot be set to this value';
 
+SET @@GLOBAL.innodb_histogram_step_size_fsync=null;
+select @@GLOBAL.innodb_histogram_step_size_fsync;
+--echo NULL Expected
+
 SET @@GLOBAL.innodb_histogram_step_size_fsync='16.5us';
 select @@GLOBAL.innodb_histogram_step_size_fsync;
 --echo 16.5us Expected

--- a/mysql-test/suite/sys_vars/t/innodb_histogram_step_size_log_write_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_histogram_step_size_log_write_basic.test
@@ -84,6 +84,10 @@ SET @@GLOBAL.innodb_histogram_step_size_log_write='32s.';
 SET @@GLOBAL.innodb_histogram_step_size_log_write='s';
 --echo Expected error 'Variable cannot be set to this value';
 
+SET @@GLOBAL.innodb_histogram_step_size_log_write=null;
+select @@GLOBAL.innodb_histogram_step_size_log_write;
+--echo NULL Expected
+
 SET @@GLOBAL.innodb_histogram_step_size_log_write='16.5us';
 select @@GLOBAL.innodb_histogram_step_size_log_write;
 --echo 16.5us Expected

--- a/mysql-test/suite/sys_vars/t/innodb_histogram_step_size_sync_read_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_histogram_step_size_sync_read_basic.test
@@ -84,6 +84,10 @@ SET @@GLOBAL.innodb_histogram_step_size_sync_read='32s.';
 SET @@GLOBAL.innodb_histogram_step_size_sync_read='s';
 --echo Expected error 'Variable cannot be set to this value';
 
+SET @@GLOBAL.innodb_histogram_step_size_sync_read=null;
+select @@GLOBAL.innodb_histogram_step_size_sync_read;
+--echo NULL Expected
+
 SET @@GLOBAL.innodb_histogram_step_size_sync_read='16.5us';
 select @@GLOBAL.innodb_histogram_step_size_sync_read;
 --echo 16.5us Expected

--- a/mysql-test/suite/sys_vars/t/innodb_histogram_step_size_sync_write_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_histogram_step_size_sync_write_basic.test
@@ -84,6 +84,10 @@ SET @@GLOBAL.innodb_histogram_step_size_sync_write='32s.';
 SET @@GLOBAL.innodb_histogram_step_size_sync_write='s';
 --echo Expected error 'Variable cannot be set to this value';
 
+SET @@GLOBAL.innodb_histogram_step_size_sync_write=null;
+select @@GLOBAL.innodb_histogram_step_size_sync_write;
+--echo NULL Expected
+
 SET @@GLOBAL.innodb_histogram_step_size_sync_write='16.5us';
 select @@GLOBAL.innodb_histogram_step_size_sync_write;
 --echo 16.5us Expected

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -3758,6 +3758,9 @@ ulonglong latency_histogram_get_count(latency_histogram* current_histogram,
 */
 int histogram_validate_step_size_string(const char* step_size_with_unit)
 {
+  if (step_size_with_unit == nullptr)
+    return 0;
+
   int ret = 0;
   char *histogram_unit = NULL;
   double histogram_step_size = strtod(step_size_with_unit, &histogram_unit);


### PR DESCRIPTION
Summary: The histogram_step_size* variables had a CHECK function that was not validating that the passed in string was non-NULL before it was used.  This meant that setting the variable to NULL would crash the server.  This diff adds the check and adds a test for each variable.

Test Plan: MTR