### PR TITLE
Use of std::stringstream requires include <sstream>.

### DIFF
--- a/storage/rocksdb/rdb_utils.cc
+++ b/storage/rocksdb/rdb_utils.cc
@@ -21,6 +21,7 @@
 #include <array>
 #include <string>
 #include <vector>
+#include <sstream>
 
 /* C standard header files */
 #include <ctype.h>


### PR DESCRIPTION
* Looking at http://www.cplusplus.com/reference/sstream/stringstream/  I see <sstream> on the right and I interpret it as this is the required header
* Adding this #include fixed compilation for me in MariaRocks.