### PR TITLE
rocksdb.issue495 test uses partitions and so must declare that with a…

### DIFF
--- a/mysql-test/suite/rocksdb/r/issue495.result
+++ b/mysql-test/suite/rocksdb/r/issue495.result
@@ -1,6 +1,4 @@
 drop table if exists t;
-Warnings:
-Note	1051	Unknown table 'test.t'
 create table t (
 a int,
 b int,

--- a/mysql-test/suite/rocksdb/t/issue495.test
+++ b/mysql-test/suite/rocksdb/t/issue495.test
@@ -1,4 +1,8 @@
+--source include/have_partition.inc
+--disable_warnings
 drop table if exists t;
+--enable_warnings
+
 create table t (
   a int,
   b int,


### PR DESCRIPTION
… source directive

also, don't fail if the table t already existed.