### PR TITLE
Load autoincrement and hidden pk only once

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -4594,7 +4594,7 @@ static ulonglong rdb_get_int_col_max_value(const Field *field) {
 }
 
 void ha_rocksdb::load_auto_incr_value() {
-  ulonglong dd_val = 0;
+  ulonglong auto_incr = 0;
   bool validate_last = false, use_datadic = true;
 #ifndef NDEBUG
   DBUG_EXECUTE_IF("myrocks_autoinc_upgrade", use_datadic = false;);
@@ -4602,21 +4602,27 @@ void ha_rocksdb::load_auto_incr_value() {
 #endif
 
   if (use_datadic && dict_manager.get_auto_incr_val(
-                         m_tbl_def->get_autoincr_gl_index_id(), &dd_val)) {
-    update_auto_incr_val(dd_val);
+                         m_tbl_def->get_autoincr_gl_index_id(), &auto_incr)) {
+    update_auto_incr_val(auto_incr);
   }
 
   // If we find nothing in the data dictionary, or if we are in debug mode,
   // then call index_last to get the last value.
   //
   // This is needed when upgrading from a server that did not support
-  // persistent auto_increment.
+  // persistent auto_increment, of if the table is empty.
   //
   // For debug mode, we are just verifying that the data dictionary value is
   // greater than or equal to the maximum value in the table.
-  if (dd_val == 0 || validate_last) {
-    ulonglong last_val = load_auto_incr_value_from_index();
-    update_auto_incr_val(last_val);
+  if (auto_incr == 0 || validate_last) {
+    auto_incr = load_auto_incr_value_from_index();
+    update_auto_incr_val(auto_incr);
+  }
+
+  // If we failed to find anything from the data dictionary and index, then
+  // initialize auto_increment to 1.
+  if (m_tbl_def->m_auto_incr_val == 0) {
+    update_auto_incr_val(1);
   }
 }
 
@@ -4724,12 +4730,12 @@ int ha_rocksdb::load_hidden_pk_value() {
   Rdb_transaction *const tx = get_or_create_tx(table->in_use);
   const bool is_new_snapshot = !tx->has_snapshot();
 
+  longlong hidden_pk_id = 1;
   // Do a lookup.
   if (!index_last(table->record[0])) {
     /*
       Decode PK field from the key
     */
-    longlong hidden_pk_id = 0;
     auto err = read_hidden_pk_id_from_rowkey(&hidden_pk_id);
     if (err) {
       if (is_new_snapshot) {
@@ -4739,11 +4745,11 @@ int ha_rocksdb::load_hidden_pk_value() {
     }
 
     hidden_pk_id++;
-    longlong old = m_tbl_def->m_hidden_pk_val;
-    while (
-        old < hidden_pk_id &&
-        !m_tbl_def->m_hidden_pk_val.compare_exchange_weak(old, hidden_pk_id)) {
-    }
+  }
+
+  longlong old = m_tbl_def->m_hidden_pk_val;
+  while (old < hidden_pk_id &&
+         !m_tbl_def->m_hidden_pk_val.compare_exchange_weak(old, hidden_pk_id)) {
   }
 
   if (is_new_snapshot) {
@@ -5845,11 +5851,13 @@ int ha_rocksdb::open(const char *const name, int mode, uint test_if_locked) {
   */
   m_verify_row_debug_checksums = false;
 
-  /* TODO: move the following to where TABLE_SHARE is opened: */
-  if (table->found_next_number_field)
+  /* Load auto_increment value only once on first use. */
+  if (table->found_next_number_field && m_tbl_def->m_auto_incr_val == 0) {
     load_auto_incr_value();
+  }
 
-  if (has_hidden_pk(table) &&
+  /* Load hidden pk only once on first use. */
+  if (has_hidden_pk(table) && m_tbl_def->m_hidden_pk_val == 0 &&
       (err = load_hidden_pk_value()) != HA_EXIT_SUCCESS) {
     free_key_buffers();
     DBUG_RETURN(err);
@@ -11542,9 +11550,11 @@ bool ha_rocksdb::commit_inplace_alter_table(
     for (inplace_alter_handler_ctx **pctx = ctx_array; *pctx; pctx++) {
       Rdb_inplace_alter_ctx *const ctx =
           static_cast<Rdb_inplace_alter_ctx *>(*pctx);
+      auto_incr_val = std::max(auto_incr_val, ctx->m_max_auto_incr);
       dict_manager.put_auto_incr_val(
-          batch, ctx->m_new_tdef->get_autoincr_gl_index_id(),
-          std::max(ctx->m_max_auto_incr, auto_incr_val), true /* overwrite */);
+          batch, ctx->m_new_tdef->get_autoincr_gl_index_id(), auto_incr_val,
+          true /* overwrite */);
+      ctx->m_new_tdef->m_auto_incr_val = auto_incr_val;
     }
 
     if (dict_manager.commit(batch)) {

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -973,17 +973,17 @@ public:
   Rdb_tbl_def &operator=(const Rdb_tbl_def &) = delete;
 
   explicit Rdb_tbl_def(const std::string &name)
-      : m_key_descr_arr(nullptr), m_hidden_pk_val(1), m_auto_incr_val(1) {
+      : m_key_descr_arr(nullptr), m_hidden_pk_val(0), m_auto_incr_val(0) {
     set_name(name);
   }
 
   Rdb_tbl_def(const char *const name, const size_t &len)
-      : m_key_descr_arr(nullptr), m_hidden_pk_val(1), m_auto_incr_val(1) {
+      : m_key_descr_arr(nullptr), m_hidden_pk_val(0), m_auto_incr_val(0) {
     set_name(std::string(name, len));
   }
 
   explicit Rdb_tbl_def(const rocksdb::Slice &slice, const size_t &pos = 0)
-      : m_key_descr_arr(nullptr), m_hidden_pk_val(1), m_auto_incr_val(1) {
+      : m_key_descr_arr(nullptr), m_hidden_pk_val(0), m_auto_incr_val(0) {
     set_name(std::string(slice.data() + pos, slice.size() - pos));
   }
 


### PR DESCRIPTION
Currently, we load hidden pk and auto increment ids unconditionally on every `ha_rocksdb::open`. This is actually not necessary, since we can rely on the in-memory value after the server initially starts up. It's only on restarts that we need to reload the value, in which case we just load from disk on the first few opens.

Closes https://github.com/facebook/mysql-5.6/issues/741