### PR TITLE
Rework rocksdb.write_sync test without using sleep calls

### DIFF
--- a/mysql-test/suite/rocksdb/r/write_sync.result
+++ b/mysql-test/suite/rocksdb/r/write_sync.result
@@ -3,6 +3,7 @@ SET GLOBAL rocksdb_write_ignore_missing_column_families=true;
 create table aaa (id int primary key, i int) engine rocksdb;
 set @save_rocksdb_flush_log_at_trx_commit=@@global.rocksdb_flush_log_at_trx_commit;
 SET GLOBAL rocksdb_flush_log_at_trx_commit=1;
+insert aaa(id, i) values(0,1);
 select variable_value into @a from information_schema.global_status where variable_name='rocksdb_wal_synced';
 insert aaa(id, i) values(1,1);
 select variable_value-@a from information_schema.global_status where variable_name='rocksdb_wal_synced';
@@ -16,11 +17,11 @@ insert aaa(id, i) values(3,1);
 select variable_value-@a from information_schema.global_status where variable_name='rocksdb_wal_synced';
 variable_value-@a
 3
+select variable_value into @a from information_schema.global_status where variable_name='rocksdb_wal_synced';
 SET GLOBAL rocksdb_flush_log_at_trx_commit=0;
-select variable_value into @a from information_schema.global_status where variable_name='rocksdb_wal_synced';
 insert aaa(id, i) values(4,1);
-SET GLOBAL rocksdb_flush_log_at_trx_commit=2;
 select variable_value into @a from information_schema.global_status where variable_name='rocksdb_wal_synced';
+SET GLOBAL rocksdb_flush_log_at_trx_commit=2;
 insert aaa(id, i) values(5,1);
 truncate table aaa;
 drop table aaa;

--- a/mysql-test/suite/rocksdb/t/write_sync.test
+++ b/mysql-test/suite/rocksdb/t/write_sync.test
@@ -7,7 +7,8 @@ create table aaa (id int primary key, i int) engine rocksdb;
 
 set @save_rocksdb_flush_log_at_trx_commit=@@global.rocksdb_flush_log_at_trx_commit;
 SET GLOBAL rocksdb_flush_log_at_trx_commit=1;
---exec sleep 5
+insert aaa(id, i) values(0,1);
+
 select variable_value into @a from information_schema.global_status where variable_name='rocksdb_wal_synced';
 insert aaa(id, i) values(1,1);
 select variable_value-@a from information_schema.global_status where variable_name='rocksdb_wal_synced';
@@ -16,18 +17,16 @@ select variable_value-@a from information_schema.global_status where variable_na
 insert aaa(id, i) values(3,1);
 select variable_value-@a from information_schema.global_status where variable_name='rocksdb_wal_synced';
 
-SET GLOBAL rocksdb_flush_log_at_trx_commit=0;
---exec sleep 5
 select variable_value into @a from information_schema.global_status where variable_name='rocksdb_wal_synced';
+SET GLOBAL rocksdb_flush_log_at_trx_commit=0;
 insert aaa(id, i) values(4,1);
 
 let $status_var=rocksdb_wal_synced;
 let $status_var_value=`select @a+1`;
 source include/wait_for_status_var.inc;
 
-SET GLOBAL rocksdb_flush_log_at_trx_commit=2;
---exec sleep 5
 select variable_value into @a from information_schema.global_status where variable_name='rocksdb_wal_synced';
+SET GLOBAL rocksdb_flush_log_at_trx_commit=2;
 insert aaa(id, i) values(5,1);
 
 let $status_var=rocksdb_wal_synced;


### PR DESCRIPTION
Summary:

Remove sleep calls from rocksdb.write_sync and make the test more
deterministic.

Test Plan:

mtr rocksdb.write_sync