### PR TITLE
fix nullifying update_cf_options sysvar

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -408,6 +408,10 @@ static void rocksdb_set_collation_exception_list(THD *thd,
                                                  void *var_ptr,
                                                  const void *save);
 
+static int rocksdb_validate_update_cf_options(THD *thd,
+                                              struct st_mysql_sys_var *var,
+                                              void *save,
+                                              st_mysql_value *value);
 void rocksdb_set_update_cf_options(THD *thd,
                                    struct st_mysql_sys_var *var,
                                    void *var_ptr,
@@ -1164,7 +1168,8 @@ static MYSQL_SYSVAR_STR(override_cf_options, rocksdb_override_cf_options,
 static MYSQL_SYSVAR_STR(update_cf_options, rocksdb_update_cf_options,
                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_MEMALLOC |
                             PLUGIN_VAR_ALLOCATED,
-                        "Option updates per column family for RocksDB", nullptr,
+                        "Option updates per column family for RocksDB",
+                        rocksdb_validate_update_cf_options,
                         rocksdb_set_update_cf_options, nullptr);
 
 enum rocksdb_flush_log_at_trx_commit_type : unsigned int {
@@ -11961,23 +11966,30 @@ static void rocksdb_set_max_background_jobs(THD *thd,
   RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
 }
 
+static int rocksdb_validate_update_cf_options(THD *thd,
+                                              struct st_mysql_sys_var *var,
+                                              void *save,
+                                              st_mysql_value *value) {
+  // just disallow setting to null; otherwise same as default string checker
+  char buff[STRING_BUFFER_USUAL_SIZE];
+  const char *str;
+  int length;
+
+  length= sizeof(buff);
+  if ((str= value->val_str(value, buff, &length)))
+    str= thd->strmake(str, length);
+  *(const char**)save= str;
+  return str == nullptr;
+}
+
 void rocksdb_set_update_cf_options(THD *const /* unused */,
                                    struct st_mysql_sys_var *const /* unused */,
                                    void *const var_ptr,
                                    const void *const save) {
   const char *const val = *static_cast<const char *const *>(save);
-
-  if (!val) {
-    // NO_LINT_DEBUG
-    sql_print_warning("MyRocks: NULL is not a valid option for updates to "
-                      "column family settings.");
-    *reinterpret_cast<char**>(var_ptr) = nullptr;
-    return;
-  }
+  DBUG_ASSERT(val != nullptr);
 
   RDB_MUTEX_LOCK_CHECK(rdb_sysvars_mutex);
-
-  DBUG_ASSERT(val != nullptr);
 
   // Do the real work of applying the changes.
   Rdb_cf_options::Name_to_config_t option_map;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -1170,7 +1170,7 @@ static MYSQL_SYSVAR_STR(update_cf_options, rocksdb_update_cf_options,
                             PLUGIN_VAR_ALLOCATED,
                         "Option updates per column family for RocksDB",
                         rocksdb_validate_update_cf_options,
-                        rocksdb_set_update_cf_options, nullptr);
+                        rocksdb_set_update_cf_options, "");
 
 enum rocksdb_flush_log_at_trx_commit_type : unsigned int {
   FLUSH_LOG_NEVER = 0,

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -11971,6 +11971,7 @@ void rocksdb_set_update_cf_options(THD *const /* unused */,
     // NO_LINT_DEBUG
     sql_print_warning("MyRocks: NULL is not a valid option for updates to "
                       "column family settings.");
+    *reinterpret_cast<char**>(var_ptr) = nullptr;
     return;
   }
 
@@ -12051,11 +12052,7 @@ void rocksdb_set_update_cf_options(THD *const /* unused */,
   // Reset the pointers regardless of how much success we had with updating
   // the CF options. This will results in consistent behavior and avoids
   // dealing with cases when only a subset of CF-s was successfully updated.
-  if (val) {
-    *reinterpret_cast<char**>(var_ptr) = my_strdup(val,  MYF(0));
-  } else {
-    *reinterpret_cast<char**>(var_ptr) = nullptr;
-  }
+  *reinterpret_cast<char**>(var_ptr) = my_strdup(val,  MYF(0));
 
   // Our caller (`plugin_var_memalloc_global_update`) will call `my_free` to
   // free up resources used before.


### PR DESCRIPTION
previously, setting this sysvar to null would result in the same memory being double-freed upon the next update to the sysvar. That's because we left `var_ptr` pointing to the string that the caller deletes.

Test Plan:

verified it fixes #696.

```
mysql> create table t1(a int, primary key(a) comment 'cf1') engine=rocksdb;
Query OK, 0 rows affected (0.01 sec)

mysql> SET @@global.rocksdb_update_cf_options = 'cf1={write_buffer_size=8m;target_file_size_base=2m};';
Query OK, 0 rows affected (0.01 sec)

mysql> SET @@global.rocksdb_update_cf_options = NULL;
ERROR 1231 (42000): Variable 'rocksdb_update_cf_options' can't be set to the value of 'NULL'
mysql> SET @@global.rocksdb_update_cf_options = NULL;
ERROR 1231 (42000): Variable 'rocksdb_update_cf_options' can't be set to the value of 'NULL'
mysql> SET @@global.rocksdb_update_cf_options = NULL;
ERROR 1231 (42000): Variable 'rocksdb_update_cf_options' can't be set to the value of 'NULL'
mysql> SET @@global.rocksdb_update_cf_options = 'cf1={write_buffer_size=8m;target_file_size_base=2m};';
Query OK, 0 rows affected (0.00 sec)

mysql> drop table t1;
Query OK, 0 rows affected (0.00 sec)

mysql> SET @@global.rocksdb_update_cf_options = 'cf1={write_buffer_size=8m;target_file_size_base=2m};';
Query OK, 0 rows affected (0.01 sec)
```