### PR TITLE
add test for prefix extractor override

### DIFF
--- a/mysql-test/suite/rocksdb/r/prefix_extractor_override.result
+++ b/mysql-test/suite/rocksdb/r/prefix_extractor_override.result
@@ -1,0 +1,76 @@
+DROP TABLE IF EXISTS t1;
+CREATE TABLE t1 (id1 BIGINT, id2 BIGINT, id3 BIGINT, id4 BIGINT, PRIMARY KEY (id1, id2, id3, id4) comment 'cf1') ENGINE=rocksdb collate latin1_bin;
+set global rocksdb_force_flush_memtable_now = 1;
+
+Original Prefix Extractor:
+
+SELECT * FROM information_schema.rocksdb_cf_options WHERE option_type like '%prefix_extractor%';
+CF_NAME	OPTION_TYPE	VALUE
+__system__	PREFIX_EXTRACTOR	rocksdb.CappedPrefix.24
+cf1	PREFIX_EXTRACTOR	rocksdb.CappedPrefix.24
+default	PREFIX_EXTRACTOR	rocksdb.CappedPrefix.24
+select variable_value into @u from information_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
+SELECT COUNT(*) FROM t1 WHERE id1=1 AND id2=1 AND id3=1;
+COUNT(*)
+1
+select variable_value-@u from information_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
+variable_value-@u
+1
+
+Prefix Extractor (after override_cf_options set, should not be changed):
+
+SELECT * FROM information_schema.rocksdb_cf_options WHERE option_type like '%prefix_extractor%';
+CF_NAME	OPTION_TYPE	VALUE
+__system__	PREFIX_EXTRACTOR	rocksdb.CappedPrefix.24
+cf1	PREFIX_EXTRACTOR	rocksdb.CappedPrefix.24
+default	PREFIX_EXTRACTOR	rocksdb.CappedPrefix.24
+
+Restarting with new Prefix Extractor...
+
+
+Changed Prefix Extractor (after restart):
+
+SELECT * FROM information_schema.rocksdb_cf_options WHERE option_type like '%prefix_extractor%';
+CF_NAME	OPTION_TYPE	VALUE
+__system__	PREFIX_EXTRACTOR	rocksdb.CappedPrefix.24
+cf1	PREFIX_EXTRACTOR	rocksdb.CappedPrefix.26
+default	PREFIX_EXTRACTOR	rocksdb.CappedPrefix.24
+select variable_value into @u from information_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
+SELECT COUNT(*) FROM t1 WHERE id1=1 AND id2=1 AND id3=1;
+COUNT(*)
+1
+select variable_value-@u from information_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
+variable_value-@u
+0
+set global rocksdb_force_flush_memtable_now = 1;
+select variable_value into @u from information_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
+SELECT COUNT(*) FROM t1 WHERE id1=1 AND id2=1 AND id3=1;
+COUNT(*)
+1
+select variable_value-@u from information_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
+variable_value-@u
+1
+SELECT COUNT(*) FROM information_schema.rocksdb_index_file_map WHERE COLUMN_FAMILY != 1;
+COUNT(*)
+2
+UPDATE t1 SET id1=1,id2 = 30,id3 = 30 WHERE id4 >= 0 AND id4 <=10;
+set global rocksdb_force_flush_memtable_now = 1;
+SELECT COUNT(*) FROM information_schema.rocksdb_index_file_map WHERE COLUMN_FAMILY != 1;
+COUNT(*)
+3
+select variable_value into @u from information_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
+SELECT COUNT(*) FROM t1 WHERE id1=1 AND id2=1 AND id3=1;
+COUNT(*)
+0
+select variable_value-@u from information_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
+variable_value-@u
+2
+set global rocksdb_compact_cf='cf1';
+select variable_value into @u from information_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
+SELECT COUNT(*) FROM t1 WHERE id1=1 AND id2=30 AND id3=30;
+COUNT(*)
+11
+select variable_value-@u from information_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
+variable_value-@u
+1
+DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/t/prefix_extractor_override-master.opt
+++ b/mysql-test/suite/rocksdb/t/prefix_extractor_override-master.opt
@@ -1,0 +1,1 @@
+--rocksdb_default_cf_options=write_buffer_size=64k;block_based_table_factory={filter_policy=bloomfilter:10:false;whole_key_filtering=0;};prefix_extractor=capped:24;disable_auto_compactions=true

