### PR TITLE
implement query read filtering for tables with TTL enabled (primary k…

### DIFF
--- a/mysql-test/r/mysqld--help-notwin-profiling.result
+++ b/mysql-test/r/mysqld--help-notwin-profiling.result
@@ -1180,9 +1180,16 @@ The following options may be given as the first argument:
  DBOptions::enable_thread_tracking for RocksDB
  (Defaults to on; use --skip-rocksdb-enable-thread-tracking to disable.)
  --rocksdb-enable-ttl 
- Disable expired ttl records from being dropped during
+ Enable expired TTL records to be dropped during
  compaction.
  (Defaults to on; use --skip-rocksdb-enable-ttl to disable.)
+ --rocksdb-enable-ttl-read-filtering 
+ For tables with TTL, expired records are skipped/filtered
+ out during processing and in query results. Disabling
+ this will allow these records to be seen, but as a result
+ rows may disappear in the middle of transactions as they
+ are dropped during compaction. Use with caution. 
+ (Defaults to on; use --skip-rocksdb-enable-ttl-read-filtering to disable.)
  --rocksdb-enable-write-thread-adaptive-yield 
  DBOptions::enable_write_thread_adaptive_yield for RocksDB
  --rocksdb-error-if-exists 
@@ -2052,6 +2059,7 @@ rocksdb-enable-2pc TRUE
 rocksdb-enable-bulk-load-api TRUE
 rocksdb-enable-thread-tracking TRUE
 rocksdb-enable-ttl TRUE
+rocksdb-enable-ttl-read-filtering TRUE
 rocksdb-enable-write-thread-adaptive-yield FALSE
 rocksdb-error-if-exists FALSE
 rocksdb-flush-log-at-trx-commit 1

--- a/mysql-test/r/mysqld--help-notwin-profiling.result
+++ b/mysql-test/r/mysqld--help-notwin-profiling.result
@@ -1163,6 +1163,25 @@ The following options may be given as the first argument:
  In case if cardinality is zero, overrides it with some
  value
  (Defaults to on; use --skip-rocksdb-debug-optimizer-no-zero-cardinality to disable.)
+ --rocksdb-debug-ttl-read-filter-ts=# 
+ For debugging purposes only.  Overrides the TTL read
+ filtering time to time + debug_ttl_read_filter_ts. A
+ value of 0 denotes that the variable is not set. This
+ variable is a no-op in non-debug builds.
+ --rocksdb-debug-ttl-rec-ts=# 
+ For debugging purposes only.  Overrides the TTL of
+ records to now() + debug_ttl_rec_ts.  The value can be
+ +/- to simulate a record inserted in the past vs a record
+ inserted in the 'future'. A value of 0 denotes that the
+ variable is not set. This variable is a no-op in
+ non-debug builds.
+ --rocksdb-debug-ttl-snapshot-ts=# 
+ For debugging purposes only.  Sets the snapshot during
+ compaction to now() + debug_set_ttl_snapshot_ts.  The
+ value can be +/- to simulate a snapshot in the past vs a
+ snapshot created in the 'future'. A value of 0 denotes
+ that the variable is not set. This variable is a no-op in
+ non-debug builds.
  --rocksdb-default-cf-options=name 
  default cf options for RocksDB
  --rocksdb-delayed-write-rate=# 
@@ -1188,7 +1207,7 @@ The following options may be given as the first argument:
  out during processing and in query results. Disabling
  this will allow these records to be seen, but as a result
  rows may disappear in the middle of transactions as they
- are dropped during compaction. Use with caution. 
+ are dropped during compaction. Use with caution.
  (Defaults to on; use --skip-rocksdb-enable-ttl-read-filtering to disable.)
  --rocksdb-enable-write-thread-adaptive-yield 
  DBOptions::enable_write_thread_adaptive_yield for RocksDB
@@ -2052,6 +2071,9 @@ rocksdb-ddl ON
 rocksdb-deadlock-detect FALSE
 rocksdb-debug-optimizer-n-rows 0
 rocksdb-debug-optimizer-no-zero-cardinality TRUE
+rocksdb-debug-ttl-read-filter-ts 0
+rocksdb-debug-ttl-rec-ts 0
+rocksdb-debug-ttl-snapshot-ts 0
 rocksdb-default-cf-options 
 rocksdb-delayed-write-rate 0
 rocksdb-delete-obsolete-files-period-micros 21600000000

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -1161,6 +1161,25 @@ The following options may be given as the first argument:
  In case if cardinality is zero, overrides it with some
  value
  (Defaults to on; use --skip-rocksdb-debug-optimizer-no-zero-cardinality to disable.)
+ --rocksdb-debug-ttl-read-filter-ts=# 
+ For debugging purposes only.  Overrides the TTL read
+ filtering time to time + debug_ttl_read_filter_ts. A
+ value of 0 denotes that the variable is not set. This
+ variable is a no-op in non-debug builds.
+ --rocksdb-debug-ttl-rec-ts=# 
+ For debugging purposes only.  Overrides the TTL of
+ records to now() + debug_ttl_rec_ts.  The value can be
+ +/- to simulate a record inserted in the past vs a record
+ inserted in the 'future'. A value of 0 denotes that the
+ variable is not set. This variable is a no-op in
+ non-debug builds.
+ --rocksdb-debug-ttl-snapshot-ts=# 
+ For debugging purposes only.  Sets the snapshot during
+ compaction to now() + debug_set_ttl_snapshot_ts.  The
+ value can be +/- to simulate a snapshot in the past vs a
+ snapshot created in the 'future'. A value of 0 denotes
+ that the variable is not set. This variable is a no-op in
+ non-debug builds.
  --rocksdb-default-cf-options=name 
  default cf options for RocksDB
  --rocksdb-delayed-write-rate=# 
@@ -1186,7 +1205,7 @@ The following options may be given as the first argument:
  out during processing and in query results. Disabling
  this will allow these records to be seen, but as a result
  rows may disappear in the middle of transactions as they
- are dropped during compaction. Use with caution. 
+ are dropped during compaction. Use with caution.
  (Defaults to on; use --skip-rocksdb-enable-ttl-read-filtering to disable.)
  --rocksdb-enable-write-thread-adaptive-yield 
  DBOptions::enable_write_thread_adaptive_yield for RocksDB
@@ -2049,6 +2068,9 @@ rocksdb-ddl ON
 rocksdb-deadlock-detect FALSE
 rocksdb-debug-optimizer-n-rows 0
 rocksdb-debug-optimizer-no-zero-cardinality TRUE
+rocksdb-debug-ttl-read-filter-ts 0
+rocksdb-debug-ttl-rec-ts 0
+rocksdb-debug-ttl-snapshot-ts 0
 rocksdb-default-cf-options 
 rocksdb-delayed-write-rate 0
 rocksdb-delete-obsolete-files-period-micros 21600000000

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -1178,9 +1178,16 @@ The following options may be given as the first argument:
  DBOptions::enable_thread_tracking for RocksDB
  (Defaults to on; use --skip-rocksdb-enable-thread-tracking to disable.)
  --rocksdb-enable-ttl 
- Disable expired ttl records from being dropped during
+ Enable expired TTL records to be dropped during
  compaction.
  (Defaults to on; use --skip-rocksdb-enable-ttl to disable.)
+ --rocksdb-enable-ttl-read-filtering 
+ For tables with TTL, expired records are skipped/filtered
+ out during processing and in query results. Disabling
+ this will allow these records to be seen, but as a result
+ rows may disappear in the middle of transactions as they
+ are dropped during compaction. Use with caution. 
+ (Defaults to on; use --skip-rocksdb-enable-ttl-read-filtering to disable.)
  --rocksdb-enable-write-thread-adaptive-yield 
  DBOptions::enable_write_thread_adaptive_yield for RocksDB
  --rocksdb-error-if-exists 
@@ -2049,6 +2056,7 @@ rocksdb-enable-2pc TRUE
 rocksdb-enable-bulk-load-api TRUE
 rocksdb-enable-thread-tracking TRUE
 rocksdb-enable-ttl TRUE
+rocksdb-enable-ttl-read-filtering TRUE
 rocksdb-enable-write-thread-adaptive-yield FALSE
 rocksdb-error-if-exists FALSE
 rocksdb-flush-log-at-trx-commit 1

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -895,6 +895,7 @@ rocksdb_enable_2pc	ON
 rocksdb_enable_bulk_load_api	ON
 rocksdb_enable_thread_tracking	ON
 rocksdb_enable_ttl	ON
+rocksdb_enable_ttl_read_filtering	ON
 rocksdb_enable_write_thread_adaptive_yield	OFF
 rocksdb_error_if_exists	OFF
 rocksdb_flush_log_at_trx_commit	1

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -888,6 +888,9 @@ rocksdb_datadir	./.rocksdb
 rocksdb_db_write_buffer_size	0
 rocksdb_deadlock_detect	OFF
 rocksdb_debug_optimizer_no_zero_cardinality	ON
+rocksdb_debug_ttl_read_filter_ts	0
+rocksdb_debug_ttl_rec_ts	0
+rocksdb_debug_ttl_snapshot_ts	0
 rocksdb_default_cf_options	
 rocksdb_delayed_write_rate	0
 rocksdb_delete_obsolete_files_period_micros	21600000000

--- a/mysql-test/suite/rocksdb/r/ttl_primary.result
+++ b/mysql-test/suite/rocksdb/r/ttl_primary.result
@@ -1,5 +1,6 @@
 DROP TABLE IF EXISTS t1;
 SET @@global.rocksdb_update_cf_options = 'default={disable_auto_compactions=true;};';
+set global rocksdb_enable_ttl_read_filtering=0;
 CREATE TABLE t1 (
 `a` binary(8) NOT NULL,
 `b` varbinary(64) NOT NULL,
@@ -442,3 +443,4 @@ variable_value-@c
 DROP TABLE t1;
 SET @@global.rocksdb_update_cf_options = 'default={disable_auto_compactions=false;};';
 SET @@global.rocksdb_update_cf_options = '';
+set global rocksdb_enable_ttl_read_filtering=1;

--- a/mysql-test/suite/rocksdb/r/ttl_primary.result
+++ b/mysql-test/suite/rocksdb/r/ttl_primary.result
@@ -1,6 +1,3 @@
-DROP TABLE IF EXISTS t1;
-SET @@global.rocksdb_update_cf_options = 'default={disable_auto_compactions=true;};';
-set global rocksdb_enable_ttl_read_filtering=0;
 CREATE TABLE t1 (
 `a` binary(8) NOT NULL,
 `b` varbinary(64) NOT NULL,
@@ -10,8 +7,10 @@ CREATE TABLE t1 (
 PRIMARY KEY (`b`,`a`,`c`)
 ) ENGINE=ROCKSDB DEFAULT CHARSET=latin1
 COMMENT='ttl_duration=1;ttl_col=ts;';
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values ('a', 'b', 'c', UNIX_TIMESTAMP(), 'd');
 INSERT INTO t1 values ('d', 'e', 'f', UNIX_TIMESTAMP(), 'g');
+set global rocksdb_debug_ttl_rec_ts = 0;
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 2
@@ -29,8 +28,10 @@ c int NOT NULL,
 PRIMARY KEY (a)
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=1;ttl_col=ts;';
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values (1, 3, UNIX_TIMESTAMP(), 5);
 INSERT INTO t1 values (2, 4, UNIX_TIMESTAMP(), 6);
+set global rocksdb_debug_ttl_rec_ts = 0;
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 2
@@ -48,8 +49,10 @@ ts bigint(20) UNSIGNED NOT NULL,
 PRIMARY KEY (a,c)
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=1;ttl_col=ts;';
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values (1, 3, 5, UNIX_TIMESTAMP());
 INSERT INTO t1 values (2, 4, 6, UNIX_TIMESTAMP());
+set global rocksdb_debug_ttl_rec_ts = 0;
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 2
@@ -67,8 +70,10 @@ ts bigint(20) UNSIGNED NOT NULL,
 PRIMARY KEY (a,c)
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=1;ttl_col=ts;';
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values (1, 3, 5, UNIX_TIMESTAMP());
 INSERT INTO t1 values (2, 4, 6, UNIX_TIMESTAMP());
+set global rocksdb_debug_ttl_rec_ts = 0;
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 2
@@ -86,8 +91,10 @@ ts bigint(20) UNSIGNED NOT NULL,
 PRIMARY KEY (a)
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=1;ttl_col=ts;';
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values (1, NULL, NULL, UNIX_TIMESTAMP());
 INSERT INTO t1 values (2, NULL, NULL, UNIX_TIMESTAMP());
+set global rocksdb_debug_ttl_rec_ts = 0;
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 2
@@ -106,8 +113,10 @@ CREATE TABLE t1 (
 PRIMARY KEY (`a`)
 ) ENGINE=ROCKSDB DEFAULT CHARSET=latin1
 COMMENT='ttl_duration=1;ttl_col=ts;';
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values ('a', NULL, 'bc', UNIX_TIMESTAMP(), 'd');
 INSERT INTO t1 values ('d', 'efghijk', NULL, UNIX_TIMESTAMP(), 'l');
+set global rocksdb_debug_ttl_rec_ts = 0;
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 2
@@ -124,8 +133,10 @@ c int NOT NULL,
 PRIMARY KEY (a)
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=1;';
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values (1, 3, 5);
 INSERT INTO t1 values (2, 4, 6);
+set global rocksdb_debug_ttl_rec_ts = 0;
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 2
@@ -136,21 +147,26 @@ COUNT(*)
 0
 DROP TABLE t1;
 CREATE TABLE t1 (
+a int,
 ts bigint(20) UNSIGNED NOT NULL,
-PRIMARY KEY (ts)
+PRIMARY KEY (a, ts)
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=5;ttl_col=ts;';
-INSERT INTO t1 values (UNIX_TIMESTAMP());
-INSERT INTO t1 values (UNIX_TIMESTAMP());
+INSERT INTO t1 values (1, UNIX_TIMESTAMP());
+INSERT INTO t1 values (2, UNIX_TIMESTAMP());
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 2
+set global rocksdb_debug_ttl_snapshot_ts = -10;
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 2
+set global rocksdb_debug_ttl_snapshot_ts = 10;
 set global rocksdb_compact_cf='default';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 0
@@ -163,8 +179,10 @@ c int NOT NULL,
 PRIMARY KEY (a, ts)
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=1;ttl_col=ts;';
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values (1, 3, UNIX_TIMESTAMP(), 5);
 INSERT INTO t1 values (2, 4, UNIX_TIMESTAMP(), 6);
+set global rocksdb_debug_ttl_rec_ts = 0;
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 2
@@ -183,8 +201,10 @@ CREATE TABLE t1 (
 PRIMARY KEY (`a`, `ts`)
 ) ENGINE=ROCKSDB DEFAULT CHARSET=latin1
 COMMENT='ttl_duration=1;ttl_col=ts;';
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values ('a', NULL, 'bc', UNIX_TIMESTAMP(), 'd');
 INSERT INTO t1 values ('de', 'fghijk', NULL, UNIX_TIMESTAMP(), 'l');
+set global rocksdb_debug_ttl_rec_ts = 0;
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 2
@@ -203,12 +223,17 @@ value mediumblob NOT NULL,
 PRIMARY KEY (b,a,c)
 ) ENGINE=ROCKSDB DEFAULT CHARSET=latin1
 COMMENT='ttl_duration=10;ttl_col=ts;';
+set global rocksdb_debug_ttl_rec_ts = -300;
 INSERT INTO t1 values (1, 'b', 'c', UNIX_TIMESTAMP(), 'd');
 INSERT INTO t1 values (2, 'e', 'f', UNIX_TIMESTAMP(), 'g');
+set global rocksdb_debug_ttl_rec_ts = 300;
 INSERT INTO t1 values (3, 'i', 'j', UNIX_TIMESTAMP(), 'k');
 INSERT INTO t1 values (4, 'm', 'n', UNIX_TIMESTAMP(), 'o');
+set global rocksdb_debug_ttl_rec_ts = 0;
+set global rocksdb_debug_ttl_snapshot_ts = -3600;
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
 SELECT a FROM t1;
 a
 1
@@ -220,7 +245,9 @@ SELECT a FROM t1;
 a
 3
 4
+set global rocksdb_debug_ttl_snapshot_ts = 3600;
 set global rocksdb_compact_cf='default';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
 SELECT a FROM t1;
 a
 DROP TABLE t1;
@@ -289,7 +316,9 @@ INSERT INTO t1 values (1);
 SELECT * FROM t1;
 a
 1
+set global rocksdb_debug_ttl_rec_ts = -300;
 ALTER TABLE t1 COMMENT = 'ttl_duration=1';
+set global rocksdb_debug_ttl_rec_ts = 0;
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -320,38 +349,49 @@ COMMENT='ttl_duration=5;';
 INSERT INTO t1 VALUES (1,1);
 INSERT INTO t1 VALUES (2,2);
 ALTER TABLE t1 DROP PRIMARY KEY, ADD PRIMARY KEY(b);
+set global rocksdb_debug_ttl_snapshot_ts = -3600;
 set global rocksdb_force_flush_memtable_now=1;
 set @@global.rocksdb_compact_cf = 'default';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 2
+set global rocksdb_debug_ttl_snapshot_ts = 3600;
 set @@global.rocksdb_compact_cf = 'default';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 0
 DROP TABLE t1;
 CREATE TABLE t1 (
 a bigint(20) UNSIGNED NOT NULL,
-PRIMARY KEY (a)
+b int,
+PRIMARY KEY (a,b)
 ) ENGINE=rocksdb
 COMMENT='asdadfasdfsadfadf ;ttl_duration=1; asfasdfasdfadfa';
-INSERT INTO t1 values (UNIX_TIMESTAMP());
+INSERT INTO t1 values (UNIX_TIMESTAMP(), 1);
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 1
+set global rocksdb_debug_ttl_snapshot_ts = 3600;
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 0
 ALTER TABLE t1 COMMENT = 'adsf;;ttl_duration=5;asfasdfa;ttl_col=a;asdfasdf;';
-INSERT INTO t1 values (UNIX_TIMESTAMP());
+set global rocksdb_debug_ttl_rec_ts = 300;
+INSERT INTO t1 values (UNIX_TIMESTAMP(), 2);
+set global rocksdb_debug_ttl_rec_ts = 0;
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 1
+set global rocksdb_debug_ttl_snapshot_ts = 3600;
 set global rocksdb_compact_cf='default';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 0
@@ -361,11 +401,14 @@ a bigint(20) NOT NULL,
 PRIMARY KEY (a)
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=5;';
+set global rocksdb_debug_ttl_rec_ts = -300;
 INSERT INTO t1 values (1);
 INSERT INTO t1 values (3);
 INSERT INTO t1 values (5);
+set global rocksdb_debug_ttl_rec_ts = 300;
 INSERT INTO t1 values (7);
 INSERT INTO t1 values (9);
+set global rocksdb_debug_ttl_rec_ts = 0;
 UPDATE t1 SET a=a+1;
 SELECT * FROM t1;
 a
@@ -387,11 +430,14 @@ b bigint(20) UNSIGNED NOT NULL,
 PRIMARY KEY (a)
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=5;ttl_col=b;';
+set global rocksdb_debug_ttl_rec_ts = -300;
 INSERT INTO t1 values (1, UNIX_TIMESTAMP());
 INSERT INTO t1 values (3, UNIX_TIMESTAMP());
 INSERT INTO t1 values (5, UNIX_TIMESTAMP());
 INSERT INTO t1 values (7, UNIX_TIMESTAMP());
+set global rocksdb_debug_ttl_rec_ts = 300;
 UPDATE t1 SET b=UNIX_TIMESTAMP() WHERE a < 4;
+set global rocksdb_debug_ttl_rec_ts = 0;
 SELECT a FROM t1;
 a
 1
@@ -410,9 +456,11 @@ a bigint(20) NOT NULL,
 PRIMARY KEY (a)
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=1;';
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values (1);
 INSERT INTO t1 values (2);
 INSERT INTO t1 values (3);
+set global rocksdb_debug_ttl_rec_ts = 0;
 set global rocksdb_enable_ttl=0;
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
@@ -441,6 +489,3 @@ select variable_value-@c from information_schema.global_status where variable_na
 variable_value-@c
 0
 DROP TABLE t1;
-SET @@global.rocksdb_update_cf_options = 'default={disable_auto_compactions=false;};';
-SET @@global.rocksdb_update_cf_options = '';
-set global rocksdb_enable_ttl_read_filtering=1;

--- a/mysql-test/suite/rocksdb/r/ttl_primary_read_filtering.result
+++ b/mysql-test/suite/rocksdb/r/ttl_primary_read_filtering.result
@@ -1,30 +1,31 @@
-DROP TABLE IF EXISTS t1;
-SET @@global.rocksdb_update_cf_options = 'default={disable_auto_compactions=true;};';
 CREATE TABLE t1 (
 a int PRIMARY KEY
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=1;';
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values (1);
 INSERT INTO t1 values (2);
+set global rocksdb_debug_ttl_rec_ts = 0;
 set global rocksdb_force_flush_memtable_now=1;
 SELECT * FROM t1;
 a
-select variable_value-@c from information_schema.global_status where variable_name='rocksdb_rows_expired';
-variable_value-@c
-NULL
+select variable_value into @c from information_schema.global_status where variable_name='rocksdb_rows_expired';
 set global rocksdb_compact_cf='default';
 select variable_value-@c from information_schema.global_status where variable_name='rocksdb_rows_expired';
 variable_value-@c
-NULL
+2
 DROP TABLE t1;
 CREATE TABLE t1 (
 a int PRIMARY KEY,
 b BIGINT UNSIGNED NOT NULL
 ) ENGINE=rocksdb
-COMMENT='ttl_duration=5;';
+COMMENT='ttl_duration=10;';
+set global rocksdb_debug_ttl_rec_ts = -300;
 INSERT INTO t1 values (1, UNIX_TIMESTAMP());
+set global rocksdb_debug_ttl_rec_ts = 300;
 INSERT INTO t1 values (2, UNIX_TIMESTAMP());
 INSERT INTO t1 values (3, UNIX_TIMESTAMP());
+set global rocksdb_debug_ttl_rec_ts = 0;
 set global rocksdb_force_flush_memtable_now=1;
 SELECT a FROM t1;
 a
@@ -35,7 +36,32 @@ SELECT a FROM t1;
 a
 2
 3
+set global rocksdb_debug_ttl_read_filter_ts = -310;
 SELECT a FROM t1;
+a
+set global rocksdb_debug_ttl_read_filter_ts = 0;
+DROP TABLE t1;
+CREATE TABLE t1 (
+a int PRIMARY KEY
+) ENGINE=rocksdb
+COMMENT='ttl_duration=1;';
+set global rocksdb_debug_ttl_rec_ts = -100;
+INSERT INTO t1 values (1);
+INSERT INTO t1 values (3);
+INSERT INTO t1 values (5);
+INSERT INTO t1 values (7);
+set global rocksdb_debug_ttl_rec_ts = 0;
+SELECT * FROM t1;
+a
+set global rocksdb_enable_ttl_read_filtering=0;
+SELECT * FROM t1;
+a
+1
+3
+5
+7
+set global rocksdb_enable_ttl_read_filtering=1;
+SELECT * FROM t1;
 a
 DROP TABLE t1;
 CREATE TABLE t1 (
@@ -45,6 +71,7 @@ c int,
 PRIMARY KEY (a,b,c)
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=1;';
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values (0,0,0);
 INSERT INTO t1 values (0,0,1);
 INSERT INTO t1 values (0,1,0);
@@ -53,6 +80,7 @@ INSERT INTO t1 values (1,1,2);
 INSERT INTO t1 values (1,2,1);
 INSERT INTO t1 values (1,2,2);
 INSERT INTO t1 values (1,2,3);
+set global rocksdb_debug_ttl_rec_ts = 0;
 select variable_value into @c from information_schema.global_status where variable_name='rocksdb_rows_expired';
 set global rocksdb_force_flush_memtable_now=1;
 SELECT * FROM t1 WHERE a=1 AND b=2 AND c=2;
@@ -89,66 +117,73 @@ DROP TABLE t1;
 CREATE TABLE t1 (
 a int PRIMARY KEY
 ) ENGINE=rocksdb
-COMMENT='ttl_duration=1;';
+COMMENT='ttl_duration=100;';
+set global rocksdb_debug_ttl_rec_ts = -110;
 INSERT INTO t1 values (1);
+set global rocksdb_debug_ttl_rec_ts = 0;
+SELECT * FROM t1;
+a
+INSERT INTO t1 values (1);
+SELECT * FROM t1;
+a
+1
+DROP TABLE t1;
 set global rocksdb_force_flush_memtable_now=1;
-SELECT * FROM t1;
-a
-INSERT INTO t1 values (1);
-ERROR 23000: Duplicate entry '1' for key 'PRIMARY'
-DROP TABLE t1;
 CREATE TABLE t1 (
 a int PRIMARY KEY
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=1;';
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values (1);
+set global rocksdb_debug_ttl_rec_ts = 0;
 SELECT * FROM t1;
 a
 UPDATE t1 set a = 1;
 DROP TABLE t1;
+set global rocksdb_force_flush_memtable_now=1;
+set global rocksdb_compact_cf='default';
 CREATE TABLE t1 (
-a int PRIMARY KEY
+a int PRIMARY KEY,
+b int
 ) ENGINE=rocksdb
-COMMENT='ttl_duration=4;';
-INSERT INTO t1 values (1);
-INSERT INTO t1 values (3);
-INSERT INTO t1 values (5);
-INSERT INTO t1 values (7);
+COMMENT='ttl_duration=100;';
+set global rocksdb_debug_ttl_rec_ts = -110;
+INSERT INTO t1 values (1,1);
+INSERT INTO t1 values (3,3);
+set global rocksdb_debug_ttl_rec_ts = 0;
+INSERT INTO t1 values (5,5);
 UPDATE t1 set a = 1;
-ERROR 23000: Duplicate entry '1' for key 'PRIMARY'
-UPDATE t1 set a = 999 where a = 5;
 SELECT * FROM t1;
-a
-7
-999
+a	b
+1	5
+set global rocksdb_enable_ttl_read_filtering=0;
+SELECT * FROM t1;
+a	b
+1	5
+3	3
+set global rocksdb_enable_ttl_read_filtering=1;
+UPDATE t1 set a = 999 where a = 1;
+SELECT * FROM t1;
+a	b
+999	5
 UPDATE t1 set a = a - 1;
 SELECT * FROM t1;
-a
-6
-998
+a	b
+998	5
 DROP TABLE t1;
 CREATE TABLE t1 (
 a int PRIMARY KEY
 ) ENGINE=rocksdb
-COMMENT='ttl_duration=3;';
+COMMENT='ttl_duration=5;';
 INSERT INTO t1 values (1);
-INSERT INTO t1 values (3);
-INSERT INTO t1 values (5);
-INSERT INTO t1 values (7);
 # Creating Snapshot (start transaction)
 BEGIN;
 SELECT * FROM t1;
 a
 1
-3
-5
-7
 SELECT * FROM t1;
 a
 1
-3
-5
-7
 # Switching to connection 2
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
@@ -158,18 +193,46 @@ a
 SELECT * FROM t1;
 a
 1
-3
-5
-7
 UPDATE t1 set a = a + 1;
 SELECT * FROM t1;
 a
 2
-4
-6
-8
 COMMIT;
 SELECT * FROM t1;
 a
 DROP TABLE t1;
-SET @@global.rocksdb_update_cf_options = '';
+set global rocksdb_force_flush_memtable_now=1;
+set global rocksdb_compact_cf='default';
+CREATE TABLE t1 (
+a int PRIMARY KEY
+) ENGINE=rocksdb
+COMMENT='ttl_duration=1;';
+# On Connection 1
+# Creating Snapshot (start transaction)
+BEGIN;
+SELECT * FROM t1;
+a
+# On Connection 2
+set global rocksdb_debug_ttl_rec_ts = -2;
+INSERT INTO t1 values (1);
+INSERT INTO t1 values (3);
+INSERT INTO t1 values (5);
+INSERT INTO t1 values (7);
+set global rocksdb_debug_ttl_rec_ts = 0;
+set global rocksdb_force_flush_memtable_now=1;
+set global rocksdb_compact_cf='default';
+# On Connection 1
+SELECT * FROM t1;
+a
+# On Connection 2
+SELECT * FROM t1;
+a
+set global rocksdb_enable_ttl_read_filtering=0;
+SELECT * FROM t1;
+a
+1
+3
+5
+7
+set global rocksdb_enable_ttl_read_filtering=1;
+DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/r/ttl_primary_read_filtering.result
+++ b/mysql-test/suite/rocksdb/r/ttl_primary_read_filtering.result
@@ -1,0 +1,175 @@
+DROP TABLE IF EXISTS t1;
+SET @@global.rocksdb_update_cf_options = 'default={disable_auto_compactions=true;};';
+CREATE TABLE t1 (
+a int PRIMARY KEY
+) ENGINE=rocksdb
+COMMENT='ttl_duration=1;';
+INSERT INTO t1 values (1);
+INSERT INTO t1 values (2);
+set global rocksdb_force_flush_memtable_now=1;
+SELECT * FROM t1;
+a
+select variable_value-@c from information_schema.global_status where variable_name='rocksdb_rows_expired';
+variable_value-@c
+NULL
+set global rocksdb_compact_cf='default';
+select variable_value-@c from information_schema.global_status where variable_name='rocksdb_rows_expired';
+variable_value-@c
+NULL
+DROP TABLE t1;
+CREATE TABLE t1 (
+a int PRIMARY KEY,
+b BIGINT UNSIGNED NOT NULL
+) ENGINE=rocksdb
+COMMENT='ttl_duration=5;';
+INSERT INTO t1 values (1, UNIX_TIMESTAMP());
+INSERT INTO t1 values (2, UNIX_TIMESTAMP());
+INSERT INTO t1 values (3, UNIX_TIMESTAMP());
+set global rocksdb_force_flush_memtable_now=1;
+SELECT a FROM t1;
+a
+2
+3
+set global rocksdb_compact_cf='default';
+SELECT a FROM t1;
+a
+2
+3
+SELECT a FROM t1;
+a
+DROP TABLE t1;
+CREATE TABLE t1 (
+a int,
+b int,
+c int,
+PRIMARY KEY (a,b,c)
+) ENGINE=rocksdb
+COMMENT='ttl_duration=1;';
+INSERT INTO t1 values (0,0,0);
+INSERT INTO t1 values (0,0,1);
+INSERT INTO t1 values (0,1,0);
+INSERT INTO t1 values (0,1,1);
+INSERT INTO t1 values (1,1,2);
+INSERT INTO t1 values (1,2,1);
+INSERT INTO t1 values (1,2,2);
+INSERT INTO t1 values (1,2,3);
+select variable_value into @c from information_schema.global_status where variable_name='rocksdb_rows_expired';
+set global rocksdb_force_flush_memtable_now=1;
+SELECT * FROM t1 WHERE a=1 AND b=2 AND c=2;
+a	b	c
+SELECT * FROM t1 WHERE a = 1;
+a	b	c
+SELECT max(a) from t1 where a < 3;
+max(a)
+NULL
+SELECT max(a) from t1 where a < 2 AND b = 1 AND c < 3;
+max(a)
+NULL
+SELECT min(a) from t1 where a >= 1;
+min(a)
+NULL
+SELECT min(a) from t1 where a > 1;
+min(a)
+NULL
+select * from t1 where a=1 and b in (1) order by c desc;
+a	b	c
+select max(a) from t1 where a <=10;
+max(a)
+NULL
+select a from t1 where a > 0 and a <= 2;
+a
+select variable_value-@c from information_schema.global_status where variable_name='rocksdb_rows_expired';
+variable_value-@c
+0
+set global rocksdb_compact_cf='default';
+select variable_value-@c from information_schema.global_status where variable_name='rocksdb_rows_expired';
+variable_value-@c
+8
+DROP TABLE t1;
+CREATE TABLE t1 (
+a int PRIMARY KEY
+) ENGINE=rocksdb
+COMMENT='ttl_duration=1;';
+INSERT INTO t1 values (1);
+set global rocksdb_force_flush_memtable_now=1;
+SELECT * FROM t1;
+a
+INSERT INTO t1 values (1);
+ERROR 23000: Duplicate entry '1' for key 'PRIMARY'
+DROP TABLE t1;
+CREATE TABLE t1 (
+a int PRIMARY KEY
+) ENGINE=rocksdb
+COMMENT='ttl_duration=1;';
+INSERT INTO t1 values (1);
+SELECT * FROM t1;
+a
+UPDATE t1 set a = 1;
+DROP TABLE t1;
+CREATE TABLE t1 (
+a int PRIMARY KEY
+) ENGINE=rocksdb
+COMMENT='ttl_duration=4;';
+INSERT INTO t1 values (1);
+INSERT INTO t1 values (3);
+INSERT INTO t1 values (5);
+INSERT INTO t1 values (7);
+UPDATE t1 set a = 1;
+ERROR 23000: Duplicate entry '1' for key 'PRIMARY'
+UPDATE t1 set a = 999 where a = 5;
+SELECT * FROM t1;
+a
+7
+999
+UPDATE t1 set a = a - 1;
+SELECT * FROM t1;
+a
+6
+998
+DROP TABLE t1;
+CREATE TABLE t1 (
+a int PRIMARY KEY
+) ENGINE=rocksdb
+COMMENT='ttl_duration=3;';
+INSERT INTO t1 values (1);
+INSERT INTO t1 values (3);
+INSERT INTO t1 values (5);
+INSERT INTO t1 values (7);
+# Creating Snapshot (start transaction)
+BEGIN;
+SELECT * FROM t1;
+a
+1
+3
+5
+7
+SELECT * FROM t1;
+a
+1
+3
+5
+7
+# Switching to connection 2
+set global rocksdb_force_flush_memtable_now=1;
+set global rocksdb_compact_cf='default';
+SELECT * FROM t1;
+a
+# Switching to connection 1
+SELECT * FROM t1;
+a
+1
+3
+5
+7
+UPDATE t1 set a = a + 1;
+SELECT * FROM t1;
+a
+2
+4
+6
+8
+COMMIT;
+SELECT * FROM t1;
+a
+DROP TABLE t1;
+SET @@global.rocksdb_update_cf_options = '';

--- a/mysql-test/suite/rocksdb/r/ttl_primary_with_partitions.result
+++ b/mysql-test/suite/rocksdb/r/ttl_primary_with_partitions.result
@@ -1,6 +1,7 @@
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS t2;
 SET @@global.rocksdb_update_cf_options = 'default={disable_auto_compactions=true;};';
+set global rocksdb_enable_ttl_read_filtering=0;
 CREATE TABLE t1 (
 c1 INT,
 PRIMARY KEY (`c1`)
@@ -245,3 +246,4 @@ c1
 DROP TABLE t1;
 SET @@global.rocksdb_update_cf_options = 'default={disable_auto_compactions=false;};';
 SET @@global.rocksdb_update_cf_options = '';
+set global rocksdb_enable_ttl_read_filtering=1;

--- a/mysql-test/suite/rocksdb/r/ttl_primary_with_partitions.result
+++ b/mysql-test/suite/rocksdb/r/ttl_primary_with_partitions.result
@@ -1,7 +1,3 @@
-DROP TABLE IF EXISTS t1;
-DROP TABLE IF EXISTS t2;
-SET @@global.rocksdb_update_cf_options = 'default={disable_auto_compactions=true;};';
-set global rocksdb_enable_ttl_read_filtering=0;
 CREATE TABLE t1 (
 c1 INT,
 PRIMARY KEY (`c1`)
@@ -12,6 +8,7 @@ PARTITION custom_p0 VALUES IN (1, 4, 7),
 PARTITION custom_p1 VALUES IN (2, 5, 8),
 PARTITION custom_p2 VALUES IN (3, 6, 9)
 );
+set global rocksdb_debug_ttl_rec_ts = -3600;
 INSERT INTO t1 values (1);
 INSERT INTO t1 values (2);
 INSERT INTO t1 values (3);
@@ -21,6 +18,7 @@ INSERT INTO t1 values (6);
 INSERT INTO t1 values (7);
 INSERT INTO t1 values (8);
 INSERT INTO t1 values (9);
+set global rocksdb_debug_ttl_rec_ts = 0;
 SELECT * FROM t1;
 c1
 1
@@ -49,21 +47,24 @@ c2 INT,
 name VARCHAR(25) NOT NULL,
 PRIMARY KEY (`c1`, `c2`) COMMENT 'custom_p0_cfname=foo;custom_p1_cfname=my_custom_cf;custom_p2_cfname=baz'
 ) ENGINE=ROCKSDB
-COMMENT="custom_p0_ttl_duration=1;custom_p1_ttl_duration=5;"
+COMMENT="custom_p0_ttl_duration=1;custom_p1_ttl_duration=7;"
 PARTITION BY LIST(c1) (
 PARTITION custom_p0 VALUES IN (1, 4, 7),
 PARTITION custom_p1 VALUES IN (2, 5, 8),
 PARTITION custom_p2 VALUES IN (3, 6, 9)
 );
+set global rocksdb_debug_ttl_rec_ts = -1200;
 INSERT INTO t1 values (1,1,'a');
+INSERT INTO t1 values (4,4,'aaaa');
+INSERT INTO t1 values (7,7,'aaaaaaa');
+set global rocksdb_debug_ttl_rec_ts = 1200;
 INSERT INTO t1 values (2,2,'aa');
 INSERT INTO t1 values (3,3,'aaa');
-INSERT INTO t1 values (4,4,'aaaa');
 INSERT INTO t1 values (5,5,'aaaaa');
 INSERT INTO t1 values (6,6,'aaaaaa');
-INSERT INTO t1 values (7,7,'aaaaaaa');
 INSERT INTO t1 values (8,8,'aaaaaaaa');
 INSERT INTO t1 values (9,9,'aaaaaaaaa');
+set global rocksdb_debug_ttl_rec_ts = 0;
 SELECT * FROM t1;
 c1	c2	name
 1	1	a
@@ -78,7 +79,6 @@ c1	c2	name
 set global rocksdb_force_flush_memtable_now=1;
 set @@global.rocksdb_compact_cf = 'foo';
 set @@global.rocksdb_compact_cf = 'my_custom_cf';
-set @@global.rocksdb_compact_cf = 'baz';
 SELECT * FROM t1;
 c1	c2	name
 2	2	aa
@@ -87,8 +87,8 @@ c1	c2	name
 6	6	aaaaaa
 8	8	aaaaaaaa
 9	9	aaaaaaaaa
+set global rocksdb_debug_ttl_snapshot_ts = 3600;
 set @@global.rocksdb_compact_cf = 'foo';
-set @@global.rocksdb_compact_cf = 'baz';
 SELECT * FROM t1;
 c1	c2	name
 2	2	aa
@@ -98,6 +98,7 @@ c1	c2	name
 8	8	aaaaaaaa
 9	9	aaaaaaaaa
 set @@global.rocksdb_compact_cf = 'my_custom_cf';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
 SELECT * FROM t1;
 c1	c2	name
 3	3	aaa
@@ -111,7 +112,7 @@ name VARCHAR(25) NOT NULL,
 event DATE,
 PRIMARY KEY (`c1`, `c2`) COMMENT 'custom_p0_cfname=foo;custom_p1_cfname=bar;custom_p2_cfname=baz;'
 ) ENGINE=ROCKSDB
-COMMENT="custom_p0_ttl_duration=100;custom_p2_ttl_duration=5;"
+COMMENT="custom_p0_ttl_duration=9999;custom_p2_ttl_duration=5;"
 PARTITION BY LIST(c1) (
 PARTITION custom_p0 VALUES IN (1, 2, 3),
 PARTITION custom_p1 VALUES IN (4, 5, 6),
@@ -126,9 +127,6 @@ INSERT INTO t1 VALUES (6, 6, "six", null);
 INSERT INTO t1 VALUES (7, 7, "seven", null);
 INSERT INTO t1 VALUES (8, 8, "eight", null);
 INSERT INTO t1 VALUES (9, 9, "nine", null);
-set global rocksdb_force_flush_memtable_now=1;
-set @@global.rocksdb_compact_cf = 'foo';
-set @@global.rocksdb_compact_cf = 'baz';
 SELECT * FROM t1;
 c1	c2	name	event
 1	1	one	NULL
@@ -140,7 +138,9 @@ c1	c2	name	event
 7	7	seven	NULL
 8	8	eight	NULL
 9	9	nine	NULL
+set global rocksdb_debug_ttl_rec_ts = 600;
 ALTER TABLE t1 DROP PRIMARY KEY, ADD PRIMARY KEY(`c2`,`c1`) COMMENT 'custom_p0_cfname=foo;custom_p1_cfname=bar;custom_p2_cfname=baz;';
+set global rocksdb_debug_ttl_rec_ts = 0;
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -149,13 +149,15 @@ t1	CREATE TABLE `t1` (
   `name` varchar(25) NOT NULL,
   `event` date DEFAULT NULL,
   PRIMARY KEY (`c2`,`c1`) COMMENT 'custom_p0_cfname=foo;custom_p1_cfname=bar;custom_p2_cfname=baz;'
-) ENGINE=ROCKSDB DEFAULT CHARSET=latin1 COMMENT='custom_p0_ttl_duration=100;custom_p2_ttl_duration=5;'
+) ENGINE=ROCKSDB DEFAULT CHARSET=latin1 COMMENT='custom_p0_ttl_duration=9999;custom_p2_ttl_duration=5;'
 /*!50100 PARTITION BY LIST (c1)
 (PARTITION custom_p0 VALUES IN (1,2,3) ENGINE = ROCKSDB,
  PARTITION custom_p1 VALUES IN (4,5,6) ENGINE = ROCKSDB,
  PARTITION custom_p2 VALUES IN (7,8,9) ENGINE = ROCKSDB) */
+set global rocksdb_debug_ttl_snapshot_ts = 100;
 set global rocksdb_force_flush_memtable_now=1;
 set @@global.rocksdb_compact_cf = 'baz';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
 SELECT * FROM t1;
 c1	c2	name	event
 1	1	one	NULL
@@ -167,8 +169,10 @@ c1	c2	name	event
 7	7	seven	NULL
 8	8	eight	NULL
 9	9	nine	NULL
+set global rocksdb_debug_ttl_snapshot_ts = 1200;
 set @@global.rocksdb_compact_cf = 'foo';
 set @@global.rocksdb_compact_cf = 'baz';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
 SELECT * FROM t1;
 c1	c2	name	event
 1	1	one	NULL
@@ -185,15 +189,17 @@ name VARCHAR(25) NOT NULL,
 event DATE,
 PRIMARY KEY (`c1`) COMMENT 'custom_p0_cfname=foo;custom_p1_cfname=bar;custom_p2_cfname=baz;'
 ) ENGINE=ROCKSDB
-COMMENT="ttl_duration=1;custom_p1_ttl_duration=5;custom_p1_ttl_col=c2;custom_p2_ttl_duration=500;"
+COMMENT="ttl_duration=1;custom_p1_ttl_duration=100;custom_p1_ttl_col=c2;custom_p2_ttl_duration=5000;"
 PARTITION BY LIST(c1) (
 PARTITION custom_p0 VALUES IN (1, 2, 3),
 PARTITION custom_p1 VALUES IN (4, 5, 6),
 PARTITION custom_p2 VALUES IN (7, 8, 9)
 );
+set global rocksdb_debug_ttl_rec_ts = -300;
 INSERT INTO t1 VALUES (1, UNIX_TIMESTAMP(), "one", null);
 INSERT INTO t1 VALUES (2, UNIX_TIMESTAMP(), "two", null);
 INSERT INTO t1 VALUES (3, UNIX_TIMESTAMP(), "three", null);
+set global rocksdb_debug_ttl_rec_ts = 0;
 INSERT INTO t1 VALUES (4, UNIX_TIMESTAMP(), "four", null);
 INSERT INTO t1 VALUES (5, UNIX_TIMESTAMP(), "five", null);
 INSERT INTO t1 VALUES (6, UNIX_TIMESTAMP(), "six", null);
@@ -212,7 +218,9 @@ c1
 7
 8
 9
+set global rocksdb_debug_ttl_snapshot_ts = 600;
 set @@global.rocksdb_compact_cf = 'bar';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
 SELECT c1 FROM t1;
 c1
 7
@@ -224,7 +232,7 @@ c1 BIGINT,
 c2 BIGINT UNSIGNED NOT NULL,
 PRIMARY KEY (`c1`, `c2`)
 ) ENGINE=ROCKSDB
-COMMENT="ttl_duration=5;ttl_col=c2;"
+COMMENT="ttl_duration=100;ttl_col=c2;"
 PARTITION BY LIST(c1) (
 PARTITION custom_p0 VALUES IN (1),
 PARTITION custom_p1 VALUES IN (2),
@@ -240,10 +248,9 @@ c1
 1
 2
 3
+set global rocksdb_debug_ttl_snapshot_ts = 300;
 set global rocksdb_compact_cf='default';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
 SELECT c1 FROM t1;
 c1
 DROP TABLE t1;
-SET @@global.rocksdb_update_cf_options = 'default={disable_auto_compactions=false;};';
-SET @@global.rocksdb_update_cf_options = '';
-set global rocksdb_enable_ttl_read_filtering=1;

--- a/mysql-test/suite/rocksdb/t/ttl_primary-master.opt
+++ b/mysql-test/suite/rocksdb/t/ttl_primary-master.opt
@@ -1,1 +1,2 @@
+--rocksdb_enable_ttl_read_filtering=0
 --rocksdb_default_cf_options=disable_auto_compactions=true

--- a/mysql-test/suite/rocksdb/t/ttl_primary.test
+++ b/mysql-test/suite/rocksdb/t/ttl_primary.test
@@ -1,13 +1,5 @@
+--source include/have_debug.inc
 --source include/have_rocksdb.inc
-
---disable_warnings
-DROP TABLE IF EXISTS t1;
---enable_warnings
-
-SET @@global.rocksdb_update_cf_options = 'default={disable_auto_compactions=true;};';
-
-# Disable read filtering for the duration of this test.
-set global rocksdb_enable_ttl_read_filtering=0;
 
 # Basic TTL test
 CREATE TABLE t1 (
@@ -20,11 +12,11 @@ PRIMARY KEY (`b`,`a`,`c`)
 ) ENGINE=ROCKSDB DEFAULT CHARSET=latin1
 COMMENT='ttl_duration=1;ttl_col=ts;';
 
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values ('a', 'b', 'c', UNIX_TIMESTAMP(), 'd');
 INSERT INTO t1 values ('d', 'e', 'f', UNIX_TIMESTAMP(), 'g');
+set global rocksdb_debug_ttl_rec_ts = 0;
 SELECT COUNT(*) FROM t1;
-
---real_sleep 3
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
 
@@ -42,11 +34,12 @@ CREATE TABLE t1 (
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=1;ttl_col=ts;';
 
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values (1, 3, UNIX_TIMESTAMP(), 5);
 INSERT INTO t1 values (2, 4, UNIX_TIMESTAMP(), 6);
+set global rocksdb_debug_ttl_rec_ts = 0;
 SELECT COUNT(*) FROM t1;
 
---real_sleep 3
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
 
@@ -64,11 +57,12 @@ CREATE TABLE t1 (
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=1;ttl_col=ts;';
 
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values (1, 3, 5, UNIX_TIMESTAMP());
 INSERT INTO t1 values (2, 4, 6, UNIX_TIMESTAMP());
+set global rocksdb_debug_ttl_rec_ts = 0;
 SELECT COUNT(*) FROM t1;
 
---real_sleep 3
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
 
@@ -86,11 +80,12 @@ CREATE TABLE t1 (
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=1;ttl_col=ts;';
 
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values (1, 3, 5, UNIX_TIMESTAMP());
 INSERT INTO t1 values (2, 4, 6, UNIX_TIMESTAMP());
+set global rocksdb_debug_ttl_rec_ts = 0;
 SELECT COUNT(*) FROM t1;
 
---real_sleep 3
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
 
@@ -108,11 +103,12 @@ CREATE TABLE t1 (
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=1;ttl_col=ts;';
 
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values (1, NULL, NULL, UNIX_TIMESTAMP());
 INSERT INTO t1 values (2, NULL, NULL, UNIX_TIMESTAMP());
+set global rocksdb_debug_ttl_rec_ts = 0;
 SELECT COUNT(*) FROM t1;
 
---real_sleep 3
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
 
@@ -131,11 +127,12 @@ PRIMARY KEY (`a`)
 ) ENGINE=ROCKSDB DEFAULT CHARSET=latin1
 COMMENT='ttl_duration=1;ttl_col=ts;';
 
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values ('a', NULL, 'bc', UNIX_TIMESTAMP(), 'd');
 INSERT INTO t1 values ('d', 'efghijk', NULL, UNIX_TIMESTAMP(), 'l');
+set global rocksdb_debug_ttl_rec_ts = 0;
 SELECT COUNT(*) FROM t1;
 
---real_sleep 3
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
 
@@ -152,11 +149,12 @@ CREATE TABLE t1 (
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=1;';
 
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values (1, 3, 5);
 INSERT INTO t1 values (2, 4, 6);
+set global rocksdb_debug_ttl_rec_ts = 0;
 SELECT COUNT(*) FROM t1;
 
---real_sleep 3
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
 
@@ -166,23 +164,26 @@ DROP TABLE t1;
 
 # TTL field as the PK
 CREATE TABLE t1 (
+	a int,
   ts bigint(20) UNSIGNED NOT NULL,
-  PRIMARY KEY (ts)
+  PRIMARY KEY (a, ts)
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=5;ttl_col=ts;';
 
-INSERT INTO t1 values (UNIX_TIMESTAMP());
---real_sleep 1
-INSERT INTO t1 values (UNIX_TIMESTAMP());
+INSERT INTO t1 values (1, UNIX_TIMESTAMP());
+INSERT INTO t1 values (2, UNIX_TIMESTAMP());
 SELECT COUNT(*) FROM t1;
 
+set global rocksdb_debug_ttl_snapshot_ts = -10;
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
 # should all still be there..
 SELECT COUNT(*) FROM t1;
 
---real_sleep 5
+set global rocksdb_debug_ttl_snapshot_ts = 10;
 set global rocksdb_compact_cf='default';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
 # should have filtered the rows out since ttl is passed in compaction filter
 SELECT COUNT(*) FROM t1;
 DROP TABLE t1;
@@ -198,11 +199,12 @@ CREATE TABLE t1 (
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=1;ttl_col=ts;';
 
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values (1, 3, UNIX_TIMESTAMP(), 5);
 INSERT INTO t1 values (2, 4, UNIX_TIMESTAMP(), 6);
+set global rocksdb_debug_ttl_rec_ts = 0;
 SELECT COUNT(*) FROM t1;
 
---real_sleep 3
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
 
@@ -221,11 +223,12 @@ PRIMARY KEY (`a`, `ts`)
 ) ENGINE=ROCKSDB DEFAULT CHARSET=latin1
 COMMENT='ttl_duration=1;ttl_col=ts;';
 
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values ('a', NULL, 'bc', UNIX_TIMESTAMP(), 'd');
 INSERT INTO t1 values ('de', 'fghijk', NULL, UNIX_TIMESTAMP(), 'l');
+set global rocksdb_debug_ttl_rec_ts = 0;
 SELECT COUNT(*) FROM t1;
 
---real_sleep 3
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
 
@@ -245,26 +248,31 @@ PRIMARY KEY (b,a,c)
 ) ENGINE=ROCKSDB DEFAULT CHARSET=latin1
 COMMENT='ttl_duration=10;ttl_col=ts;';
 
+set global rocksdb_debug_ttl_rec_ts = -300;
 INSERT INTO t1 values (1, 'b', 'c', UNIX_TIMESTAMP(), 'd');
 INSERT INTO t1 values (2, 'e', 'f', UNIX_TIMESTAMP(), 'g');
-
---real_sleep 5
-
+set global rocksdb_debug_ttl_rec_ts = 300;
 INSERT INTO t1 values (3, 'i', 'j', UNIX_TIMESTAMP(), 'k');
 INSERT INTO t1 values (4, 'm', 'n', UNIX_TIMESTAMP(), 'o');
+set global rocksdb_debug_ttl_rec_ts = 0;
 
+# Nothing should get removed here.
+set global rocksdb_debug_ttl_snapshot_ts = -3600;
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
 --sorted_result
 SELECT a FROM t1;
 
---real_sleep 6
+# 1 and 2 should get removed here.
 set global rocksdb_compact_cf='default';
 --sorted_result
 SELECT a FROM t1;
 
---real_sleep 5
+# 3 and 4 should get removed here.
+set global rocksdb_debug_ttl_snapshot_ts = 3600;
 set global rocksdb_compact_cf='default';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
 --sorted_result
 SELECT a FROM t1;
 
@@ -331,8 +339,6 @@ COMMENT='ttl_duration=500;';
 
 INSERT INTO t1 values (1);
 SELECT COUNT(*) FROM t1;
-
---real_sleep 1
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
 
@@ -349,10 +355,10 @@ COMMENT='ttl_duration=100;';
 INSERT INTO t1 values (1);
 SELECT * FROM t1;
 
+set global rocksdb_debug_ttl_rec_ts = -300;
 ALTER TABLE t1 COMMENT = 'ttl_duration=1';
+set global rocksdb_debug_ttl_rec_ts = 0;
 SHOW CREATE TABLE t1;
-
---real_sleep 3
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
 
@@ -384,14 +390,18 @@ INSERT INTO t1 VALUES (1,1);
 INSERT INTO t1 VALUES (2,2);
 
 ALTER TABLE t1 DROP PRIMARY KEY, ADD PRIMARY KEY(b);
+set global rocksdb_debug_ttl_snapshot_ts = -3600;
 set global rocksdb_force_flush_memtable_now=1;
---real_sleep 1
 set @@global.rocksdb_compact_cf = 'default';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
+
 --sorted_result
 SELECT COUNT(*) FROM t1;
 
---real_sleep 5
+set global rocksdb_debug_ttl_snapshot_ts = 3600;
 set @@global.rocksdb_compact_cf = 'default';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
+
 --sorted_result
 SELECT COUNT(*) FROM t1;
 
@@ -401,27 +411,35 @@ DROP TABLE t1;
 # (basically, it needs semicolon before and after)
 CREATE TABLE t1 (
   a bigint(20) UNSIGNED NOT NULL,
-  PRIMARY KEY (a)
+  b int,
+  PRIMARY KEY (a,b)
 ) ENGINE=rocksdb
 COMMENT='asdadfasdfsadfadf ;ttl_duration=1; asfasdfasdfadfa';
-INSERT INTO t1 values (UNIX_TIMESTAMP());
+INSERT INTO t1 values (UNIX_TIMESTAMP(), 1);
 SELECT COUNT(*) FROM t1;
 
---real_sleep 3
+set global rocksdb_debug_ttl_snapshot_ts = 3600;
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
 
 SELECT COUNT(*) FROM t1;
 
 ALTER TABLE t1 COMMENT = 'adsf;;ttl_duration=5;asfasdfa;ttl_col=a;asdfasdf;';
-INSERT INTO t1 values (UNIX_TIMESTAMP());
+
+set global rocksdb_debug_ttl_rec_ts = 300;
+INSERT INTO t1 values (UNIX_TIMESTAMP(), 2);
+set global rocksdb_debug_ttl_rec_ts = 0;
 set global rocksdb_force_flush_memtable_now=1;
 
---real_sleep 1
+# nothing removed here
 set global rocksdb_compact_cf='default';
 SELECT COUNT(*) FROM t1;
---real_sleep 5
+
+# all removed here
+set global rocksdb_debug_ttl_snapshot_ts = 3600;
 set global rocksdb_compact_cf='default';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
 SELECT COUNT(*) FROM t1;
 
 DROP TABLE t1;
@@ -433,12 +451,14 @@ CREATE TABLE t1 (
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=5;';
 
+set global rocksdb_debug_ttl_rec_ts = -300;
 INSERT INTO t1 values (1);
 INSERT INTO t1 values (3);
 INSERT INTO t1 values (5);
---real_sleep 6
+set global rocksdb_debug_ttl_rec_ts = 300;
 INSERT INTO t1 values (7);
 INSERT INTO t1 values (9);
+set global rocksdb_debug_ttl_rec_ts = 0;
 
 UPDATE t1 SET a=a+1;
 --sorted_result
@@ -447,6 +467,7 @@ SELECT * FROM t1;
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
 
+# 1,3,5 should be dropped
 --sorted_result
 SELECT * FROM t1;
 DROP TABLE t1;
@@ -459,19 +480,23 @@ CREATE TABLE t1 (
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=5;ttl_col=b;';
 
+set global rocksdb_debug_ttl_rec_ts = -300;
 INSERT INTO t1 values (1, UNIX_TIMESTAMP());
 INSERT INTO t1 values (3, UNIX_TIMESTAMP());
 INSERT INTO t1 values (5, UNIX_TIMESTAMP());
 INSERT INTO t1 values (7, UNIX_TIMESTAMP());
---real_sleep 5
 
+set global rocksdb_debug_ttl_rec_ts = 300;
 UPDATE t1 SET b=UNIX_TIMESTAMP() WHERE a < 4;
+set global rocksdb_debug_ttl_rec_ts = 0;
+
 --sorted_result
 SELECT a FROM t1;
 
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
 
+# 5 and 7 should be gone here
 --sorted_result
 SELECT a FROM t1;
 DROP TABLE t1;
@@ -483,11 +508,12 @@ CREATE TABLE t1 (
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=1;';
 
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values (1);
 INSERT INTO t1 values (2);
 INSERT INTO t1 values (3);
+set global rocksdb_debug_ttl_rec_ts = 0;
 
---real_sleep 3
 set global rocksdb_enable_ttl=0;
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
@@ -517,10 +543,5 @@ select variable_value into @c from information_schema.global_status where variab
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
 select variable_value-@c from information_schema.global_status where variable_name='rocksdb_rows_expired';
+
 DROP TABLE t1;
-
-SET @@global.rocksdb_update_cf_options = 'default={disable_auto_compactions=false;};';
-SET @@global.rocksdb_update_cf_options = '';
-set global rocksdb_enable_ttl_read_filtering=1;
-
-

--- a/mysql-test/suite/rocksdb/t/ttl_primary.test
+++ b/mysql-test/suite/rocksdb/t/ttl_primary.test
@@ -6,6 +6,9 @@ DROP TABLE IF EXISTS t1;
 
 SET @@global.rocksdb_update_cf_options = 'default={disable_auto_compactions=true;};';
 
+# Disable read filtering for the duration of this test.
+set global rocksdb_enable_ttl_read_filtering=0;
+
 # Basic TTL test
 CREATE TABLE t1 (
 `a` binary(8) NOT NULL,
@@ -518,6 +521,6 @@ DROP TABLE t1;
 
 SET @@global.rocksdb_update_cf_options = 'default={disable_auto_compactions=false;};';
 SET @@global.rocksdb_update_cf_options = '';
-
+set global rocksdb_enable_ttl_read_filtering=1;
 
 

--- a/mysql-test/suite/rocksdb/t/ttl_primary_read_filtering.test
+++ b/mysql-test/suite/rocksdb/t/ttl_primary_read_filtering.test
@@ -1,0 +1,245 @@
+--source include/have_rocksdb.inc
+--source include/have_debug.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS t1;
+--enable_warnings
+
+SET @@global.rocksdb_update_cf_options = 'default={disable_auto_compactions=true;};';
+
+# The purpose of read filtering for tables with TTL is to ensure that during a
+# transaction a key which has expired already but not removed by compaction
+# yet, is not returned to the user.
+#
+# Without this the user might be hit with problems such as disappearing rows
+# within a transaction, etc, because the compaction filter ignores snapshots
+# when filtering keys.
+
+# Basic read filtering test
+CREATE TABLE t1 (
+  a int PRIMARY KEY
+) ENGINE=rocksdb
+COMMENT='ttl_duration=1;';
+
+INSERT INTO t1 values (1);
+INSERT INTO t1 values (2);
+set global rocksdb_force_flush_memtable_now=1;
+
+--sleep 1
+--sorted_result
+SELECT * FROM t1;
+
+select variable_value-@c from information_schema.global_status where variable_name='rocksdb_rows_expired';
+set global rocksdb_compact_cf='default';
+select variable_value-@c from information_schema.global_status where variable_name='rocksdb_rows_expired';
+
+DROP TABLE t1;
+
+# Test that some rows are hidden but others aren't...
+CREATE TABLE t1 (
+  a int PRIMARY KEY,
+  b BIGINT UNSIGNED NOT NULL
+) ENGINE=rocksdb
+COMMENT='ttl_duration=5;';
+
+INSERT INTO t1 values (1, UNIX_TIMESTAMP());
+--sleep 5
+INSERT INTO t1 values (2, UNIX_TIMESTAMP());
+INSERT INTO t1 values (3, UNIX_TIMESTAMP());
+
+set global rocksdb_force_flush_memtable_now=1;
+
+# 1 should be hidden even though compaction hasn't run.
+--sorted_result
+SELECT a FROM t1;
+
+set global rocksdb_compact_cf='default';
+
+# none should be hidden yet, compaction runs but records arent expired
+--sorted_result
+SELECT a FROM t1;
+
+# all should be hidden now, even though compaction hasnt run again
+--sleep 5
+--sorted_result
+SELECT a FROM t1;
+
+DROP TABLE t1;
+
+# Read filtering index scan tests (None of these queries should return any results)
+CREATE TABLE t1 (
+  a int,
+  b int,
+  c int,
+  PRIMARY KEY (a,b,c)
+) ENGINE=rocksdb
+COMMENT='ttl_duration=1;';
+
+INSERT INTO t1 values (0,0,0);
+INSERT INTO t1 values (0,0,1);
+INSERT INTO t1 values (0,1,0);
+INSERT INTO t1 values (0,1,1);
+INSERT INTO t1 values (1,1,2);
+INSERT INTO t1 values (1,2,1);
+INSERT INTO t1 values (1,2,2);
+INSERT INTO t1 values (1,2,3);
+
+select variable_value into @c from information_schema.global_status where variable_name='rocksdb_rows_expired';
+
+set global rocksdb_force_flush_memtable_now=1;
+
+--sleep 1
+# HA_READ_KEY_EXACT, using full key
+SELECT * FROM t1 WHERE a=1 AND b=2 AND c=2;
+
+# HA_READ_KEY_EXACT, not using full key
+SELECT * FROM t1 WHERE a = 1;
+
+# HA_READ_BEFORE_KEY, not using full key
+SELECT max(a) from t1 where a < 3;
+
+#HA_READ_BEFORE_KEY, using full key
+SELECT max(a) from t1 where a < 2 AND b = 1 AND c < 3;
+
+# HA_READ_KEY_OR_NEXT
+SELECT min(a) from t1 where a >= 1;
+
+# HA_READ_AFTER_KEY,              /* Find next rec. after key-record */
+SELECT min(a) from t1 where a > 1;
+
+# HA_READ_PREFIX_LAST,            /* Last key with the same prefix */
+select * from t1 where a=1 and b in (1) order by c desc;
+
+# HA_READ_PREFIX_LAST_OR_PREV,    /* Last or prev key with the same prefix */
+select max(a) from t1 where a <=10;
+
+# need to test read_range_first()
+# calls into read_range_next() and uses compare_keys() to see if its out of
+# range
+select a from t1 where a > 0 and a <= 2;
+
+select variable_value-@c from information_schema.global_status where variable_name='rocksdb_rows_expired';
+set global rocksdb_compact_cf='default';
+select variable_value-@c from information_schema.global_status where variable_name='rocksdb_rows_expired';
+DROP TABLE t1;
+
+
+# duplicate PK value attempt to be inserted when old one is expired...
+# in this case, since it's still inside rocksdb, we don't allow it to be
+# inserted.
+CREATE TABLE t1 (
+  a int PRIMARY KEY
+) ENGINE=rocksdb
+COMMENT='ttl_duration=1;';
+INSERT INTO t1 values (1);
+set global rocksdb_force_flush_memtable_now=1;
+--sleep 1
+SELECT * FROM t1;
+--error 1062
+INSERT INTO t1 values (1);
+DROP TABLE t1;
+
+# Attempt to update expired value, should filter out
+CREATE TABLE t1 (
+  a int PRIMARY KEY
+) ENGINE=rocksdb
+COMMENT='ttl_duration=1;';
+INSERT INTO t1 values (1);
+--sleep 1
+
+--sorted_result
+SELECT * FROM t1;
+
+# No error is thrown here, under the hood rnd_next_with_direction is
+# filtering out the record from being seen in the first place.
+UPDATE t1 set a = 1;
+DROP TABLE t1;
+
+##
+## More tests on update behaviour with expired keys.
+##
+
+CREATE TABLE t1 (
+  a int PRIMARY KEY
+) ENGINE=rocksdb
+COMMENT='ttl_duration=4;';
+INSERT INTO t1 values (1);
+INSERT INTO t1 values (3);
+--sleep 3
+
+INSERT INTO t1 values (5);
+INSERT INTO t1 values (7);
+--sleep 1
+
+# Expect error because expired key (1) is still around under the hood, but
+# this time rnd_next_with_direction finds other non-expired keys (5 and 7). So the
+# execution flow in the SQL layer moves onto update_write_row, where it then
+# finds the dupicate key (1).
+--error 1062
+UPDATE t1 set a = 1;
+
+# get_row_by_rowid tested here via index_read_map_impl
+UPDATE t1 set a = 999 where a = 5;
+--sorted_result
+SELECT * FROM t1;
+
+
+UPDATE t1 set a = a - 1;
+--sorted_result
+SELECT * FROM t1;
+
+DROP TABLE t1;
+
+# Ensure no rows can disappear in the middle of long-running transactions
+# Also ensure repeatable-read works as expected
+connect (con1,localhost,root,,);
+connect (con2,localhost,root,,);
+connection con1;
+
+CREATE TABLE t1 (
+  a int PRIMARY KEY
+) ENGINE=rocksdb
+COMMENT='ttl_duration=3;';
+
+INSERT INTO t1 values (1);
+INSERT INTO t1 values (3);
+INSERT INTO t1 values (5);
+INSERT INTO t1 values (7);
+
+--echo # Creating Snapshot (start transaction)
+BEGIN;
+--sorted_result
+SELECT * FROM t1;
+
+--sleep 3
+
+--sorted_result
+SELECT * FROM t1; # <= shouldn't be filtered out here
+
+--echo # Switching to connection 2
+connection con2;
+set global rocksdb_force_flush_memtable_now=1;
+set global rocksdb_compact_cf='default';
+# filtered out, because on a different connection, on
+# this connection the records have 'expired' already so they are filtered out
+# even though they have not yet been removed by compaction
+--sorted_result
+SELECT * FROM t1;
+
+--echo # Switching to connection 1
+connection con1;
+--sorted_result
+SELECT * FROM t1; # <= shouldn't be filtered out here
+
+UPDATE t1 set a = a + 1;
+--sorted_result
+SELECT * FROM t1; # <= shouldn't be filtered out here
+
+COMMIT;
+
+--sorted_result # <= filtered out here because time has past.  This is correct.
+SELECT * FROM t1;
+
+DROP TABLE t1;
+
+SET @@global.rocksdb_update_cf_options = '';

--- a/mysql-test/suite/rocksdb/t/ttl_primary_read_filtering.test
+++ b/mysql-test/suite/rocksdb/t/ttl_primary_read_filtering.test
@@ -1,11 +1,5 @@
---source include/have_rocksdb.inc
 --source include/have_debug.inc
-
---disable_warnings
-DROP TABLE IF EXISTS t1;
---enable_warnings
-
-SET @@global.rocksdb_update_cf_options = 'default={disable_auto_compactions=true;};';
+--source include/have_rocksdb.inc
 
 # The purpose of read filtering for tables with TTL is to ensure that during a
 # transaction a key which has expired already but not removed by compaction
@@ -21,15 +15,16 @@ CREATE TABLE t1 (
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=1;';
 
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values (1);
 INSERT INTO t1 values (2);
+set global rocksdb_debug_ttl_rec_ts = 0;
 set global rocksdb_force_flush_memtable_now=1;
 
---sleep 1
 --sorted_result
 SELECT * FROM t1;
 
-select variable_value-@c from information_schema.global_status where variable_name='rocksdb_rows_expired';
+select variable_value into @c from information_schema.global_status where variable_name='rocksdb_rows_expired';
 set global rocksdb_compact_cf='default';
 select variable_value-@c from information_schema.global_status where variable_name='rocksdb_rows_expired';
 
@@ -40,12 +35,14 @@ CREATE TABLE t1 (
   a int PRIMARY KEY,
   b BIGINT UNSIGNED NOT NULL
 ) ENGINE=rocksdb
-COMMENT='ttl_duration=5;';
+COMMENT='ttl_duration=10;';
 
+set global rocksdb_debug_ttl_rec_ts = -300;
 INSERT INTO t1 values (1, UNIX_TIMESTAMP());
---sleep 5
+set global rocksdb_debug_ttl_rec_ts = 300;
 INSERT INTO t1 values (2, UNIX_TIMESTAMP());
 INSERT INTO t1 values (3, UNIX_TIMESTAMP());
+set global rocksdb_debug_ttl_rec_ts = 0;
 
 set global rocksdb_force_flush_memtable_now=1;
 
@@ -55,14 +52,48 @@ SELECT a FROM t1;
 
 set global rocksdb_compact_cf='default';
 
-# none should be hidden yet, compaction runs but records arent expired
+# none should be hidden yet, compaction runs but records aren't expired
 --sorted_result
 SELECT a FROM t1;
 
-# all should be hidden now, even though compaction hasnt run again
---sleep 5
+# all should be hidden now, even though compaction hasn't run again
+set global rocksdb_debug_ttl_read_filter_ts = -310;
 --sorted_result
 SELECT a FROM t1;
+set global rocksdb_debug_ttl_read_filter_ts = 0;
+
+DROP TABLE t1;
+
+# Test the filtering code explicitly.
+CREATE TABLE t1 (
+  a int PRIMARY KEY
+) ENGINE=rocksdb
+COMMENT='ttl_duration=1;';
+
+set global rocksdb_debug_ttl_rec_ts = -100;
+INSERT INTO t1 values (1);
+INSERT INTO t1 values (3);
+INSERT INTO t1 values (5);
+INSERT INTO t1 values (7);
+set global rocksdb_debug_ttl_rec_ts = 0;
+
+# should return nothing.
+--sorted_result
+SELECT * FROM t1;
+
+# disable filtering
+set global rocksdb_enable_ttl_read_filtering=0;
+
+# should return everything
+--sorted_result
+SELECT * FROM t1;
+
+# disable filtering
+set global rocksdb_enable_ttl_read_filtering=1;
+
+# should return nothing.
+--sorted_result
+SELECT * FROM t1;
 
 DROP TABLE t1;
 
@@ -75,6 +106,7 @@ CREATE TABLE t1 (
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=1;';
 
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values (0,0,0);
 INSERT INTO t1 values (0,0,1);
 INSERT INTO t1 values (0,1,0);
@@ -83,12 +115,12 @@ INSERT INTO t1 values (1,1,2);
 INSERT INTO t1 values (1,2,1);
 INSERT INTO t1 values (1,2,2);
 INSERT INTO t1 values (1,2,3);
+set global rocksdb_debug_ttl_rec_ts = 0;
 
 select variable_value into @c from information_schema.global_status where variable_name='rocksdb_rows_expired';
 
 set global rocksdb_force_flush_memtable_now=1;
 
---sleep 1
 # HA_READ_KEY_EXACT, using full key
 SELECT * FROM t1 WHERE a=1 AND b=2 AND c=2;
 
@@ -123,29 +155,35 @@ set global rocksdb_compact_cf='default';
 select variable_value-@c from information_schema.global_status where variable_name='rocksdb_rows_expired';
 DROP TABLE t1;
 
-
 # duplicate PK value attempt to be inserted when old one is expired...
-# in this case, since it's still inside rocksdb, we don't allow it to be
-# inserted.
+# in this case, we pretend the expired key was not found and insert into PK
 CREATE TABLE t1 (
   a int PRIMARY KEY
 ) ENGINE=rocksdb
-COMMENT='ttl_duration=1;';
+COMMENT='ttl_duration=100;';
+set global rocksdb_debug_ttl_rec_ts = -110;
 INSERT INTO t1 values (1);
-set global rocksdb_force_flush_memtable_now=1;
---sleep 1
+set global rocksdb_debug_ttl_rec_ts = 0;
+
 SELECT * FROM t1;
---error 1062
+
+# this should work, even if old value is not filtered out yet.
 INSERT INTO t1 values (1);
+
+# should show (1) result
+SELECT * FROM t1;
+
 DROP TABLE t1;
 
 # Attempt to update expired value, should filter out
+set global rocksdb_force_flush_memtable_now=1;
 CREATE TABLE t1 (
   a int PRIMARY KEY
 ) ENGINE=rocksdb
 COMMENT='ttl_duration=1;';
+set global rocksdb_debug_ttl_rec_ts = -100;
 INSERT INTO t1 values (1);
---sleep 1
+set global rocksdb_debug_ttl_rec_ts = 0;
 
 --sorted_result
 SELECT * FROM t1;
@@ -158,31 +196,41 @@ DROP TABLE t1;
 ##
 ## More tests on update behaviour with expired keys.
 ##
-
+set global rocksdb_force_flush_memtable_now=1;
+set global rocksdb_compact_cf='default';
 CREATE TABLE t1 (
-  a int PRIMARY KEY
+  a int PRIMARY KEY,
+  b int
 ) ENGINE=rocksdb
-COMMENT='ttl_duration=4;';
-INSERT INTO t1 values (1);
-INSERT INTO t1 values (3);
---sleep 3
+COMMENT='ttl_duration=100;';
 
-INSERT INTO t1 values (5);
-INSERT INTO t1 values (7);
---sleep 1
+set global rocksdb_debug_ttl_rec_ts = -110;
+INSERT INTO t1 values (1,1);
+INSERT INTO t1 values (3,3);
+set global rocksdb_debug_ttl_rec_ts = 0;
+INSERT INTO t1 values (5,5);
 
-# Expect error because expired key (1) is still around under the hood, but
-# this time rnd_next_with_direction finds other non-expired keys (5 and 7). So the
+# expired key (1) is still around under the hood, but
+# this time rnd_next_with_direction finds non-expired key (5). So the
 # execution flow in the SQL layer moves onto update_write_row, where it then
-# finds the dupicate key (1).
---error 1062
+# finds the duplicate key (1). But the duplicate key is expired, so it allows
+# the overwrite.
 UPDATE t1 set a = 1;
 
-# get_row_by_rowid tested here via index_read_map_impl
-UPDATE t1 set a = 999 where a = 5;
 --sorted_result
 SELECT * FROM t1;
 
+set global rocksdb_enable_ttl_read_filtering=0;
+# 1,1 should be gone, even with read filtering disabled as it has been
+# overwritten
+--sorted_result
+SELECT * FROM t1;
+set global rocksdb_enable_ttl_read_filtering=1;
+
+# get_row_by_rowid tested here via index_read_map_impl
+UPDATE t1 set a = 999 where a = 1;
+--sorted_result
+SELECT * FROM t1;
 
 UPDATE t1 set a = a - 1;
 --sorted_result
@@ -192,35 +240,56 @@ DROP TABLE t1;
 
 # Ensure no rows can disappear in the middle of long-running transactions
 # Also ensure repeatable-read works as expected
+--source include/count_sessions.inc
 connect (con1,localhost,root,,);
 connect (con2,localhost,root,,);
-connection con1;
 
 CREATE TABLE t1 (
   a int PRIMARY KEY
 ) ENGINE=rocksdb
-COMMENT='ttl_duration=3;';
+COMMENT='ttl_duration=5;';
 
 INSERT INTO t1 values (1);
-INSERT INTO t1 values (3);
-INSERT INTO t1 values (5);
-INSERT INTO t1 values (7);
 
+connection con1;
 --echo # Creating Snapshot (start transaction)
 BEGIN;
+
+# We need the below snippet in case establishing con1 took an arbitrary
+# amount of time. See https://github.com/facebook/mysql-5.6/pull/617#discussion_r120525391.
+--disable_query_log
+--let $snapshot_size= `SELECT COUNT(*) FROM t1`
+--let $i= 0
+while ($snapshot_size != 1)
+{
+	if ($i == 1000)
+	{
+		--die Your testing host is too slow for reasonable TTL testing
+	}
+
+  $i++;
+  ROLLBACK;
+	INSERT INTO t1 values (1);
+  BEGIN;
+  --let $snapshot_size= `SELECT COUNT(*) FROM t1`
+}
+--enable_query_log
+
+# Nothing filtered out here
 --sorted_result
 SELECT * FROM t1;
 
---sleep 3
+--sleep 5
 
 --sorted_result
 SELECT * FROM t1; # <= shouldn't be filtered out here
 
 --echo # Switching to connection 2
 connection con2;
+# compaction doesn't do anythign since con1 snapshot is still open
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
-# filtered out, because on a different connection, on
+# read filtered out, because on a different connection, on
 # this connection the records have 'expired' already so they are filtered out
 # even though they have not yet been removed by compaction
 --sorted_result
@@ -237,11 +306,66 @@ SELECT * FROM t1; # <= shouldn't be filtered out here
 
 COMMIT;
 
---sorted_result # <= filtered out here because time has past.  This is correct.
+--sorted_result # <= filtered out here because time has passed.
 SELECT * FROM t1;
 
 DROP TABLE t1;
 disconnect con1;
 disconnect con2;
 
-SET @@global.rocksdb_update_cf_options = '';
+#transaction 1, create a snapshot and select * => returns nothing.
+#transaction 2, insert into table, flush
+#transaction 1, select * => returns nothing, but the snapshot should prevent the compaction code from removing the rows, no matter what the ttl duration is.
+#transaction 2, select * -> sees nothing, disable filter, select * -> sees everything, enable filter, select * -> sees nothing.
+connect (con1,localhost,root,,);
+connect (con2,localhost,root,,);
+set global rocksdb_force_flush_memtable_now=1;
+set global rocksdb_compact_cf='default';
+
+CREATE TABLE t1 (
+  a int PRIMARY KEY
+) ENGINE=rocksdb
+COMMENT='ttl_duration=1;';
+
+--echo # On Connection 1
+connection con1;
+--echo # Creating Snapshot (start transaction)
+BEGIN;
+--sorted_result
+SELECT * FROM t1;
+# Sleep 5 secs after creating snapshot, this ensures any records created after
+# this can't be removed by compaction until this snapshot is released.
+--sleep 5
+
+--echo # On Connection 2
+connection con2;
+set global rocksdb_debug_ttl_rec_ts = -2;
+INSERT INTO t1 values (1);
+INSERT INTO t1 values (3);
+INSERT INTO t1 values (5);
+INSERT INTO t1 values (7);
+set global rocksdb_debug_ttl_rec_ts = 0;
+set global rocksdb_force_flush_memtable_now=1;
+set global rocksdb_compact_cf='default';
+
+--echo # On Connection 1
+connection con1;
+--sorted_result
+SELECT * FROM t1;
+
+--echo # On Connection 2
+connection con2;
+--sorted_result
+SELECT * FROM t1;
+set global rocksdb_enable_ttl_read_filtering=0;
+--sorted_result
+SELECT * FROM t1;
+set global rocksdb_enable_ttl_read_filtering=1;
+
+disconnect con2;
+disconnect con1;
+connection default;
+
+DROP TABLE t1;
+# Wait till we reached the initial number of concurrent sessions
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/rocksdb/t/ttl_primary_read_filtering.test
+++ b/mysql-test/suite/rocksdb/t/ttl_primary_read_filtering.test
@@ -241,5 +241,7 @@ COMMIT;
 SELECT * FROM t1;
 
 DROP TABLE t1;
+disconnect con1;
+disconnect con2;
 
 SET @@global.rocksdb_update_cf_options = '';

--- a/mysql-test/suite/rocksdb/t/ttl_primary_with_partitions-master.opt
+++ b/mysql-test/suite/rocksdb/t/ttl_primary_with_partitions-master.opt
@@ -1,1 +1,2 @@
+--rocksdb_enable_ttl_read_filtering=0
 --rocksdb_default_cf_options=disable_auto_compactions=true

--- a/mysql-test/suite/rocksdb/t/ttl_primary_with_partitions.test
+++ b/mysql-test/suite/rocksdb/t/ttl_primary_with_partitions.test
@@ -7,6 +7,9 @@ DROP TABLE IF EXISTS t2;
 
 SET @@global.rocksdb_update_cf_options = 'default={disable_auto_compactions=true;};';
 
+# Disable read filtering for the duration of this test.
+set global rocksdb_enable_ttl_read_filtering=0;
+
 #
 # Create a table with multiple partitions, but in the comment don't specify
 # that per-partition based column families (CF) should be created. Expect that
@@ -248,3 +251,4 @@ DROP TABLE t1;
 
 SET @@global.rocksdb_update_cf_options = 'default={disable_auto_compactions=false;};';
 SET @@global.rocksdb_update_cf_options = '';
+set global rocksdb_enable_ttl_read_filtering=1;

--- a/mysql-test/suite/rocksdb/t/ttl_primary_with_partitions.test
+++ b/mysql-test/suite/rocksdb/t/ttl_primary_with_partitions.test
@@ -1,14 +1,5 @@
+--source include/have_debug.inc
 --source include/have_rocksdb.inc
-
---disable_warnings
-DROP TABLE IF EXISTS t1;
-DROP TABLE IF EXISTS t2;
---enable_warnings
-
-SET @@global.rocksdb_update_cf_options = 'default={disable_auto_compactions=true;};';
-
-# Disable read filtering for the duration of this test.
-set global rocksdb_enable_ttl_read_filtering=0;
 
 #
 # Create a table with multiple partitions, but in the comment don't specify
@@ -30,6 +21,7 @@ PARTITION BY LIST(c1) (
     PARTITION custom_p2 VALUES IN (3, 6, 9)
 );
 
+set global rocksdb_debug_ttl_rec_ts = -3600;
 INSERT INTO t1 values (1);
 INSERT INTO t1 values (2);
 INSERT INTO t1 values (3);
@@ -39,10 +31,10 @@ INSERT INTO t1 values (6);
 INSERT INTO t1 values (7);
 INSERT INTO t1 values (8);
 INSERT INTO t1 values (9);
+set global rocksdb_debug_ttl_rec_ts = 0;
 
 --sorted_result
 SELECT * FROM t1;
---real_sleep 3
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
 
@@ -60,49 +52,51 @@ DROP TABLE t1;
 # inside all the partitions, verify after compaction that the rows inside the
 # partition with TTL has disappeared.
 #
-
 CREATE TABLE t1 (
     c1 INT,
     c2 INT,
     name VARCHAR(25) NOT NULL,
     PRIMARY KEY (`c1`, `c2`) COMMENT 'custom_p0_cfname=foo;custom_p1_cfname=my_custom_cf;custom_p2_cfname=baz'
 ) ENGINE=ROCKSDB
-COMMENT="custom_p0_ttl_duration=1;custom_p1_ttl_duration=5;"
+COMMENT="custom_p0_ttl_duration=1;custom_p1_ttl_duration=7;"
 PARTITION BY LIST(c1) (
     PARTITION custom_p0 VALUES IN (1, 4, 7),
     PARTITION custom_p1 VALUES IN (2, 5, 8),
     PARTITION custom_p2 VALUES IN (3, 6, 9)
 );
 
+set global rocksdb_debug_ttl_rec_ts = -1200;
 INSERT INTO t1 values (1,1,'a');
+INSERT INTO t1 values (4,4,'aaaa');
+INSERT INTO t1 values (7,7,'aaaaaaa');
+
+set global rocksdb_debug_ttl_rec_ts = 1200;
 INSERT INTO t1 values (2,2,'aa');
 INSERT INTO t1 values (3,3,'aaa');
-INSERT INTO t1 values (4,4,'aaaa');
 INSERT INTO t1 values (5,5,'aaaaa');
 INSERT INTO t1 values (6,6,'aaaaaa');
-INSERT INTO t1 values (7,7,'aaaaaaa');
 INSERT INTO t1 values (8,8,'aaaaaaaa');
 INSERT INTO t1 values (9,9,'aaaaaaaaa');
+set global rocksdb_debug_ttl_rec_ts = 0;
 
 --sorted_result
 SELECT * FROM t1;
---real_sleep 2
+
 set global rocksdb_force_flush_memtable_now=1;
 set @@global.rocksdb_compact_cf = 'foo';
 set @@global.rocksdb_compact_cf = 'my_custom_cf';
-set @@global.rocksdb_compact_cf = 'baz';
 --sorted_result
 SELECT * FROM t1;
 
---real_sleep 4
+set global rocksdb_debug_ttl_snapshot_ts = 3600;
 set @@global.rocksdb_compact_cf = 'foo';
-set @@global.rocksdb_compact_cf = 'baz';
 --sorted_result
 SELECT * FROM t1;
 
 # Now 2,5,8 should be removed (this verifies that TTL is only operating on the
 # particular CF.
 set @@global.rocksdb_compact_cf = 'my_custom_cf';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
 --sorted_result
 SELECT * FROM t1;
 
@@ -120,7 +114,7 @@ CREATE TABLE t1 (
     event DATE,
     PRIMARY KEY (`c1`, `c2`) COMMENT 'custom_p0_cfname=foo;custom_p1_cfname=bar;custom_p2_cfname=baz;'
 ) ENGINE=ROCKSDB
-COMMENT="custom_p0_ttl_duration=100;custom_p2_ttl_duration=5;"
+COMMENT="custom_p0_ttl_duration=9999;custom_p2_ttl_duration=5;"
 PARTITION BY LIST(c1) (
     PARTITION custom_p0 VALUES IN (1, 2, 3),
     PARTITION custom_p1 VALUES IN (4, 5, 6),
@@ -130,32 +124,36 @@ PARTITION BY LIST(c1) (
 INSERT INTO t1 VALUES (1, 1, "one", null);
 INSERT INTO t1 VALUES (2, 2, "two", null);
 INSERT INTO t1 VALUES (3, 3, "three", null);
+
 INSERT INTO t1 VALUES (4, 4, "four", null);
 INSERT INTO t1 VALUES (5, 5, "five", null);
 INSERT INTO t1 VALUES (6, 6, "six", null);
+
 INSERT INTO t1 VALUES (7, 7, "seven", null);
 INSERT INTO t1 VALUES (8, 8, "eight", null);
 INSERT INTO t1 VALUES (9, 9, "nine", null);
-set global rocksdb_force_flush_memtable_now=1;
-set @@global.rocksdb_compact_cf = 'foo';
-set @@global.rocksdb_compact_cf = 'baz';
 
 --sorted_result
 SELECT * FROM t1;
 
 # TTL should be reset after alter table
+set global rocksdb_debug_ttl_rec_ts = 600;
 ALTER TABLE t1 DROP PRIMARY KEY, ADD PRIMARY KEY(`c2`,`c1`) COMMENT 'custom_p0_cfname=foo;custom_p1_cfname=bar;custom_p2_cfname=baz;';
+set global rocksdb_debug_ttl_rec_ts = 0;
 SHOW CREATE TABLE t1;
 
 # ...so nothing should be gone here
+set global rocksdb_debug_ttl_snapshot_ts = 100;
 set global rocksdb_force_flush_memtable_now=1;
 set @@global.rocksdb_compact_cf = 'baz';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
 --sorted_result
 SELECT * FROM t1;
 
---real_sleep 6
+set global rocksdb_debug_ttl_snapshot_ts = 1200;
 set @@global.rocksdb_compact_cf = 'foo';
 set @@global.rocksdb_compact_cf = 'baz';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
 --sorted_result
 SELECT * FROM t1;
 
@@ -176,24 +174,28 @@ CREATE TABLE t1 (
     event DATE,
     PRIMARY KEY (`c1`) COMMENT 'custom_p0_cfname=foo;custom_p1_cfname=bar;custom_p2_cfname=baz;'
 ) ENGINE=ROCKSDB
-COMMENT="ttl_duration=1;custom_p1_ttl_duration=5;custom_p1_ttl_col=c2;custom_p2_ttl_duration=500;"
+COMMENT="ttl_duration=1;custom_p1_ttl_duration=100;custom_p1_ttl_col=c2;custom_p2_ttl_duration=5000;"
 PARTITION BY LIST(c1) (
     PARTITION custom_p0 VALUES IN (1, 2, 3),
     PARTITION custom_p1 VALUES IN (4, 5, 6),
     PARTITION custom_p2 VALUES IN (7, 8, 9)
 );
 
+set global rocksdb_debug_ttl_rec_ts = -300;
 INSERT INTO t1 VALUES (1, UNIX_TIMESTAMP(), "one", null);
 INSERT INTO t1 VALUES (2, UNIX_TIMESTAMP(), "two", null);
 INSERT INTO t1 VALUES (3, UNIX_TIMESTAMP(), "three", null);
+set global rocksdb_debug_ttl_rec_ts = 0;
+
 INSERT INTO t1 VALUES (4, UNIX_TIMESTAMP(), "four", null);
 INSERT INTO t1 VALUES (5, UNIX_TIMESTAMP(), "five", null);
 INSERT INTO t1 VALUES (6, UNIX_TIMESTAMP(), "six", null);
+
 INSERT INTO t1 VALUES (7, UNIX_TIMESTAMP(), "seven", null);
 INSERT INTO t1 VALUES (8, UNIX_TIMESTAMP(), "eight", null);
 INSERT INTO t1 VALUES (9, UNIX_TIMESTAMP(), "nine", null);
+
 set global rocksdb_force_flush_memtable_now=1;
---real_sleep 2
 set @@global.rocksdb_compact_cf = 'foo';
 set @@global.rocksdb_compact_cf = 'baz';
 set @@global.rocksdb_compact_cf = 'bar';
@@ -203,8 +205,9 @@ set @@global.rocksdb_compact_cf = 'bar';
 SELECT c1 FROM t1;
 
 # here we expect only 4,5,6 to be gone, ttl based on column c2.
---real_sleep 4
+set global rocksdb_debug_ttl_snapshot_ts = 600;
 set @@global.rocksdb_compact_cf = 'bar';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
 --sorted_result
 SELECT c1 FROM t1;
 
@@ -222,7 +225,7 @@ CREATE TABLE t1 (
     c2 BIGINT UNSIGNED NOT NULL,
     PRIMARY KEY (`c1`, `c2`)
 ) ENGINE=ROCKSDB
-COMMENT="ttl_duration=5;ttl_col=c2;"
+COMMENT="ttl_duration=100;ttl_col=c2;"
 PARTITION BY LIST(c1) (
     PARTITION custom_p0 VALUES IN (1),
     PARTITION custom_p1 VALUES IN (2),
@@ -233,7 +236,6 @@ INSERT INTO t1 values (1, UNIX_TIMESTAMP());
 INSERT INTO t1 values (2, UNIX_TIMESTAMP());
 INSERT INTO t1 values (3, UNIX_TIMESTAMP());
 
---real_sleep 1
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
 
@@ -241,14 +243,11 @@ set global rocksdb_compact_cf='default';
 --sorted_result
 SELECT c1 FROM t1;
 
---real_sleep 5
+set global rocksdb_debug_ttl_snapshot_ts = 300;
 set global rocksdb_compact_cf='default';
+set global rocksdb_debug_ttl_snapshot_ts = 0;
 # everything should now be gone
 --sorted_result
 SELECT c1 FROM t1;
 
 DROP TABLE t1;
-
-SET @@global.rocksdb_update_cf_options = 'default={disable_auto_compactions=false;};';
-SET @@global.rocksdb_update_cf_options = '';
-set global rocksdb_enable_ttl_read_filtering=1;

--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_debug_ttl_read_filter_ts_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_debug_ttl_read_filter_ts_basic.result
@@ -1,0 +1,46 @@
+CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(2400);
+INSERT INTO valid_values VALUES(-2400);
+CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO invalid_values VALUES('\'aaa\'');
+SET @start_global_value = @@global.ROCKSDB_DEBUG_TTL_READ_FILTER_TS;
+SELECT @start_global_value;
+@start_global_value
+0
+'# Setting to valid values in global scope#'
+"Trying to set variable @@global.ROCKSDB_DEBUG_TTL_READ_FILTER_TS to 2400"
+SET @@global.ROCKSDB_DEBUG_TTL_READ_FILTER_TS   = 2400;
+SELECT @@global.ROCKSDB_DEBUG_TTL_READ_FILTER_TS;
+@@global.ROCKSDB_DEBUG_TTL_READ_FILTER_TS
+2400
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_DEBUG_TTL_READ_FILTER_TS = DEFAULT;
+SELECT @@global.ROCKSDB_DEBUG_TTL_READ_FILTER_TS;
+@@global.ROCKSDB_DEBUG_TTL_READ_FILTER_TS
+0
+"Trying to set variable @@global.ROCKSDB_DEBUG_TTL_READ_FILTER_TS to -2400"
+SET @@global.ROCKSDB_DEBUG_TTL_READ_FILTER_TS   = -2400;
+SELECT @@global.ROCKSDB_DEBUG_TTL_READ_FILTER_TS;
+@@global.ROCKSDB_DEBUG_TTL_READ_FILTER_TS
+-2400
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_DEBUG_TTL_READ_FILTER_TS = DEFAULT;
+SELECT @@global.ROCKSDB_DEBUG_TTL_READ_FILTER_TS;
+@@global.ROCKSDB_DEBUG_TTL_READ_FILTER_TS
+0
+"Trying to set variable @@session.ROCKSDB_DEBUG_TTL_READ_FILTER_TS to 444. It should fail because it is not session."
+SET @@session.ROCKSDB_DEBUG_TTL_READ_FILTER_TS   = 444;
+ERROR HY000: Variable 'rocksdb_debug_ttl_read_filter_ts' is a GLOBAL variable and should be set with SET GLOBAL
+'# Testing with invalid values in global scope #'
+"Trying to set variable @@global.ROCKSDB_DEBUG_TTL_READ_FILTER_TS to 'aaa'"
+SET @@global.ROCKSDB_DEBUG_TTL_READ_FILTER_TS   = 'aaa';
+Got one of the listed errors
+SELECT @@global.ROCKSDB_DEBUG_TTL_READ_FILTER_TS;
+@@global.ROCKSDB_DEBUG_TTL_READ_FILTER_TS
+0
+SET @@global.ROCKSDB_DEBUG_TTL_READ_FILTER_TS = @start_global_value;
+SELECT @@global.ROCKSDB_DEBUG_TTL_READ_FILTER_TS;
+@@global.ROCKSDB_DEBUG_TTL_READ_FILTER_TS
+0
+DROP TABLE valid_values;
+DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_debug_ttl_rec_ts_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_debug_ttl_rec_ts_basic.result
@@ -1,0 +1,46 @@
+CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(2400);
+INSERT INTO valid_values VALUES(-2400);
+CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO invalid_values VALUES('\'aaa\'');
+SET @start_global_value = @@global.ROCKSDB_DEBUG_TTL_REC_TS;
+SELECT @start_global_value;
+@start_global_value
+0
+'# Setting to valid values in global scope#'
+"Trying to set variable @@global.ROCKSDB_DEBUG_TTL_REC_TS to 2400"
+SET @@global.ROCKSDB_DEBUG_TTL_REC_TS   = 2400;
+SELECT @@global.ROCKSDB_DEBUG_TTL_REC_TS;
+@@global.ROCKSDB_DEBUG_TTL_REC_TS
+2400
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_DEBUG_TTL_REC_TS = DEFAULT;
+SELECT @@global.ROCKSDB_DEBUG_TTL_REC_TS;
+@@global.ROCKSDB_DEBUG_TTL_REC_TS
+0
+"Trying to set variable @@global.ROCKSDB_DEBUG_TTL_REC_TS to -2400"
+SET @@global.ROCKSDB_DEBUG_TTL_REC_TS   = -2400;
+SELECT @@global.ROCKSDB_DEBUG_TTL_REC_TS;
+@@global.ROCKSDB_DEBUG_TTL_REC_TS
+-2400
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_DEBUG_TTL_REC_TS = DEFAULT;
+SELECT @@global.ROCKSDB_DEBUG_TTL_REC_TS;
+@@global.ROCKSDB_DEBUG_TTL_REC_TS
+0
+"Trying to set variable @@session.ROCKSDB_DEBUG_TTL_REC_TS to 444. It should fail because it is not session."
+SET @@session.ROCKSDB_DEBUG_TTL_REC_TS   = 444;
+ERROR HY000: Variable 'rocksdb_debug_ttl_rec_ts' is a GLOBAL variable and should be set with SET GLOBAL
+'# Testing with invalid values in global scope #'
+"Trying to set variable @@global.ROCKSDB_DEBUG_TTL_REC_TS to 'aaa'"
+SET @@global.ROCKSDB_DEBUG_TTL_REC_TS   = 'aaa';
+Got one of the listed errors
+SELECT @@global.ROCKSDB_DEBUG_TTL_REC_TS;
+@@global.ROCKSDB_DEBUG_TTL_REC_TS
+0
+SET @@global.ROCKSDB_DEBUG_TTL_REC_TS = @start_global_value;
+SELECT @@global.ROCKSDB_DEBUG_TTL_REC_TS;
+@@global.ROCKSDB_DEBUG_TTL_REC_TS
+0
+DROP TABLE valid_values;
+DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_debug_ttl_snapshot_ts_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_debug_ttl_snapshot_ts_basic.result
@@ -1,0 +1,46 @@
+CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(2400);
+INSERT INTO valid_values VALUES(-2400);
+CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO invalid_values VALUES('\'aaa\'');
+SET @start_global_value = @@global.ROCKSDB_DEBUG_TTL_SNAPSHOT_TS;
+SELECT @start_global_value;
+@start_global_value
+0
+'# Setting to valid values in global scope#'
+"Trying to set variable @@global.ROCKSDB_DEBUG_TTL_SNAPSHOT_TS to 2400"
+SET @@global.ROCKSDB_DEBUG_TTL_SNAPSHOT_TS   = 2400;
+SELECT @@global.ROCKSDB_DEBUG_TTL_SNAPSHOT_TS;
+@@global.ROCKSDB_DEBUG_TTL_SNAPSHOT_TS
+2400
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_DEBUG_TTL_SNAPSHOT_TS = DEFAULT;
+SELECT @@global.ROCKSDB_DEBUG_TTL_SNAPSHOT_TS;
+@@global.ROCKSDB_DEBUG_TTL_SNAPSHOT_TS
+0
+"Trying to set variable @@global.ROCKSDB_DEBUG_TTL_SNAPSHOT_TS to -2400"
+SET @@global.ROCKSDB_DEBUG_TTL_SNAPSHOT_TS   = -2400;
+SELECT @@global.ROCKSDB_DEBUG_TTL_SNAPSHOT_TS;
+@@global.ROCKSDB_DEBUG_TTL_SNAPSHOT_TS
+-2400
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_DEBUG_TTL_SNAPSHOT_TS = DEFAULT;
+SELECT @@global.ROCKSDB_DEBUG_TTL_SNAPSHOT_TS;
+@@global.ROCKSDB_DEBUG_TTL_SNAPSHOT_TS
+0
+"Trying to set variable @@session.ROCKSDB_DEBUG_TTL_SNAPSHOT_TS to 444. It should fail because it is not session."
+SET @@session.ROCKSDB_DEBUG_TTL_SNAPSHOT_TS   = 444;
+ERROR HY000: Variable 'rocksdb_debug_ttl_snapshot_ts' is a GLOBAL variable and should be set with SET GLOBAL
+'# Testing with invalid values in global scope #'
+"Trying to set variable @@global.ROCKSDB_DEBUG_TTL_SNAPSHOT_TS to 'aaa'"
+SET @@global.ROCKSDB_DEBUG_TTL_SNAPSHOT_TS   = 'aaa';
+Got one of the listed errors
+SELECT @@global.ROCKSDB_DEBUG_TTL_SNAPSHOT_TS;
+@@global.ROCKSDB_DEBUG_TTL_SNAPSHOT_TS
+0
+SET @@global.ROCKSDB_DEBUG_TTL_SNAPSHOT_TS = @start_global_value;
+SELECT @@global.ROCKSDB_DEBUG_TTL_SNAPSHOT_TS;
+@@global.ROCKSDB_DEBUG_TTL_SNAPSHOT_TS
+0
+DROP TABLE valid_values;
+DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_enable_ttl_read_filtering_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_enable_ttl_read_filtering_basic.result
@@ -1,0 +1,64 @@
+CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(1);
+INSERT INTO valid_values VALUES(0);
+INSERT INTO valid_values VALUES('on');
+CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO invalid_values VALUES('\'aaa\'');
+INSERT INTO invalid_values VALUES('\'bbb\'');
+SET @start_global_value = @@global.ROCKSDB_ENABLE_TTL_READ_FILTERING;
+SELECT @start_global_value;
+@start_global_value
+1
+'# Setting to valid values in global scope#'
+"Trying to set variable @@global.ROCKSDB_ENABLE_TTL_READ_FILTERING to 1"
+SET @@global.ROCKSDB_ENABLE_TTL_READ_FILTERING   = 1;
+SELECT @@global.ROCKSDB_ENABLE_TTL_READ_FILTERING;
+@@global.ROCKSDB_ENABLE_TTL_READ_FILTERING
+1
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_ENABLE_TTL_READ_FILTERING = DEFAULT;
+SELECT @@global.ROCKSDB_ENABLE_TTL_READ_FILTERING;
+@@global.ROCKSDB_ENABLE_TTL_READ_FILTERING
+1
+"Trying to set variable @@global.ROCKSDB_ENABLE_TTL_READ_FILTERING to 0"
+SET @@global.ROCKSDB_ENABLE_TTL_READ_FILTERING   = 0;
+SELECT @@global.ROCKSDB_ENABLE_TTL_READ_FILTERING;
+@@global.ROCKSDB_ENABLE_TTL_READ_FILTERING
+0
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_ENABLE_TTL_READ_FILTERING = DEFAULT;
+SELECT @@global.ROCKSDB_ENABLE_TTL_READ_FILTERING;
+@@global.ROCKSDB_ENABLE_TTL_READ_FILTERING
+1
+"Trying to set variable @@global.ROCKSDB_ENABLE_TTL_READ_FILTERING to on"
+SET @@global.ROCKSDB_ENABLE_TTL_READ_FILTERING   = on;
+SELECT @@global.ROCKSDB_ENABLE_TTL_READ_FILTERING;
+@@global.ROCKSDB_ENABLE_TTL_READ_FILTERING
+1
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_ENABLE_TTL_READ_FILTERING = DEFAULT;
+SELECT @@global.ROCKSDB_ENABLE_TTL_READ_FILTERING;
+@@global.ROCKSDB_ENABLE_TTL_READ_FILTERING
+1
+"Trying to set variable @@session.ROCKSDB_ENABLE_TTL_READ_FILTERING to 444. It should fail because it is not session."
+SET @@session.ROCKSDB_ENABLE_TTL_READ_FILTERING   = 444;
+ERROR HY000: Variable 'rocksdb_enable_ttl_read_filtering' is a GLOBAL variable and should be set with SET GLOBAL
+'# Testing with invalid values in global scope #'
+"Trying to set variable @@global.ROCKSDB_ENABLE_TTL_READ_FILTERING to 'aaa'"
+SET @@global.ROCKSDB_ENABLE_TTL_READ_FILTERING   = 'aaa';
+Got one of the listed errors
+SELECT @@global.ROCKSDB_ENABLE_TTL_READ_FILTERING;
+@@global.ROCKSDB_ENABLE_TTL_READ_FILTERING
+1
+"Trying to set variable @@global.ROCKSDB_ENABLE_TTL_READ_FILTERING to 'bbb'"
+SET @@global.ROCKSDB_ENABLE_TTL_READ_FILTERING   = 'bbb';
+Got one of the listed errors
+SELECT @@global.ROCKSDB_ENABLE_TTL_READ_FILTERING;
+@@global.ROCKSDB_ENABLE_TTL_READ_FILTERING
+1
+SET @@global.ROCKSDB_ENABLE_TTL_READ_FILTERING = @start_global_value;
+SELECT @@global.ROCKSDB_ENABLE_TTL_READ_FILTERING;
+@@global.ROCKSDB_ENABLE_TTL_READ_FILTERING
+1
+DROP TABLE valid_values;
+DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_debug_ttl_read_filter_ts_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_debug_ttl_read_filter_ts_basic.test
@@ -1,0 +1,16 @@
+--source include/have_rocksdb.inc
+
+CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(2400);
+INSERT INTO valid_values VALUES(-2400);
+
+CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO invalid_values VALUES('\'aaa\'');
+
+--let $sys_var=ROCKSDB_DEBUG_TTL_READ_FILTER_TS
+--let $read_only=0
+--let $session=0
+--source suite/sys_vars/inc/rocksdb_sys_var.inc
+
+DROP TABLE valid_values;
+DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_debug_ttl_read_filter_ts_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_debug_ttl_read_filter_ts_basic.test
@@ -10,7 +10,7 @@ INSERT INTO invalid_values VALUES('\'aaa\'');
 --let $sys_var=ROCKSDB_DEBUG_TTL_READ_FILTER_TS
 --let $read_only=0
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_debug_ttl_rec_ts_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_debug_ttl_rec_ts_basic.test
@@ -1,0 +1,16 @@
+--source include/have_rocksdb.inc
+
+CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(2400);
+INSERT INTO valid_values VALUES(-2400);
+
+CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO invalid_values VALUES('\'aaa\'');
+
+--let $sys_var=ROCKSDB_DEBUG_TTL_REC_TS
+--let $read_only=0
+--let $session=0
+--source suite/sys_vars/inc/rocksdb_sys_var.inc
+
+DROP TABLE valid_values;
+DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_debug_ttl_rec_ts_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_debug_ttl_rec_ts_basic.test
@@ -10,7 +10,7 @@ INSERT INTO invalid_values VALUES('\'aaa\'');
 --let $sys_var=ROCKSDB_DEBUG_TTL_REC_TS
 --let $read_only=0
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_debug_ttl_snapshot_ts_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_debug_ttl_snapshot_ts_basic.test
@@ -1,0 +1,16 @@
+--source include/have_rocksdb.inc
+
+CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(2400);
+INSERT INTO valid_values VALUES(-2400);
+
+CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO invalid_values VALUES('\'aaa\'');
+
+--let $sys_var=ROCKSDB_DEBUG_TTL_SNAPSHOT_TS
+--let $read_only=0
+--let $session=0
+--source suite/sys_vars/inc/rocksdb_sys_var.inc
+
+DROP TABLE valid_values;
+DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_debug_ttl_snapshot_ts_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_debug_ttl_snapshot_ts_basic.test
@@ -10,7 +10,7 @@ INSERT INTO invalid_values VALUES('\'aaa\'');
 --let $sys_var=ROCKSDB_DEBUG_TTL_SNAPSHOT_TS
 --let $read_only=0
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_enable_ttl_read_filtering_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_enable_ttl_read_filtering_basic.test
@@ -12,7 +12,7 @@ INSERT INTO invalid_values VALUES('\'bbb\'');
 --let $sys_var=ROCKSDB_ENABLE_TTL_READ_FILTERING
 --let $read_only=0
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_enable_ttl_read_filtering_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_enable_ttl_read_filtering_basic.test
@@ -1,0 +1,18 @@
+--source include/have_rocksdb.inc
+
+CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(1);
+INSERT INTO valid_values VALUES(0);
+INSERT INTO valid_values VALUES('on');
+
+CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO invalid_values VALUES('\'aaa\'');
+INSERT INTO invalid_values VALUES('\'bbb\'');
+
+--let $sys_var=ROCKSDB_ENABLE_TTL_READ_FILTERING
+--let $read_only=0
+--let $session=0
+--source suite/sys_vars/inc/rocksdb_sys_var.inc
+
+DROP TABLE valid_values;
+DROP TABLE invalid_values;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -1089,7 +1089,7 @@ static MYSQL_SYSVAR_STR(update_cf_options, rocksdb_update_cf_options,
                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_MEMALLOC |
                             PLUGIN_VAR_ALLOCATED,
                         "Option updates per column family for RocksDB", nullptr,
-                        rocksdb_set_update_cf_options, "");
+                        rocksdb_set_update_cf_options, nullptr);
 
 static MYSQL_SYSVAR_UINT(flush_log_at_trx_commit,
                          rocksdb_flush_log_at_trx_commit, PLUGIN_VAR_RQCMDARG,

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -365,30 +365,6 @@ static void rocksdb_set_pause_background_work(
   RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
 }
 
-static void rocksdb_set_enable_ttl(
-    my_core::THD *const thd,
-    my_core::st_mysql_sys_var *const var MY_ATTRIBUTE((__unused__)),
-    void *const var_ptr, const void *const save) {
-  DBUG_ASSERT(save != nullptr);
-  RDB_MUTEX_LOCK_CHECK(rdb_sysvars_mutex);
-
-  *static_cast<bool *>(var_ptr) = *static_cast<const bool *>(save);
-
-  RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
-}
-
-static void rocksdb_set_enable_ttl_read_filtering(
-    my_core::THD *const thd,
-    my_core::st_mysql_sys_var *const var MY_ATTRIBUTE((__unused__)),
-    void *const var_ptr, const void *const save) {
-  DBUG_ASSERT(save != nullptr);
-  RDB_MUTEX_LOCK_CHECK(rdb_sysvars_mutex);
-
-  *static_cast<bool *>(var_ptr) = *static_cast<const bool *>(save);
-
-  RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
-}
-
 static void rocksdb_set_compaction_options(THD *thd,
                                            struct st_mysql_sys_var *var,
                                            void *var_ptr, const void *save);
@@ -464,6 +440,9 @@ static my_bool rocksdb_force_flush_memtable_now_var = 0;
 static my_bool rocksdb_force_flush_memtable_and_lzero_now_var = 0;
 static my_bool rocksdb_enable_ttl = 1;
 static my_bool rocksdb_enable_ttl_read_filtering = 1;
+static int rocksdb_debug_ttl_rec_ts = 0;
+static int rocksdb_debug_ttl_snapshot_ts = 0;
+static int rocksdb_debug_ttl_read_filter_ts = 0;
 static my_bool rocksdb_reset_stats = 0;
 static uint32_t rocksdb_io_write_timeout_secs = 0;
 static uint64_t rocksdb_number_stat_computes = 0;
@@ -1108,10 +1087,9 @@ static MYSQL_SYSVAR_STR(override_cf_options, rocksdb_override_cf_options,
 
 static MYSQL_SYSVAR_STR(update_cf_options, rocksdb_update_cf_options,
                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_MEMALLOC |
-                        PLUGIN_VAR_ALLOCATED,
-                        "Option updates per column family for RocksDB",
-                        nullptr, rocksdb_set_update_cf_options,
-                        nullptr);
+                            PLUGIN_VAR_ALLOCATED,
+                        "Option updates per column family for RocksDB", nullptr,
+                        rocksdb_set_update_cf_options, "");
 
 static MYSQL_SYSVAR_UINT(flush_log_at_trx_commit,
                          rocksdb_flush_log_at_trx_commit, PLUGIN_VAR_RQCMDARG,
@@ -1191,7 +1169,7 @@ static MYSQL_SYSVAR_BOOL(pause_background_work, rocksdb_pause_background_work,
 static MYSQL_SYSVAR_BOOL(
     enable_ttl, rocksdb_enable_ttl, PLUGIN_VAR_RQCMDARG,
     "Enable expired TTL records to be dropped during compaction.", nullptr,
-    rocksdb_set_enable_ttl, TRUE);
+    nullptr, TRUE);
 
 static MYSQL_SYSVAR_BOOL(
     enable_ttl_read_filtering, rocksdb_enable_ttl_read_filtering,
@@ -1199,8 +1177,34 @@ static MYSQL_SYSVAR_BOOL(
     "For tables with TTL, expired records are skipped/filtered out during "
     "processing and in query results. Disabling this will allow these records "
     "to be seen, but as a result rows may disappear in the middle of "
-    "transactions as they are dropped during compaction. Use with caution. ",
-    nullptr, rocksdb_set_enable_ttl_read_filtering, TRUE);
+    "transactions as they are dropped during compaction. Use with caution.",
+    nullptr, nullptr, TRUE);
+
+static MYSQL_SYSVAR_INT(
+    debug_ttl_rec_ts, rocksdb_debug_ttl_rec_ts, PLUGIN_VAR_RQCMDARG,
+    "For debugging purposes only.  Overrides the TTL of records to "
+    "now() + debug_ttl_rec_ts.  The value can be +/- to simulate "
+    "a record inserted in the past vs a record inserted in the 'future'. "
+    "A value of 0 denotes that the variable is not set. This variable is a "
+    "no-op in non-debug builds.",
+    nullptr, nullptr, 0, /* min */ -3600, /* max */ 3600, 0);
+
+static MYSQL_SYSVAR_INT(
+    debug_ttl_snapshot_ts, rocksdb_debug_ttl_snapshot_ts, PLUGIN_VAR_RQCMDARG,
+    "For debugging purposes only.  Sets the snapshot during compaction to "
+    "now() + debug_set_ttl_snapshot_ts.  The value can be +/- to simulate "
+    "a snapshot in the past vs a snapshot created in the 'future'. "
+    "A value of 0 denotes that the variable is not set. This variable is a "
+    "no-op in non-debug builds.",
+    nullptr, nullptr, 0, /* min */ -3600, /* max */ 3600, 0);
+
+static MYSQL_SYSVAR_INT(
+    debug_ttl_read_filter_ts, rocksdb_debug_ttl_read_filter_ts,
+    PLUGIN_VAR_RQCMDARG,
+    "For debugging purposes only.  Overrides the TTL read filtering time to "
+    "time + debug_ttl_read_filter_ts. A value of 0 denotes that the variable "
+    "is not set. This variable is a no-op in non-debug builds.",
+    nullptr, nullptr, 0, /* min */ -3600, /* max */ 3600, 0);
 
 static MYSQL_SYSVAR_BOOL(
     reset_stats, rocksdb_reset_stats, PLUGIN_VAR_RQCMDARG,
@@ -1464,6 +1468,9 @@ static struct st_mysql_sys_var *rocksdb_system_variables[] = {
     MYSQL_SYSVAR(force_flush_memtable_and_lzero_now),
     MYSQL_SYSVAR(enable_ttl),
     MYSQL_SYSVAR(enable_ttl_read_filtering),
+    MYSQL_SYSVAR(debug_ttl_rec_ts),
+    MYSQL_SYSVAR(debug_ttl_snapshot_ts),
+    MYSQL_SYSVAR(debug_ttl_read_filter_ts),
     MYSQL_SYSVAR(reset_stats),
     MYSQL_SYSVAR(io_write_timeout),
     MYSQL_SYSVAR(flush_memtable_on_analyze),
@@ -4322,7 +4329,6 @@ bool ha_rocksdb::init_with_fields() {
   DBUG_RETURN(false); /* Ok */
 }
 
-
 /*
   If the key is a TTL key, we may need to filter it out.
 
@@ -4334,10 +4340,25 @@ bool ha_rocksdb::init_with_fields() {
   rows within a transaction, etc, because the compaction filter ignores
   snapshots when filtering keys.
 */
-int ha_rocksdb::should_hide_ttl_rec(const rocksdb::Slice &ttl_rec_val,
-                                    const int64_t curr_ts) const {
+bool ha_rocksdb::should_hide_ttl_rec(const rocksdb::Slice &ttl_rec_val,
+                                     const int64_t curr_ts) {
   DBUG_ASSERT(m_pk_descr != nullptr);
   DBUG_ASSERT(m_pk_descr->has_ttl());
+  DBUG_ASSERT(m_pk_descr->m_ttl_rec_offset != UINT_MAX);
+
+  /*
+    Curr_ts can only be 0 if there are no snapshots open.
+    should_hide_ttl_rec can only be called when there is >=1 snapshots, unless
+    we are filtering on the write path (single INSERT/UPDATE) in which case
+    we are passed in the current time as curr_ts.
+
+    In the event curr_ts is 0, we always decide not to filter the record. We
+    also log a warning and increment a diagnostic counter.
+  */
+  if (curr_ts == 0) {
+    update_row_stats(ROWS_HIDDEN_NO_SNAPSHOT);
+    return false;
+  }
 
   if (!rdb_is_ttl_read_filtering_enabled() || !rdb_is_ttl_enabled()) {
     return false;
@@ -4345,8 +4366,11 @@ int ha_rocksdb::should_hide_ttl_rec(const rocksdb::Slice &ttl_rec_val,
 
   Rdb_string_reader reader(&ttl_rec_val);
 
+  /*
+    Find where the 8-byte ttl is for each record in this index.
+  */
   uint64 ts;
-  if (reader.read_uint64(&ts)) {
+  if (!reader.read(m_pk_descr->m_ttl_rec_offset) || reader.read_uint64(&ts)) {
     /*
       This condition should never be reached since all TTL records have an
       8 byte ttl field in front. Don't filter the record out, and log an error.
@@ -4364,8 +4388,12 @@ int ha_rocksdb::should_hide_ttl_rec(const rocksdb::Slice &ttl_rec_val,
   }
 
   /* Hide record if it has expired before the current snapshot time. */
-  uint64 time_diff = std::difftime(curr_ts ? curr_ts : std::time(nullptr), ts);
-  return time_diff >= m_pk_descr->m_ttl_duration;
+  uint64 read_filter_ts = 0;
+#ifndef NDEBUG
+  read_filter_ts += rdb_dbug_set_ttl_read_filter_ts();
+#endif
+  return ts + m_pk_descr->m_ttl_duration + read_filter_ts <=
+         static_cast<uint64>(curr_ts);
 }
 
 /**
@@ -4416,7 +4444,13 @@ int ha_rocksdb::convert_record_to_storage_format(
 
       char *const data = const_cast<char *>(m_storage_record.ptr());
       memcpy(data, ts, ROCKSDB_SIZEOF_TTL_RECORD);
-
+#ifndef NDEBUG
+      // Adjust for test case if needed
+      rdb_netbuf_store_uint64(
+          reinterpret_cast<uchar *>(data),
+          rdb_netbuf_to_uint64(reinterpret_cast<const uchar *>(data)) +
+              rdb_dbug_set_ttl_rec_ts());
+#endif
     } else if (!has_ttl_column) {
       /*
         For implicitly generated TTL records we need to copy over the old
@@ -4430,6 +4464,9 @@ int ha_rocksdb::convert_record_to_storage_format(
         memcpy(data, m_ttl_bytes, sizeof(uint64));
       } else {
         uint64 ts = static_cast<uint64>(std::time(nullptr));
+#ifndef NDEBUG
+        ts += rdb_dbug_set_ttl_rec_ts();
+#endif
         char *const data = const_cast<char *>(m_storage_record.ptr());
         rdb_netbuf_store_uint64(reinterpret_cast<uchar *>(data), ts);
       }
@@ -4509,6 +4546,9 @@ int ha_rocksdb::convert_record_to_storage_format(
 
         char *const data = const_cast<char *>(m_storage_record.ptr());
         uint64 ts = uint8korr(field->ptr);
+#ifndef NDEBUG
+        ts += rdb_dbug_set_ttl_rec_ts();
+#endif
         rdb_netbuf_store_uint64(reinterpret_cast<uchar *>(data), ts);
       }
     }
@@ -4772,9 +4812,13 @@ int ha_rocksdb::convert_record_from_storage_format(
   rocksdb::Slice unpack_slice;
 
   /* If it's a TTL record, skip the 8 byte TTL value */
-  if (m_pk_descr->has_ttl() &&
-      !(m_ttl_bytes = reader.read(ROCKSDB_SIZEOF_TTL_RECORD))) {
-    return HA_ERR_ROCKSDB_CORRUPT_DATA;
+  const char *ttl_bytes;
+  if (m_pk_descr->has_ttl()) {
+    if ((ttl_bytes = reader.read(ROCKSDB_SIZEOF_TTL_RECORD))) {
+      memcpy(m_ttl_bytes, ttl_bytes, ROCKSDB_SIZEOF_TTL_RECORD);
+    } else {
+      return HA_ERR_ROCKSDB_CORRUPT_DATA;
+    }
   }
 
   /* Other fields are decoded from the value */
@@ -5615,14 +5659,9 @@ int ha_rocksdb::create_inplace_key_defs(
       */
       const Rdb_key_def &okd = *old_key_descr[it->second];
 
-      uint16 index_dict_version = 0;
-      uchar index_type = 0;
-      uint16 kv_version = 0;
-      uint64 ttl_duration = 0;
       const GL_INDEX_ID gl_index_id = okd.get_gl_index_id();
-      if (!dict_manager.get_index_info(gl_index_id, &index_dict_version,
-                                       &index_type, &kv_version,
-                                       &ttl_duration)) {
+      struct Rdb_index_info index_info;
+      if (!dict_manager.get_index_info(gl_index_id, &index_info)) {
         // NO_LINT_DEBUG
         sql_print_error("RocksDB: Could not get index information "
                         "for Index Number (%u,%u), table %s",
@@ -5631,16 +5670,25 @@ int ha_rocksdb::create_inplace_key_defs(
         DBUG_RETURN(HA_EXIT_FAILURE);
       }
 
+      uint32 ttl_rec_offset =
+          Rdb_key_def::has_index_flag(index_info.m_index_flags,
+                                      Rdb_key_def::TTL_FLAG)
+              ? Rdb_key_def::calculate_index_flag_offset(
+                    index_info.m_index_flags, Rdb_key_def::TTL_FLAG)
+              : UINT_MAX;
+
       /*
         We can't use the copy constructor because we need to update the
         keynr within the pack_info for each field and the keyno of the keydef
         itself.
       */
       new_key_descr[i] = std::make_shared<Rdb_key_def>(
-          okd.get_index_number(), i, okd.get_cf(), index_dict_version,
-          index_type, kv_version, okd.m_is_reverse_cf,
+          okd.get_index_number(), i, okd.get_cf(),
+          index_info.m_index_dict_version, index_info.m_index_type,
+          index_info.m_kv_version, okd.m_is_reverse_cf,
           okd.m_is_per_partition_cf, okd.m_name.c_str(),
-          dict_manager.get_stats(gl_index_id), ttl_duration);
+          dict_manager.get_stats(gl_index_id), index_info.m_index_flags,
+          ttl_rec_offset, index_info.m_ttl_duration);
     } else if (create_key_def(table_arg, i, tbl_def_arg, &new_key_descr[i],
                               cfs[i])) {
       DBUG_RETURN(HA_EXIT_FAILURE);
@@ -5868,11 +5916,19 @@ int ha_rocksdb::create_key_def(const TABLE *const table_arg, const uint &i,
     kv_version = Rdb_key_def::PRIMARY_FORMAT_VERSION_UPDATE1;
   });
 
+  uint32 index_flags = (ttl_duration > 0 ? Rdb_key_def::TTL_FLAG : 0);
+
+  uint32 ttl_rec_offset =
+      Rdb_key_def::has_index_flag(index_flags, Rdb_key_def::TTL_FLAG)
+          ? Rdb_key_def::calculate_index_flag_offset(index_flags,
+                                                     Rdb_key_def::TTL_FLAG)
+          : UINT_MAX;
+
   const char *const key_name = get_key_name(i, table_arg, m_tbl_def);
   *new_key_def = std::make_shared<Rdb_key_def>(
       index_id, i, cf_info.cf_handle, index_dict_version, index_type,
       kv_version, cf_info.is_reverse_cf, cf_info.is_per_partition_cf, key_name,
-      Rdb_index_stats(), ttl_duration);
+      Rdb_index_stats(), index_flags, ttl_rec_offset, ttl_duration);
 
   if (!ttl_column.empty()) {
     (*new_key_def)->m_ttl_column = ttl_column;
@@ -6198,10 +6254,10 @@ bool ha_rocksdb::check_keyread_allowed(uint inx, uint part,
 }
 
 int ha_rocksdb::read_key_exact(const Rdb_key_def &kd,
-                               Rdb_transaction *const tx,
                                rocksdb::Iterator *const iter,
                                const bool &full_key_match,
-                               const rocksdb::Slice &key_slice) const {
+                               const rocksdb::Slice &key_slice,
+                               const int64_t ttl_filter_ts) {
   DBUG_ASSERT(iter != nullptr);
 
   /*
@@ -6211,72 +6267,62 @@ int ha_rocksdb::read_key_exact(const Rdb_key_def &kd,
   */
   rocksdb_smart_seek(kd.m_is_reverse_cf, iter, key_slice);
 
-  for (;;) {
-    if (!iter->Valid() || !kd.value_matches_prefix(iter->key(), key_slice)) {
-      /*
-        Got a record that is not equal to the lookup value, or even a record
-        from another table.index.
-      */
-      return HA_ERR_KEY_NOT_FOUND;
-    }
-
+  while (iter->Valid() && kd.value_matches_prefix(iter->key(), key_slice)) {
     /*
       If TTL is enabled we need to check if the given key has already expired
       from the POV of the current transaction.  If it has, try going to the next
       key.
     */
-    if (kd.has_ttl() &&
-        should_hide_ttl_rec(iter->value(), tx->m_snapshot_timestamp)) {
+    if (kd.has_ttl() && should_hide_ttl_rec(iter->value(), ttl_filter_ts)) {
       rocksdb_smart_next(kd.m_is_reverse_cf, iter);
       continue;
     }
 
-    break;
+    return HA_EXIT_SUCCESS;
   }
 
-  return HA_EXIT_SUCCESS;
+  /*
+    Got a record that is not equal to the lookup value, or even a record
+    from another table.index.
+  */
+  return HA_ERR_KEY_NOT_FOUND;
 }
 
 int ha_rocksdb::read_before_key(const Rdb_key_def &kd,
-                                Rdb_transaction *const tx,
                                 const bool &full_key_match,
-                                const rocksdb::Slice &key_slice) {
+                                const rocksdb::Slice &key_slice,
+                                const int64_t ttl_filter_ts) {
   /*
     We are looking for record with the biggest t.key such that
     t.key < lookup_tuple.
   */
   rocksdb_smart_seek(!kd.m_is_reverse_cf, m_scan_it, key_slice);
 
-  for (;;) {
-    if (m_scan_it->Valid() && full_key_match &&
-        kd.value_matches_prefix(m_scan_it->key(), key_slice)) {
-      /* We are using full key and we've hit an exact match */
-      rocksdb_smart_next(!kd.m_is_reverse_cf, m_scan_it);
-    }
-
-    if (!m_scan_it->Valid()) {
-      return HA_ERR_KEY_NOT_FOUND;
-    }
-
+  while (m_scan_it->Valid()) {
     /*
+      We are using full key and we've hit an exact match, or...
+
       If TTL is enabled we need to check if the given key has already expired
       from the POV of the current transaction.  If it has, try going to the next
       key.
     */
-    if (kd.has_ttl() &&
-        should_hide_ttl_rec(m_scan_it->value(), tx->m_snapshot_timestamp)) {
+    if ((full_key_match &&
+         kd.value_matches_prefix(m_scan_it->key(), key_slice)) ||
+        (kd.has_ttl() &&
+         should_hide_ttl_rec(m_scan_it->value(), ttl_filter_ts))) {
       rocksdb_smart_next(!kd.m_is_reverse_cf, m_scan_it);
       continue;
     }
 
-    break;
+    return HA_EXIT_SUCCESS;
   }
 
-  return HA_EXIT_SUCCESS;
+  return HA_ERR_KEY_NOT_FOUND;
 }
 
-int ha_rocksdb::read_after_key(const Rdb_key_def &kd, Rdb_transaction *const tx,
-                               const rocksdb::Slice &key_slice) {
+int ha_rocksdb::read_after_key(const Rdb_key_def &kd,
+                               const rocksdb::Slice &key_slice,
+                               const int64_t ttl_filter_ts) {
   /*
     We are looking for the first record such that
 
@@ -6287,44 +6333,36 @@ int ha_rocksdb::read_after_key(const Rdb_key_def &kd, Rdb_transaction *const tx,
   */
   rocksdb_smart_seek(kd.m_is_reverse_cf, m_scan_it, key_slice);
 
-  for (;;) {
-    if (!m_scan_it->Valid()) {
-      return HA_ERR_KEY_NOT_FOUND;
-    }
-
-    /*
-      If TTL is enabled we need to check if the given key has already expired
-      from the POV of the current transaction.  If it has, try going to the next
-      key.
-    */
-    if (kd.has_ttl() &&
-        should_hide_ttl_rec(m_scan_it->value(), tx->m_snapshot_timestamp)) {
-      rocksdb_smart_next(kd.m_is_reverse_cf, m_scan_it);
-      continue;
-    }
-
-    break;
+  /*
+    If TTL is enabled we need to check if the given key has already expired
+    from the POV of the current transaction.  If it has, try going to the next
+    key.
+  */
+  while (m_scan_it->Valid() && kd.has_ttl() &&
+         should_hide_ttl_rec(m_scan_it->value(), ttl_filter_ts)) {
+    rocksdb_smart_next(kd.m_is_reverse_cf, m_scan_it);
   }
 
-  return HA_EXIT_SUCCESS;
+  return m_scan_it->Valid() ? HA_EXIT_SUCCESS : HA_ERR_KEY_NOT_FOUND;
 }
 
 int ha_rocksdb::position_to_correct_key(
-    const Rdb_key_def &kd, Rdb_transaction *const tx,
-    const enum ha_rkey_function &find_flag, const bool &full_key_match,
-    const uchar *const key, const key_part_map &keypart_map,
-    const rocksdb::Slice &key_slice, bool *const move_forward) {
+    const Rdb_key_def &kd, const enum ha_rkey_function &find_flag,
+    const bool &full_key_match, const uchar *const key,
+    const key_part_map &keypart_map, const rocksdb::Slice &key_slice,
+    bool *const move_forward, const int64_t ttl_filter_ts) {
   int rc = 0;
 
   *move_forward = true;
 
   switch (find_flag) {
   case HA_READ_KEY_EXACT:
-    rc = read_key_exact(kd, tx, m_scan_it, full_key_match, key_slice);
+    rc =
+        read_key_exact(kd, m_scan_it, full_key_match, key_slice, ttl_filter_ts);
     break;
   case HA_READ_BEFORE_KEY:
     *move_forward = false;
-    rc = read_before_key(kd, tx, full_key_match, key_slice);
+    rc = read_before_key(kd, full_key_match, key_slice, ttl_filter_ts);
     if (rc == 0 && !kd.covers_key(m_scan_it->key())) {
       /* The record we've got is not from this index */
       rc = HA_ERR_KEY_NOT_FOUND;
@@ -6332,7 +6370,7 @@ int ha_rocksdb::position_to_correct_key(
     break;
   case HA_READ_AFTER_KEY:
   case HA_READ_KEY_OR_NEXT:
-    rc = read_after_key(kd, tx, key_slice);
+    rc = read_after_key(kd, key_slice, ttl_filter_ts);
     if (rc == 0 && !kd.covers_key(m_scan_it->key())) {
       /* The record we've got is not from this index */
       rc = HA_ERR_KEY_NOT_FOUND;
@@ -6355,7 +6393,7 @@ int ha_rocksdb::position_to_correct_key(
         records with prefix=lookup, we should return the last record
         before that.
     */
-    rc = read_before_key(kd, tx, full_key_match, key_slice);
+    rc = read_before_key(kd, full_key_match, key_slice, ttl_filter_ts);
     if (rc == 0) {
       const rocksdb::Slice &rkey = m_scan_it->key();
       if (!kd.covers_key(rkey)) {
@@ -6799,8 +6837,9 @@ int ha_rocksdb::index_read_map_impl(uchar *const buf, const uchar *const key,
       want: See storage/rocksdb/rocksdb-range-access.txt
     */
     bool move_forward;
-    rc = position_to_correct_key(kd, tx, find_flag, using_full_key, key,
-                                 keypart_map, slice, &move_forward);
+    rc =
+        position_to_correct_key(kd, find_flag, using_full_key, key, keypart_map,
+                                slice, &move_forward, tx->m_snapshot_timestamp);
 
     if (rc) {
       /* This status is returned on any error */
@@ -7895,7 +7934,7 @@ int ha_rocksdb::check_and_lock_unique_pk(const uint &key_id,
 
 int ha_rocksdb::check_and_lock_sk(const uint &key_id,
                                   const struct update_row_info &row_info,
-                                  bool *const found) const {
+                                  bool *const found) {
   DBUG_ASSERT(found != nullptr);
   *found = false;
 
@@ -8009,7 +8048,8 @@ int ha_rocksdb::check_and_lock_sk(const uint &key_id,
     in the transaction.
   */
   iter->Seek(new_slice);
-  *found = !read_key_exact(kd, row_info.tx, iter, all_parts_used, new_slice);
+  *found = !read_key_exact(kd, iter, all_parts_used, new_slice,
+                           row_info.tx->m_snapshot_timestamp);
   delete iter;
 
   return HA_EXIT_SUCCESS;
@@ -8035,6 +8075,20 @@ int ha_rocksdb::check_uniqueness_and_lock(
 
     if (rc != HA_EXIT_SUCCESS) {
       return rc;
+    }
+
+    /*
+      If the pk key has ttl, we may need to pretend the row wasn't
+      found if it is already expired. The pk record is read into
+      m_retrieved_record by check_and_lock_unique_pk().
+    */
+    if (is_pk(key_id, table, m_tbl_def) && found && m_pk_descr->has_ttl() &&
+        should_hide_ttl_rec(rocksdb::Slice(&m_retrieved_record.front(),
+                                           m_retrieved_record.size()),
+                            (row_info.tx->m_snapshot_timestamp
+                                 ? row_info.tx->m_snapshot_timestamp
+                                 : static_cast<int64_t>(std::time(nullptr))))) {
+      found = false;
     }
 
     if (found) {
@@ -11042,6 +11096,13 @@ bool rdb_is_ttl_enabled() { return rocksdb_enable_ttl; }
 bool rdb_is_ttl_read_filtering_enabled() {
   return rocksdb_enable_ttl_read_filtering;
 }
+#ifndef NDEBUG
+int rdb_dbug_set_ttl_rec_ts() { return rocksdb_debug_ttl_rec_ts; }
+int rdb_dbug_set_ttl_snapshot_ts() { return rocksdb_debug_ttl_snapshot_ts; }
+int rdb_dbug_set_ttl_read_filter_ts() {
+  return rocksdb_debug_ttl_read_filter_ts;
+}
+#endif
 
 void rdb_update_global_stats(const operation_type &type, uint count,
                              bool is_system_table) {

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -338,6 +338,7 @@ enum operation_type : int {
   ROWS_UPDATED,
   ROWS_DELETED_BLIND,
   ROWS_EXPIRED,
+  ROWS_HIDDEN_NO_SNAPSHOT,
   ROWS_MAX
 };
 
@@ -368,6 +369,7 @@ struct st_export_stats {
   ulonglong rows_updated;
   ulonglong rows_deleted_blind;
   ulonglong rows_expired;
+  ulonglong rows_hidden_no_snapshot;
 
   ulonglong system_rows_deleted;
   ulonglong system_rows_inserted;
@@ -491,7 +493,7 @@ class ha_rocksdb : public my_core::handler {
   /*
     Pointer to the original TTL timestamp value (8 bytes) during UPDATE.
   */
-  const char *m_ttl_bytes;
+  char m_ttl_bytes[ROCKSDB_SIZEOF_TTL_RECORD];
 
   /* rowkey of the last record we've read, in StorageFormat. */
   String m_last_rowkey;
@@ -1037,8 +1039,8 @@ private:
                                        rocksdb::Slice *const packed_rec)
       MY_ATTRIBUTE((__nonnull__));
 
-  int should_hide_ttl_rec(const rocksdb::Slice &ttl_rec_val,
-                          const int64_t curr_ts) const
+  bool should_hide_ttl_rec(const rocksdb::Slice &ttl_rec_val,
+                           const int64_t curr_ts)
       MY_ATTRIBUTE((__warn_unused_result__));
 
   int index_first_intern(uchar *buf)
@@ -1061,7 +1063,7 @@ private:
       MY_ATTRIBUTE((__warn_unused_result__));
   int check_and_lock_sk(const uint &key_id,
                         const struct update_row_info &row_info,
-                        bool *const found) const
+                        bool *const found)
       MY_ATTRIBUTE((__warn_unused_result__));
   int check_uniqueness_and_lock(const struct update_row_info &row_info,
                                 bool *const pk_changed)
@@ -1084,24 +1086,23 @@ private:
                      const bool &pk_changed)
       MY_ATTRIBUTE((__warn_unused_result__));
 
-  int read_key_exact(const Rdb_key_def &kd, Rdb_transaction *const tx,
-                     rocksdb::Iterator *const iter, const bool &using_full_key,
-                     const rocksdb::Slice &key_slice) const
+  int read_key_exact(const Rdb_key_def &kd, rocksdb::Iterator *const iter,
+                     const bool &using_full_key,
+                     const rocksdb::Slice &key_slice,
+                     const int64_t ttl_filter_ts)
       MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
-  int read_before_key(const Rdb_key_def &kd, Rdb_transaction *const tx,
-                      const bool &using_full_key,
-                      const rocksdb::Slice &key_slice)
+  int read_before_key(const Rdb_key_def &kd, const bool &using_full_key,
+                      const rocksdb::Slice &key_slice,
+                      const int64_t ttl_filter_ts)
       MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
-  int read_after_key(const Rdb_key_def &kd, Rdb_transaction *const tx,
-                     const rocksdb::Slice &key_slice)
+  int read_after_key(const Rdb_key_def &kd, const rocksdb::Slice &key_slice,
+                     const int64_t ttl_filter_ts)
       MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
-  int position_to_correct_key(const Rdb_key_def &kd, Rdb_transaction *const tx,
-                              const enum ha_rkey_function &find_flag,
-                              const bool &full_key_match,
-                              const uchar *const key,
-                              const key_part_map &keypart_map,
-                              const rocksdb::Slice &key_slice,
-                              bool *const move_forward)
+  int position_to_correct_key(
+      const Rdb_key_def &kd, const enum ha_rkey_function &find_flag,
+      const bool &full_key_match, const uchar *const key,
+      const key_part_map &keypart_map, const rocksdb::Slice &key_slice,
+      bool *const move_forward, const int64_t ttl_filter_ts)
       MY_ATTRIBUTE((__warn_unused_result__));
 
   int read_row_from_primary_key(uchar *const buf)
@@ -1318,5 +1319,4 @@ private:
   Rdb_inplace_alter_ctx(const Rdb_inplace_alter_ctx &);
   Rdb_inplace_alter_ctx &operator=(const Rdb_inplace_alter_ctx &);
 };
-
 } // namespace myrocks

--- a/storage/rocksdb/ha_rocksdb_proto.h
+++ b/storage/rocksdb/ha_rocksdb_proto.h
@@ -72,6 +72,11 @@ Rdb_cf_manager &rdb_get_cf_manager();
 const rocksdb::BlockBasedTableOptions &rdb_get_table_options();
 bool rdb_is_ttl_enabled();
 bool rdb_is_ttl_read_filtering_enabled();
+#ifndef NDEBUG
+int rdb_dbug_set_ttl_rec_ts();
+int rdb_dbug_set_ttl_snapshot_ts();
+int rdb_dbug_set_ttl_read_filter_ts();
+#endif
 
 enum operation_type : int;
 void rdb_update_global_stats(const operation_type &type, uint count,
@@ -88,5 +93,4 @@ Rdb_ddl_manager *rdb_get_ddl_manager(void)
 class Rdb_binlog_manager;
 Rdb_binlog_manager *rdb_get_binlog_manager(void)
     MY_ATTRIBUTE((__warn_unused_result__));
-
 } // namespace myrocks

--- a/storage/rocksdb/ha_rocksdb_proto.h
+++ b/storage/rocksdb/ha_rocksdb_proto.h
@@ -71,6 +71,7 @@ Rdb_cf_manager &rdb_get_cf_manager();
 
 const rocksdb::BlockBasedTableOptions &rdb_get_table_options();
 bool rdb_is_ttl_enabled();
+bool rdb_is_ttl_read_filtering_enabled();
 
 enum operation_type : int;
 void rdb_update_global_stats(const operation_type &type, uint count,

--- a/storage/rocksdb/rdb_compact_filter.h
+++ b/storage/rocksdb/rdb_compact_filter.h
@@ -64,17 +64,28 @@ public:
           rdb_get_dict_manager()->is_drop_index_ongoing(gl_index_id);
 
       if (!m_should_delete) {
-        get_ttl_duration(gl_index_id, &m_ttl_duration);
+        get_ttl_duration_and_offset(gl_index_id, &m_ttl_duration,
+                                    &m_ttl_offset);
 
-        /*
-          For efficiency reasons, we lazily call GetIntProperty to get the
-          oldest snapshot time, each time we find a new index to be processed.
-        */
-        rocksdb::DB *const rdb = rdb_get_rocksdb_db();
-        if (!rdb->GetIntProperty(rocksdb::DB::Properties::kOldestSnapshotTime,
-                                 &m_snapshot_timestamp) ||
-            m_snapshot_timestamp == 0) {
-          m_snapshot_timestamp = static_cast<uint64_t>(std::time(nullptr));
+        if (m_ttl_duration != 0 && m_snapshot_timestamp == 0) {
+          /*
+            For efficiency reasons, we lazily call GetIntProperty to get the
+            oldest snapshot time (occurs once per compaction).
+          */
+          rocksdb::DB *const rdb = rdb_get_rocksdb_db();
+          if (!rdb->GetIntProperty(rocksdb::DB::Properties::kOldestSnapshotTime,
+                                   &m_snapshot_timestamp) ||
+              m_snapshot_timestamp == 0) {
+            m_snapshot_timestamp = static_cast<uint64_t>(std::time(nullptr));
+          }
+
+#ifndef NDEBUG
+          int snapshot_ts = rdb_dbug_set_ttl_snapshot_ts();
+          if (snapshot_ts) {
+            m_snapshot_timestamp =
+                static_cast<uint64_t>(std::time(nullptr)) + snapshot_ts;
+          }
+#endif
         }
       }
 
@@ -97,8 +108,9 @@ public:
 
   virtual const char *Name() const override { return "Rdb_compact_filter"; }
 
-  void get_ttl_duration(const GL_INDEX_ID &gl_index_id,
-                        uint64 *ttl_duration) const {
+  void get_ttl_duration_and_offset(const GL_INDEX_ID &gl_index_id,
+                                   uint64 *ttl_duration,
+                                   uint32 *ttl_offset) const {
     DBUG_ASSERT(ttl_duration != nullptr);
     /*
       If TTL is disabled set ttl_duration to 0.  This prevents the compaction
@@ -118,31 +130,43 @@ public:
       return;
     }
 
-    uint16 m_index_dict_version = 0;
-    uchar m_index_type = 0;
-    uint16 kv_version = 0;
-    if (!rdb_get_dict_manager()->get_index_info(
-            gl_index_id, &m_index_dict_version, &m_index_type, &kv_version,
-            ttl_duration)) {
+    struct Rdb_index_info index_info;
+    if (!rdb_get_dict_manager()->get_index_info(gl_index_id, &index_info)) {
       // NO_LINT_DEBUG
       sql_print_error("RocksDB: Could not get index information "
                       "for Index Number (%u,%u)",
                       gl_index_id.cf_id, gl_index_id.index_id);
     }
+
+    *ttl_duration = index_info.m_ttl_duration;
+    if (Rdb_key_def::has_index_flag(index_info.m_index_flags,
+                                    Rdb_key_def::TTL_FLAG)) {
+      *ttl_offset = Rdb_key_def::calculate_index_flag_offset(
+          index_info.m_index_flags, Rdb_key_def::TTL_FLAG);
+    }
   }
 
   bool should_filter_ttl_rec(const rocksdb::Slice &key,
                              const rocksdb::Slice &existing_value) const {
-    uint64 ttl_timestamp =
-        rdb_netbuf_to_uint64((const uchar *)existing_value.data());
+    uint64 ttl_timestamp;
+    Rdb_string_reader reader(&existing_value);
+    if (!reader.read(m_ttl_offset) || reader.read_uint64(&ttl_timestamp)) {
+      std::string buf;
+      buf = rdb_hexdump(existing_value.data(), existing_value.size(),
+                        RDB_MAX_HEXDUMP_LEN);
+      // NO_LINT_DEBUG
+      sql_print_error("Decoding ttl from PK value failed in compaction filter, "
+                      "for index (%u,%u), val: %s",
+                      m_prev_index.cf_id, m_prev_index.index_id, buf.c_str());
+      abort_with_stack_traces();
+    }
 
     /*
       Filter out the record only if it is older than the oldest snapshot
       timestamp.  This prevents any rows from expiring in the middle of
       long-running transactions.
     */
-    uint64 time_diff = std::difftime(m_snapshot_timestamp, ttl_timestamp);
-    return time_diff >= m_ttl_duration;
+    return ttl_timestamp + m_ttl_duration <= m_snapshot_timestamp;
   }
 
  private:
@@ -158,6 +182,8 @@ public:
   mutable bool m_should_delete = false;
   // TTL duration for the current index if TTL is enabled
   mutable uint64 m_ttl_duration = 0;
+  // TTL offset for all records in the current index
+  mutable uint32 m_ttl_offset = 0;
   // Oldest snapshot timestamp at the time a TTL index is discovered
   mutable uint64_t m_snapshot_timestamp = 0;
 };

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -56,15 +56,17 @@ Rdb_key_def::Rdb_key_def(uint indexnr_arg, uint keyno_arg,
                          uint16_t index_dict_version_arg, uchar index_type_arg,
                          uint16_t kv_format_version_arg, bool is_reverse_cf_arg,
                          bool is_per_partition_cf_arg, const char *_name,
-                         Rdb_index_stats _stats, uint64 ttl_duration)
+                         Rdb_index_stats _stats, uint32 index_flags_bitmap,
+                         uint32 ttl_rec_offset, uint64 ttl_duration)
     : m_index_number(indexnr_arg), m_cf_handle(cf_handle_arg),
       m_index_dict_version(index_dict_version_arg),
       m_index_type(index_type_arg), m_kv_format_version(kv_format_version_arg),
       m_is_reverse_cf(is_reverse_cf_arg),
       m_is_per_partition_cf(is_per_partition_cf_arg), m_name(_name),
-      m_stats(_stats), m_ttl_duration(ttl_duration), m_ttl_column(""),
-      m_pk_part_no(nullptr), m_pack_info(nullptr), m_keyno(keyno_arg),
-      m_key_parts(0), m_ttl_pk_key_part_offset(UINT_MAX),
+      m_stats(_stats), m_index_flags_bitmap(index_flags_bitmap),
+      m_ttl_rec_offset(ttl_rec_offset), m_ttl_duration(ttl_duration),
+      m_ttl_column(""), m_pk_part_no(nullptr), m_pack_info(nullptr),
+      m_keyno(keyno_arg), m_key_parts(0), m_ttl_pk_key_part_offset(UINT_MAX),
       m_ttl_field_offset(UINT_MAX), m_prefix_extractor(nullptr),
       m_maxlength(0)  // means 'not intialized'
 {
@@ -77,7 +79,8 @@ Rdb_key_def::Rdb_key_def(const Rdb_key_def &k)
     : m_index_number(k.m_index_number), m_cf_handle(k.m_cf_handle),
       m_is_reverse_cf(k.m_is_reverse_cf),
       m_is_per_partition_cf(k.m_is_per_partition_cf), m_name(k.m_name),
-      m_stats(k.m_stats), m_ttl_duration(k.m_ttl_duration),
+      m_stats(k.m_stats), m_index_flags_bitmap(k.m_index_flags_bitmap),
+      m_ttl_rec_offset(k.m_ttl_rec_offset), m_ttl_duration(k.m_ttl_duration),
       m_ttl_column(k.m_ttl_column), m_pk_part_no(k.m_pk_part_no),
       m_pack_info(k.m_pack_info), m_keyno(k.m_keyno),
       m_key_parts(k.m_key_parts),
@@ -3125,9 +3128,16 @@ bool Rdb_tbl_def::put_dict(Rdb_dict_manager *const dict,
 
     rdb_netstr_append_uint32(&indexes, cf_id);
     rdb_netstr_append_uint32(&indexes, kd.m_index_number);
-    dict->add_or_update_index_cf_mapping(
-        batch, kd.m_index_type, kd.m_kv_format_version, kd.m_index_number,
-        cf_id, kd.m_ttl_duration);
+
+    struct Rdb_index_info index_info;
+    index_info.m_gl_index_id = {cf_id, kd.m_index_number};
+    index_info.m_index_dict_version = Rdb_key_def::INDEX_INFO_VERSION_LATEST;
+    index_info.m_index_type = kd.m_index_type;
+    index_info.m_kv_version = kd.m_kv_format_version;
+    index_info.m_index_flags = kd.m_index_flags_bitmap;
+    index_info.m_ttl_duration = kd.m_ttl_duration;
+
+    dict->add_or_update_index_cf_mapping(batch, &index_info);
   }
 
   const rocksdb::Slice skey((char *)key, keylen);
@@ -3135,6 +3145,38 @@ bool Rdb_tbl_def::put_dict(Rdb_dict_manager *const dict,
 
   dict->put_key(batch, skey, svalue);
   return false;
+}
+
+// Length that each index flag takes inside the record.
+// Each index in the array maps to the enum INDEX_FLAG
+static const std::array<int, 1> index_flag_lengths = {
+    {ROCKSDB_SIZEOF_TTL_RECORD}};
+
+
+bool Rdb_key_def::has_index_flag(uint32 index_flags, enum INDEX_FLAG flag) {
+  return flag & index_flags;
+}
+
+uint32 Rdb_key_def::calculate_index_flag_offset(uint32 index_flags,
+                                                enum INDEX_FLAG flag) {
+
+  DBUG_ASSERT(Rdb_key_def::has_index_flag(index_flags, flag));
+
+  uint offset = 0;
+  for (size_t bit = 0; bit < sizeof(index_flags) * CHAR_BIT; ++bit) {
+    int mask = 1 << bit;
+
+    /* Exit once we've reached the proper flag */
+    if (flag == mask) {
+      break;
+    }
+
+    if (index_flags & mask) {
+      offset += index_flag_lengths[bit];
+    }
+  }
+
+	return offset;
 }
 
 void Rdb_tbl_def::check_if_is_mysql_system_table() {
@@ -3485,13 +3527,9 @@ bool Rdb_ddl_manager::init(Rdb_dict_manager *const dict_arg,
     for (uint keyno = 0; ptr < ptr_end; keyno++) {
       GL_INDEX_ID gl_index_id;
       rdb_netbuf_read_gl_index(&ptr, &gl_index_id);
-      uint16 m_index_dict_version = 0;
-      uchar m_index_type = 0;
-      uint16 kv_version = 0;
-      uint64 ttl_duration = 0;
       uint flags = 0;
-      if (!m_dict->get_index_info(gl_index_id, &m_index_dict_version,
-                                  &m_index_type, &kv_version, &ttl_duration)) {
+      struct Rdb_index_info index_info;
+      if (!m_dict->get_index_info(gl_index_id, &index_info)) {
         sql_print_error("RocksDB: Could not get index information "
                         "for Index Number (%u,%u), table %s",
                         gl_index_id.cf_id, gl_index_id.index_id,
@@ -3524,16 +3562,25 @@ bool Rdb_ddl_manager::init(Rdb_dict_manager *const dict_arg,
           cf_manager->get_cf(gl_index_id.cf_id);
       DBUG_ASSERT(cfh != nullptr);
 
+      uint32 ttl_rec_offset =
+          Rdb_key_def::has_index_flag(index_info.m_index_flags,
+                                      Rdb_key_def::TTL_FLAG)
+              ? Rdb_key_def::calculate_index_flag_offset(
+                    index_info.m_index_flags, Rdb_key_def::TTL_FLAG)
+              : UINT_MAX;
+
       /*
         We can't fully initialize Rdb_key_def object here, because full
         initialization requires that there is an open TABLE* where we could
         look at Field* objects and set max_length and other attributes
       */
       tdef->m_key_descr_arr[keyno] = std::make_shared<Rdb_key_def>(
-          gl_index_id.index_id, keyno, cfh, m_index_dict_version, m_index_type,
-          kv_version, flags & Rdb_key_def::REVERSE_CF_FLAG,
+          gl_index_id.index_id, keyno, cfh, index_info.m_index_dict_version,
+          index_info.m_index_type, index_info.m_kv_version,
+          flags & Rdb_key_def::REVERSE_CF_FLAG,
           flags & Rdb_key_def::PER_PARTITION_CF_FLAG, "",
-          m_dict->get_stats(gl_index_id), ttl_duration);
+          m_dict->get_stats(gl_index_id), index_info.m_index_flags,
+          ttl_rec_offset, index_info.m_ttl_duration);
     }
     put(tdef);
     i++;
@@ -4191,23 +4238,22 @@ void Rdb_dict_manager::delete_with_prefix(
 }
 
 void Rdb_dict_manager::add_or_update_index_cf_mapping(
-    rocksdb::WriteBatch *batch, const uchar m_index_type,
-    const uint16_t kv_version, const uint32_t index_id, const uint32_t cf_id,
-    const uint64 ttl_duration) const {
+    rocksdb::WriteBatch *batch, struct Rdb_index_info *const index_info) const {
   uchar key_buf[Rdb_key_def::INDEX_NUMBER_SIZE * 3] = {0};
   uchar value_buf[256] = {0};
-  GL_INDEX_ID gl_index_id = {cf_id, index_id};
-  dump_index_id(key_buf, Rdb_key_def::INDEX_INFO, gl_index_id);
+  dump_index_id(key_buf, Rdb_key_def::INDEX_INFO, index_info->m_gl_index_id);
   const rocksdb::Slice key = rocksdb::Slice((char *)key_buf, sizeof(key_buf));
 
   uchar *ptr = value_buf;
   rdb_netbuf_store_uint16(ptr, Rdb_key_def::INDEX_INFO_VERSION_LATEST);
   ptr += RDB_SIZEOF_INDEX_INFO_VERSION;
-  rdb_netbuf_store_byte(ptr, m_index_type);
+  rdb_netbuf_store_byte(ptr, index_info->m_index_type);
   ptr += RDB_SIZEOF_INDEX_TYPE;
-  rdb_netbuf_store_uint16(ptr, kv_version);
+  rdb_netbuf_store_uint16(ptr, index_info->m_kv_version);
   ptr += RDB_SIZEOF_KV_VERSION;
-  rdb_netbuf_store_uint64(ptr, ttl_duration);
+  rdb_netbuf_store_uint32(ptr, index_info->m_index_flags);
+  ptr += RDB_SIZEOF_INDEX_FLAGS;
+  rdb_netbuf_store_uint64(ptr, index_info->m_ttl_duration);
   ptr += ROCKSDB_SIZEOF_TTL_RECORD;
 
   const rocksdb::Slice value =
@@ -4240,10 +4286,12 @@ void Rdb_dict_manager::delete_index_info(rocksdb::WriteBatch *batch,
   delete_with_prefix(batch, Rdb_key_def::INDEX_STATISTICS, gl_index_id);
 }
 
-bool Rdb_dict_manager::get_index_info(const GL_INDEX_ID &gl_index_id,
-                                      uint16_t *m_index_dict_version,
-                                      uchar *m_index_type, uint16_t *kv_version,
-                                      uint64 *ttl_duration) const {
+bool Rdb_dict_manager::get_index_info(
+    const GL_INDEX_ID &gl_index_id,
+    struct Rdb_index_info *const index_info) const {
+
+  index_info->m_gl_index_id = gl_index_id;
+
   bool found = false;
   bool error = false;
   std::string value;
@@ -4255,33 +4303,50 @@ bool Rdb_dict_manager::get_index_info(const GL_INDEX_ID &gl_index_id,
   if (status.ok()) {
     const uchar *const val = (const uchar *)value.c_str();
     const uchar *ptr = val;
-    *m_index_dict_version = rdb_netbuf_to_uint16(val);
-    *kv_version = 0;
-    *m_index_type = 0;
-    *ttl_duration = 0;
+    index_info->m_index_dict_version = rdb_netbuf_to_uint16(val);
     ptr += RDB_SIZEOF_INDEX_INFO_VERSION;
-    switch (*m_index_dict_version) {
-    case Rdb_key_def::INDEX_INFO_VERSION_TTL:
-      /* Sanity check to prevent reading bogus into TTL record. */
-      if (value.size() !=
-          RDB_SIZEOF_INDEX_INFO_VERSION + RDB_SIZEOF_INDEX_TYPE +
-              RDB_SIZEOF_KV_VERSION + ROCKSDB_SIZEOF_TTL_RECORD) {
+
+    switch (index_info->m_index_dict_version) {
+    case Rdb_key_def::INDEX_INFO_VERSION_FIELD_FLAGS:
+      /* Sanity check to prevent reading bogus TTL record. */
+      if (value.size() != RDB_SIZEOF_INDEX_INFO_VERSION +
+                              RDB_SIZEOF_INDEX_TYPE + RDB_SIZEOF_KV_VERSION +
+                              RDB_SIZEOF_INDEX_FLAGS +
+                              ROCKSDB_SIZEOF_TTL_RECORD) {
         error = true;
         break;
       }
-      *m_index_type = rdb_netbuf_to_byte(ptr);
+      index_info->m_index_type = rdb_netbuf_to_byte(ptr);
       ptr += RDB_SIZEOF_INDEX_TYPE;
-      *kv_version = rdb_netbuf_to_uint16(ptr);
+      index_info->m_kv_version = rdb_netbuf_to_uint16(ptr);
       ptr += RDB_SIZEOF_KV_VERSION;
-      *ttl_duration = rdb_netbuf_to_uint64(ptr);
+      index_info->m_index_flags = rdb_netbuf_to_uint32(ptr);
+      ptr += RDB_SIZEOF_INDEX_FLAGS;
+      index_info->m_ttl_duration = rdb_netbuf_to_uint64(ptr);
+      found = true;
+      break;
+
+    case Rdb_key_def::INDEX_INFO_VERSION_TTL:
+      /* Sanity check to prevent reading bogus into TTL record. */
+      if (value.size() != RDB_SIZEOF_INDEX_INFO_VERSION +
+                              RDB_SIZEOF_INDEX_TYPE + RDB_SIZEOF_KV_VERSION +
+                              ROCKSDB_SIZEOF_TTL_RECORD) {
+        error = true;
+        break;
+      }
+      index_info->m_index_type = rdb_netbuf_to_byte(ptr);
+      ptr += RDB_SIZEOF_INDEX_TYPE;
+      index_info->m_kv_version = rdb_netbuf_to_uint16(ptr);
+      ptr += RDB_SIZEOF_KV_VERSION;
+      index_info->m_ttl_duration = rdb_netbuf_to_uint64(ptr);
       found = true;
       break;
 
     case Rdb_key_def::INDEX_INFO_VERSION_VERIFY_KV_FORMAT:
     case Rdb_key_def::INDEX_INFO_VERSION_GLOBAL_ID:
-      *m_index_type = rdb_netbuf_to_byte(ptr);
+      index_info->m_index_type = rdb_netbuf_to_byte(ptr);
       ptr += RDB_SIZEOF_INDEX_TYPE;
-      *kv_version = rdb_netbuf_to_uint16(ptr);
+      index_info->m_kv_version = rdb_netbuf_to_uint16(ptr);
       found = true;
       break;
 
@@ -4290,14 +4355,16 @@ bool Rdb_dict_manager::get_index_info(const GL_INDEX_ID &gl_index_id,
       break;
     }
 
-    switch (*m_index_type) {
+    switch (index_info->m_index_type) {
     case Rdb_key_def::INDEX_TYPE_PRIMARY:
     case Rdb_key_def::INDEX_TYPE_HIDDEN_PRIMARY: {
-      error = *kv_version > Rdb_key_def::PRIMARY_FORMAT_VERSION_LATEST;
+      error =
+          index_info->m_kv_version > Rdb_key_def::PRIMARY_FORMAT_VERSION_LATEST;
       break;
     }
     case Rdb_key_def::INDEX_TYPE_SECONDARY:
-      error = *kv_version > Rdb_key_def::SECONDARY_FORMAT_VERSION_LATEST;
+      error = index_info->m_kv_version >
+              Rdb_key_def::SECONDARY_FORMAT_VERSION_LATEST;
       break;
     default:
       error = true;
@@ -4311,7 +4378,8 @@ bool Rdb_dict_manager::get_index_info(const GL_INDEX_ID &gl_index_id,
         "RocksDB: Found invalid key version number (%u, %u, %u, %llu) "
         "from data dictionary. This should never happen "
         "and it may be a bug.",
-        *m_index_dict_version, *m_index_type, *kv_version, *ttl_duration);
+        index_info->m_index_dict_version, index_info->m_index_type,
+        index_info->m_kv_version, index_info->m_ttl_duration);
     abort_with_stack_traces();
   }
 
@@ -4608,13 +4676,8 @@ void Rdb_dict_manager::log_start_drop_table(
 
 void Rdb_dict_manager::log_start_drop_index(GL_INDEX_ID gl_index_id,
                                             const char *log_action) const {
-  uint16 m_index_dict_version = 0;
-  uchar m_index_type = 0;
-  uint16 kv_version = 0;
-  uint64 ttl_duration = 0;
-
-  if (!get_index_info(gl_index_id, &m_index_dict_version, &m_index_type,
-                      &kv_version, &ttl_duration)) {
+  struct Rdb_index_info index_info;
+  if (!get_index_info(gl_index_id, &index_info)) {
     /*
       If we don't find the index info, it could be that it's because it was a
       partially created index that isn't in the data dictionary yet that needs

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -3167,7 +3167,7 @@ uint32 Rdb_key_def::calculate_index_flag_offset(uint32 index_flags,
     int mask = 1 << bit;
 
     /* Exit once we've reached the proper flag */
-    if (flag == mask) {
+    if (flag & mask) {
       break;
     }
 
@@ -3176,7 +3176,7 @@ uint32 Rdb_key_def::calculate_index_flag_offset(uint32 index_flags,
     }
   }
 
-	return offset;
+  return offset;
 }
 
 void Rdb_tbl_def::check_if_is_mysql_system_table() {

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -69,6 +69,7 @@ public:
 };
 
 struct Rdb_collation_codec;
+struct Rdb_index_info;
 
 /*
   C-style "virtual table" allowing different handling of packing logic based
@@ -119,6 +120,7 @@ const size_t RDB_UNPACK_HEADER_SIZE =
 const size_t RDB_SIZEOF_INDEX_INFO_VERSION = sizeof(uint16);
 const size_t RDB_SIZEOF_INDEX_TYPE = sizeof(uchar);
 const size_t RDB_SIZEOF_KV_VERSION = sizeof(uint16);
+const size_t RDB_SIZEOF_INDEX_FLAGS = sizeof(uint32);
 
 // Possible return values for rdb_index_field_unpack_t functions.
 enum {
@@ -307,8 +309,8 @@ public:
               uint16_t index_dict_version_arg, uchar index_type_arg,
               uint16_t kv_format_version_arg, bool is_reverse_cf_arg,
               bool is_per_partition_cf, const char *name,
-              Rdb_index_stats stats = Rdb_index_stats(),
-              uint64 ttl_duration = 0);
+              Rdb_index_stats stats = Rdb_index_stats(), uint32 index_flags = 0,
+              uint32 ttl_rec_offset = UINT_MAX, uint64 ttl_duration = 0);
   ~Rdb_key_def();
 
   enum {
@@ -324,6 +326,13 @@ public:
     REVERSE_CF_FLAG = 1,
     AUTO_CF_FLAG = 2,  // Deprecated
     PER_PARTITION_CF_FLAG = 4,
+  };
+
+  // bit flags which denote myrocks specific fields stored in the record
+  // currently only used for TTL.
+  enum INDEX_FLAG {
+    TTL_FLAG = 1 << 0,
+    MAX_FLAG = TTL_FLAG << 1, // Marks where actual record starts
   };
 
   // Set of flags to ignore when comparing two CF-s and determining if
@@ -369,8 +378,12 @@ public:
     INDEX_INFO_VERSION_VERIFY_KV_FORMAT,
     // This changes the data format to include a 8 byte TTL duration for tables
     INDEX_INFO_VERSION_TTL,
+    // This changes the data format to include a bitmap before the TTL duration
+    // which will indicate in the future whether TTL or other special fields
+    // are turned on or off.
+    INDEX_INFO_VERSION_FIELD_FLAGS,
     // This normally point to the latest (currently it does).
-    INDEX_INFO_VERSION_LATEST = INDEX_INFO_VERSION_TTL,
+    INDEX_INFO_VERSION_LATEST = INDEX_INFO_VERSION_FIELD_FLAGS,
   };
 
   // MyRocks index types
@@ -422,6 +435,10 @@ public:
                               std::string *ttl_column, uint *ttl_field_offset,
                               bool skip_checks = false);
   inline bool has_ttl() const { return m_ttl_duration > 0; }
+
+  static bool has_index_flag(uint32 index_flags, enum INDEX_FLAG flag);
+  static uint32 calculate_index_flag_offset(uint32 index_flags,
+                                            enum INDEX_FLAG flag);
 
   static const std::string
   gen_qualifier_for_table(const char *const qualifier,
@@ -613,8 +630,21 @@ public:
   std::string m_name;
   mutable Rdb_index_stats m_stats;
 
-  /* TTL default value and corresponding column to apply TTL to in table */
+  /*
+    Bitmap containing information about whether TTL or other special fields
+    are enabled for the given index.
+  */
+  uint32 m_index_flags_bitmap;
+
+  /*
+    Offset in the records where the 8-byte TTL is stored (UINT_MAX if no TTL)
+  */
+  uint32 m_ttl_rec_offset;
+
+  /* Default TTL duration */
   uint64 m_ttl_duration;
+
+  /* TTL column (if defined by user, otherwise implicit TTL is used) */
   std::string m_ttl_column;
 
  private:
@@ -1172,16 +1202,13 @@ public:
   rocksdb::Iterator *new_iterator() const;
 
   /* Internal Index id => CF */
-  void add_or_update_index_cf_mapping(rocksdb::WriteBatch *batch,
-                                      const uchar index_type,
-                                      const uint16_t kv_version,
-                                      const uint index_id, const uint cf_id,
-                                      const uint64 ttl_duration) const;
+  void
+  add_or_update_index_cf_mapping(rocksdb::WriteBatch *batch,
+                                 struct Rdb_index_info *const index_info) const;
   void delete_index_info(rocksdb::WriteBatch *batch,
                          const GL_INDEX_ID &index_id) const;
   bool get_index_info(const GL_INDEX_ID &gl_index_id,
-                      uint16_t *index_dict_version, uchar *index_type,
-                      uint16_t *kv_version, uint64 *ttl_duration) const;
+                      struct Rdb_index_info *const index_info) const;
 
   /* CF id => CF flags */
   void add_cf_flags(rocksdb::WriteBatch *const batch, const uint &cf_id,
@@ -1257,6 +1284,15 @@ public:
   void add_stats(rocksdb::WriteBatch *const batch,
                  const std::vector<Rdb_index_stats> &stats) const;
   Rdb_index_stats get_stats(GL_INDEX_ID gl_index_id) const;
+};
+
+struct Rdb_index_info {
+  GL_INDEX_ID m_gl_index_id;
+  uint16_t m_index_dict_version = 0;
+  uchar m_index_type = 0;
+  uint16_t m_kv_version = 0;
+  uint32 m_index_flags = 0;
+  uint64 m_ttl_duration = 0;
 };
 
 } // namespace myrocks

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -332,7 +332,10 @@ public:
   // currently only used for TTL.
   enum INDEX_FLAG {
     TTL_FLAG = 1 << 0,
-    MAX_FLAG = TTL_FLAG << 1, // Marks where actual record starts
+
+    // MAX_FLAG marks where the actual record starts
+    // This flag always needs to be set to the last index flag enum.
+    MAX_FLAG = TTL_FLAG << 1,
   };
 
   // Set of flags to ignore when comparing two CF-s and determining if


### PR DESCRIPTION
…ey only)

This diff adds support for query read filtering for TTL records.  This is needed for a few reasons.  The first is that the compaction filter does not respect snapshots when filtering out records.  The second is that records stay around even after they have expired, until compaction happens.

An example describing the problems with this scenario is shown below:

```
CREATE TABLE t1 (a INT PRIMARY KEY) Engine=ROCKSDB COMMENT='ttl_duration=100';
# some records are inserted here...

BEGIN; # opens snapshot
# at this time, some records expire
select * from t1; # <= returns all records
# at this time compaction runs, and removes records
select * from t1; # <= some records have been removed, even from within the same snapshot!
```

So as you can see this breaks repeatable read behavior, which can give the user unexpected results.  Also, in the future when we support TTL with secondary keys, we need to avoid race conditions where compaction has removed the primary key, but not the secondary key.  This changeset lays the foundation for that as well.

In MyRocks, during index reads or table scans, there is now logic to check if the table has TTL enabled.  If so, it will see if it needs to filter out the record based on the current transaction start time.  This means that anything that SHOULD be expired from the POV of the transaction when it starts will be filtered out of the results. 

In the compaction filter, we check the oldest snapshot time from RocksDB.  Nothing after the oldest snapshot time is dropped.  This prevents keys that expire during long-running transactions to disappear from out under you.  

The combination of the above two fixes should lead to consistent behaviour from the POV of the server.