### PR TITLE
Prevent direct writes and setting rocksdb_flush_log_at_trx_commit from

### DIFF
--- a/mysql-test/include/restart_mysqld_with_invalid_option.inc
+++ b/mysql-test/include/restart_mysqld_with_invalid_option.inc
@@ -1,0 +1,8 @@
+--source include/shutdown_mysqld.inc
+
+# Expect the server to fail to come up with these options
+--error 1
+--exec $MYSQLD_CMD $_mysqld_option
+
+# Restart the server with the default options
+--source include/start_mysqld.inc

--- a/mysql-test/suite/rocksdb/r/use_direct_reads_writes.result
+++ b/mysql-test/suite/rocksdb/r/use_direct_reads_writes.result
@@ -1,2 +1,9 @@
- RocksDB: Can't enable both use_direct_reads and allow_mmap_reads
- RocksDB: Can't enable both use_direct_io_for_flush_and_compaction and allow_mmap_writes
+Checking direct reads
+Checking direct writes
+Checking rocksdb_flush_log_at_trx_commit
+Validate flush_log settings when direct writes is enabled
+set global rocksdb_flush_log_at_trx_commit=0;
+set global rocksdb_flush_log_at_trx_commit=1;
+ERROR 42000: Variable 'rocksdb_flush_log_at_trx_commit' can't be set to the value of '1'
+set global rocksdb_flush_log_at_trx_commit=2;
+ERROR 42000: Variable 'rocksdb_flush_log_at_trx_commit' can't be set to the value of '2'

--- a/mysql-test/suite/rocksdb/t/use_direct_reads_writes.test
+++ b/mysql-test/suite/rocksdb/t/use_direct_reads_writes.test
@@ -5,43 +5,51 @@
 # caused an assertion in RocksDB.  Now it should not be allowed and the
 # server will not start with that configuration
 
-# Write file to make mysql-test-run.pl expect the "crash", but don't restart
-# the server until it is told to
---let $_server_id= `SELECT @@server_id`
---let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.$_server_id.expect
---exec echo "wait" >$_expect_file_name
-shutdown_server 10;
+--let LOG=$MYSQLTEST_VARDIR/tmp/use_direct_reads_writes.err
+--let SEARCH_FILE=$LOG
 
-# Clear the log
---exec echo "" >$MYSQLTEST_VARDIR/log/mysqld.1.err
+--echo Checking direct reads
+--let $_mysqld_option=--log-error=$LOG --rocksdb_use_direct_reads=1 --rocksdb_allow_mmap_reads=1
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--source include/restart_mysqld_with_invalid_option.inc
 
-# Attempt to restart the server with invalid options
---exec echo "restart:--rocksdb_use_direct_reads=1 --rocksdb_allow_mmap_reads=1" >$_expect_file_name
---sleep 0.1  # Wait 100ms - that is how long the sleep is in check_expected_crash_and_restart
---exec echo "restart:" >$_expect_file_name
+--let SEARCH_PATTERN=enable both use_direct_reads
+--source include/search_pattern_in_file.inc
+--remove_file $LOG
+
+
+# Repeat with direct-writes
+--echo Checking direct writes
+--let $_mysqld_option=--log-error=$LOG --rocksdb_use_direct_io_for_flush_and_compaction=1 --rocksdb_allow_mmap_writes=1
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--source include/restart_mysqld_with_invalid_option.inc
+
+--let SEARCH_PATTERN=enable both use_direct_io_for_flush_and_compaction
+--source include/search_pattern_in_file.inc
+--remove_file $LOG
+
+
+# Verify invalid direct-writes and --rocksdb_flush_log_at_trx_commit combination at startup fails
+--echo Checking rocksdb_flush_log_at_trx_commit
+--let $_mysqld_option=--log-error=$LOG --rocksdb_flush_log_at_trx_commit=1 --rocksdb_allow_mmap_writes=1
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--source include/restart_mysqld_with_invalid_option.inc
+
+--let SEARCH_PATTERN=rocksdb_flush_log_at_trx_commit needs to be
+--source include/search_pattern_in_file.inc
+--remove_file $LOG
+
+
+# Verify rocksdb_flush_log_at_trx_commit cannot be changed if direct writes are used
+--echo Validate flush_log settings when direct writes is enabled
+--let $_mysqld_option=--rocksdb_flush_log_at_trx_commit=0 --rocksdb_allow_mmap_writes=1
+--source include/restart_mysqld_with_option.inc
+
+set global rocksdb_flush_log_at_trx_commit=0;
+--error ER_WRONG_VALUE_FOR_VAR
+set global rocksdb_flush_log_at_trx_commit=1;
+--error ER_WRONG_VALUE_FOR_VAR
+set global rocksdb_flush_log_at_trx_commit=2;
 
 # Cleanup
---enable_reconnect
---source include/wait_until_connected_again.inc
---disable_reconnect
-
-# We should now have an error message
---exec grep "enable both use_direct_reads" $MYSQLTEST_VARDIR/log/mysqld.1.err | cut -d] -f2
-
-# Repeat with --rocksdb-use-direct-writes
---let $_server_id= `SELECT @@server_id`
---let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.$_server_id.expect
---exec echo "wait" >$_expect_file_name
-shutdown_server 10;
-
---exec echo "" >$MYSQLTEST_VARDIR/log/mysqld.1.err
-
---exec echo "restart:--rocksdb_use_direct_io_for_flush_and_compaction=1 --rocksdb_allow_mmap_writes=1" >$_expect_file_name
---sleep 0.1
---exec echo "restart:" >$_expect_file_name
-
---enable_reconnect
---source include/wait_until_connected_again.inc
---disable_reconnect
-
---exec grep "enable both use_direct_io_for_flush_and_compaction" $MYSQLTEST_VARDIR/log/mysqld.1.err | cut -d] -f2
+--source include/restart_mysqld.inc

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -572,6 +572,33 @@ static void rocksdb_set_io_write_timeout(
   RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
 }
 
