### PR TITLE
Correctly handle setting auto increment to largest value

### DIFF
--- a/mysql-test/suite/rocksdb/r/issue255.result
+++ b/mysql-test/suite/rocksdb/r/issue255.result
@@ -1,0 +1,21 @@
+CREATE TABLE t1 (pk BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT);
+INSERT INTO t1 VALUES (5);
+SHOW TABLE STATUS LIKE 't1';
+Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
+t1	ROCKSDB	#	Fixed	1	#	#	#	#	#	6	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+INSERT INTO t1 VALUES ('538647864786478647864');
+Warnings:
+Warning	1264	Out of range value for column 'pk' at row 1
+SHOW TABLE STATUS LIKE 't1';
+Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
+t1	ROCKSDB	#	Fixed	2	#	#	#	#	#	9223372036854775807	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+INSERT INTO t1 VALUES ();
+ERROR 23000: Duplicate entry '9223372036854775807' for key 'PRIMARY'
+SELECT * FROM t1;
+pk
+5
+9223372036854775807
+SHOW TABLE STATUS LIKE 't1';
+Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
+t1	ROCKSDB	#	Fixed	2	#	#	#	#	#	9223372036854775807	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/t/issue255.test
+++ b/mysql-test/suite/rocksdb/t/issue255.test
@@ -1,0 +1,19 @@
+--source include/have_rocksdb.inc
+
+CREATE TABLE t1 (pk BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT);
+
+INSERT INTO t1 VALUES (5);
+--replace_column 3 # 6 # 7 # 8 # 9 # 10 #
+SHOW TABLE STATUS LIKE 't1';
+
+INSERT INTO t1 VALUES ('538647864786478647864');
+--replace_column 3 # 6 # 7 # 8 # 9 # 10 #
+SHOW TABLE STATUS LIKE 't1';
+
+--error ER_DUP_ENTRY
+INSERT INTO t1 VALUES ();
+SELECT * FROM t1;
+--replace_column 3 # 6 # 7 # 8 # 9 # 10 #
+SHOW TABLE STATUS LIKE 't1';
+
+DROP TABLE t1;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -25,6 +25,7 @@
 
 /* C++ standard header files */
 #include <algorithm>
+#include <limits>
 #include <queue>
 #include <set>
 #include <string>
@@ -3740,7 +3741,12 @@ void ha_rocksdb::update_auto_incr_val() {
 
   my_bitmap_map *const old_map =
       dbug_tmp_use_all_columns(table, table->read_set);
-  new_val = field->val_int() + 1;
+  new_val = field->val_int();
+  // don't increment if we would wrap around
+  if (new_val != std::numeric_limits<longlong>::max()) {
+    new_val++;
+  }
+
   dbug_tmp_restore_column_map(table->read_set, old_map);
 
   longlong auto_incr_val = m_tbl_def->m_auto_incr_val;
@@ -8962,27 +8968,61 @@ void ha_rocksdb::get_auto_increment(ulonglong off, ulonglong inc,
     off = 1;
   }
 
+  longlong new_val;
+
   // Local variable reference to simplify code below
   std::atomic<longlong> &auto_incr = m_tbl_def->m_auto_incr_val;
 
   if (inc == 1 && off == 1) {
     // Optimization for the standard case where we are always simply
     // incrementing from the last position
-    *first_value = auto_incr++;
+
+    // Use CAS operation in a loop to make sure automically get the next auto
+    // increment value while ensuring tha we don't wrap around to a negative
+    // number.
+    new_val = auto_incr;
+    while (new_val != std::numeric_limits<longlong>::max()) {
+      if (auto_incr.compare_exchange_weak(new_val, new_val + 1)) {
+        break;
+      }
+    }
   } else {
     // The next value can be more complicated if either `inc` or 'off' is not 1
-    longlong new_val;
     longlong last_val = auto_incr;
 
     // Loop until we can correctly update the atomic value
     do {
+      if (((last_val - off) / inc) ==
+          (std::numeric_limits<longlong>::max() - off) / inc) {
+        // The 'last_val' value is already equal to or larger than the largest
+        // value in the sequence.  Continuing would wrap around (technically
+        // the behavior would be undefined).  What should we do?
+        // We could:
+        //   1) set the new value to the last possible number in our sequence
+        //      as described above.  The problem with this is that this
+        //      number could be smaller than a value in an existing row.
+        //   2) set the new value to the largest possible number.  This number
+        //      may not be in our sequence, but it is guaranteed to be equal
+        //      to or larger than any other value already inserted.
+        //
+        //  For now I'm going to take option @2.
+        new_val = std::numeric_limits<longlong>::max();
+        auto_incr = new_val;  // Store the largest value into auto_incr
+        break;
+      }
+
       // Calculate the next value in the auto increment series:
       //   offset + N * increment
       // where N is 0, 1, 2, ...
       //
       // For further information please visit:
       // http://dev.mysql.com/doc/refman/5.7/en/replication-options-master.html
-      new_val = ((last_val + (inc - off) - 1) / inc) * inc + off;
+      //
+      // The following is confusing so here is an explanation:
+      // To get the next number in the sequence above you subtract out
+      // the offset, calculate the next sequence (N * increment) and then add
+      // the offset back in.
+      new_val = (((last_val - off) + (inc - 1)) / inc) * inc + off;
 
       // Attempt to store the new value (plus 1 since m_auto_incr_val contains
       // the next available value) into the atomic value.  If the current
@@ -8990,10 +9030,9 @@ void ha_rocksdb::get_auto_increment(ulonglong off, ulonglong inc,
       // we will repeat the loop (`last_val` will automatically get updated
       // with the current value).
     } while (!auto_incr.compare_exchange_weak(last_val, new_val + 1));
-
-    *first_value = new_val;
   }
 
+  *first_value = new_val;
   *nb_reserved_values = 1;
 }
 


### PR DESCRIPTION
Summary: The auto increment code in MyRocks allowed a wrap-around, yield incorrect results

Test Plan: MTR and new rocksdb.issue255 test