### PR TITLE
Fixed incorrect use of pointer to internal data of a temporary instance.

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -12805,8 +12805,9 @@ double ha_rocksdb::read_time(uint index, uint ranges, ha_rows rows) {
 }
 
 std::string rdb_corruption_marker_file_name() {
-  return std::string(std::string(rocksdb_datadir) +
-                     std::string("/ROCKSDB_CORRUPTED"));
+  std::string ret(rocksdb_datadir);
+  ret.append("/ROCKSDB_CORRUPTED");
+  return ret;
 }
 
 } // namespace myrocks

--- a/storage/rocksdb/rdb_utils.cc
+++ b/storage/rocksdb/rdb_utils.cc
@@ -308,22 +308,22 @@ bool rdb_check_rocksdb_corruption() {
 }
 
 void rdb_persist_corruption_marker() {
-  const char *fileName = myrocks::rdb_corruption_marker_file_name().c_str();
-  int fd = my_open(fileName, O_CREAT | O_SYNC, MYF(MY_WME));
+  const std::string& fileName(myrocks::rdb_corruption_marker_file_name());
+  int fd = my_open(fileName.c_str(), O_CREAT | O_SYNC, MYF(MY_WME));
   if (fd < 0) {
     sql_print_error("RocksDB: Can't create file %s to mark rocksdb as "
                     "corrupted.",
-                    fileName);
+                    fileName.c_str());
   } else {
     sql_print_information("RocksDB: Creating the file %s to abort mysqld "
                           "restarts. Remove this file from the data directory "
                           "after fixing the corruption to recover. ",
-                          fileName);
+                          fileName.c_str());
   }
 
   int ret = my_close(fd, MYF(MY_WME));
   if (ret) {
-    sql_print_error("RocksDB: Error (%d) closing the file %s", ret, fileName);
+    sql_print_error("RocksDB: Error (%d) closing the file %s", ret, fileName.c_str());
   }
 }
 


### PR DESCRIPTION
- std::string instance is being returned as a temporary. C++ standard defines
  that its lifetime is the end of the complete lexical expession. The expression
  is maintaining a pointer to the internal char* (c_str) pointer that is getting
  destroyed at the completion of the expression, this rendering the pointer
  as pointing to invalid data.
- Changed to a const reference to the returned temporary, avoiding a little
  extra overhead of an additional copy and forcing the temporary to remain in
  scope beyond the expression where it is created.
- Slightly optimized rdb_corruption_file_name to reduce number of copy
  constructions and temporary heap allocations.