### PR TITLE
Initialize SstFileManager with proper delete rate

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -3898,11 +3898,9 @@ static int rocksdb_init_func(void *const p) {
   // sst_file_manager will move deleted rocksdb sst files to trash_dir
   // to be deleted in a background thread.
   std::string trash_dir = std::string(rocksdb_datadir) + "/trash";
-  rocksdb_db_options->sst_file_manager.reset(
-      NewSstFileManager(rocksdb_db_options->env, myrocks_logger, trash_dir));
-
-  rocksdb_db_options->sst_file_manager->SetDeleteRateBytesPerSecond(
-      rocksdb_sst_mgr_rate_bytes_per_sec);
+  rocksdb_db_options->sst_file_manager.reset(NewSstFileManager(
+      rocksdb_db_options->env, myrocks_logger, trash_dir,
+      rocksdb_sst_mgr_rate_bytes_per_sec, true /* delete_existing_trash */));
 
   std::vector<std::string> cf_names;
   rocksdb::Status status;


### PR DESCRIPTION
When we Create SstFileManager it checks if there are existing files in trash and delete them using the assigned delete rate.
Since we create the object then assign the rate later we end up deleting all files immediately.

The fix is to create the SstFileManager object with the assigned delete rate