### PR TITLE
Changing default rocksdb_sst_mgr_rate_bytes_per_sec to 0

### DIFF
--- a/mysql-test/r/mysqld--help-notwin-profiling.result
+++ b/mysql-test/r/mysqld--help-notwin-profiling.result
@@ -2080,7 +2080,7 @@ rocksdb-signal-drop-index-thread FALSE
 rocksdb-skip-bloom-filter-on-read FALSE
 rocksdb-skip-fill-cache FALSE
 rocksdb-skip-unique-check-tables (No default value)
-rocksdb-sst-mgr-rate-bytes-per-sec 67108864
+rocksdb-sst-mgr-rate-bytes-per-sec 0
 rocksdb-stats-dump-period-sec 600
 rocksdb-store-row-debug-checksums FALSE
 rocksdb-strict-collation-check TRUE

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -2077,7 +2077,7 @@ rocksdb-signal-drop-index-thread FALSE
 rocksdb-skip-bloom-filter-on-read FALSE
 rocksdb-skip-fill-cache FALSE
 rocksdb-skip-unique-check-tables (No default value)
-rocksdb-sst-mgr-rate-bytes-per-sec 67108864
+rocksdb-sst-mgr-rate-bytes-per-sec 0
 rocksdb-stats-dump-period-sec 600
 rocksdb-store-row-debug-checksums FALSE
 rocksdb-strict-collation-check TRUE

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -943,7 +943,7 @@ rocksdb_signal_drop_index_thread	OFF
 rocksdb_skip_bloom_filter_on_read	OFF
 rocksdb_skip_fill_cache	OFF
 rocksdb_skip_unique_check_tables	.*
-rocksdb_sst_mgr_rate_bytes_per_sec	67108864
+rocksdb_sst_mgr_rate_bytes_per_sec	0
 rocksdb_stats_dump_period_sec	600
 rocksdb_store_row_debug_checksums	OFF
 rocksdb_strict_collation_check	OFF

--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_sst_mgr_rate_bytes_per_sec_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_sst_mgr_rate_bytes_per_sec_basic.result
@@ -11,7 +11,7 @@ INSERT INTO invalid_values VALUES('\'484436\'');
 SET @start_global_value = @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC;
 SELECT @start_global_value;
 @start_global_value
-67108864
+0
 '# Setting to valid values in global scope#'
 "Trying to set variable @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC to 100"
 SET @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC   = 100;
@@ -22,7 +22,7 @@ SELECT @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC;
 SET @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC = DEFAULT;
 SELECT @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC;
 @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC
-67108864
+0
 "Trying to set variable @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC to 1"
 SET @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC   = 1;
 SELECT @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC;
@@ -32,7 +32,7 @@ SELECT @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC;
 SET @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC = DEFAULT;
 SELECT @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC;
 @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC
-67108864
+0
 "Trying to set variable @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC to 0"
 SET @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC   = 0;
 SELECT @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC;
@@ -42,7 +42,7 @@ SELECT @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC;
 SET @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC = DEFAULT;
 SELECT @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC;
 @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC
-67108864
+0
 "Trying to set variable @@session.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC to 444. It should fail because it is not session."
 SET @@session.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC   = 444;
 ERROR HY000: Variable 'rocksdb_sst_mgr_rate_bytes_per_sec' is a GLOBAL variable and should be set with SET GLOBAL
@@ -52,34 +52,34 @@ SET @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC   = 'aaa';
 Got one of the listed errors
 SELECT @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC;
 @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC
-67108864
+0
 "Trying to set variable @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC to 'bbb'"
 SET @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC   = 'bbb';
 Got one of the listed errors
 SELECT @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC;
 @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC
-67108864
+0
 "Trying to set variable @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC to '-1'"
 SET @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC   = '-1';
 Got one of the listed errors
 SELECT @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC;
 @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC
-67108864
+0
 "Trying to set variable @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC to '101'"
 SET @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC   = '101';
 Got one of the listed errors
 SELECT @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC;
 @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC
-67108864
+0
 "Trying to set variable @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC to '484436'"
 SET @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC   = '484436';
 Got one of the listed errors
 SELECT @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC;
 @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC
-67108864
+0
 SET @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC = @start_global_value;
 SELECT @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC;
 @@global.ROCKSDB_SST_MGR_RATE_BYTES_PER_SEC
-67108864
+0
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -196,9 +196,9 @@ const char *const RDB_TTL_COL_QUALIFIER = "ttl_col";
 #define MAX_SUBCOMPACTIONS 64
 
 /*
-  Default value for rocksdb_sst_mgr_rate_bytes_per_sec = 64 MB.
+  Default value for rocksdb_sst_mgr_rate_bytes_per_sec = 0 (disabled).
 */
-#define DEFAULT_SST_MGR_RATE_BYTES_PER_SEC (64 * 1024 * 1024)
+#define DEFAULT_SST_MGR_RATE_BYTES_PER_SEC 0
 
 /*
   Defines the field sizes for serializing XID object to a string representation.


### PR DESCRIPTION
Summary: This diff changes default rocksdb_sst_mgr_rate_bytes_per_sec
from 64MB to 0. Default 64MB has caused some issues for benchmarks (e.g.
filling up space because of trash). And this option is not effective on
HDD.

Test Plan: mtr

Subscribers:

Tasks:

Tags:

Blame Revision: