### PR TITLE
[MyRocks] Setting iterate_upper_bounds as rocksdb.ReadOptions

### DIFF
--- a/mysql-test/suite/rocksdb/r/optimizer_loose_index_scans.result
+++ b/mysql-test/suite/rocksdb/r/optimizer_loose_index_scans.result
@@ -36,7 +36,7 @@ explain select b, d from t where d > 4;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t	range	PRIMARY,b	b	8	NULL	#	Using where; Using index for skip scan
 rows_read
-1509
+1505
 include/diff_tables.inc [temp_orig, temp_skip]
 set optimizer_switch = 'skip_scan=off,skip_scan_cost_based=on';
 set optimizer_switch = 'skip_scan=off';
@@ -44,7 +44,7 @@ explain select a, b, c, d from t where a = 5 and d <= 3;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t	ref	PRIMARY	PRIMARY	4	const	#	Using where; Using index
 rows_read
-251
+250
 set optimizer_switch = 'skip_scan=on,skip_scan_cost_based=off';
 explain select a, b, c, d from t where a = 5 and d <= 3;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
@@ -58,13 +58,13 @@ explain select e from t where a = 5 and d <= 3;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t	ref	PRIMARY	PRIMARY	4	const	#	Using where
 rows_read
-251
+250
 set optimizer_switch = 'skip_scan=on,skip_scan_cost_based=off';
 explain select e from t where a = 5 and d <= 3;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t	ref	PRIMARY,b	PRIMARY	4	const	#	Using where
 rows_read
-251
+250
 include/diff_tables.inc [temp_orig, temp_skip]
 set optimizer_switch = 'skip_scan=off,skip_scan_cost_based=on';
 set optimizer_switch = 'skip_scan=off';
@@ -72,13 +72,13 @@ explain select a, b, c, d from t where a = 5 and d >= 98;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t	ref	PRIMARY	PRIMARY	4	const	#	Using where; Using index
 rows_read
-251
+250
 set optimizer_switch = 'skip_scan=on,skip_scan_cost_based=off';
 explain select a, b, c, d from t where a = 5 and d >= 98;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t	range	PRIMARY,b	PRIMARY	16	NULL	#	Using where; Using index for skip scan
 rows_read
-46
+26
 include/diff_tables.inc [temp_orig, temp_skip]
 set optimizer_switch = 'skip_scan=off,skip_scan_cost_based=on';
 set optimizer_switch = 'skip_scan=off';
@@ -86,13 +86,13 @@ explain select e from t where a = 5 and d >= 98;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t	ref	PRIMARY	PRIMARY	4	const	#	Using where
 rows_read
-251
+250
 set optimizer_switch = 'skip_scan=on,skip_scan_cost_based=off';
 explain select e from t where a = 5 and d >= 98;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t	ref	PRIMARY,b	PRIMARY	4	const	#	Using where
 rows_read
-251
+250
 include/diff_tables.inc [temp_orig, temp_skip]
 set optimizer_switch = 'skip_scan=off,skip_scan_cost_based=on';
 set optimizer_switch = 'skip_scan=off';
@@ -100,13 +100,13 @@ explain select a, b, c, d from t where a in (1, 5) and d >= 98;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t	range	PRIMARY	PRIMARY	4	NULL	#	Using where; Using index
 rows_read
-502
+500
 set optimizer_switch = 'skip_scan=on,skip_scan_cost_based=off';
 explain select a, b, c, d from t where a in (1, 5) and d >= 98;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t	range	PRIMARY,b	PRIMARY	16	NULL	#	Using where; Using index for skip scan
 rows_read
-92
+52
 include/diff_tables.inc [temp_orig, temp_skip]
 set optimizer_switch = 'skip_scan=off,skip_scan_cost_based=on';
 set optimizer_switch = 'skip_scan=off';
@@ -114,13 +114,13 @@ explain select a, b, c, d from t where a in (1, 3, 5) and d >= 98;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t	range	PRIMARY	PRIMARY	4	NULL	#	Using where; Using index
 rows_read
-753
+750
 set optimizer_switch = 'skip_scan=on,skip_scan_cost_based=off';
 explain select a, b, c, d from t where a in (1, 3, 5) and d >= 98;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t	range	PRIMARY,b	PRIMARY	16	NULL	#	Using where; Using index for skip scan
 rows_read
-138
+78
 include/diff_tables.inc [temp_orig, temp_skip]
 set optimizer_switch = 'skip_scan=off,skip_scan_cost_based=on';
 set optimizer_switch = 'skip_scan=off';
@@ -134,7 +134,7 @@ explain select a, b, c, d from t where a in (1, 5) and b in (1, 2) and d >= 98;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t	range	PRIMARY,b	PRIMARY	16	NULL	#	Using where; Using index for skip scan
 rows_read
-40
+24
 include/diff_tables.inc [temp_orig, temp_skip]
 set optimizer_switch = 'skip_scan=off,skip_scan_cost_based=on';
 set optimizer_switch = 'skip_scan=off';
@@ -148,7 +148,7 @@ explain select a, b, c, d from t where a in (1, 2, 3, 4, 5) and b in (1, 2, 3) a
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t	range	PRIMARY,b	PRIMARY	16	NULL	#	Using where; Using index for skip scan
 rows_read
-150
+90
 include/diff_tables.inc [temp_orig, temp_skip]
 set optimizer_switch = 'skip_scan=off,skip_scan_cost_based=on';
 set optimizer_switch = 'skip_scan=off';
@@ -162,7 +162,7 @@ explain select a, b, c, d from t where a = 5 and b = 2 and d >= 98;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t	range	PRIMARY,b	PRIMARY	16	NULL	#	Using where; Using index for skip scan
 rows_read
-10
+6
 include/diff_tables.inc [temp_orig, temp_skip]
 set optimizer_switch = 'skip_scan=off,skip_scan_cost_based=on';
 set optimizer_switch = 'skip_scan=off';
@@ -170,7 +170,7 @@ explain select a+1, b, c, d from t where a = 5 and d < 3;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t	ref	PRIMARY	PRIMARY	4	const	#	Using where; Using index
 rows_read
-251
+250
 set optimizer_switch = 'skip_scan=on,skip_scan_cost_based=off';
 explain select a+1, b, c, d from t where a = 5 and d < 3;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
@@ -184,7 +184,7 @@ explain select b, c, d from t where a = 5 and d < 3;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t	ref	PRIMARY	PRIMARY	4	const	#	Using where; Using index
 rows_read
-251
+250
 set optimizer_switch = 'skip_scan=on,skip_scan_cost_based=off';
 explain select b, c, d from t where a = 5 and d < 3;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
@@ -204,7 +204,7 @@ explain select a, b, c, d from t where a = b and d >= 98;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t	range	PRIMARY,b	b	8	NULL	#	Using where; Using index for skip scan
 rows_read
-9
+5
 include/diff_tables.inc [temp_orig, temp_skip]
 set optimizer_switch = 'skip_scan=off,skip_scan_cost_based=on';
 set optimizer_switch = 'skip_scan=on';

--- a/mysql-test/suite/rocksdb/t/optimizer_loose_index_scans-master.opt
+++ b/mysql-test/suite/rocksdb/t/optimizer_loose_index_scans-master.opt
@@ -1,1 +1,0 @@
---rocksdb_default_cf_options=prefix_extractor=capped:12

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -126,10 +126,6 @@ static handler *rocksdb_create_handler(my_core::handlerton *hton,
                                        my_core::TABLE_SHARE *table_arg,
                                        my_core::MEM_ROOT *mem_root);
 
