### PR TITLE
Set rocksdb_max_open_files to reasonable value at startup from open_f…

### DIFF
--- a/mysql-test/suite/rocksdb/r/max_open_files.result
+++ b/mysql-test/suite/rocksdb/r/max_open_files.result
@@ -1,0 +1,14 @@
+CALL mtr.add_suppression("RocksDB: rocksdb_max_open_files should not be greater than the open_files_limit*");
+SELECT FLOOR(@@global.open_files_limit / 2) = @@global.rocksdb_max_open_files;
+FLOOR(@@global.open_files_limit / 2) = @@global.rocksdb_max_open_files
+1
+SELECT @@global.rocksdb_max_open_files;
+@@global.rocksdb_max_open_files
+0
+CREATE TABLE t1(a INT) ENGINE=ROCKSDB;
+INSERT INTO t1 VALUES(0),(1),(2),(3),(4);
+SET GLOBAL rocksdb_force_flush_memtable_and_lzero_now=1;
+DROP TABLE t1;
+SELECT FLOOR(@@global.open_files_limit / 2) = @@global.rocksdb_max_open_files;
+FLOOR(@@global.open_files_limit / 2) = @@global.rocksdb_max_open_files
+1

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -852,7 +852,7 @@ ERROR 42S02: Unknown table 'test.t45'
 # Now it fails if there is data overlap with what
 # already exists
 #
-show variables like 'rocksdb%';
+show variables where variable_name like 'rocksdb%' and variable_name not like 'rocksdb_max_open_files';
 Variable_name	Value
 rocksdb_access_hint_on_compaction_start	1
 rocksdb_advise_random_on_open	ON
@@ -925,7 +925,6 @@ rocksdb_max_background_jobs	2
 rocksdb_max_latest_deadlocks	5
 rocksdb_max_log_file_size	0
 rocksdb_max_manifest_file_size	18446744073709551615
-rocksdb_max_open_files	-1
 rocksdb_max_row_locks	1073741824
 rocksdb_max_subcompactions	1
 rocksdb_max_total_wal_size	0

--- a/mysql-test/suite/rocksdb/t/max_open_files.test
+++ b/mysql-test/suite/rocksdb/t/max_open_files.test
@@ -1,0 +1,40 @@
+--source include/have_rocksdb.inc
+
+# Basic Sysbench run fails with basic MyROCKS install due to lack of open files
+
+# test for over limit
+CALL mtr.add_suppression("RocksDB: rocksdb_max_open_files should not be greater than the open_files_limit*");
+
+--let $over_rocksdb_max_open_files=`SELECT @@global.open_files_limit + 100`
+--let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/rocksdb.max_open_files.err
+--let SEARCH_PATTERN=RocksDB: rocksdb_max_open_files should not be greater than the open_files_limit
+
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR $over_rocksdb_max_open_files over_rocksdb_max_open_files
+--let $_mysqld_option=--log-error=$SEARCH_FILE --rocksdb_max_open_files=$over_rocksdb_max_open_files
+--source include/restart_mysqld_with_option.inc
+--source include/search_pattern_in_file.inc
+
+SELECT FLOOR(@@global.open_files_limit / 2) = @@global.rocksdb_max_open_files;
+
+# test for minimal value
+--let $_mysqld_option=--rocksdb_max_open_files=0
+--source include/restart_mysqld_with_option.inc
+
+SELECT @@global.rocksdb_max_open_files;
+
+# verify that we can still do work with no descriptor cache
+CREATE TABLE t1(a INT) ENGINE=ROCKSDB;
+INSERT INTO t1 VALUES(0),(1),(2),(3),(4);
+SET GLOBAL rocksdb_force_flush_memtable_and_lzero_now=1;
+DROP TABLE t1;
+
+# test for unlimited
+--let $_mysqld_option=--rocksdb_max_open_files=-1
+--source include/restart_mysqld_with_option.inc
+
+SELECT FLOOR(@@global.open_files_limit / 2) = @@global.rocksdb_max_open_files;
+
+# cleanup
+--let _$mysqld_option=
+--source include/restart_mysqld.inc
+--remove_file $SEARCH_FILE

--- a/mysql-test/suite/rocksdb/t/rocksdb.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb.test
@@ -784,7 +784,10 @@ drop table t45;
 --echo # Now it fails if there is data overlap with what
 --echo # already exists
 --echo #
-show variables like 'rocksdb%';
+# We exclude rocksdb_max_open_files here because it value is dependent on
+# the value of the servers open_file_limit and is expected to be different
+# across distros and installs
+show variables where variable_name like 'rocksdb%' and variable_name not like 'rocksdb_max_open_files';
 create table t47 (pk int primary key, col1 varchar(12)) engine=rocksdb;
 insert into t47 values (1, 'row1');
 insert into t47 values (2, 'row2');

--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_max_open_files_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_max_open_files_basic.result
@@ -1,7 +1,3 @@
-SET @start_global_value = @@global.ROCKSDB_MAX_OPEN_FILES;
-SELECT @start_global_value;
-@start_global_value
--1
-"Trying to set variable @@global.ROCKSDB_MAX_OPEN_FILES to 444. It should fail because it is readonly."
-SET @@global.ROCKSDB_MAX_OPEN_FILES   = 444;
-ERROR HY000: Variable 'rocksdb_max_open_files' is a read only variable
+show variables like 'rocksdb_max_open_files';
+Variable_name	Value
+rocksdb_max_open_files	#

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_max_open_files_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_max_open_files_basic.test
@@ -1,6 +1,8 @@
 --source include/have_rocksdb.inc
 
---let $sys_var=ROCKSDB_MAX_OPEN_FILES
---let $read_only=1
---let $session=0
---source ../include/rocksdb_sys_var.inc
+# We can not use rocksdb_sys_var.inc here as this is a global, read only option
+# whose value is dependent on the servers open_files_limit. It is more fully
+# tested in the rocksdb.max_open_files test.
+
+--replace_column 2 #
+show variables like 'rocksdb_max_open_files';

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -4004,6 +4004,15 @@ static int rocksdb_init_func(void *const p) {
 
   DBUG_ASSERT(!mysqld_embedded);
 
+  if (rocksdb_db_options->max_open_files > (long)open_files_limit ||
+      rocksdb_db_options->max_open_files < 0) {
+    sql_print_information("RocksDB: rocksdb_max_open_files should not be "
+                          "greater than the open_files_limit, effective value "
+                          "of rocksdb_max_open_files is being set to "
+                          "open_files_limit / 2.");
+    rocksdb_db_options->max_open_files = open_files_limit / 2;
+  }
+
   rocksdb_stats = rocksdb::CreateDBStatistics();
   rocksdb_db_options->statistics = rocksdb_stats;
 


### PR DESCRIPTION
…iles_limit

- Leave the default of max_open_files to -1 to trigger auto-tune-ish.
- On start, after server sets open_files_limit, during plugin init, check to see
  if max_open_files is > open_files_limit or < 0, if it is, set it to
  open_files_limit / 2.
- Added new test that restarts the server with different known good and bad
  values for max_open_files and validates that it is either left alone or set
  to open_files_limit / 2.
- Touched rocksdb.rocksdb test to account for 'floating' effective default value
  of rocksdb_max_open_files across installs, distros, and local configs.