### PR TITLE
[Backport 5.7 597a1d] Added openssl multithreading to client.

### DIFF
--- a/include/violite.h
+++ b/include/violite.h
@@ -190,6 +190,9 @@ struct st_VioSSLFd
                       const char *cipher, enum enum_ssl_init_error *error,
                       const char *crl_file, const char *crl_path);
 void free_vio_ssl_fd(struct st_VioSSLFd *fd);
+
+void vio_ssl_end();
+
 #endif /* ! EMBEDDED_LIBRARY */
 #endif /* HAVE_OPENSSL */
 

--- a/libmysql/libmysql.c
+++ b/libmysql/libmysql.c
@@ -125,6 +125,10 @@ int STDCALL mysql_server_init(int argc MY_ATTRIBUTE((unused)),
     init_client_errs();
     if (mysql_client_plugin_init())
       return 1;
+#if defined (HAVE_OPENSSL) && !defined(HAVE_YASSL)
+    ssl_start();
+#endif
+
     if (!mysql_port)
     {
       char *env;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -398,10 +398,6 @@ static PSI_thread_key key_thread_handle_con_admin_sockets;
 #ifdef __WIN__
 static PSI_thread_key key_thread_handle_shutdown;
 #endif /* __WIN__ */
-
-#if defined (HAVE_OPENSSL) && !defined(HAVE_YASSL)
-static PSI_rwlock_key key_rwlock_openssl;
-#endif
 #endif /* HAVE_PSI_INTERFACE */
 
 /**
@@ -1488,20 +1484,6 @@ char *opt_ssl_ca= NULL, *opt_ssl_capath= NULL, *opt_ssl_cert= NULL,
      *opt_ssl_crlpath= NULL;
 
 #ifdef HAVE_OPENSSL
-#include <openssl/crypto.h>
-#ifndef HAVE_YASSL
-typedef struct CRYPTO_dynlock_value
-{
-  mysql_rwlock_t lock;
-} openssl_lock_t;
-
-static openssl_lock_t *openssl_stdlocks;
-static openssl_lock_t *openssl_dynlock_create(const char *, int);
-static void openssl_dynlock_destroy(openssl_lock_t *, const char *, int);
-static void openssl_lock_function(int, int, const char *, int);
-static void openssl_lock(int, openssl_lock_t *, const char *, int);
-static unsigned long openssl_id_function();
-#endif
 char *des_key_file;
 #ifndef EMBEDDED_LIBRARY
 struct st_VioSSLFd *ssl_acceptor_fd;
@@ -2384,11 +2366,6 @@ static void clean_up_mutexes()
 #ifdef HAVE_OPENSSL
   mysql_mutex_destroy(&LOCK_des_key_file);
   mysql_rwlock_destroy(&LOCK_use_ssl);
-#ifndef HAVE_YASSL
-  for (int i= 0; i < CRYPTO_num_locks(); ++i)
-    mysql_rwlock_destroy(&openssl_stdlocks[i].lock);
-  OPENSSL_free(openssl_stdlocks);
-#endif
 #endif
   mysql_mutex_destroy(&LOCK_active_mi);
   mysql_rwlock_destroy(&LOCK_sys_init_connect);
@@ -5216,17 +5193,6 @@ static int init_thread_environment()
   mysql_mutex_init(key_LOCK_des_key_file,
                    &LOCK_des_key_file, MY_MUTEX_INIT_FAST);
   mysql_rwlock_init(key_rwlock_LOCK_use_ssl, &LOCK_use_ssl);
-#ifndef HAVE_YASSL
-  openssl_stdlocks= (openssl_lock_t*) OPENSSL_malloc(CRYPTO_num_locks() *
-                                                     sizeof(openssl_lock_t));
-  for (int i= 0; i < CRYPTO_num_locks(); ++i)
-    mysql_rwlock_init(key_rwlock_openssl, &openssl_stdlocks[i].lock);
-  CRYPTO_set_dynlock_create_callback(openssl_dynlock_create);
-  CRYPTO_set_dynlock_destroy_callback(openssl_dynlock_destroy);
-  CRYPTO_set_dynlock_lock_callback(openssl_lock);
-  CRYPTO_set_locking_callback(openssl_lock_function);
-  CRYPTO_set_id_callback(openssl_id_function);
-#endif
 #endif
   mysql_rwlock_init(key_rwlock_LOCK_sys_init_connect, &LOCK_sys_init_connect);
   mysql_rwlock_init(key_rwlock_LOCK_sys_init_slave, &LOCK_sys_init_slave);
@@ -5268,76 +5234,6 @@ static int init_thread_environment()
   }
   return 0;
 }
-
-
-#if defined(HAVE_OPENSSL) && !defined(HAVE_YASSL)
-static unsigned long openssl_id_function()
-{
-  return (unsigned long) pthread_self();
-}
-
-
-static openssl_lock_t *openssl_dynlock_create(const char *file, int line)
-{
-  openssl_lock_t *lock= new openssl_lock_t;
-  mysql_rwlock_init(key_rwlock_openssl, &lock->lock);
-  return lock;
-}
-
-
-static void openssl_dynlock_destroy(openssl_lock_t *lock, const char *file,
-            int line)
-{
-  mysql_rwlock_destroy(&lock->lock);
-  delete lock;
-}
-
-
-static void openssl_lock_function(int mode, int n, const char *file, int line)
-{
-  if (n < 0 || n > CRYPTO_num_locks())
-  {
-    /* Lock number out of bounds. */
-    sql_print_error("Fatal: OpenSSL interface problem (n = %d)", n);
-    abort();
-  }
-  openssl_lock(mode, &openssl_stdlocks[n], file, line);
-}
-
-
-static void openssl_lock(int mode, openssl_lock_t *lock, const char *file,
-       int line)
-{
-  int err;
-  char const *what;
-
-  switch (mode) {
-  case CRYPTO_LOCK|CRYPTO_READ:
-    what = "read lock";
-    err= mysql_rwlock_rdlock(&lock->lock);
-    break;
-  case CRYPTO_LOCK|CRYPTO_WRITE:
-    what = "write lock";
-    err= mysql_rwlock_wrlock(&lock->lock);
-    break;
-  case CRYPTO_UNLOCK|CRYPTO_READ:
-  case CRYPTO_UNLOCK|CRYPTO_WRITE:
-    what = "unlock";
-    err= mysql_rwlock_unlock(&lock->lock);
-    break;
-  default:
-    /* Unknown locking mode. */
-    sql_print_error("Fatal: OpenSSL interface problem (mode=0x%x)", mode);
-    abort();
-  }
-  if (err)
-  {
-    sql_print_error("Fatal: can't %s OpenSSL lock", what);
-    abort();
-  }
-}
-#endif /* HAVE_OPENSSL */
-
 
 bool init_ssl()
 {
@@ -12212,9 +12108,6 @@ PSI_rwlock_key key_rwlock_Binlog_relay_IO_delegate_lock;
 
 static PSI_rwlock_info all_server_rwlocks[]=
 {
-#if defined (HAVE_OPENSSL) && !defined(HAVE_YASSL)
-  { &key_rwlock_openssl, "CRYPTO_dynlock_value::lock", 0},
-#endif
 #ifdef HAVE_REPLICATION
   { &key_rwlock_Binlog_transmit_delegate_lock, "Binlog_transmit_delegate::lock", PSI_FLAG_GLOBAL},
   { &key_rwlock_Binlog_relay_IO_delegate_lock, "Binlog_relay_IO_delegate::lock", PSI_FLAG_GLOBAL},

--- a/vio/vio.c
+++ b/vio/vio.c
@@ -388,10 +388,6 @@ void vio_end(void)
 #if defined(HAVE_YASSL)
   yaSSL_CleanUp();
 #elif defined(HAVE_OPENSSL)
-  // This one is needed on the client side
-  ERR_remove_state(0);
-  ERR_free_strings();
-  EVP_cleanup();
-  CRYPTO_cleanup_all_ex_data();
+  vio_ssl_end();
 #endif
 }

--- a/vio/viosslfactories.c
+++ b/vio/viosslfactories.c
@@ -176,21 +176,201 @@ vio_set_cert_stuff(SSL_CTX *ctx, const char *cert_file, const char *key_file,
 pthread_mutex_t ssl_init_mutex = PTHREAD_MUTEX_INITIALIZER;
 static my_bool ssl_initialized = FALSE;
 
+#ifndef HAVE_YASSL
+/* OpenSSL specific */
+
+#ifdef HAVE_PSI_INTERFACE
+static PSI_rwlock_key key_rwlock_openssl;
+
+static PSI_rwlock_info openssl_rwlocks[]=
+{
+  { &key_rwlock_openssl, "CRYPTO_dynlock_value::lock", 0}
+};
+#endif
+
+
+typedef struct CRYPTO_dynlock_value
+{
+  mysql_rwlock_t lock;
+} openssl_lock_t;
+
+
+/* Array of locks used by openssl internally for thread synchronization.
+   The number of locks is equal to CRYPTO_num_locks.
+*/
+static openssl_lock_t *openssl_stdlocks;
+
+/*OpenSSL callback functions for multithreading. We implement all the functions
+  as we are using our own locking mechanism.
+*/
+static void openssl_lock(int mode, openssl_lock_t *lock,
+                         const char *file MY_ATTRIBUTE((unused)),
+                         int line MY_ATTRIBUTE((unused)))
+{
+  int err = 0;
+  char const *what = 0;
+
+  switch (mode) {
+    case CRYPTO_LOCK|CRYPTO_READ:
+      what = "read lock";
+      err= mysql_rwlock_rdlock(&lock->lock);
+      break;
+    case CRYPTO_LOCK|CRYPTO_WRITE:
+      what = "write lock";
+      err= mysql_rwlock_wrlock(&lock->lock);
+      break;
+    case CRYPTO_UNLOCK|CRYPTO_READ:
+    case CRYPTO_UNLOCK|CRYPTO_WRITE:
+      what = "unlock";
+      err= mysql_rwlock_unlock(&lock->lock);
+      break;
+    default:
+      /* Unknown locking mode. */
+      DBUG_PRINT("error",
+        ("Fatal OpenSSL: %s:%d: interface problem (mode=0x%x)\n",
+          file, line, mode));
+
+      //NO_LINT_DEBUG
+      fprintf(stderr, "Fatal: OpenSSL interface problem (mode=0x%x)", mode);
+      fflush(stderr);
+      abort();
+  }
+  if (err && what) {
+    DBUG_PRINT("error",
+      ("Fatal OpenSSL: %s:%d: can't %s OpenSSL lock\n",
+      file, line, what));
+
+    //NO_LINT_DEBUG
+    fprintf(stderr, "Fatal: can't %s OpenSSL lock", what);
+    fflush(stderr);
+    abort();
+  }
+}
+
+static void openssl_lock_function(int mode, int n, const char *file, int line)
+{
+  if (n < 0 || n > CRYPTO_num_locks())
+  {
+    /* Lock number out of bounds. */
+    DBUG_PRINT("error",
+      ("Fatal OpenSSL: %s:%d: interface problem (n = %d)", file, line, n));
+
+    //NO_LINT_DEBUG
+    fprintf(stderr, "Fatal: OpenSSL interface problem (n = %d)", n);
+    fflush(stderr);
+    abort();
+  }
+  openssl_lock(mode, &openssl_stdlocks[n], file, line);
+}
+
+static openssl_lock_t *openssl_dynlock_create(
+                         const char *file MY_ATTRIBUTE((unused)),
+                         int line MY_ATTRIBUTE((unused)))
+{
+  DBUG_PRINT("info", ("openssl_dynlock_create: %s:%d", file, line));
+
+  openssl_lock_t *lock= (openssl_lock_t*)
+                          my_malloc(sizeof(openssl_lock_t),MYF(0));
+  mysql_rwlock_init(key_rwlock_openssl, &lock->lock);
+
+  return lock;
+}
+
+
+static void openssl_dynlock_destroy(openssl_lock_t *lock,
+                         const char *file MY_ATTRIBUTE((unused)),
+                         int line MY_ATTRIBUTE((unused)))
+{
+  DBUG_PRINT("info", ("openssl_dynlock_destroy: %s:%d", file, line));
+
+  mysql_rwlock_destroy(&lock->lock);
+  my_free(lock);
+}
+
+static unsigned long openssl_id_function()
+{
+  return (unsigned long) pthread_self();
+}
+
+//End of mutlithreading callback functions
+
+static void init_ssl_locks()
+{
+  int i= 0;
+#ifdef HAVE_PSI_INTERFACE
+  const char* category= "sql";
+  int count= array_elements(openssl_rwlocks);
+  mysql_rwlock_register(category, openssl_rwlocks, count);
+#endif
+
+  openssl_stdlocks= (openssl_lock_t*) OPENSSL_malloc(CRYPTO_num_locks() *
+    sizeof(openssl_lock_t));
+  for (i= 0; i < CRYPTO_num_locks(); ++i)
+#ifdef HAVE_PSI_INTERFACE
+    mysql_rwlock_init(key_rwlock_openssl, &openssl_stdlocks[i].lock);
+#else
+    mysql_rwlock_init(0, &openssl_stdlocks[i].lock);
+#endif
+}
+
+static void set_lock_callback_functions(my_bool init)
+{
+  CRYPTO_set_locking_callback(init ? openssl_lock_function : NULL);
+  CRYPTO_set_id_callback(init ? openssl_id_function : NULL);
+  CRYPTO_set_dynlock_create_callback(init ? openssl_dynlock_create : NULL);
+  CRYPTO_set_dynlock_destroy_callback(init ? openssl_dynlock_destroy : NULL);
+  CRYPTO_set_dynlock_lock_callback(init ? openssl_lock : NULL);
+}
+
+static void init_lock_callback_functions()
+{
+  set_lock_callback_functions(TRUE);
+}
+
+static void deinit_lock_callback_functions()
+{
+  set_lock_callback_functions(FALSE);
+}
+
+void vio_ssl_end()
+{
+  int i= 0;
+
+  if (ssl_initialized) {
+    ERR_remove_state(0);
+    ERR_free_strings();
+    EVP_cleanup();
+
+    CRYPTO_cleanup_all_ex_data();
+
+    deinit_lock_callback_functions();
+
+    for (; i < CRYPTO_num_locks(); ++i)
+      mysql_rwlock_destroy(&openssl_stdlocks[i].lock);
+    OPENSSL_free(openssl_stdlocks);
+
+    ssl_initialized= FALSE;
+  }
+}
+
+#endif //OpenSSL specific
+
 void ssl_start()
 {
-  pthread_mutex_lock(&ssl_init_mutex);
-  if (ssl_initialized) {
-    pthread_mutex_unlock(&ssl_init_mutex);
-    return;
-  }
+  if (!ssl_initialized)
+  {
+    ssl_initialized= TRUE;
 
-  SSL_library_init();
-  OpenSSL_add_all_algorithms();
-  SSL_load_error_strings();
+    SSL_library_init();
+    OpenSSL_add_all_algorithms();
+    SSL_load_error_strings();
 
-  ssl_initialized = TRUE;
-  pthread_mutex_unlock(&ssl_init_mutex);
-}
+#ifndef HAVE_YASSL
+    init_ssl_locks();
+    init_lock_callback_functions();
+#endif
+   }
+ }
 
 /************************ VioSSLFd **********************************/
 static struct st_VioSSLFd *
@@ -215,7 +395,6 @@ new_VioSSLFd(const char *key_file, const char *cert_file,
               crl_file ? crl_file : "NULL",
               crl_path ? crl_path : "NULL"));
 
-  ssl_start();
 
   if (!(ssl_fd= ((struct st_VioSSLFd*)
                  my_malloc(sizeof(struct st_VioSSLFd),MYF(0)))))


### PR DESCRIPTION
Summary: Backport fix present in 5.7 to correctly initialize openssl multithreading for client library

Test Plan:
mysqltest.sh ssl_8k_key ssl_and_innodb ssl-big-packet ssl-big ssl_ca ssl_cipher ssl_compress ssl_connections_count ssl_connect ssl_crl_clients ssl_crl_clients_valid ssl_crl_crlpath ssl_l ssl_mode_no_ssl ssl_mode ssl-session-reuse ssl-sha512 ssl

Reviewers: abalsara, mung

Reviewed By: abalsara

Subscribers: webscalesql-eng@fb.com, ssl-diffs@fb.com

Differential Revision: https://phabricator.intern.facebook.com/D4734810

Signature: t1:4734810:1489820133:11adc7b7c6eafad47551d81cd87facba53754ef8