+enum rocksdb_flush_log_at_trx_commit_type : unsigned int {
+  FLUSH_LOG_NEVER = 0,
+  FLUSH_LOG_SYNC,
+  FLUSH_LOG_BACKGROUND,
+  FLUSH_LOG_MAX /* must be last */
+};
+
+static int rocksdb_validate_flush_log_at_trx_commit(
+    THD *const thd,
+    struct st_mysql_sys_var *const var, /* in: pointer to system variable */
+    void *var_ptr, /* out: immediate result for update function */
+    struct st_mysql_value *const value /* in: incoming value */) {
+  long long new_value;
+
+  /* value is NULL */
+  if (value->val_int(value, &new_value)) {
+    return HA_EXIT_FAILURE;
+  }
+
+  if (rocksdb_db_options->allow_mmap_writes && new_value != FLUSH_LOG_NEVER) {
+    return HA_EXIT_FAILURE;
+  }
+
+  *static_cast<uint32_t *>(var_ptr) = static_cast<uint32_t>(new_value);
+  return HA_EXIT_SUCCESS;
+}
+
 static const char *index_type_names[] = {"kBinarySearch", "kHashSearch", NullS};
 
 static TYPELIB index_type_typelib = {array_elements(index_type_names) - 1,
@@ -1168,19 +1195,13 @@ static MYSQL_SYSVAR_STR(update_cf_options, rocksdb_update_cf_options,
                         "Option updates per column family for RocksDB", nullptr,
                         rocksdb_set_update_cf_options, nullptr);
 
-enum rocksdb_flush_log_at_trx_commit_type : unsigned int {
-  FLUSH_LOG_NEVER = 0,
-  FLUSH_LOG_SYNC,
-  FLUSH_LOG_BACKGROUND,
-  FLUSH_LOG_MAX /* must be last */
-};
-
 static MYSQL_SYSVAR_UINT(flush_log_at_trx_commit,
                          rocksdb_flush_log_at_trx_commit, PLUGIN_VAR_RQCMDARG,
                          "Sync on transaction commit. Similar to "
                          "innodb_flush_log_at_trx_commit. 1: sync on commit, "
                          "0,2: not sync on commit",
-                         nullptr, nullptr, /* default */ FLUSH_LOG_SYNC,
+                         rocksdb_validate_flush_log_at_trx_commit, nullptr,
+                         /* default */ FLUSH_LOG_SYNC,
                          /* min */ FLUSH_LOG_NEVER,
                          /* max */ FLUSH_LOG_BACKGROUND, 0);
 
@@ -2778,7 +2799,8 @@ static bool rocksdb_flush_wal(handlerton *const hton MY_ATTRIBUTE((__unused__)),
   /*
     target_lsn is set to 0 when MySQL wants to sync the wal files
   */
-  if (target_lsn == 0 || rocksdb_flush_log_at_trx_commit != FLUSH_LOG_NEVER) {
+  if ((target_lsn == 0 && !rocksdb_db_options->allow_mmap_writes) ||
+      rocksdb_flush_log_at_trx_commit != FLUSH_LOG_NEVER) {
     rocksdb_wal_group_syncs++;
     s = rdb->FlushWAL(target_lsn == 0 ||
                       rocksdb_flush_log_at_trx_commit == FLUSH_LOG_SYNC);
@@ -3900,6 +3922,14 @@ static int rocksdb_init_func(void *const p) {
                     "use_direct_io_for_flush_and_compaction and "
                     "allow_mmap_writes\n");
     rdb_open_tables.free_hash();
+    DBUG_RETURN(HA_EXIT_FAILURE);
+  }
+
+  if (rocksdb_db_options->allow_mmap_writes &&
+      rocksdb_flush_log_at_trx_commit != FLUSH_LOG_NEVER) {
+    // NO_LINT_DEBUG
+    sql_print_error("RocksDB: rocksdb_flush_log_at_trx_commit needs to be 0 "
+                    "to use allow_mmap_writes");
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
@@ -11627,8 +11657,8 @@ void Rdb_background_thread::run() {
     // InnoDB's behavior. For mode never, the wal file isn't even written,
     // whereas background writes to the wal file, but issues the syncs in a
     // background thread.
-    if (rdb && (rocksdb_flush_log_at_trx_commit != FLUSH_LOG_SYNC)) {
-      DBUG_ASSERT(!rocksdb_db_options->allow_mmap_writes);
+    if (rdb && (rocksdb_flush_log_at_trx_commit != FLUSH_LOG_SYNC) &&
+        !rocksdb_db_options->allow_mmap_writes) {
       const rocksdb::Status s = rdb->FlushWAL(true);
       if (!s.ok()) {
         rdb_handle_io_error(s, RDB_IO_ERROR_BG_THREAD);


### PR DESCRIPTION
asserting

Summary:

Fix the interaction between rocksdb_flush_log_at_trx_commit and allowing
direct writes. When direct writes are allowed, FlushWAL() should not be
called. If these settings are conflicting, then report an error on
startup or when trying to set the variable.

Test Plan:

run mtr and add new test case