### PR TITLE
Minor fix to rocksdb.allow_no_primary_key_with_sk.test

### DIFF
--- a/mysql-test/suite/rocksdb/r/allow_no_primary_key_with_sk.result
+++ b/mysql-test/suite/rocksdb/r/allow_no_primary_key_with_sk.result
@@ -778,7 +778,7 @@ set global rocksdb_force_flush_memtable_now = true;
 select * from t1;
 col1	col2	extra
 DROP TABLE t1;
-create table t1 (i int auto_increment, key(i));
+create table t1 (i int auto_increment, key(i)) engine=rocksdb;
 insert into t1 values();
 insert into t1 values();
 insert into t1 values();

--- a/mysql-test/suite/rocksdb/t/allow_no_primary_key_with_sk.test
+++ b/mysql-test/suite/rocksdb/t/allow_no_primary_key_with_sk.test
@@ -137,7 +137,7 @@ select * from t1;
 DROP TABLE t1;
 
 ## https://github.com/facebook/mysql-5.6/issues/736
-create table t1 (i int auto_increment, key(i));
+create table t1 (i int auto_increment, key(i)) engine=rocksdb;
 insert into t1 values();
 insert into t1 values();
 insert into t1 values();


### PR DESCRIPTION
Add engine=rocksdb to create table introduced in 3e68a8cd409ea63e296a5c788daec188d3a4b864