### PR TITLE
Change LOCK_global_table_stats to error-checking mutex to avoid deadlock

### DIFF
--- a/mysql-test/include/check-testcase.test
+++ b/mysql-test/include/check-testcase.test
@@ -91,5 +91,5 @@ if (!$tmp) {
   SHOW SLAVE STATUS;
 }
 
-#call mtr.check_testcase();
+call mtr.check_testcase();
 --enable_query_log

--- a/mysql-test/include/check-testcase.test
+++ b/mysql-test/include/check-testcase.test
@@ -91,5 +91,5 @@ if (!$tmp) {
   SHOW SLAVE STATUS;
 }
 
-call mtr.check_testcase();
+#call mtr.check_testcase();
 --enable_query_log

--- a/mysql-test/r/deadlock_myisam.result
+++ b/mysql-test/r/deadlock_myisam.result
@@ -1,0 +1,5 @@
+SET SESSION debug="+d,myisam_simulate_err_in_write_row";
+SET TMP_TABLE_SIZE=1024;
+SELECT * FROM INFORMATION_SCHEMA.TABLE_STATISTICS;
+ERROR HY000: Temporary table file is too big
+SET SESSION debug="-d,myisam_simulate_err_in_write_row";

--- a/mysql-test/t/deadlock_myisam.test
+++ b/mysql-test/t/deadlock_myisam.test
@@ -1,0 +1,17 @@
+--source include/have_debug.inc
+
+# Issue https://github.com/facebook/mysql-5.6/issues/132
+SET SESSION debug="+d,myisam_simulate_crash_in_write_row";
+
+# If an internal in-memory temporary table exceeds this size, MySQL "
+# will automatically convert it to an on-disk MyISAM table"
+SET TMP_TABLE_SIZE=1024;
+
+# This then causes this select statement to go into ha_myisam::write_row
+# where we have set it to error out, which previously caused a deadlock
+# due to recursive lock acquisition.
+--error 1891
+SELECT * FROM INFORMATION_SCHEMA.TABLE_STATISTICS;
+
+SET SESSION debug="-d,myisam_simulate_crash_in_write_row";
+

--- a/mysql-test/t/deadlock_myisam.test
+++ b/mysql-test/t/deadlock_myisam.test
@@ -1,7 +1,7 @@
 --source include/have_debug.inc
 
 # Issue https://github.com/facebook/mysql-5.6/issues/132
-SET SESSION debug="+d,myisam_simulate_crash_in_write_row";
+SET SESSION debug="+d,myisam_simulate_err_in_write_row";
 
 # If an internal in-memory temporary table exceeds this size, MySQL "
 # will automatically convert it to an on-disk MyISAM table"
@@ -13,5 +13,5 @@ SET TMP_TABLE_SIZE=1024;
 --error 1891
 SELECT * FROM INFORMATION_SCHEMA.TABLE_STATISTICS;
 
-SET SESSION debug="-d,myisam_simulate_crash_in_write_row";
+SET SESSION debug="-d,myisam_simulate_err_in_write_row";
 

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5195,7 +5195,7 @@ static int init_thread_environment()
   mysql_mutex_init(key_LOCK_log_throttle_legacy,
                    &LOCK_log_throttle_legacy, MY_MUTEX_INIT_FAST);
   mysql_mutex_init(key_LOCK_global_table_stats,
-                   &LOCK_global_table_stats, MY_MUTEX_INIT_FAST);
+                   &LOCK_global_table_stats, MY_MUTEX_INIT_ERRCHK);
 #ifdef HAVE_OPENSSL
   mysql_mutex_init(key_LOCK_des_key_file,
                    &LOCK_des_key_file, MY_MUTEX_INIT_FAST);

--- a/sql/sql_base.h
+++ b/sql/sql_base.h
@@ -302,6 +302,8 @@ void update_global_db_stats_access(unsigned char db_stats_index,
 void init_global_db_stats(void);
 void free_global_db_stats(void);
 void reset_global_db_stats(void);
+bool global_table_stats_lock(void);
+void global_table_stats_unlock(bool acquired);
 extern ST_FIELD_INFO db_stats_fields_info[];
 int fill_db_stats(THD *thd, TABLE_LIST *tables, Item *cond);
 

--- a/storage/myisam/ha_myisam.cc
+++ b/storage/myisam/ha_myisam.cc
@@ -813,7 +813,7 @@ int ha_myisam::write_row(uchar *buf)
 {
   ha_statistic_increment(&SSV::ha_write_count);
 
-  DBUG_EXECUTE_IF("myisam_simulate_crash_in_write_row", {
+  DBUG_EXECUTE_IF("myisam_simulate_err_in_write_row", {
     return (my_errno= HA_ERR_TMP_TABLE_MAX_FILE_SIZE_EXCEEDED);
   };);
 

--- a/storage/myisam/ha_myisam.cc
+++ b/storage/myisam/ha_myisam.cc
@@ -813,6 +813,10 @@ int ha_myisam::write_row(uchar *buf)
 {
   ha_statistic_increment(&SSV::ha_write_count);
 
+  DBUG_EXECUTE_IF("myisam_simulate_crash_in_write_row", {
+    return (my_errno= HA_ERR_TMP_TABLE_MAX_FILE_SIZE_EXCEEDED);
+  };);
+
   if (get_max_bytes() &&
       (file->state->data_file_length + file->state->key_file_length)
       > get_max_bytes())


### PR DESCRIPTION
It's possible for this mutex to be locked twice by one thread when
`ha_myisam::write_row()` errors out during an information schema query.

We use an error checking mutex here so we can handle this situation.
Fixes https://github.com/facebook/mysql-5.6/issues/132.