### PR TITLE
Fix a race condition in rocksdb.rocksdb test

### DIFF
--- a/mysql-test/suite/rocksdb/t/rocksdb.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb.test
@@ -1104,6 +1104,10 @@ set autocommit = 1;
 update t1 set a = sleep(100) where pk = 1;
 
 --connect (con1,localhost,root,,)
+
+let $wait_condition= select State='User sleep' from information_schema.processlist where id=$con_id;
+--source include/wait_condition.inc
+
 --echo kill query \$con_id;
 --disable_query_log
 eval kill query $con_id;


### PR DESCRIPTION
Before issuing KILL QUERY, we need to wait until the query
that we intend to kill is actually running.