### PR TITLE
Record missing help test for Persistent Cache Refactor

### DIFF
--- a/mysql-test/r/mysqld--help-notwin-profiling.result
+++ b/mysql-test/r/mysqld--help-notwin-profiling.result
@@ -1254,7 +1254,7 @@ The following options may be given as the first argument:
  Path for BlockBasedTableOptions::persistent_cache for
  RocksDB
  --rocksdb-persistent-cache-size-mb=# 
- Size of cache for
+ Size of cache in MB for
  BlockBasedTableOptions::persistent_cache for RocksDB
  --rocksdb-pin-l0-filter-and-index-blocks-in-cache 
  pin_l0_filter_and_index_blocks_in_cache for RocksDB

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -1252,7 +1252,7 @@ The following options may be given as the first argument:
  Path for BlockBasedTableOptions::persistent_cache for
  RocksDB
  --rocksdb-persistent-cache-size-mb=# 
- Size of cache for
+ Size of cache in MB for
  BlockBasedTableOptions::persistent_cache for RocksDB
  --rocksdb-pin-l0-filter-and-index-blocks-in-cache 
  pin_l0_filter_and_index_blocks_in_cache for RocksDB


### PR DESCRIPTION
I missed the help tests when refactoring the persistent cache sys var. This fixed that.