### PR TITLE
test: slocket_listen.py /bin/env -> /usr/bin/env

### DIFF
--- a/mysql-test/t/slocket_listen.py
+++ b/mysql-test/t/slocket_listen.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 from socket import socket, AF_UNIX, SOCK_DGRAM
 from select import select
 from os import unlink, getcwd, stat


### PR DESCRIPTION
Ubuntu-16.04 doesn't have /bin/env, only /usr/bin/env. Centos7.3 has
both installed (and not hard/soft linked). So change to the compatible
instance.