### PR TITLE
[myrocks_hotbackup] Exclude trash files

### DIFF
--- a/scripts/myrocks_hotbackup
+++ b/scripts/myrocks_hotbackup
@@ -28,7 +28,7 @@ rocksdb_files = ['MANIFEST', 'CURRENT', 'OPTIONS']
 rocksdb_data_suffix = '.sst'
 rocksdb_wal_suffix = '.log'
 exclude_files = ['master.info', 'relay-log.info', 'worker-relay-log.info',
-                 'auto.cnf', 'gaplock.log', 'ibdata', 'ib_logfile']
+                 'auto.cnf', 'gaplock.log', 'ibdata', 'ib_logfile', '.trash']
 wdt_bin = 'wdt'
 
 def is_manifest(fname):


### PR DESCRIPTION
Summary: This diff excludes .trash files from backups.
".trash" was introduced at
https://github.com/facebook/rocksdb/commit/05993155ef72e0beb5286593f7ab63774dc137a1