### PR TITLE
Fixed rocksdb_bulk_load_allow_unsorted option callback.

### DIFF
--- a/mysql-test/suite/rocksdb/t/bulk_load_unsorted_errors.test
+++ b/mysql-test/suite/rocksdb/t/bulk_load_unsorted_errors.test
@@ -1,5 +1,4 @@
 --source include/have_rocksdb.inc
---source include/have_nodebug.inc
 
 # Cannot change unsorted input preference during bulk load
 SET rocksdb_bulk_load=1;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -415,9 +415,9 @@ static int rocksdb_check_bulk_load(THD *const thd,
                                    void *save,
                                    struct st_mysql_value *value);
 
-static void rocksdb_set_bulk_load_allow_unsorted(
-    THD *thd, struct st_mysql_sys_var *var MY_ATTRIBUTE((__unused__)),
-    void *var_ptr, const void *save);
+static int rocksdb_check_bulk_load_allow_unsorted(
+    THD *const thd, struct st_mysql_sys_var *var MY_ATTRIBUTE((__unused__)),
+    void *save, struct st_mysql_value *value);
 
 static void rocksdb_set_max_background_jobs(THD *thd,
                                             struct st_mysql_sys_var *const var,
@@ -659,7 +659,8 @@ static MYSQL_THDVAR_BOOL(
 static MYSQL_THDVAR_BOOL(bulk_load_allow_unsorted, PLUGIN_VAR_RQCMDARG,
                          "Allow unsorted input during bulk-load. "
                          "Can be changed only when bulk load is disabled.",
-                         nullptr, rocksdb_set_bulk_load_allow_unsorted, FALSE);
+                         rocksdb_check_bulk_load_allow_unsorted, nullptr,
+                         FALSE);
 
 static MYSQL_SYSVAR_BOOL(enable_bulk_load_api, rocksdb_enable_bulk_load_api,
                          PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
@@ -12518,16 +12519,43 @@ int rocksdb_check_bulk_load(THD *const thd, struct st_mysql_sys_var *var
   return 0;
 }
 
-void rocksdb_set_bulk_load_allow_unsorted(
-    THD *const thd,
-    struct st_mysql_sys_var *const var MY_ATTRIBUTE((__unused__)),
-    void *const var_ptr, const void *const save) {
+int rocksdb_check_bulk_load_allow_unsorted(
+    THD *const thd, struct st_mysql_sys_var *var MY_ATTRIBUTE((__unused__)),
+    void *save, struct st_mysql_value *value) {
+  my_bool new_value;
+  int new_value_type = value->value_type(value);
+  if (new_value_type == MYSQL_VALUE_TYPE_STRING) {
+    char buf[16];
+    int len = sizeof(buf);
+    const char *str = value->val_str(value, buf, &len);
+    if (str && (my_strcasecmp(system_charset_info, "true", str) == 0 ||
+                my_strcasecmp(system_charset_info, "on", str) == 0)) {
+      new_value = TRUE;
+    } else if (str && (my_strcasecmp(system_charset_info, "false", str) == 0 ||
+                       my_strcasecmp(system_charset_info, "off", str) == 0)) {
+      new_value = FALSE;
+    } else {
+      return 1;
+    }
+  } else if (new_value_type == MYSQL_VALUE_TYPE_INT) {
+    long long intbuf;
+    value->val_int(value, &intbuf);
+    if (intbuf > 1)
+      return 1;
+    new_value = intbuf > 0 ? TRUE : FALSE;
+  } else {
+    return 1;
+  }
+
   if (THDVAR(thd, bulk_load)) {
     my_error(ER_ERROR_WHEN_EXECUTING_COMMAND, MYF(0), "SET",
              "Cannot change this setting while bulk load is enabled");
-  } else {
-    *static_cast<bool *>(var_ptr) = *static_cast<const bool *>(save);
+
+    return 1;
   }
+
+  *static_cast<bool *>(save) = new_value;
+  return 0;
 }
 
 static void rocksdb_set_max_background_jobs(THD *thd,


### PR DESCRIPTION
The option uses a 'set' callback to set/return an error to the client which is
an invalid thing to do. This is proven by the debug assertion that is hit on a
debug build when executing the sequence in the rocksdb.bulk_load_unsorted_errors
test. The proper way to return an error from a SET is to use a 'check' callback
instead. This patch changes the 'set' to a 'check' and removes the no-debug
constraint on the bulk_load_unsorted_errors test.