-bool can_use_bloom_filter(THD *thd, const Rdb_key_def &kd,
-                          const rocksdb::Slice &eq_cond,
-                          const bool use_all_keys);
-
 static rocksdb::CompactRangeOptions getCompactRangeOptions() {
   rocksdb::CompactRangeOptions compact_range_options;
   compact_range_options.bottommost_level_compaction =
@@ -2159,6 +2155,8 @@ public:
   rocksdb::Iterator *
   get_iterator(rocksdb::ColumnFamilyHandle *const column_family,
                bool skip_bloom_filter, bool fill_cache,
+               const rocksdb::Slice &eq_cond_lower_bound,
+               const rocksdb::Slice &eq_cond_upper_bound,
                bool read_current = false, bool create_snapshot = true) {
     // Make sure we are not doing both read_current (which implies we don't
     // want a snapshot) and create_snapshot which makes sure we create
@@ -2173,6 +2171,8 @@ public:
 
     if (skip_bloom_filter) {
       options.total_order_seek = true;
+      // TODO(yoshinori): options.iterate_lower_bound = &eq_cond_lower_bound;
+      options.iterate_upper_bound = &eq_cond_upper_bound;
     } else {
       // With this option, Iterator::Valid() returns false if key
       // is outside of the prefix bloom filter range set at Seek().
@@ -4830,7 +4830,8 @@ ha_rocksdb::ha_rocksdb(my_core::handlerton *const hton,
       m_sk_packed_tuple(nullptr), m_end_key_packed_tuple(nullptr),
       m_sk_match_prefix(nullptr), m_sk_match_prefix_buf(nullptr),
       m_sk_packed_tuple_old(nullptr), m_dup_sk_packed_tuple(nullptr),
-      m_dup_sk_packed_tuple_old(nullptr), m_pack_buffer(nullptr),
+      m_dup_sk_packed_tuple_old(nullptr), m_eq_cond_lower_bound(nullptr),
+      m_eq_cond_upper_bound(nullptr), m_pack_buffer(nullptr),
       m_lock_rows(RDB_LOCK_NONE), m_keyread_only(FALSE),
       m_bulk_load_tx(nullptr), m_encoder_arr(nullptr),
       m_row_checksums_checked(0), m_in_rpl_delete_rows(false),
@@ -5675,6 +5676,11 @@ int ha_rocksdb::alloc_key_buffers(const TABLE *const table_arg,
   m_pack_buffer =
       reinterpret_cast<uchar *>(my_malloc(max_packed_sk_len, MYF(0)));
 
+  m_eq_cond_upper_bound =
+      reinterpret_cast<uchar *>(my_malloc(max_packed_sk_len, MYF(0)));
+  m_eq_cond_lower_bound =
+      reinterpret_cast<uchar *>(my_malloc(max_packed_sk_len, MYF(0)));
+
   /*
     If inplace alter is happening, allocate special buffers for unique
     secondary index duplicate checking.
@@ -5689,6 +5695,7 @@ int ha_rocksdb::alloc_key_buffers(const TABLE *const table_arg,
   if (m_pk_tuple == nullptr || m_pk_packed_tuple == nullptr ||
       m_sk_packed_tuple == nullptr || m_sk_packed_tuple_old == nullptr ||
       m_end_key_packed_tuple == nullptr || m_pack_buffer == nullptr ||
+      m_eq_cond_upper_bound == nullptr || m_eq_cond_lower_bound == nullptr ||
       (alloc_alter_buffers && (m_dup_sk_packed_tuple == nullptr ||
                                m_dup_sk_packed_tuple_old == nullptr))) {
     // One or more of the above allocations failed.  Clean up and exit
@@ -5727,6 +5734,12 @@ void ha_rocksdb::free_key_buffers() {
 
   my_free(m_dup_sk_packed_tuple_old);
   m_dup_sk_packed_tuple_old = nullptr;
+
+  my_free(m_eq_cond_upper_bound);
+  m_eq_cond_upper_bound = nullptr;
+
+  my_free(m_eq_cond_lower_bound);
+  m_eq_cond_lower_bound = nullptr;
 }
 
 void ha_rocksdb::set_use_read_free_rpl(const char *const whitelist) {
@@ -8640,7 +8653,7 @@ int ha_rocksdb::check_and_lock_sk(const uint &key_id,
 
     The bloom filter may need to be disabled for this lookup.
   */
-  const bool total_order_seek = !can_use_bloom_filter(
+  const bool total_order_seek = !check_bloom_and_set_bounds(
       ha_thd(), kd, new_slice, all_parts_used);
   const bool fill_cache = !THDVAR(ha_thd(), skip_fill_cache);
 
@@ -8652,7 +8665,9 @@ int ha_rocksdb::check_and_lock_sk(const uint &key_id,
   }
 
   rocksdb::Iterator *const iter = row_info.tx->get_iterator(
-      kd.get_cf(), total_order_seek, fill_cache, true /* read current data */,
+      kd.get_cf(), total_order_seek, fill_cache,
+      m_eq_cond_lower_bound_slice, m_eq_cond_upper_bound_slice,
+      true /* read current data */,
       false /* acquire snapshot */);
   /*
     Need to scan the transaction to see if there is a duplicate key.
@@ -9108,6 +9123,42 @@ int ha_rocksdb::update_write_row(const uchar *const old_data,
 }
 
 /*
+ Setting iterator upper/lower bounds for Seek/SeekForPrev.
+ This makes RocksDB to avoid scanning tombstones outside of
+ the given key ranges, when prefix_same_as_start=true was not passed
+ (when prefix bloom filter can not be used).
+ Inversing upper/lower bound is necessary on reverse order CF.
+ This covers HA_READ_PREFIX_LAST* case as well. For example,
+ if given query eq condition was 12 bytes and condition was
+ 0x0000b3eb003f65c5e78858b8, and if doing HA_READ_PREFIX_LAST,
+ eq_cond_len was 11 (see calc_eq_cond_len() for details).
+ If the index was reverse order, upper bound would be
+ 0x0000b3eb003f65c5e78857, and lower bound would be
+ 0x0000b3eb003f65c5e78859. These cover given eq condition range.
+*/
+void ha_rocksdb::setup_iterator_bounds(const Rdb_key_def &kd,
+                                       const rocksdb::Slice &eq_cond) {
+  uint eq_cond_len = eq_cond.size();
+  DBUG_ASSERT(eq_cond_len >= Rdb_key_def::INDEX_NUMBER_SIZE);
+  memcpy(m_eq_cond_upper_bound, eq_cond.data(), eq_cond_len);
+  kd.successor(m_eq_cond_upper_bound, eq_cond_len);
+  memcpy(m_eq_cond_lower_bound, eq_cond.data(), eq_cond_len);
+  kd.predecessor(m_eq_cond_lower_bound, eq_cond_len);
+
+  if (kd.m_is_reverse_cf) {
+    m_eq_cond_upper_bound_slice =
+        rocksdb::Slice((const char *)m_eq_cond_lower_bound, eq_cond_len);
+    m_eq_cond_lower_bound_slice =
+        rocksdb::Slice((const char *)m_eq_cond_upper_bound, eq_cond_len);
+  } else {
+    m_eq_cond_upper_bound_slice =
+        rocksdb::Slice((const char *)m_eq_cond_upper_bound, eq_cond_len);
+    m_eq_cond_lower_bound_slice =
+        rocksdb::Slice((const char *)m_eq_cond_lower_bound, eq_cond_len);
+  }
+}
+
+/*
   Open a cursor
 */
 
@@ -9123,7 +9174,7 @@ void ha_rocksdb::setup_scan_iterator(const Rdb_key_def &kd,
   bool skip_bloom = true;
 
   const rocksdb::Slice eq_cond(slice->data(), eq_cond_len);
-  if (can_use_bloom_filter(ha_thd(), kd, eq_cond, use_all_keys)) {
+  if (check_bloom_and_set_bounds(ha_thd(), kd, eq_cond, use_all_keys)) {
     skip_bloom = false;
   }
 
@@ -9163,7 +9214,9 @@ void ha_rocksdb::setup_scan_iterator(const Rdb_key_def &kd,
       read_opts.snapshot = m_scan_it_snapshot;
       m_scan_it = rdb->NewIterator(read_opts, kd.get_cf());
     } else {
-      m_scan_it = tx->get_iterator(kd.get_cf(), skip_bloom, fill_cache);
+      m_scan_it = tx->get_iterator(kd.get_cf(), skip_bloom, fill_cache,
+                                   m_eq_cond_lower_bound_slice,
+                                   m_eq_cond_upper_bound_slice);
     }
     m_scan_it_skips_bloom = skip_bloom;
   }
@@ -9186,7 +9239,8 @@ void ha_rocksdb::setup_iterator_for_rnd_scan() {
 
   rocksdb::Slice table_key((const char *)m_pk_packed_tuple, key_size);
 
-  setup_scan_iterator(*m_pk_descr, &table_key);
+  setup_scan_iterator(*m_pk_descr, &table_key, false,
+                      Rdb_key_def::INDEX_NUMBER_SIZE);
   m_scan_it->Seek(table_key);
   m_skip_scan_it_next_call = true;
 }
@@ -10048,6 +10102,13 @@ ha_rocksdb::get_range(const int &i,
   return myrocks::get_range(*m_key_descr_arr[i], buf);
 }
 
+/*
+ This function is called with total_order_seek=true, but
+ upper/lower bound setting is not necessary.
+ Boundary set is useful when there is no matching key,
+ but in drop_index_thread's case, it means index is marked as removed,
+ so no further seek will happen for the index id.
+*/
 static bool is_myrocks_index_empty(
   rocksdb::ColumnFamilyHandle *cfh, const bool is_reverse_cf,
   const rocksdb::ReadOptions &read_opts,
@@ -10238,10 +10299,12 @@ int ha_rocksdb::remove_rows(Rdb_tbl_def *const tbl) {
     const Rdb_key_def &kd = *tbl->m_key_descr_arr[i];
     kd.get_infimum_key(reinterpret_cast<uchar *>(key_buf), &key_len);
     rocksdb::ColumnFamilyHandle *cf = kd.get_cf();
-
+    const rocksdb::Slice table_key(key_buf, key_len);
+    setup_iterator_bounds(kd, table_key);
+    // TODO(yoshinori): opts.iterate_lower_bound=&m_eq_cond_lower_bound_slice;
+    opts.iterate_upper_bound = &m_eq_cond_upper_bound_slice;
     std::unique_ptr<rocksdb::Iterator> it(rdb->NewIterator(opts, cf));
 
-    const rocksdb::Slice table_key(key_buf, key_len);
     it->Seek(table_key);
     while (it->Valid()) {
       const rocksdb::Slice key = it->key();
@@ -12043,6 +12106,16 @@ void Rdb_background_thread::run() {
   ddl_manager.persist_stats();
 }
 
+bool ha_rocksdb::check_bloom_and_set_bounds(THD *thd, const Rdb_key_def &kd,
+                                            const rocksdb::Slice &eq_cond,
+                                            const bool use_all_keys) {
+  bool can_use_bloom = can_use_bloom_filter(thd, kd, eq_cond, use_all_keys);
+  if (!can_use_bloom) {
+    setup_iterator_bounds(kd, eq_cond);
+  }
+  return can_use_bloom;
+}
+
 /**
   Deciding if it is possible to use bloom filter or not.
 
@@ -12061,9 +12134,9 @@ void Rdb_background_thread::run() {
   @param use_all_keys True if all key parts are set with equal conditions.
                       This is aware of extended keys.
 */
-bool can_use_bloom_filter(THD *thd, const Rdb_key_def &kd,
-                          const rocksdb::Slice &eq_cond,
-                          const bool use_all_keys) {
+bool ha_rocksdb::can_use_bloom_filter(THD *thd, const Rdb_key_def &kd,
+                                      const rocksdb::Slice &eq_cond,
+                                      const bool use_all_keys) {
   bool can_use = false;
 
   if (THDVAR(thd, skip_bloom_filter_on_read)) {

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -806,6 +806,25 @@ int Rdb_key_def::successor(uchar *const packed_tuple, const uint &len) {
   return changed;
 }
 
+/*
+  @return Number of bytes that were changed
+*/
+int Rdb_key_def::predecessor(uchar *const packed_tuple, const uint &len) {
+  DBUG_ASSERT(packed_tuple != nullptr);
+
+  int changed = 0;
+  uchar *p = packed_tuple + len - 1;
+  for (; p > packed_tuple; p--) {
+    changed++;
+    if (*p != uchar(0x00)) {
+      *p = *p - 1;
+      break;
+    }
+    *p = 0xFF;
+  }
+  return changed;
+}
+
 static const std::map<char, size_t> UNPACK_HEADER_SIZES = {
     {RDB_UNPACK_DATA_TAG, RDB_UNPACK_HEADER_SIZE},
     {RDB_UNPACK_COVERED_DATA_TAG, RDB_UNPACK_COVERED_HEADER_SIZE}};

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -243,6 +243,9 @@ public:
   /* Make a key that is right after the given key. */
   static int successor(uchar *const packed_tuple, const uint &len);
 
+  /* Make a key that is right before the given key. */
+  static int predecessor(uchar *const packed_tuple, const uint &len);
+
   /*
     This can be used to compare prefixes.
     if  X is a prefix of Y, then we consider that X = Y.


### PR DESCRIPTION
Summary: This diff explicitly sets iterate_upper_bounds
and passes to rocksdb read options. This will avoid
scanning tombstones outside of the given key ranges.
This does not change behaviors when prefix bloom filter is used,
since prefix_same_as_start can be set in that case.

This diff will be updated when RocksDB supports
iterate_lower_bounds.