### PR TITLE
Pass rocksdb logger and trash directory to SstFileManager

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -3589,8 +3589,11 @@ static int rocksdb_init_func(void *const p) {
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
+  // sst_file_manager will move deleted rocksdb sst files to trash_dir
+  // to be deleted in a background thread.
+  std::string trash_dir = std::string(rocksdb_datadir) + "/trash";
   rocksdb_db_options->sst_file_manager.reset(
-      NewSstFileManager(rocksdb_db_options->env));
+      NewSstFileManager(rocksdb_db_options->env, myrocks_logger, trash_dir));
 
   rocksdb_db_options->sst_file_manager->SetDeleteRateBytesPerSecond(
       rocksdb_sst_mgr_rate_bytes_per_sec);


### PR DESCRIPTION
We need to pass a trash directory to SstFileManager component to be able to smooth file deletions.