### PR TITLE
Fix assertion on covers_key(b) with debug build (#728)

### DIFF
--- a/mysql-test/suite/rocksdb/r/rocksdb_debug.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_debug.result
@@ -1,0 +1,11 @@
+#
+# Issue #728: Assertion `covers_key(b)' failed in int
+# myrocks::Rdb_key_def::cmp_full_keys(const rocks db::Slice&,
+# const rocksdb::Slice&) 
+#
+CREATE TABLE t2(c1 TINYINT SIGNED KEY,c2 TINYINT UNSIGNED,c3 INT);
+INSERT INTO t2(c1)VALUES(0);
+SELECT * FROM t2 WHERE c1<=127 ORDER BY c1 DESC;
+c1	c2	c3
+0	NULL	NULL
+DROP TABLE t2;

--- a/mysql-test/suite/rocksdb/t/rocksdb_debug.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_debug.test
@@ -1,0 +1,14 @@
+--source include/have_rocksdb.inc
+--source include/have_debug.inc
+
+--echo #
+--echo # Issue #728: Assertion `covers_key(b)' failed in int
+--echo # myrocks::Rdb_key_def::cmp_full_keys(const rocks db::Slice&,
+--echo # const rocksdb::Slice&) 
+--echo #
+
+CREATE TABLE t2(c1 TINYINT SIGNED KEY,c2 TINYINT UNSIGNED,c3 INT);
+INSERT INTO t2(c1)VALUES(0);
+SELECT * FROM t2 WHERE c1<=127 ORDER BY c1 DESC;
+DROP TABLE t2;
+

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -240,9 +240,9 @@ public:
     if  X is a prefix of Y, then we consider that X = Y.
   */
   // b describes the lookup key, which can be a prefix of a.
+  // b might be outside of the index_number range, if successor() is called.
   int cmp_full_keys(const rocksdb::Slice &a, const rocksdb::Slice &b) const {
     DBUG_ASSERT(covers_key(a));
-    DBUG_ASSERT(covers_key(b));
 
     return memcmp(a.data(), b.data(), std::min(a.size(), b.size()));
   }


### PR DESCRIPTION
Summary: This diff removes an extra assertion on covers_key(b).
Prefix condition might be incremented by successor(). It may
overflow and points to outside of the index_id. This is an expected
behavior and it should not fail.

Test Plan: mtr