### PR TITLE
- Removed debug assertion from Rdb_sst_file_ordered::put when keys ar…

### DIFF
--- a/mysql-test/suite/rocksdb/r/bulk_load_errors.result
+++ b/mysql-test/suite/rocksdb/r/bulk_load_errors.result
@@ -1,4 +1,4 @@
-CREATE TABLE t1(pk INT, PRIMARY KEY(pk));
+CREATE TABLE t1(pk INT, PRIMARY KEY(pk)) ENGINE=ROCKSDB;
 SET rocksdb_bulk_load=1;
 INSERT INTO t1 VALUES(10);
 INSERT INTO t1 VALUES(11);
@@ -15,7 +15,23 @@ INSERT INTO t1 VALUES(2);
 INSERT INTO t1 VALUES(20);
 INSERT INTO t1 VALUES(21);
 SET rocksdb_bulk_load=0;
-ERROR HY000: Lost connection to MySQL server during query
+ERROR HY000: Rows inserted during bulk load must not overlap existing rows
+SHOW VARIABLES LIKE 'rocksdb_bulk_load';
+Variable_name	Value
+rocksdb_bulk_load	OFF
+SELECT * FROM t1;
+pk
+10
+11
+SET rocksdb_bulk_load=1;
+INSERT INTO t1 VALUES(1);
+INSERT INTO t1 VALUES(2);
+INSERT INTO t1 VALUES(20);
+INSERT INTO t1 VALUES(21);
+SELECT * FROM t1;
+pk
+10
+11
 TRUNCATE TABLE t1;
 SET rocksdb_bulk_load_allow_unsorted=1;
 SET rocksdb_bulk_load=1;
@@ -43,3 +59,23 @@ pk
 202
 SET rocksdb_bulk_load_allow_unsorted=DEFAULT;
 DROP TABLE t1;
+CREATE TABLE t1(c1 INT KEY) ENGINE=ROCKSDB;
+SET rocksdb_bulk_load=1;
+INSERT INTO t1 VALUES (),(),();
+ERROR HY000: Rows must be inserted in primary key order during bulk load operation
+SET rocksdb_bulk_load=0;
+DROP TABLE t1;
+SET @orig_table_open_cache=@@global.table_open_cache;
+CREATE TABLE t1(a INT AUTO_INCREMENT, b INT, PRIMARY KEY (a)) ENGINE=ROCKSDB DEFAULT CHARSET=latin1;
+SET rocksdb_bulk_load=1;
+INSERT INTO t1 VALUES(13, 0);
+INSERT INTO t1 VALUES(2, 'test 2');
+Warnings:
+Warning	1366	Incorrect integer value: 'test 2' for column 'b' at row 1
+INSERT INTO t1 VALUES(@id, @arg04);
+SET @@global.table_open_cache=FALSE;
+Warnings:
+Warning	1292	Truncated incorrect table_open_cache value: '0'
+INSERT INTO t1 VALUES(51479+0.333333333,1);
+DROP TABLE t1;
+SET @@global.table_open_cache=@orig_table_open_cache;

--- a/mysql-test/suite/rocksdb/t/bulk_load_errors.test
+++ b/mysql-test/suite/rocksdb/t/bulk_load_errors.test
@@ -1,7 +1,13 @@
 --source include/have_rocksdb.inc
+--source include/count_sessions.inc
+
+--let LOG1=$MYSQLTEST_VARDIR/tmp/rocksdb.bulk_load_errors.1.err
+--let $_mysqld_option=--log-error=$LOG1
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--source include/restart_mysqld_with_option.inc
 
 ### Bulk load ###
-CREATE TABLE t1(pk INT, PRIMARY KEY(pk));
+CREATE TABLE t1(pk INT, PRIMARY KEY(pk)) ENGINE=ROCKSDB;
 
 # Make sure we get an error with out of order keys during bulk load
 SET rocksdb_bulk_load=1;
@@ -21,21 +27,45 @@ INSERT INTO t1 VALUES(2);
 INSERT INTO t1 VALUES(20);
 INSERT INTO t1 VALUES(21);
 
