### PR TITLE
Alter the rocksdb_max_open_files limit checking to allow pass-through…

### DIFF
--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -2176,7 +2176,7 @@ rocksdb-max-background-jobs 2
 rocksdb-max-latest-deadlocks 5
 rocksdb-max-log-file-size 0
 rocksdb-max-manifest-file-size 18446744073709551615
-rocksdb-max-open-files -1
+rocksdb-max-open-files -2
 rocksdb-max-row-locks 1073741824
 rocksdb-max-subcompactions 1
 rocksdb-max-total-wal-size 0

--- a/mysql-test/suite/rocksdb/r/max_open_files.result
+++ b/mysql-test/suite/rocksdb/r/max_open_files.result
@@ -2,6 +2,9 @@ CALL mtr.add_suppression("RocksDB: rocksdb_max_open_files should not be greater 
 SELECT FLOOR(@@global.open_files_limit / 2) = @@global.rocksdb_max_open_files;
 FLOOR(@@global.open_files_limit / 2) = @@global.rocksdb_max_open_files
 1
+SELECT @@global.open_files_limit - 1 = @@global.rocksdb_max_open_files;
+@@global.open_files_limit - 1 = @@global.rocksdb_max_open_files
+1
 SELECT @@global.rocksdb_max_open_files;
 @@global.rocksdb_max_open_files
 0
@@ -9,6 +12,9 @@ CREATE TABLE t1(a INT) ENGINE=ROCKSDB;
 INSERT INTO t1 VALUES(0),(1),(2),(3),(4);
 SET GLOBAL rocksdb_force_flush_memtable_and_lzero_now=1;
 DROP TABLE t1;
+SELECT @@global.rocksdb_max_open_files;
+@@global.rocksdb_max_open_files
+-1
 SELECT FLOOR(@@global.open_files_limit / 2) = @@global.rocksdb_max_open_files;
 FLOOR(@@global.open_files_limit / 2) = @@global.rocksdb_max_open_files
 1

--- a/mysql-test/suite/rocksdb/t/max_open_files.test
+++ b/mysql-test/suite/rocksdb/t/max_open_files.test
@@ -6,6 +6,7 @@
 CALL mtr.add_suppression("RocksDB: rocksdb_max_open_files should not be greater than the open_files_limit*");
 
 --let $over_rocksdb_max_open_files=`SELECT @@global.open_files_limit + 100`
+--let $under_rocksdb_max_open_files=`SELECT @@global.open_files_limit -1`
 --let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/rocksdb.max_open_files.err
 --let SEARCH_PATTERN=RocksDB: rocksdb_max_open_files should not be greater than the open_files_limit
 
@@ -15,6 +16,12 @@ CALL mtr.add_suppression("RocksDB: rocksdb_max_open_files should not be greater 
 --source include/search_pattern_in_file.inc
 
 SELECT FLOOR(@@global.open_files_limit / 2) = @@global.rocksdb_max_open_files;
+
+# test for within limit
+--let $_mysqld_option=--rocksdb_max_open_files=$under_rocksdb_max_open_files
+--source include/restart_mysqld_with_option.inc
+
+SELECT @@global.open_files_limit - 1 = @@global.rocksdb_max_open_files;
 
 # test for minimal value
 --let $_mysqld_option=--rocksdb_max_open_files=0
@@ -30,6 +37,12 @@ DROP TABLE t1;
 
 # test for unlimited
 --let $_mysqld_option=--rocksdb_max_open_files=-1
+--source include/restart_mysqld_with_option.inc
+
+SELECT @@global.rocksdb_max_open_files;
+
+# test for auto-tune
+--let $_mysqld_option=--rocksdb_max_open_files=-2
 --source include/restart_mysqld_with_option.inc
 
 SELECT FLOOR(@@global.open_files_limit / 2) = @@global.rocksdb_max_open_files;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -500,6 +500,7 @@ static std::unique_ptr<rocksdb::DBOptions> rdb_init_rocksdb_db_options(void) {
   o->listeners.push_back(std::make_shared<Rdb_event_listener>(&ddl_manager));
   o->info_log_level = rocksdb::InfoLogLevel::INFO_LEVEL;
   o->max_subcompactions = DEFAULT_SUBCOMPACTIONS;
+  o->max_open_files = -2; // auto-tune to 50% open_files_limit
 
   o->two_write_queues = true;
   o->manual_wal_flush = true;
@@ -892,7 +893,7 @@ static MYSQL_SYSVAR_INT(max_open_files, rocksdb_db_options->max_open_files,
                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
                         "DBOptions::max_open_files for RocksDB", nullptr,
                         nullptr, rocksdb_db_options->max_open_files,
-                        /* min */ -1, /* max */ INT_MAX, 0);
+                        /* min */ -2, /* max */ INT_MAX, 0);
 
 static MYSQL_SYSVAR_ULONG(max_total_wal_size,
                           rocksdb_db_options->max_total_wal_size,
@@ -4098,12 +4099,13 @@ static int rocksdb_init_func(void *const p) {
 
   DBUG_ASSERT(!mysqld_embedded);
 
-  if (rocksdb_db_options->max_open_files > (long)open_files_limit ||
-      rocksdb_db_options->max_open_files < 0) {
+  if (rocksdb_db_options->max_open_files > (long)open_files_limit) {
     sql_print_information("RocksDB: rocksdb_max_open_files should not be "
                           "greater than the open_files_limit, effective value "
                           "of rocksdb_max_open_files is being set to "
                           "open_files_limit / 2.");
+    rocksdb_db_options->max_open_files = open_files_limit / 2;
+  } else if (rocksdb_db_options->max_open_files == -2) {
     rocksdb_db_options->max_open_files = open_files_limit / 2;
   }
 


### PR DESCRIPTION
… of -1.

New behavior for rocksdb_max_open_files is as such :
* -1 : infinite, pass -1 to rocksdb
* 0 : 'auto-tune', silently set rocksdb_max_open_files to 1/2 of mysql
  open_files_limit
* > 0 <= open_files_limit : take value as-is
* > open_files_lmit :  set rocksdb_max_open_files to 1/2 of mysql open_files_limit
  and emit a warning to the mysqld error log.