### PR TITLE
Delete the INDEX_STATISTICS key when the INDEX_INFO key is deleted

### DIFF
--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -3746,6 +3746,7 @@ void Rdb_dict_manager::add_cf_flags(rocksdb::WriteBatch *const batch,
 void Rdb_dict_manager::delete_index_info(rocksdb::WriteBatch *batch,
                                          const GL_INDEX_ID &gl_index_id) const {
   delete_with_prefix(batch, Rdb_key_def::INDEX_INFO, gl_index_id);
+  delete_with_prefix(batch, Rdb_key_def::INDEX_STATISTICS, gl_index_id);
 }
 
 bool Rdb_dict_manager::get_index_info(const GL_INDEX_ID &gl_index_id,


### PR DESCRIPTION
Summary: Any time an index is dropped the data is deleted and then the INDEX_INFO key is removed, but the INDEX_STATISTICS key was left behind.  Add code to remove it.

Test Plan: MTR - I can't think of a way of seeing the INDEX_STATISTICS keys in order to validate that they are getting deleted.