-# This last crashes the server (intentionally) because we can't return any
-# error information from a SET <variable>=<value>
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---error 2013
+--error ER_OVERLAPPING_KEYS
 SET rocksdb_bulk_load=0;
 
---exec grep "RocksDB: Error 197 finalizing last SST file while setting bulk loading variable" $MYSQLTEST_VARDIR/log/mysqld.1.err | cut -d] -f2
---exec echo "" >$MYSQLTEST_VARDIR/log/mysqld.1.err
+SHOW VARIABLES LIKE 'rocksdb_bulk_load';
 
-# restart the crashed server
---exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+SELECT * FROM t1;
 
-# Make sure the error exists in the .err log and then restart the server
---enable_reconnect
---source include/wait_until_connected_again.inc
+--let SEARCH_FILE=$LOG1
+--let SEARCH_PATTERN=RocksDB: Error 198 finalizing last SST file while setting bulk loading variable
+--source include/search_pattern_in_file.inc
+
+--let LOG2=$MYSQLTEST_VARDIR/tmp/rocksdb.bulk_load_errors.2.err
+--let $_mysqld_option=--log-error=$LOG2
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--source include/restart_mysqld_with_option.inc
+--remove_file $LOG1
+
+
+# Make sure we get an error in log when we disconnect and do not assert the server
+--connect (con1,localhost,root,,)
+SET rocksdb_bulk_load=1;
+INSERT INTO t1 VALUES(1);
+INSERT INTO t1 VALUES(2);
+INSERT INTO t1 VALUES(20);
+INSERT INTO t1 VALUES(21);
+--connection default
+--disconnect con1
+
+SELECT * FROM t1;
+
+--let SEARCH_FILE=$LOG2
+--let SEARCH_PATTERN=RocksDB: Error 198 finalizing last SST file while disconnecting
+--source include/search_pattern_in_file.inc
+
+--let LOG3=$MYSQLTEST_VARDIR/tmp/rocksdb.bulk_load_errors.3.err
+--let $_mysqld_option=--log-error=$LOG3
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--source include/restart_mysqld_with_option.inc
+--remove_file $LOG2
 
 TRUNCATE TABLE t1;
 
@@ -63,3 +93,33 @@ SELECT * FROM t1;
 
 SET rocksdb_bulk_load_allow_unsorted=DEFAULT;
 DROP TABLE t1;
+
+# This would trigger a debug assertion that is just an error in release builds
+CREATE TABLE t1(c1 INT KEY) ENGINE=ROCKSDB;
+SET rocksdb_bulk_load=1;
+--error ER_KEYS_OUT_OF_ORDER
+INSERT INTO t1 VALUES (),(),();
+SET rocksdb_bulk_load=0;
+DROP TABLE t1;
+
+# Crash when table open cache closes handler with bulk load operation not finalized
+SET @orig_table_open_cache=@@global.table_open_cache;
+CREATE TABLE t1(a INT AUTO_INCREMENT, b INT, PRIMARY KEY (a)) ENGINE=ROCKSDB DEFAULT CHARSET=latin1;
+SET rocksdb_bulk_load=1;
+INSERT INTO t1 VALUES(13, 0);
+INSERT INTO t1 VALUES(2, 'test 2');
+INSERT INTO t1 VALUES(@id, @arg04);
+SET @@global.table_open_cache=FALSE;
+INSERT INTO t1 VALUES(51479+0.333333333,1);
+DROP TABLE t1;
+SET @@global.table_open_cache=@orig_table_open_cache;
+
+--let SEARCH_FILE=$LOG3
+--let SEARCH_PATTERN=RocksDB: Error 198 finalizing bulk load while closing handler
+--source include/search_pattern_in_file.inc
+
+--source include/restart_mysqld.inc
+
+--remove_file $LOG3
+
+--source include/wait_until_count_sessions.inc

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -413,10 +413,11 @@ void rocksdb_set_update_cf_options(THD *thd,
                                    void *var_ptr,
                                    const void *save);
 
