### PR TITLE
The srv_monitor_event event needs to be created even in read-only mode

### DIFF
--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -1140,12 +1140,12 @@ srv_init(void)
 
 		srv_error_event = os_event_create();
 
-		srv_monitor_event = os_event_create();
-
 		srv_buf_dump_event = os_event_create();
 
 		UT_LIST_INIT(srv_sys->tasks);
 	}
+
+	srv_monitor_event = os_event_create();
 
 	srv_buf_resize_event = os_event_create();
 


### PR DESCRIPTION
Summary:
In a past diff a change was made to use srv_monitor_event more often.  This means that it needs to be created even if the server is in read-only mode.

Squash with: https://reviews.facebook.net/D17673

Test Plan: MTR
