### PR TITLE
Rename concurrent_prepare to two_write_queues

### DIFF
--- a/mysql-test/r/mysqld--help-notwin-profiling.result
+++ b/mysql-test/r/mysqld--help-notwin-profiling.result
@@ -1162,7 +1162,7 @@ The following options may be given as the first argument:
  Possible values are ON, OFF, FORCE (don't start if the
  plugin fails to load).
  --rocksdb-concurrent-prepare 
- DBOptions::concurrent_prepare for RocksDB
+ DBOptions::two_write_queues for RocksDB
  (Defaults to on; use --skip-rocksdb-concurrent-prepare to disable.)
  --rocksdb-create-checkpoint=name 
  Checkpoint directory

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -1160,7 +1160,7 @@ The following options may be given as the first argument:
  Possible values are ON, OFF, FORCE (don't start if the
  plugin fails to load).
  --rocksdb-concurrent-prepare 
- DBOptions::concurrent_prepare for RocksDB
+ DBOptions::two_write_queues for RocksDB
  (Defaults to on; use --skip-rocksdb-concurrent-prepare to disable.)
  --rocksdb-create-checkpoint=name 
  Checkpoint directory

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -879,7 +879,7 @@ rocksdb_compaction_sequential_deletes	0
 rocksdb_compaction_sequential_deletes_count_sd	OFF
 rocksdb_compaction_sequential_deletes_file_size	0
 rocksdb_compaction_sequential_deletes_window	0
-rocksdb_concurrent_prepare	ON
+rocksdb_two_write_queues	ON
 rocksdb_create_checkpoint	
 rocksdb_create_if_missing	ON
 rocksdb_create_missing_column_families	OFF

--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_concurrent_prepare_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_concurrent_prepare_basic.result
@@ -9,6 +9,6 @@ SELECT @start_global_value;
 1
 "Trying to set variable @@global.ROCKSDB_CONCURRENT_PREPARE to 444. It should fail because it is readonly."
 SET @@global.ROCKSDB_CONCURRENT_PREPARE   = 444;
-ERROR HY000: Variable 'rocksdb_concurrent_prepare' is a read only variable
+ERROR HY000: Variable 'rocksdb_two_write_queues' is a read only variable
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -501,7 +501,7 @@ static std::unique_ptr<rocksdb::DBOptions> rdb_init_rocksdb_db_options(void) {
   o->info_log_level = rocksdb::InfoLogLevel::INFO_LEVEL;
   o->max_subcompactions = DEFAULT_SUBCOMPACTIONS;
 
-  o->concurrent_prepare = true;
+  o->two_write_queues = true;
   o->manual_wal_flush = true;
   return o;
 }
@@ -761,11 +761,11 @@ static MYSQL_SYSVAR_BOOL(
     rocksdb_db_options->create_if_missing);
 
 static MYSQL_SYSVAR_BOOL(
-    concurrent_prepare,
-    *reinterpret_cast<my_bool *>(&rocksdb_db_options->concurrent_prepare),
+    two_write_queues,
+    *reinterpret_cast<my_bool *>(&rocksdb_db_options->two_write_queues),
     PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
-    "DBOptions::concurrent_prepare for RocksDB", nullptr, nullptr,
-    rocksdb_db_options->concurrent_prepare);
+    "DBOptions::two_write_queues for RocksDB", nullptr, nullptr,
+    rocksdb_db_options->two_write_queues);
 
 static MYSQL_SYSVAR_BOOL(
     manual_wal_flush,
@@ -1530,7 +1530,7 @@ static struct st_mysql_sys_var *rocksdb_system_variables[] = {
     MYSQL_SYSVAR(skip_bloom_filter_on_read),
 
     MYSQL_SYSVAR(create_if_missing),
-    MYSQL_SYSVAR(concurrent_prepare),
+    MYSQL_SYSVAR(two_write_queues),
     MYSQL_SYSVAR(manual_wal_flush),
     MYSQL_SYSVAR(create_missing_column_families),
     MYSQL_SYSVAR(error_if_exists),


### PR DESCRIPTION
concurrent_prepare in rocksdb is renamed to two_write_queues.
This patch updates the rocksdb submodule and make similar change in
myrocks.

@update-submodule: rocksdb