-static void
-rocksdb_set_bulk_load(THD *thd,
-                      struct st_mysql_sys_var *var MY_ATTRIBUTE((__unused__)),
-                      void *var_ptr, const void *save);
+static int rocksdb_check_bulk_load(THD *const thd,
+                                   struct st_mysql_sys_var *var
+                                       MY_ATTRIBUTE((__unused__)),
+                                   void *save,
+                                   struct st_mysql_value *value);
 
 static void rocksdb_set_bulk_load_allow_unsorted(
     THD *thd, struct st_mysql_sys_var *var MY_ATTRIBUTE((__unused__)),
@@ -619,7 +620,7 @@ static MYSQL_THDVAR_BOOL(
     bulk_load, PLUGIN_VAR_RQCMDARG,
     "Use bulk-load mode for inserts. This disables "
     "unique_checks and enables rocksdb_commit_in_the_middle.",
-    nullptr, rocksdb_set_bulk_load, FALSE);
+    rocksdb_check_bulk_load, nullptr, FALSE);
 
 static MYSQL_THDVAR_BOOL(bulk_load_allow_unsorted, PLUGIN_VAR_RQCMDARG,
                          "Allow unsorted input during bulk-load. "
@@ -1979,12 +1980,12 @@ private:
   std::vector<ha_rocksdb *> m_curr_bulk_load;
 
 public:
-  int finish_bulk_load() {
+  int finish_bulk_load(bool print_client_error = true) {
     int rc = 0;
 
     std::vector<ha_rocksdb *>::iterator it;
     while ((it = m_curr_bulk_load.begin()) != m_curr_bulk_load.end()) {
-      int rc2 = (*it)->finalize_bulk_load();
+      int rc2 = (*it)->finalize_bulk_load(print_client_error);
       if (rc2 != 0 && rc == 0) {
         rc = rc2;
       }
@@ -2716,13 +2717,12 @@ static Rdb_transaction *get_or_create_tx(THD *const thd) {
 static int rocksdb_close_connection(handlerton *const hton, THD *const thd) {
   Rdb_transaction *&tx = get_tx_from_thd(thd);
   if (tx != nullptr) {
-    int rc = tx->finish_bulk_load();
+    int rc = tx->finish_bulk_load(false);
     if (rc != 0) {
       // NO_LINT_DEBUG
       sql_print_error("RocksDB: Error %d finalizing last SST file while "
                       "disconnecting",
                       rc);
-      abort_with_stack_traces();
     }
 
     delete tx;
@@ -8496,7 +8496,7 @@ int ha_rocksdb::bulk_load_key(Rdb_transaction *const tx, const Rdb_key_def &kd,
   DBUG_RETURN(res);
 }
 
-int ha_rocksdb::finalize_bulk_load() {
+int ha_rocksdb::finalize_bulk_load(bool print_client_error) {
   DBUG_ENTER_FUNC();
 
   DBUG_ASSERT_IMP(!m_key_merge.empty() || m_sst_info,
@@ -8512,7 +8512,7 @@ int ha_rocksdb::finalize_bulk_load() {
   RDB_MUTEX_LOCK_CHECK(m_bulk_load_mutex);
 
   if (m_sst_info) {
-    res = m_sst_info->commit();
+    res = m_sst_info->commit(print_client_error);
     m_sst_info.reset();
   }
 
@@ -8534,7 +8534,7 @@ int ha_rocksdb::finalize_bulk_load() {
       }
       // res == -1 => finished ok; res > 0 => error
       if (res <= 0) {
-        if ((res = sst_info.commit()) != 0) {
+        if ((res = sst_info.commit(print_client_error)) != 0) {
           break;
         }
       }
@@ -11973,9 +11973,33 @@ void rocksdb_set_collation_exception_list(THD *const thd,
   *static_cast<const char **>(var_ptr) = val;
 }
 
-void rocksdb_set_bulk_load(THD *const thd, struct st_mysql_sys_var *const var
-                                               MY_ATTRIBUTE((__unused__)),
-                           void *const var_ptr, const void *const save) {
+int rocksdb_check_bulk_load(THD *const thd, struct st_mysql_sys_var *var
+                                                MY_ATTRIBUTE((__unused__)),
+                            void *save, struct st_mysql_value *value) {
+  my_bool new_value;
+  int new_value_type = value->value_type(value);
+  if (new_value_type == MYSQL_VALUE_TYPE_STRING) {
+    char buf[16];
+    int len = sizeof(buf);
+    const char *str = value->val_str(value, buf, &len);
+    if (str && (my_strcasecmp(system_charset_info, "true", str) == 0 ||
+                my_strcasecmp(system_charset_info, "on", str) == 0)) {
+      new_value = TRUE;
+    } else if (str && (my_strcasecmp(system_charset_info, "false", str) == 0 ||
+                       my_strcasecmp(system_charset_info, "off", str) == 0)) {
+      new_value = FALSE;
+    } else {
+      return 1;
+    }
+  } else if (new_value_type == MYSQL_VALUE_TYPE_INT) {
+    long long intbuf;
+    value->val_int(value, &intbuf);
+    if (intbuf > 1)
+      return 1;
+    new_value = intbuf > 0 ? TRUE : FALSE;
+  } else {
+    return 1;
+  }
   Rdb_transaction *&tx = get_tx_from_thd(thd);
 
   if (tx != nullptr) {
@@ -11985,11 +12009,13 @@ void rocksdb_set_bulk_load(THD *const thd, struct st_mysql_sys_var *const var
       sql_print_error("RocksDB: Error %d finalizing last SST file while "
                       "setting bulk loading variable",
                       rc);
-      abort_with_stack_traces();
+      THDVAR(thd, bulk_load) = 0;
+      return 1;
     }
   }
 
-  *static_cast<bool *>(var_ptr) = *static_cast<const bool *>(save);
+  *static_cast<bool *>(save) = new_value;
+  return 0;
 }
 
 void rocksdb_set_bulk_load_allow_unsorted(

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -739,8 +739,12 @@ public:
              my_core::TABLE_SHARE *const table_arg);
   ~ha_rocksdb() {
     int err MY_ATTRIBUTE((__unused__));
-    err = finalize_bulk_load();
-    DBUG_ASSERT(err == 0);
+    err = finalize_bulk_load(false);
+    if (err != 0) {
+      sql_print_error("RocksDB: Error %d finalizing bulk load while closing "
+                      "handler.",
+                      err);
+    }
     mysql_mutex_destroy(&m_bulk_load_mutex);
   }
 
@@ -1304,7 +1308,8 @@ public:
                              my_core::Alter_inplace_info *const ha_alter_info,
                              bool commit) override;
 
-  int finalize_bulk_load() MY_ATTRIBUTE((__warn_unused_result__));
+  int finalize_bulk_load(bool print_client_error = true)
+      MY_ATTRIBUTE((__warn_unused_result__));
 
   void set_use_read_free_rpl(const char *const whitelist);
   void set_skip_unique_check_tables(const char *const whitelist);

--- a/storage/rocksdb/rdb_sst_info.h
+++ b/storage/rocksdb/rdb_sst_info.h
@@ -137,6 +137,7 @@ class Rdb_sst_info {
 #endif
   Rdb_sst_file_ordered *m_sst_file;
   const bool m_tracing;
+  bool m_print_client_error;
 
   int open_new_sst_file();
   void close_curr_sst_file();
@@ -157,7 +158,7 @@ class Rdb_sst_info {
   ~Rdb_sst_info();
 
   int put(const rocksdb::Slice &key, const rocksdb::Slice &value);
-  int commit();
+  int commit(bool print_client_error = true);
 
   bool have_background_error() { return m_background_error != 0; }
 


### PR DESCRIPTION
…e out of order as now there is proper SQL error handling for the situation.

- Extended rocksdb.bulk_load_errors.test to induce situation that would lead to debug assertion in  Rdb_sst_file_ordered::put and recorded result.
- Fixed assertion in rocksdb_update_bulk_load by converting it to a 'check' function which can take action and return a failure.
- Fixed up rocksdb.bulk_load_errors.test to remove check for assertion on overlapping keys and just check for proper error return and validate residual state of rocksdb_bulk_load and table.
- Fixed code paths that would call my_print_error to a client where no client exists, this would cause an assertion in the server code.
- Altered rocksdb.bulk_load_errors.test to watch for new errors in log and re-recorded.
- Fixed edge case where if a handler is closed while a bulk load operation with a fault is in process ~ha_rocksdb would assert. Added another sql_print_error and test case to rocksdb.bulk_load_errors.test.