### PR TITLE
reset detailed error string for deadlock error

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -1695,6 +1695,7 @@ public:
     if (s.IsDeadlock()) {
       my_core::thd_mark_transaction_to_rollback(thd,
                                                 false /* just statement */);
+      m_detailed_error = String();
       return HA_ERR_LOCK_DEADLOCK;
     } else if (s.IsBusy()) {
       rocksdb_snapshot_conflict_errors++;


### PR DESCRIPTION
Changes:
* reset m_detailed_error to empty string
* added tests to verify snapshot conflicts message disappears on consecutive deadlocks