### PR TITLE
Rename concurrent_prepare to two_write_queues

### DIFF
--- a/mysql-test/r/mysqld--help-notwin-profiling.result
+++ b/mysql-test/r/mysqld--help-notwin-profiling.result
@@ -1161,9 +1161,6 @@ The following options may be given as the first argument:
  Enable or disable ROCKSDB_COMPACTION_STATS plugin.
  Possible values are ON, OFF, FORCE (don't start if the
  plugin fails to load).
- --rocksdb-concurrent-prepare 
- DBOptions::concurrent_prepare for RocksDB
- (Defaults to on; use --skip-rocksdb-concurrent-prepare to disable.)
  --rocksdb-create-checkpoint=name 
  Checkpoint directory
  --rocksdb-create-if-missing 
@@ -1438,6 +1435,9 @@ The following options may be given as the first argument:
  --rocksdb-trx[=name] 
  Enable or disable ROCKSDB_TRX plugin. Possible values are
  ON, OFF, FORCE (don't start if the plugin fails to load).
+ --rocksdb-two-write-queues 
+ DBOptions::two_write_queues for RocksDB
+ (Defaults to on; use --skip-rocksdb-two-write-queues to disable.)
  --rocksdb-unsafe-for-binlog 
  Allowing statement based binary logging which may break
  consistency
@@ -2126,7 +2126,6 @@ rocksdb-compaction-sequential-deletes-count-sd FALSE
 rocksdb-compaction-sequential-deletes-file-size 0
 rocksdb-compaction-sequential-deletes-window 0
 rocksdb-compaction-stats ON
-rocksdb-concurrent-prepare TRUE
 rocksdb-create-checkpoint 
 rocksdb-create-if-missing TRUE
 rocksdb-create-missing-column-families FALSE
@@ -2219,6 +2218,7 @@ rocksdb-table-stats-sampling-pct 10
 rocksdb-tmpdir (No default value)
 rocksdb-trace-sst-api FALSE
 rocksdb-trx ON
+rocksdb-two-write-queues TRUE
 rocksdb-unsafe-for-binlog FALSE
 rocksdb-update-cf-options (No default value)
 rocksdb-use-adaptive-mutex FALSE

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -1159,9 +1159,6 @@ The following options may be given as the first argument:
  Enable or disable ROCKSDB_COMPACTION_STATS plugin.
  Possible values are ON, OFF, FORCE (don't start if the
  plugin fails to load).
- --rocksdb-concurrent-prepare 
- DBOptions::concurrent_prepare for RocksDB
- (Defaults to on; use --skip-rocksdb-concurrent-prepare to disable.)
  --rocksdb-create-checkpoint=name 
  Checkpoint directory
  --rocksdb-create-if-missing 
@@ -1436,6 +1433,9 @@ The following options may be given as the first argument:
  --rocksdb-trx[=name] 
  Enable or disable ROCKSDB_TRX plugin. Possible values are
  ON, OFF, FORCE (don't start if the plugin fails to load).
+ --rocksdb-two-write-queues 
+ DBOptions::two_write_queues for RocksDB
+ (Defaults to on; use --skip-rocksdb-two-write-queues to disable.)
  --rocksdb-unsafe-for-binlog 
  Allowing statement based binary logging which may break
  consistency
@@ -2123,7 +2123,6 @@ rocksdb-compaction-sequential-deletes-count-sd FALSE
 rocksdb-compaction-sequential-deletes-file-size 0
 rocksdb-compaction-sequential-deletes-window 0
 rocksdb-compaction-stats ON
-rocksdb-concurrent-prepare TRUE
 rocksdb-create-checkpoint 
 rocksdb-create-if-missing TRUE
 rocksdb-create-missing-column-families FALSE
@@ -2216,6 +2215,7 @@ rocksdb-table-stats-sampling-pct 10
 rocksdb-tmpdir (No default value)
 rocksdb-trace-sst-api FALSE
 rocksdb-trx ON
+rocksdb-two-write-queues TRUE
 rocksdb-unsafe-for-binlog FALSE
 rocksdb-update-cf-options (No default value)
 rocksdb-use-adaptive-mutex FALSE

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -879,7 +879,6 @@ rocksdb_compaction_sequential_deletes	0
 rocksdb_compaction_sequential_deletes_count_sd	OFF
 rocksdb_compaction_sequential_deletes_file_size	0
 rocksdb_compaction_sequential_deletes_window	0
-rocksdb_concurrent_prepare	ON
 rocksdb_create_checkpoint	
 rocksdb_create_if_missing	ON
 rocksdb_create_missing_column_families	OFF
@@ -962,6 +961,7 @@ rocksdb_table_cache_numshardbits	6
 rocksdb_table_stats_sampling_pct	10
 rocksdb_tmpdir	
 rocksdb_trace_sst_api	OFF
+rocksdb_two_write_queues	ON
 rocksdb_unsafe_for_binlog	OFF
 rocksdb_update_cf_options	
 rocksdb_use_adaptive_mutex	OFF

--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_two_write_queues_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_two_write_queues_basic.result
@@ -3,12 +3,12 @@ INSERT INTO valid_values VALUES(1);
 INSERT INTO valid_values VALUES(1024);
 CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
 INSERT INTO invalid_values VALUES('\'aaa\'');
-SET @start_global_value = @@global.ROCKSDB_CONCURRENT_PREPARE;
+SET @start_global_value = @@global.ROCKSDB_TWO_WRITE_QUEUES;
 SELECT @start_global_value;
 @start_global_value
 1
-"Trying to set variable @@global.ROCKSDB_CONCURRENT_PREPARE to 444. It should fail because it is readonly."
-SET @@global.ROCKSDB_CONCURRENT_PREPARE   = 444;
-ERROR HY000: Variable 'rocksdb_concurrent_prepare' is a read only variable
+"Trying to set variable @@global.ROCKSDB_TWO_WRITE_QUEUES to 444. It should fail because it is readonly."
+SET @@global.ROCKSDB_TWO_WRITE_QUEUES   = 444;
+ERROR HY000: Variable 'rocksdb_two_write_queues' is a read only variable
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_two_write_queues_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_two_write_queues_basic.test
@@ -7,7 +7,7 @@ INSERT INTO valid_values VALUES(1024);
 CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
 INSERT INTO invalid_values VALUES('\'aaa\'');
 
---let $sys_var=ROCKSDB_CONCURRENT_PREPARE
+--let $sys_var=ROCKSDB_TWO_WRITE_QUEUES
 --let $read_only=1
 --let $session=0
 --source ../include/rocksdb_sys_var.inc

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -501,7 +501,7 @@ static std::unique_ptr<rocksdb::DBOptions> rdb_init_rocksdb_db_options(void) {
   o->info_log_level = rocksdb::InfoLogLevel::INFO_LEVEL;
   o->max_subcompactions = DEFAULT_SUBCOMPACTIONS;
 
-  o->concurrent_prepare = true;
+  o->two_write_queues = true;
   o->manual_wal_flush = true;
   return o;
 }
@@ -761,11 +761,11 @@ static MYSQL_SYSVAR_BOOL(
     rocksdb_db_options->create_if_missing);
 
 static MYSQL_SYSVAR_BOOL(
-    concurrent_prepare,
-    *reinterpret_cast<my_bool *>(&rocksdb_db_options->concurrent_prepare),
+    two_write_queues,
+    *reinterpret_cast<my_bool *>(&rocksdb_db_options->two_write_queues),
     PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
-    "DBOptions::concurrent_prepare for RocksDB", nullptr, nullptr,
-    rocksdb_db_options->concurrent_prepare);
+    "DBOptions::two_write_queues for RocksDB", nullptr, nullptr,
+    rocksdb_db_options->two_write_queues);
 
 static MYSQL_SYSVAR_BOOL(
     manual_wal_flush,
@@ -1530,7 +1530,7 @@ static struct st_mysql_sys_var *rocksdb_system_variables[] = {
     MYSQL_SYSVAR(skip_bloom_filter_on_read),
 
     MYSQL_SYSVAR(create_if_missing),
-    MYSQL_SYSVAR(concurrent_prepare),
+    MYSQL_SYSVAR(two_write_queues),
     MYSQL_SYSVAR(manual_wal_flush),
     MYSQL_SYSVAR(create_missing_column_families),
     MYSQL_SYSVAR(error_if_exists),


### PR DESCRIPTION
Summary: concurrent_prepare in rocksdb is renamed to two_write_queues.
This patch updates the rocksdb submodule and make similar change in
myrocks.
@update-submodule: rocksdb