### PR TITLE
Fix loading auto_increment values in tables with hidden pk

### DIFF
--- a/mysql-test/suite/rocksdb/r/allow_no_primary_key_with_sk.result
+++ b/mysql-test/suite/rocksdb/r/allow_no_primary_key_with_sk.result
@@ -778,3 +778,20 @@ set global rocksdb_force_flush_memtable_now = true;
 select * from t1;
 col1	col2	extra
 DROP TABLE t1;
+create table t1 (i int auto_increment, key(i));
+insert into t1 values();
+insert into t1 values();
+insert into t1 values();
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int(11) NOT NULL AUTO_INCREMENT,
+  KEY `i` (`i`)
+) ENGINE=ROCKSDB AUTO_INCREMENT=4 DEFAULT CHARSET=latin1
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int(11) NOT NULL AUTO_INCREMENT,
+  KEY `i` (`i`)
+) ENGINE=ROCKSDB AUTO_INCREMENT=4 DEFAULT CHARSET=latin1
+drop table t1;

--- a/mysql-test/suite/rocksdb/t/allow_no_primary_key_with_sk.test
+++ b/mysql-test/suite/rocksdb/t/allow_no_primary_key_with_sk.test
@@ -135,3 +135,15 @@ set global rocksdb_force_flush_memtable_now = true;
 
 select * from t1;
 DROP TABLE t1;
+
+## https://github.com/facebook/mysql-5.6/issues/736
+create table t1 (i int auto_increment, key(i));
+insert into t1 values();
+insert into t1 values();
+insert into t1 values();
+
+show create table t1;
+--source include/restart_mysqld.inc
+show create table t1;
+
+drop table t1;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -7086,7 +7086,7 @@ int ha_rocksdb::read_row_from_secondary_key(uchar *const buf,
 
   bool covered_lookup =
       m_keyread_only || kd.covers_lookup(table, &value, &m_lookup_bitmap);
-  if (covered_lookup && m_lock_rows == RDB_LOCK_NONE && !has_hidden_pk(table)) {
+  if (covered_lookup && m_lock_rows == RDB_LOCK_NONE) {
     pk_size =
         kd.get_primary_key_tuple(table, *m_pk_descr, &rkey, m_pk_packed_tuple);
     if (pk_size == RDB_INVALID_KEY_LEN) {
@@ -7208,8 +7208,7 @@ int ha_rocksdb::secondary_index_read(const int keyno, uchar *const buf) {
       bool covered_lookup =
           m_keyread_only || m_key_descr_arr[keyno]->covers_lookup(
                                 table, &value, &m_lookup_bitmap);
-      if (covered_lookup && m_lock_rows == RDB_LOCK_NONE &&
-          !has_hidden_pk(table)) {
+      if (covered_lookup && m_lock_rows == RDB_LOCK_NONE) {
         rc = m_key_descr_arr[keyno]->unpack_record(
             table, buf, &key, &value, m_verify_row_debug_checksums);
         global_stats.covered_secondary_key_lookups.inc();


### PR DESCRIPTION
We don't decode from secondary keys if hidden pk exists for some reason. Remove this check.

Closes https://github.com/facebook/mysql-5.6/issues/736