### PR TITLE
Fixing test cases affected by type change of mts_dependency_replication

### DIFF
--- a/mysql-test/r/mysqld--help-notwin-profiling.result
+++ b/mysql-test/r/mysqld--help-notwin-profiling.result
@@ -637,7 +637,7 @@ The following options may be given as the first argument:
  --mts-dependency-refill-threshold[=#] 
  Capacity in percentage at which to start refilling the
  dependency buffer
- --mts-dependency-replication[=name]
+ --mts-dependency-replication[=name] 
  Use dependency based replication
  --mts-dependency-size[=#] 
  Max size of the dependency buffer

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -637,7 +637,7 @@ The following options may be given as the first argument:
  --mts-dependency-refill-threshold[=#] 
  Capacity in percentage at which to start refilling the
  dependency buffer
- --mts-dependency-replication[=name]
+ --mts-dependency-replication[=name] 
  Use dependency based replication
  --mts-dependency-size[=#] 
  Max size of the dependency buffer

--- a/mysql-test/suite/rpl_mts/combinations
+++ b/mysql-test/suite/rpl_mts/combinations
@@ -7,7 +7,12 @@ binlog-format=statement
 [mix]
 binlog-format=mixed
 
-[dep]
+[dep-tbl]
 binlog-format=row
 slave_use_idempotent_for_recovery=yes
-mts_dependency_replication=true
+mts_dependency_replication=TBL
+
+[dep-stmt]
+binlog-format=row
+slave_use_idempotent_for_recovery=yes
+mts_dependency_replication=STMT

--- a/mysql-test/suite/rpl_mts/r/rpl_mts_dependency_replication_master_binlog_format.result
+++ b/mysql-test/suite/rpl_mts/r/rpl_mts_dependency_replication_master_binlog_format.result
@@ -4,6 +4,7 @@ Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
 Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
 [connection master]
 call mtr.add_suppression("Master's binlog format is not ROW");
+set @save.mts_dependency_replication= @@global.mts_dependency_replication;
 create table t1(a int) engine=innodb;
 set session binlog_format=STATEMENT;
 insert into t1 values(1);
@@ -12,7 +13,7 @@ Last_SQL_Error = 'Master's binlog format is not ROW but mts_dependency_replicati
 "Table after error"
 select * from t1;
 a
-set global mts_dependency_replication= false;
+set global mts_dependency_replication= NONE;
 start slave;
 "Table after error fixed"
 select * from t1;
@@ -20,6 +21,6 @@ a
 1
 drop table t1;
 stop slave;
-set global mts_dependency_replication= true;
+set @@global.mts_dependency_replication= @save.mts_dependency_replication;
 start slave;
 include/rpl_end.inc

--- a/mysql-test/suite/rpl_mts/t/rpl_mts_dependency_replication_master_binlog_format.test
+++ b/mysql-test/suite/rpl_mts/t/rpl_mts_dependency_replication_master_binlog_format.test
@@ -5,6 +5,9 @@
 
 call mtr.add_suppression("Master's binlog format is not ROW");
 
+connection slave;
+set @save.mts_dependency_replication= @@global.mts_dependency_replication;
+
 connection master;
 create table t1(a int) engine=innodb;
 set session binlog_format=STATEMENT;
@@ -23,7 +26,7 @@ select * from t1;
 
 connection slave;
 # Turn off dependency replication and start the slave again
-set global mts_dependency_replication= false;
+set global mts_dependency_replication= NONE;
 start slave;
 
 connection master;
@@ -41,7 +44,7 @@ sync_slave_with_master;
 
 connection slave;
 stop slave;
-set global mts_dependency_replication= true;
+set @@global.mts_dependency_replication= @save.mts_dependency_replication;
 start slave;
 
 -- source include/rpl_end.inc

--- a/mysql-test/suite/sys_vars/r/mts_dependency_replication_basic.result
+++ b/mysql-test/suite/sys_vars/r/mts_dependency_replication_basic.result
@@ -7,7 +7,7 @@ select variable_name from information_schema.session_variables where variable_na
 variable_name
 set @save.slave_use_idempotent_for_recovery= @@global.slave_use_idempotent_for_recovery;
 set @@global.slave_use_idempotent_for_recovery= NO;
-set @@global.mts_dependency_replication= true;
+set @@global.mts_dependency_replication= tbl;
 ERROR HY000: @@GLOBAL.MTS_DEPENDENCY_REPLICATION cannot be set when @@GLOBAL.SLAVE_USE_IDEMPOTENT_FOR_RECOVERY = NO
 set @@global.slave_use_idempotent_for_recovery= YES;
 set @@global.mts_dependency_replication= tbl;

--- a/mysql-test/suite/sys_vars/t/mts_dependency_replication_basic.test
+++ b/mysql-test/suite/sys_vars/t/mts_dependency_replication_basic.test
@@ -18,7 +18,7 @@ select variable_name from information_schema.session_variables where variable_na
 eval set @save.slave_use_idempotent_for_recovery= @@global.slave_use_idempotent_for_recovery;
 eval set @@global.slave_use_idempotent_for_recovery= NO;
 --error ER_CANT_SET_DEPENDENCY_REPLICATION_WITHOUT_IDEMPOTENT_RECOVERY
-eval set @@global.$var= true;
+eval set @@global.$var= tbl;
 
 eval set @@global.slave_use_idempotent_for_recovery= YES;
 


### PR DESCRIPTION
Summary:
mts_dependency_replication was changed from a boolean variable to an
enum. Modifying and re-recording test cases accordingly.

Squash with: D6138167

Test Plan: MTR