### PR TITLE
Fix build with partition engine disabled

### DIFF
--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -2022,10 +2022,12 @@ err:
   }
 
 end:
+#ifdef WITH_PARTITION_STORAGE_ENGINE
   if (old_part_info)
   {
     lpt->table->file->set_part_info(old_part_info, false);
   }
+#endif
   DBUG_RETURN(error);
 }
 


### PR DESCRIPTION
Build currently fails when partition engine is disabled (FEATURE_SET=small):

arthur@devel:~/git/mysql-5.6$ make sql 
[  0%] Built target gen_lex_hash
[  0%] Built target GenServerSource
[  0%] Built target gen_lex_token
[  0%] Built target GenDigestServerSource
[  8%] Built target strings
[ 10%] Built target zlib
[ 27%] Built target mysys
[ 27%] Built target dbug
[ 27%] Built target mysys_ssl
[ 27%] Built target comp_err
[ 27%] Built target GenError
[ 27%] Built target csv
[ 31%] Built target heap
[ 40%] Built target myisam
[ 42%] Built target myisammrg
[ 72%] Built target rocksdb_se
[ 74%] Built target semisync_master
[ 74%] Built target semisync_slave
[ 74%] Built target vio
[ 74%] Built target regex
[ 74%] Building CXX object sql/CMakeFiles/sql.dir/sql_table.cc.o
/home/arthur/git/mysql-5.6/sql/sql_table.cc: In function ‘bool mysql_write_frm(ALTER_PARTITION_PARAM_TYPE*, uint)’:
/home/arthur/git/mysql-5.6/sql/sql_table.cc:2025:7: error: ‘old_part_info’ was not declared in this scope
   if (old_part_info)
       ^
sql/CMakeFiles/sql.dir/build.make:2964: recipe for target 'sql/CMakeFiles/sql.dir/sql_table.cc.o' failed
make[3]: *** [sql/CMakeFiles/sql.dir/sql_table.cc.o] Error 1
CMakeFiles/Makefile2:4891: recipe for target 'sql/CMakeFiles/sql.dir/all' failed
make[2]: *** [sql/CMakeFiles/sql.dir/all] Error 2
CMakeFiles/Makefile2:4903: recipe for target 'sql/CMakeFiles/sql.dir/rule' failed
make[1]: *** [sql/CMakeFiles/sql.dir/rule] Error 2
Makefile:1508: recipe for target 'sql' failed
make: *** [sql] Error 2
