### PR TITLE
On windows, pthread_t is not defined by the OS

### DIFF
--- a/storage/rocksdb/rdb_psi.h
+++ b/storage/rocksdb/rdb_psi.h
@@ -19,6 +19,7 @@
 
 /* MySQL header files */
 #include <my_global.h>
+#include <my_pthread.h>
 #include <mysql/psi/psi.h>
 
 /* MyRocks header files */


### PR DESCRIPTION
Based on this one:
https://github.com/MariaDB/server/commit/17aa495b641238619497205f4f4d47070362cf63