### PR TITLE
Code cleanup: remove unused global m_mysql_gtid variable

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -158,7 +158,6 @@ static std::shared_ptr<Rdb_tbl_prop_coll_factory> properties_collector_factory;
 Rdb_dict_manager dict_manager;
 Rdb_cf_manager cf_manager;
 Rdb_ddl_manager ddl_manager;
-const char *m_mysql_gtid;
 Rdb_binlog_manager binlog_manager;
 Rdb_io_watchdog *io_watchdog = nullptr;
 


### PR DESCRIPTION
- Rdb_transaction::m_mysql_gtid is the one is used
- why a global variable is named m_... ?