### PR TITLE
Optimize favicon

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,7 +10,7 @@
   <meta property="og:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}" />
 
   <link rel="stylesheet" href="{{ '/css/main.css' }}" media="screen">
-  <link rel="icon" href="{{ '/static/favicon.png' }}" type="image/x-icon">
+  <link rel="icon" href="{{ '/static/favicon.png' }}" type="image/png">
   {% if site.searchconfig %}
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.css" />
   {% endif %}


### PR DESCRIPTION
This was a 16MB 2000x2000 pixel image. It may be long cached but this is
never rendered at more than maybe 64x64. It's now 99.97% smaller.

I also fixed the mime type, it's not an x-icon.