### PR TITLE
Add table factory options to information_schema

### DIFF
--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -8004,7 +8004,7 @@ std::vector<std::string> split_into_vector(const std::string& input,
 
   // Add a possible string since the last delimiter
   if (input.length() > start)
-    elems.push_back(input.substr(start));
+    elems.emplace_back(input.substr(start));
 
   // Return the resulting list back to the caller
   return elems;

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -7982,6 +7982,34 @@ std::unordered_set<std::string> split_into_set(const std::string& input,
   return elems;
 }
 
+// Split a string based on a delimiter.  Two delimiters in a row will not add
+// an empty string in the vector.
+std::vector<std::string> split_into_vector(const std::string& input,
+                                           char delimiter)
+{
+  size_t                   pos;
+  size_t                   start = 0;
+  std::vector<std::string> elems;
+
+  // Find next delimiter
+  while ((pos = input.find(delimiter, start)) != std::string::npos)
+  {
+    // If there is any data since the last delimiter add it to the list
+    if (pos > start)
+      elems.emplace_back(input.substr(start, pos - start));
+
+    // Set our start position to the character after the delimiter
+    start = pos + 1;
+  }
+
+  // Add a possible string since the last delimiter
+  if (input.length() > start)
+    elems.push_back(input.substr(start));
+
+  // Return the resulting list back to the caller
+  return elems;
+}
+
 bool can_hold_read_locks_on_select(THD *thd, thr_lock_type lock_type)
 {
   return (lock_type == TL_READ_WITH_SHARED_LOCKS

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -1892,6 +1892,8 @@ class Regex_list_handler
 extern Regex_list_handler* gap_lock_exceptions;
 std::unordered_set<std::string> split_into_set(const std::string& input,
                                                char delimiter);
+std::vector<std::string> split_into_vector(const std::string& input,
+                                           char delimiter);
 void warn_about_bad_patterns(const Regex_list_handler* regex_list_handler,
                              const char *name);
 

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -11063,4 +11063,4 @@ mysql_declare_plugin(rocksdb_se){
     myrocks::rdb_i_s_cfoptions, myrocks::rdb_i_s_compact_stats,
     myrocks::rdb_i_s_global_info, myrocks::rdb_i_s_ddl,
     myrocks::rdb_i_s_index_file_map, myrocks::rdb_i_s_lock_info,
-    myrocks::rdb_i_s_trx_info mysql_declare_plugin_end;
+    myrocks::rdb_i_s_trx_info, myrocks::rdb_i_s_tfoptions mysql_declare_plugin_end;

--- a/storage/rocksdb/rdb_i_s.h
+++ b/storage/rocksdb/rdb_i_s.h
@@ -32,4 +32,5 @@ extern struct st_mysql_plugin rdb_i_s_ddl;
 extern struct st_mysql_plugin rdb_i_s_index_file_map;
 extern struct st_mysql_plugin rdb_i_s_lock_info;
 extern struct st_mysql_plugin rdb_i_s_trx_info;
+extern struct st_mysql_plugin rdb_i_s_tfoptions;
 } // namespace myrocks


### PR DESCRIPTION
- Add `TABLE_FACTORY_NAME` to table `information_schema.ROCKSDB_CF_OPTIONS`
- Add table `ROCKSDB_TF_OPTIONS` to information_schema, while the table shows table factory options(add function `split_into_vector` for split options with order)