### PR TITLE
track Semisync_ack and Engine_commit time in slow query log

### DIFF
--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -7997,8 +7997,12 @@ commit_stage:
   }
   semisync_queue =
     stage_manager.fetch_queue_for(Stage_manager::SEMISYNC_STAGE);
+  
+  ulonglong start_time;
+  start_time = my_timer_now();
   process_semisync_stage_queue(semisync_queue);
-
+  thd->semisync_ack_time = my_timer_since(start_time);
+  
   leave_mutex_before_commit_stage= &LOCK_semisync;
 
   /*
@@ -8026,7 +8030,9 @@ commit_stage:
       DBUG_RETURN(finish_commit(thd, async));
     }
     THD *commit_queue= stage_manager.fetch_queue_for(Stage_manager::COMMIT_STAGE);
+    start_time = my_timer_now();
     process_commit_stage_queue(thd, commit_queue, async);
+    thd->engine_commit_time = my_timer_since(start_time);
     mysql_mutex_unlock(&LOCK_commit);
     final_queue= commit_queue;
   }

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -2108,6 +2108,8 @@ bool MYSQL_QUERY_LOG::write(THD *thd, time_t current_time,
   char start_time_buff[80] = "";
   char end_time_buff[80] = "";
   char read_time_buff[80] = "";
+  char semisync_ack_time_buff[80] = "";
+  char engine_commit_time_buff[80] = "";
   char query_time_buff[22+7], lock_time_buff[22+7];
   bool use_query_start = false;
   uint buff_len= 0;
@@ -2163,6 +2165,12 @@ bool MYSQL_QUERY_LOG::write(THD *thd, time_t current_time,
   /* For slow query log */
   sprintf(query_time_buff, "%.6f", ulonglong2double(query_utime)/1000000.0);
   sprintf(lock_time_buff,  "%.6f", ulonglong2double(lock_utime)/1000000.0);
+  /*Semisync ack time and Engine commit time  */
+  sprintf(semisync_ack_time_buff,"%.6f",
+          my_timer_to_seconds(thd->semisync_ack_time));
+  sprintf(engine_commit_time_buff,"%.6f",
+          my_timer_to_seconds(thd->engine_commit_time));
+  
   if (opt_log_slow_extra && query_start_arg && query_start)
   {
     struct tm tm_tmp;
@@ -2236,7 +2244,8 @@ bool MYSQL_QUERY_LOG::write(THD *thd, time_t current_time,
                       " Created_tmp_tables: %lu"
                       " Tmp_table_bytes_written: %lu"
                       " Start: %s End: %s"
-                      " Reads: %lu Read_time: %s\n",
+                      " Reads: %lu Read_time: %s"
+                      " Semisync_ack time: %s Engine_commit time %s\n",
                       query_time_buff, lock_time_buff,
                       (ulong) thd->get_sent_row_count(),
                       (ulong) thd->get_examined_row_count(),
@@ -2282,7 +2291,9 @@ bool MYSQL_QUERY_LOG::write(THD *thd, time_t current_time,
                       start_time_buff, end_time_buff,
                       (ulong) (thd->status_var.read_requests -
                           query_start->read_requests),
-                      read_time_buff) == (uint) -1)
+                      read_time_buff,
+                      semisync_ack_time_buff,
+                      engine_commit_time_buff) == (uint) -1)
       tmp_errno=errno;
     }
     else // don't substract query_start status
@@ -2302,7 +2313,8 @@ bool MYSQL_QUERY_LOG::write(THD *thd, time_t current_time,
                       " Created_tmp_tables: %lu"
                       " Tmp_table_bytes_written: %lu"
                       " Start: %s End: %s"
-                      " Reads: %lu Read_time: %s\n",
+                      " Reads: %lu Read_time: %s"
+                      " Semisync_ack time: %s Engine_commit time %s\n",
                       query_time_buff, lock_time_buff,
                       (ulong) thd->get_sent_row_count(),
                       (ulong) thd->get_examined_row_count(),
@@ -2329,7 +2341,9 @@ bool MYSQL_QUERY_LOG::write(THD *thd, time_t current_time,
                       (ulong) thd->status_var.tmp_table_bytes_written,
                       start_time_buff, end_time_buff,
                       (ulong) thd->status_var.read_requests,
-                      read_time_buff) == (uint) -1)
+                      read_time_buff,
+                      semisync_ack_time_buff,
+                      engine_commit_time_buff) == (uint) -1)
       tmp_errno=errno;
     }
 
@@ -3479,4 +3493,3 @@ void exec_binlog_error_action_abort(const char* err_string)
   thd->protocol->end_statement();
   abort();
 }
-

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -2446,7 +2446,11 @@ public:
   ulonglong stmt_start = 0;
   /* record the transaction time (including in-fly) */
   ulonglong trx_time = 0;
-
+  /* record the semisync ack time */
+  ulonglong semisync_ack_time = 0;
+  /* record the engine commit time */
+  ulonglong engine_commit_time = 0;
+  
   /* whether the session is already in admission control for queries */
   bool is_in_ac = false;
   /**


### PR DESCRIPTION
First pass at this.  Please note that this will modify / append to the format of the slow query log.