### PR TITLE
Fix rocksdb.skip_validate_tmp_table

### DIFF
--- a/mysql-test/suite/rocksdb/r/skip_validate_tmp_table.result
+++ b/mysql-test/suite/rocksdb/r/skip_validate_tmp_table.result
@@ -1,4 +1,19 @@
-CREATE TABLE t1 (pk int primary key) ENGINE=ROCKSDB;
+create table t1 (pk int primary key) engine=rocksdb;
+show tables;
+Tables_in_test
+#mysql50#t1#sql-test
+t1
 set session debug="+d,gen_sql_table_name";
 rename table t1 to t2;
 set session debug= "-d,gen_sql_table_name";
+show tables;
+Tables_in_test
+#mysql50#t1#sql-test
+t2
+show tables;
+Tables_in_test
+create table t2 (pk int primary key) engine=rocksdb;
+show tables;
+Tables_in_test
+t2
+drop table t2;

--- a/mysql-test/suite/rocksdb/t/skip_validate_tmp_table.test
+++ b/mysql-test/suite/rocksdb/t/skip_validate_tmp_table.test
@@ -1,39 +1,36 @@
 --source include/have_rocksdb.inc
 --source include/have_debug.inc
 
-# Write file to make mysql-test-run.pl expect the "crash", but don't restart the
-# server until it is told to
 --let $_server_id= `SELECT @@server_id`
---let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.$_server_id.expect
 
-CREATE TABLE t1 (pk int primary key) ENGINE=ROCKSDB;
+create table t1 (pk int primary key) engine=rocksdb;
 
 # Create a .frm file without a matching table
 --exec cp $MYSQLTEST_VARDIR/mysqld.$_server_id/data/test/t1.frm $MYSQLTEST_VARDIR/mysqld.$_server_id/data/test/t1#sql-test.frm
 
-# Restart the server with a .frm file exist but that table is not registered in RocksDB
---exec echo "wait" >$_expect_file_name
-shutdown_server 10;
---exec echo "restart" >$_expect_file_name
---sleep 5
---enable_reconnect
---source include/wait_until_connected_again.inc
---disable_reconnect
+--source include/restart_mysqld.inc
+
+show tables;
 
 # This will append '#sql-test' to the end of new name
 set session debug="+d,gen_sql_table_name";
 rename table t1 to t2;
 set session debug= "-d,gen_sql_table_name";
 
+show tables;
+
 # Remove the corresponding .frm files
 --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.$_server_id/data/test *t1*.frm
 --remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.$_server_id/data/test *t2*.frm
 
 # Restart the server with a table registered in RocksDB but does not have a .frm file
---exec echo "wait" >$_expect_file_name
-shutdown_server 10;
---exec echo "restart" >$_expect_file_name
---sleep 5
---enable_reconnect
---source include/wait_until_connected_again.inc
---disable_reconnect
+--source include/restart_mysqld.inc
+
+show tables;
+
+# try to recreate a table with the same name
+create table t2 (pk int primary key) engine=rocksdb;
+
+show tables;
+
+drop table t2;


### PR DESCRIPTION
- Updated test to remove invalid/inaccurate comment and converted to using
  modern mtr semantics via include/restart_mysqld.inc.
- Added some extra validation via 'show tables' to confirm tables that
  server believes should exist.