### PR TITLE
Stabilize rocksdb_rpl.multiclient_2pc

### DIFF
--- a/mysql-test/suite/rocksdb_rpl/t/multiclient_2pc.test
+++ b/mysql-test/suite/rocksdb_rpl/t/multiclient_2pc.test
@@ -62,6 +62,7 @@ SET GLOBAL SYNC_BINLOG = 1;
 
 insert into t1 values (1000000, 1, "i_am_just_here_to_trigger_a_flush");
 
+--error 0,2013
 SET DEBUG_SYNC='now SIGNAL go';
 --source include/wait_until_disconnected.inc
 --enable_reconnect


### PR DESCRIPTION
The test fails sporadically because the statement to signal a crash doesn't always return before the crash actually happens, depending how the threads are scheduled.

Closes #716