### PR TITLE
Improve drop_table{,2,3} testcases

### DIFF
--- a/mysql-test/suite/rocksdb/r/drop_table.result
+++ b/mysql-test/suite/rocksdb/r/drop_table.result
@@ -3,6 +3,8 @@ DROP TABLE IF EXISTS t2;
 DROP TABLE IF EXISTS t3;
 DROP TABLE IF EXISTS t4;
 DROP TABLE IF EXISTS t5;
+call mtr.add_suppression("Column family 'cf1' not found");
+call mtr.add_suppression("Column family 'rev:cf2' not found");
 set global rocksdb_compact_cf = 'cf1';
 set global rocksdb_compact_cf = 'rev:cf2';
 set global rocksdb_signal_drop_index_thread = 1;

--- a/mysql-test/suite/rocksdb/r/drop_table2.result
+++ b/mysql-test/suite/rocksdb/r/drop_table2.result
@@ -3,6 +3,8 @@ DROP TABLE IF EXISTS t2;
 DROP TABLE IF EXISTS t3;
 DROP TABLE IF EXISTS t4;
 DROP TABLE IF EXISTS t5;
+call mtr.add_suppression("Column family 'cf1' not found");
+call mtr.add_suppression("Column family 'rev:cf2' not found");
 set global rocksdb_compact_cf = 'cf1';
 set global rocksdb_compact_cf = 'rev:cf2';
 set global rocksdb_signal_drop_index_thread = 1;

--- a/mysql-test/suite/rocksdb/r/drop_table3.result
+++ b/mysql-test/suite/rocksdb/r/drop_table3.result
@@ -1,4 +1,6 @@
 DROP TABLE IF EXISTS t1;
+call mtr.add_suppression("Column family 'cf1' not found");
+call mtr.add_suppression("Column family 'rev:cf2' not found");
 set global rocksdb_compact_cf = 'cf1';
 set global rocksdb_compact_cf = 'rev:cf2';
 set global rocksdb_signal_drop_index_thread = 1;

--- a/mysql-test/suite/rocksdb/t/drop_table-master.opt
+++ b/mysql-test/suite/rocksdb/t/drop_table-master.opt
@@ -1,4 +1,3 @@
 --rocksdb_max_subcompactions=1
---rocksdb_info_log_level=info_level
 --rocksdb_default_cf_options=write_buffer_size=512k;target_file_size_base=512k;level0_file_num_compaction_trigger=2;level0_slowdown_writes_trigger=-1;level0_stop_writes_trigger=1000;max_bytes_for_level_base=1m
 

--- a/mysql-test/suite/rocksdb/t/drop_table-master.opt
+++ b/mysql-test/suite/rocksdb/t/drop_table-master.opt
@@ -1,3 +1,4 @@
 --rocksdb_max_subcompactions=1
+---rocksdb_info_log_level=info_level
 --rocksdb_default_cf_options=write_buffer_size=512k;target_file_size_base=512k;level0_file_num_compaction_trigger=2;level0_slowdown_writes_trigger=-1;level0_stop_writes_trigger=1000;max_bytes_for_level_base=1m
 

--- a/mysql-test/suite/rocksdb/t/drop_table.test
+++ b/mysql-test/suite/rocksdb/t/drop_table.test
@@ -8,12 +8,14 @@ DROP TABLE IF EXISTS t4;
 DROP TABLE IF EXISTS t5;
 --enable_warnings
 
+call mtr.add_suppression("Column family 'cf1' not found");
+call mtr.add_suppression("Column family 'rev:cf2' not found");
+
 # Start from clean slate
 set global rocksdb_compact_cf = 'cf1';
 set global rocksdb_compact_cf = 'rev:cf2';
 set global rocksdb_signal_drop_index_thread = 1;
 --source include/restart_mysqld.inc
---exec truncate --size=0 $MYSQLTEST_VARDIR/log/mysqld.1.err
 
 CREATE TABLE t1 (
   a int not null,

--- a/mysql-test/suite/rocksdb/t/drop_table2.test
+++ b/mysql-test/suite/rocksdb/t/drop_table2.test
@@ -8,12 +8,14 @@ DROP TABLE IF EXISTS t4;
 DROP TABLE IF EXISTS t5;
 --enable_warnings
 
+call mtr.add_suppression("Column family 'cf1' not found");
+call mtr.add_suppression("Column family 'rev:cf2' not found");
+
 # Start from clean slate
 set global rocksdb_compact_cf = 'cf1';
 set global rocksdb_compact_cf = 'rev:cf2';
 set global rocksdb_signal_drop_index_thread = 1;
 --source include/restart_mysqld.inc
---exec truncate --size=0 $MYSQLTEST_VARDIR/log/mysqld.1.err
 
 CREATE TABLE t1 (
   a int not null,

--- a/mysql-test/suite/rocksdb/t/drop_table3.inc
+++ b/mysql-test/suite/rocksdb/t/drop_table3.inc
@@ -4,12 +4,14 @@
 DROP TABLE IF EXISTS t1;
 --enable_warnings
 
+call mtr.add_suppression("Column family 'cf1' not found");
+call mtr.add_suppression("Column family 'rev:cf2' not found");
+
 # Start from clean slate
 set global rocksdb_compact_cf = 'cf1';
 set global rocksdb_compact_cf = 'rev:cf2';
 set global rocksdb_signal_drop_index_thread = 1;
 --source include/restart_mysqld.inc
---exec truncate --size=0 $MYSQLTEST_VARDIR/log/mysqld.1.err
 
 CREATE TABLE t1 (
   a int not null,


### PR DESCRIPTION
- Don't truncate mysqld.1.err file, it's a bad practice
- remove --rocksdb_info_log_level=info_level from .opt file as it is
  not necessary anymore.
- Add test suppressions for harmless "Column family not found" messages.
- See https://jira.mariadb.org/browse/MDEV-13413 for the background