### PR TITLE
Return error from start_bulk_load() instead of SHIP_ASSERT

### DIFF
--- a/mysql-test/suite/rocksdb/r/bulk_load_errors.result
+++ b/mysql-test/suite/rocksdb/r/bulk_load_errors.result
@@ -79,3 +79,14 @@ Warning	1292	Truncated incorrect table_open_cache value: '0'
 INSERT INTO t1 VALUES(51479+0.333333333,1);
 DROP TABLE t1;
 SET @@global.table_open_cache=@orig_table_open_cache;
+CREATE TABLE t1 (pk INT, PRIMARY KEY (pk)) ENGINE=ROCKSDB;
+CREATE TABLE t2 (pk INT, PRIMARY KEY (pk)) ENGINE=ROCKSDB;
+SET rocksdb_bulk_load=1;
+INSERT INTO t1 VALUES (1), (2);
+INSERT INTO t2 VALUES (1), (2);
+INSERT INTO t1 VALUES (1);
+INSERT INTO t2 VALUES (3);
+ERROR HY000: Rows inserted during bulk load must not overlap existing rows
+SET rocksdb_bulk_load=0;
+DROP TABLE t1;
+DROP TABLE t2;

--- a/mysql-test/suite/rocksdb/t/bulk_load_errors.test
+++ b/mysql-test/suite/rocksdb/t/bulk_load_errors.test
@@ -124,4 +124,17 @@ SET @@global.table_open_cache=@orig_table_open_cache;
 
 --remove_file $LOG3
 
+# Switch between tables, but also introduce duplicate key errors
+CREATE TABLE t1 (pk INT, PRIMARY KEY (pk)) ENGINE=ROCKSDB;
+CREATE TABLE t2 (pk INT, PRIMARY KEY (pk)) ENGINE=ROCKSDB;
+SET rocksdb_bulk_load=1;
+INSERT INTO t1 VALUES (1), (2);
+INSERT INTO t2 VALUES (1), (2);
+INSERT INTO t1 VALUES (1);
+--error ER_OVERLAPPING_KEYS
+INSERT INTO t2 VALUES (3);
+SET rocksdb_bulk_load=0;
+DROP TABLE t1;
+DROP TABLE t2;
+
 --source include/wait_until_count_sessions.inc

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -2135,7 +2135,7 @@ public:
     return rc;
   }
 
-  void start_bulk_load(ha_rocksdb *const bulk_load,
+  int start_bulk_load(ha_rocksdb *const bulk_load,
                        std::shared_ptr<Rdb_sst_info> sst_info) {
     /*
      If we already have an open bulk load of a table and the name doesn't
@@ -2148,7 +2148,11 @@ public:
     if (!m_curr_bulk_load.empty() &&
         bulk_load->get_table_basename() != m_curr_bulk_load_tablename) {
       const auto res = finish_bulk_load();
-      SHIP_ASSERT(res == 0);
+      if (res != HA_EXIT_SUCCESS) {
+        m_curr_bulk_load.clear();
+        m_curr_bulk_load_tablename.clear();
+        return res;
+      }
     }
 
     /*
@@ -2164,6 +2168,7 @@ public:
     */
     m_curr_bulk_load.push_back(sst_info);
     m_curr_bulk_load_tablename = bulk_load->get_table_basename();
+    return HA_EXIT_SUCCESS;
   }
 
   int num_ongoing_bulk_load() const { return m_curr_bulk_load.size(); }
@@ -8888,7 +8893,10 @@ int ha_rocksdb::bulk_load_key(Rdb_transaction *const tx, const Rdb_key_def &kd,
     m_sst_info.reset(new Rdb_sst_info(rdb, m_table_handler->m_table_name,
                                       kd.get_name(), cf, *rocksdb_db_options,
                                       THDVAR(ha_thd(), trace_sst_api)));
-    tx->start_bulk_load(this, m_sst_info);
+    res = tx->start_bulk_load(this, m_sst_info);
+    if (res != HA_EXIT_SUCCESS) {
+      DBUG_RETURN(res);
+    }
   }
   DBUG_ASSERT(m_sst_info);
 


### PR DESCRIPTION
Summary:

When start_bulk_load detects the user is switching between tables, it
flushes the old table data out first. However, if there are problems
flushing out the data, an error is returned from RocksDB and this
triggers a SHIP_ASSERT(). This error should be propagated back up
instead.

This fixes https://github.com/facebook/mysql-5.6/issues/770

Test Plan:

new test case