--- a/mysql-test/suite/rocksdb/t/prefix_extractor_override.test
+++ b/mysql-test/suite/rocksdb/t/prefix_extractor_override.test
@@ -1,0 +1,96 @@
+--source include/have_rocksdb.inc
+
+--disable_warnings
+DROP TABLE IF EXISTS t1;
+--enable_warnings
+
+CREATE TABLE t1 (id1 BIGINT, id2 BIGINT, id3 BIGINT, id4 BIGINT, PRIMARY KEY (id1, id2, id3, id4) comment 'cf1') ENGINE=rocksdb collate latin1_bin;
+--disable_query_log
+let $i = 1;
+while ($i <= 100) {
+  let $insert = INSERT INTO t1 VALUES(1, $i, $i, $i);
+  eval $insert;
+  inc $i;
+}
+--enable_query_log
+set global rocksdb_force_flush_memtable_now = 1;
+
+--echo
+--echo Original Prefix Extractor:
+--echo
+--sorted_result
+SELECT * FROM information_schema.rocksdb_cf_options WHERE option_type like '%prefix_extractor%';
+
+# BF used (4+8+8+8)
+select variable_value into @u from information_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
+SELECT COUNT(*) FROM t1 WHERE id1=1 AND id2=1 AND id3=1;
+select variable_value-@u from information_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
+
+--exec echo "" > $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $_mysqld_option=--rocksdb_override_cf_options=cf1={prefix_extractor=capped:26};
+
+--echo
+--echo Prefix Extractor (after override_cf_options set, should not be changed):
+--echo
+--sorted_result
+SELECT * FROM information_schema.rocksdb_cf_options WHERE option_type like '%prefix_extractor%';
+
+# This should no longer crash. See https://github.com/facebook/mysql-5.6/issues/641
+--echo
+--echo Restarting with new Prefix Extractor...
+--echo
+--source include/restart_mysqld_with_option.inc
+
+--echo
+--echo Changed Prefix Extractor (after restart):
+--echo
+--sorted_result
+SELECT * FROM information_schema.rocksdb_cf_options WHERE option_type like '%prefix_extractor%';
+
+# Satisfies can_use_bloom_filter (4+8+8+8), but can't use because the old SST
+# files have old prefix extractor
+select variable_value into @u from information_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
+SELECT COUNT(*) FROM t1 WHERE id1=1 AND id2=1 AND id3=1;
+select variable_value-@u from information_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
+
+# Insert more data into t1, verify it uses new bloom filter
+--disable_query_log
+let $i = 101;
+while ($i <= 200) {
+  let $insert = INSERT INTO t1 VALUES(1, $i, $i, $i);
+  eval $insert;
+  inc $i;
+}
+--enable_query_log
+
+set global rocksdb_force_flush_memtable_now = 1;
+
+# BF used w/ new prefix extractor (4+8+8+8) (still increments once because it
+# needs to check the new SST file, but doesnt increment for SST file with old
+# extractor)
+select variable_value into @u from information_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
+SELECT COUNT(*) FROM t1 WHERE id1=1 AND id2=1 AND id3=1;
+select variable_value-@u from information_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
+
+# should have 2 sst files, one with old prefix extractor and one with new
+SELECT COUNT(*) FROM information_schema.rocksdb_index_file_map WHERE COLUMN_FAMILY != 1;
+
+# update some old data, force compaction, verify that new SST files use
+# new bloom filter
+UPDATE t1 SET id1=1,id2 = 30,id3 = 30 WHERE id4 >= 0 AND id4 <=10;
+set global rocksdb_force_flush_memtable_now = 1;
+
+# should have 3 sst files, one with old prefix extractor and two with new
+SELECT COUNT(*) FROM information_schema.rocksdb_index_file_map WHERE COLUMN_FAMILY != 1;
+select variable_value into @u from information_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
+SELECT COUNT(*) FROM t1 WHERE id1=1 AND id2=1 AND id3=1;
+select variable_value-@u from information_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
+
+set global rocksdb_compact_cf='cf1';
+
+# Select the updated, make sure bloom filter is checked now
+select variable_value into @u from information_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
+SELECT COUNT(*) FROM t1 WHERE id1=1 AND id2=30 AND id3=30;
+select variable_value-@u from information_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
+
+DROP TABLE t1;


### PR DESCRIPTION
Add accompanying test to verify prefix extractor override now works in MyRocks.  When DB is opened with new prefix extractor we expect the old files to ignore the old prefix extractor.

See https://github.com/facebook/rocksdb/commit/c7004840d2f4ad5fc1bdce042902b822492f3a0e for more details

Fixes https://github.com/facebook/mysql-5.6/issues/641.
Squash with D5307132.