### PR TITLE
Update build instructions to reflect boost dependency

### DIFF
--- a/_docs/getting-started.md
+++ b/_docs/getting-started.md
@@ -44,14 +44,13 @@ Best effort is made to support the following OSs:
 
 ##### *Setting up Prerequisites*
 
-On a fresh AWS Ubuntu 14.04.2 LTS instance:
+On a fresh AWS Ubuntu 16.04.3 LTS instance:
 
 ```bash
 sudo apt-get update
 sudo apt-get install g++ cmake libbz2-dev libaio-dev bison \
-zlib1g-dev libsnappy-dev
-sudo apt-get install libgflags-dev libreadline6-dev libncurses5-dev \
-libssl-dev liblz4-dev gdb git
+zlib1g-dev libsnappy-dev libgflags-dev libreadline6-dev libncurses5-dev \
+libssl-dev liblz4-dev libboost-dev gdb git
 ```
 
 On Fedora and Redhat:


### PR DESCRIPTION
As of few months ago we have boost dependency for JSON validation.
We may want to reflect that in the doc. Also, updating to latest LTS to 
show that we keep up with times, kinda.