### PR TITLE
fix issue #766

### DIFF
--- a/sql-common/client.c
+++ b/sql-common/client.c
@@ -792,11 +792,31 @@ void read_ok_ex(MYSQL *mysql, ulong length)
           switch (type)
           {
           case SESSION_TRACK_SYSTEM_VARIABLES:
-          case SESSION_TRACK_SCHEMA:
-          case SESSION_TRACK_TRANSACTION_CHARACTERISTICS:
+            /* Move past the total length of the changed entity. */
+            (void) net_field_length(&pos);
+
+            /* Name of the system variable. */
+            len= (size_t) net_field_length(&pos);
+
+            pos += len;
+
+            /* Value of the system variable. */
+            len= (size_t) net_field_length(&pos);
+            pos += len;
+
+            break;
           case SESSION_TRACK_TRANSACTION_STATE:
-            /* not backported */
-           break;
+          case SESSION_TRACK_TRANSACTION_CHARACTERISTICS:
+          case SESSION_TRACK_SCHEMA:
+
+            /* Move past the total length of the changed entity. */
+            (void) net_field_length(&pos);
+
+            len= (size_t) net_field_length(&pos);
+
+            pos += len;
+
+            break;
           case SESSION_TRACK_GTIDS:
             if (!my_multi_malloc(MYF(0),
               &element, sizeof(LIST),


### PR DESCRIPTION
This Pull-RQ fixes #766 
The SESSION_TRACK_SYSTEM_VARIABLES field type was not backported, which led to incorrect handling when the system variable "character_set_client" changed (as was the case in #766 )

I also backported SESSION_TRACK_TRANSACTION_STATE, SESSION_TRACK_TRANSACTION_CHARACTERISTICS, SESSION_TRACK_SCHEMA as we should also handle those in accordance with the standard mysql client library.