### PR TITLE
mark rocksdb_allow_concurrent_memtable_write and rocksdb_enable_write_thread_adaptive_yield as readonly since they cannot be changed dynamically

### DIFF
--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_allow_concurrent_memtable_write_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_allow_concurrent_memtable_write_basic.result
@@ -1,64 +1,7 @@
-CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
-INSERT INTO valid_values VALUES(1);
-INSERT INTO valid_values VALUES(0);
-INSERT INTO valid_values VALUES('on');
-CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
-INSERT INTO invalid_values VALUES('\'aaa\'');
-INSERT INTO invalid_values VALUES('\'bbb\'');
 SET @start_global_value = @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE;
 SELECT @start_global_value;
 @start_global_value
 0
-'# Setting to valid values in global scope#'
-"Trying to set variable @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE to 1"
-SET @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE   = 1;
-SELECT @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE;
-@@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE
-1
-"Setting the global scope variable back to default"
-SET @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE = DEFAULT;
-SELECT @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE;
-@@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE
-0
-"Trying to set variable @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE to 0"
-SET @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE   = 0;
-SELECT @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE;
-@@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE
-0
-"Setting the global scope variable back to default"
-SET @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE = DEFAULT;
-SELECT @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE;
-@@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE
-0
-"Trying to set variable @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE to on"
-SET @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE   = on;
-SELECT @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE;
-@@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE
-1
-"Setting the global scope variable back to default"
-SET @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE = DEFAULT;
-SELECT @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE;
-@@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE
-0
-"Trying to set variable @@session.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE to 444. It should fail because it is not session."
-SET @@session.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE   = 444;
-ERROR HY000: Variable 'rocksdb_allow_concurrent_memtable_write' is a GLOBAL variable and should be set with SET GLOBAL
-'# Testing with invalid values in global scope #'
-"Trying to set variable @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE to 'aaa'"
-SET @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE   = 'aaa';
-Got one of the listed errors
-SELECT @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE;
-@@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE
-0
-"Trying to set variable @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE to 'bbb'"
-SET @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE   = 'bbb';
-Got one of the listed errors
-SELECT @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE;
-@@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE
-0
-SET @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE = @start_global_value;
-SELECT @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE;
-@@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE
-0
-DROP TABLE valid_values;
-DROP TABLE invalid_values;
+"Trying to set variable @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE to 444. It should fail because it is readonly."
+SET @@global.ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE   = 444;
+ERROR HY000: Variable 'rocksdb_allow_concurrent_memtable_write' is a read only variable

--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_enable_write_thread_adaptive_yield_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_enable_write_thread_adaptive_yield_basic.result
@@ -1,64 +1,7 @@
-CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
-INSERT INTO valid_values VALUES(1);
-INSERT INTO valid_values VALUES(0);
-INSERT INTO valid_values VALUES('on');
-CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
-INSERT INTO invalid_values VALUES('\'aaa\'');
-INSERT INTO invalid_values VALUES('\'bbb\'');
 SET @start_global_value = @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD;
 SELECT @start_global_value;
 @start_global_value
 0
-'# Setting to valid values in global scope#'
-"Trying to set variable @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD to 1"
-SET @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD   = 1;
-SELECT @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD;
-@@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD
-1
-"Setting the global scope variable back to default"
-SET @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD = DEFAULT;
-SELECT @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD;
-@@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD
-0
-"Trying to set variable @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD to 0"
-SET @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD   = 0;
-SELECT @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD;
-@@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD
-0
-"Setting the global scope variable back to default"
-SET @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD = DEFAULT;
-SELECT @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD;
-@@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD
-0
-"Trying to set variable @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD to on"
-SET @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD   = on;
-SELECT @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD;
-@@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD
-1
-"Setting the global scope variable back to default"
-SET @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD = DEFAULT;
-SELECT @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD;
-@@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD
-0
-"Trying to set variable @@session.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD to 444. It should fail because it is not session."
-SET @@session.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD   = 444;
-ERROR HY000: Variable 'rocksdb_enable_write_thread_adaptive_yield' is a GLOBAL variable and should be set with SET GLOBAL
-'# Testing with invalid values in global scope #'
-"Trying to set variable @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD to 'aaa'"
-SET @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD   = 'aaa';
-Got one of the listed errors
-SELECT @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD;
-@@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD
-0
-"Trying to set variable @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD to 'bbb'"
-SET @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD   = 'bbb';
-Got one of the listed errors
-SELECT @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD;
-@@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD
-0
-SET @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD = @start_global_value;
-SELECT @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD;
-@@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD
-0
-DROP TABLE valid_values;
-DROP TABLE invalid_values;
+"Trying to set variable @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD to 444. It should fail because it is readonly."
+SET @@global.ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD   = 444;
+ERROR HY000: Variable 'rocksdb_enable_write_thread_adaptive_yield' is a read only variable

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_allow_concurrent_memtable_write_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_allow_concurrent_memtable_write_basic.test
@@ -1,18 +1,5 @@
 --source include/have_rocksdb.inc
-
-CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
-INSERT INTO valid_values VALUES(1);
-INSERT INTO valid_values VALUES(0);
-INSERT INTO valid_values VALUES('on');
-
-CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
-INSERT INTO invalid_values VALUES('\'aaa\'');
-INSERT INTO invalid_values VALUES('\'bbb\'');
-
 --let $sys_var=ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE
---let $read_only=0
+--let $read_only=1
 --let $session=0
 --source suite/sys_vars/inc/rocksdb_sys_var.inc
-
-DROP TABLE valid_values;
-DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_enable_write_thread_adaptive_yield_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_enable_write_thread_adaptive_yield_basic.test
@@ -1,18 +1,5 @@
 --source include/have_rocksdb.inc
-
-CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
-INSERT INTO valid_values VALUES(1);
-INSERT INTO valid_values VALUES(0);
-INSERT INTO valid_values VALUES('on');
-
-CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
-INSERT INTO invalid_values VALUES('\'aaa\'');
-INSERT INTO invalid_values VALUES('\'bbb\'');
-
 --let $sys_var=ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD
---let $read_only=0
+--let $read_only=1
 --let $session=0
 --source suite/sys_vars/inc/rocksdb_sys_var.inc
-
-DROP TABLE valid_values;
-DROP TABLE invalid_values;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -688,7 +688,7 @@ static MYSQL_SYSVAR_BOOL(
     allow_concurrent_memtable_write,
     *reinterpret_cast<my_bool *>(
         &rocksdb_db_options.allow_concurrent_memtable_write),
-    PLUGIN_VAR_RQCMDARG,
+    PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
     "DBOptions::allow_concurrent_memtable_write for RocksDB", nullptr, nullptr,
     false);
 
@@ -696,7 +696,7 @@ static MYSQL_SYSVAR_BOOL(
     enable_write_thread_adaptive_yield,
     *reinterpret_cast<my_bool *>(
         &rocksdb_db_options.enable_write_thread_adaptive_yield),
-    PLUGIN_VAR_RQCMDARG,
+    PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
     "DBOptions::enable_write_thread_adaptive_yield for RocksDB", nullptr,
     nullptr, false);
 


### PR DESCRIPTION
fixes #382 

set `PLUGIN_VAR_READONLY`  bit on `rocksdb_allow_concurrent_memtable_write` and `rocksdb_enable_write_thread_adaptive_yield` to make them as readonly.