### PR TITLE
Introduce new variable 'rocksdb_error_on_suboptimal_collation'.

### DIFF
--- a/mysql-test/r/mysqld--help-notwin-profiling.result
+++ b/mysql-test/r/mysqld--help-notwin-profiling.result
@@ -1255,6 +1255,10 @@ The following options may be given as the first argument:
  DBOptions::enable_write_thread_adaptive_yield for RocksDB
  --rocksdb-error-if-exists 
  DBOptions::error_if_exists for RocksDB
+ --rocksdb-error-on-suboptimal-collation 
+ Raise an error instead of warning if a sub-optimal
+ collation is used
+ (Defaults to on; use --skip-rocksdb-error-on-suboptimal-collation to disable.)
  --rocksdb-flush-log-at-trx-commit=# 
  Sync on transaction commit. Similar to
  innodb_flush_log_at_trx_commit. 1: sync on commit, 0,2:
@@ -2165,6 +2169,7 @@ rocksdb-enable-ttl TRUE
 rocksdb-enable-ttl-read-filtering TRUE
 rocksdb-enable-write-thread-adaptive-yield FALSE
 rocksdb-error-if-exists FALSE
+rocksdb-error-on-suboptimal-collation TRUE
 rocksdb-flush-log-at-trx-commit 1
 rocksdb-force-compute-memtable-stats TRUE
 rocksdb-force-compute-memtable-stats-cachetime 60000000

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -1253,6 +1253,10 @@ The following options may be given as the first argument:
  DBOptions::enable_write_thread_adaptive_yield for RocksDB
  --rocksdb-error-if-exists 
  DBOptions::error_if_exists for RocksDB
+ --rocksdb-error-on-suboptimal-collation 
+ Raise an error instead of warning if a sub-optimal
+ collation is used
+ (Defaults to on; use --skip-rocksdb-error-on-suboptimal-collation to disable.)
  --rocksdb-flush-log-at-trx-commit=# 
  Sync on transaction commit. Similar to
  innodb_flush_log_at_trx_commit. 1: sync on commit, 0,2:
@@ -2162,6 +2166,7 @@ rocksdb-enable-ttl TRUE
 rocksdb-enable-ttl-read-filtering TRUE
 rocksdb-enable-write-thread-adaptive-yield FALSE
 rocksdb-error-if-exists FALSE
+rocksdb-error-on-suboptimal-collation TRUE
 rocksdb-flush-log-at-trx-commit 1
 rocksdb-force-compute-memtable-stats TRUE
 rocksdb-force-compute-memtable-stats-cachetime 60000000

--- a/mysql-test/suite/rocksdb/r/collation.result
+++ b/mysql-test/suite/rocksdb/r/collation.result
@@ -1,7 +1,7 @@
 call mtr.add_suppression("Invalid pattern");
-SET @start_global_value = @@global.ROCKSDB_STRICT_COLLATION_EXCEPTIONS;
-DROP TABLE IF EXISTS t1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text) engine=rocksdb charset utf8;
+ALTER TABLE t1 ADD INDEX (value);
+ERROR HY000: Unsupported collation on string indexed column test.t1.value Use binary collation (binary, latin1_bin, utf8_bin).
 DROP TABLE t1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value)) engine=rocksdb charset utf8;
 ERROR HY000: Unsupported collation on string indexed column test.t1.value Use binary collation (binary, latin1_bin, utf8_bin).
@@ -14,6 +14,7 @@ SET GLOBAL rocksdb_strict_collation_check=1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value2)) engine=rocksdb charset utf8;
 DROP TABLE t1;
 CREATE TABLE t1 (id varchar(20), value varchar(50), value2 varchar(50), value3 text, primary key (id), index(value, value2)) engine=rocksdb charset latin1 collate latin1_bin;
+ALTER TABLE t1 collate=latin1_general_ci;
 DROP TABLE t1;
 CREATE TABLE t1 (id varchar(20), value varchar(50), value2 varchar(50), value3 text, primary key (id), index(value, value2)) engine=rocksdb charset utf8 collate utf8_bin;
 DROP TABLE t1;
@@ -127,4 +128,16 @@ CREATE TABLE abcd (id INT PRIMARY KEY, value varchar(50), index(value)) engine=r
 ERROR HY000: Unsupported collation on string indexed column test.abcd.value Use binary collation (binary, latin1_bin, utf8_bin).
 DROP TABLE abc;
 SET GLOBAL rocksdb_strict_collation_exceptions=null;
-SET GLOBAL rocksdb_strict_collation_exceptions=@start_global_value;
+SET GLOBAL rocksdb_strict_collation_check=1;
+CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value)) engine=rocksdb charset utf8;
+Warnings:
+Warning	1210	Unsupported collation on string indexed column test.t1.value Use binary collation (binary, latin1_bin, utf8_bin).
+DROP TABLE t1;
+CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text) engine=rocksdb charset utf8;
+ALTER TABLE t1 ADD INDEX (value);
+Warnings:
+Warning	1210	Unsupported collation on string indexed column test.t1.value Use binary collation (binary, latin1_bin, utf8_bin).
+DROP TABLE t1;
+CREATE TABLE t1 (id varchar(20), value varchar(50), value2 varchar(50), value3 text, primary key (id), index(value, value2)) engine=rocksdb charset latin1 collate latin1_bin;
+ALTER TABLE t1 collate=latin1_general_ci;
+DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -903,6 +903,7 @@ rocksdb_enable_ttl	ON
 rocksdb_enable_ttl_read_filtering	ON
 rocksdb_enable_write_thread_adaptive_yield	OFF
 rocksdb_error_if_exists	OFF
+rocksdb_error_on_suboptimal_collation	ON
 rocksdb_flush_log_at_trx_commit	1
 rocksdb_force_compute_memtable_stats	ON
 rocksdb_force_compute_memtable_stats_cachetime	0

--- a/mysql-test/suite/rocksdb/t/collation.test
+++ b/mysql-test/suite/rocksdb/t/collation.test
@@ -2,14 +2,12 @@
 --source include/have_fullregex.inc
 
 call mtr.add_suppression("Invalid pattern");
-SET @start_global_value = @@global.ROCKSDB_STRICT_COLLATION_EXCEPTIONS;
-
---disable_warnings
-DROP TABLE IF EXISTS t1;
---enable_warnings
 
 # ci non-indexed column is allowed
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text) engine=rocksdb charset utf8;
+# ci indexed column is not allowed
+--error ER_UNSUPPORTED_COLLATION
+ALTER TABLE t1 ADD INDEX (value);
 DROP TABLE t1;
 
 # ci indexed column is not allowed
@@ -29,6 +27,8 @@ DROP TABLE t1;
 
 # cs latin1_bin is allowed
 CREATE TABLE t1 (id varchar(20), value varchar(50), value2 varchar(50), value3 text, primary key (id), index(value, value2)) engine=rocksdb charset latin1 collate latin1_bin;
+# THIS SHOULD FAIL BUT IT DOES NOT
+ALTER TABLE t1 collate=latin1_general_ci;
 DROP TABLE t1;
 
 # cs utf8_bin is allowed
@@ -179,5 +179,28 @@ DROP TABLE abc;
 # test bad regex (null caused a crash) - Issue 493
 SET GLOBAL rocksdb_strict_collation_exceptions=null;
 
+# test for warnings instead of errors
+--let $_mysqld_option=--rocksdb_error_on_suboptimal_collation=0
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--source include/restart_mysqld_with_option.inc
+
+SET GLOBAL rocksdb_strict_collation_check=1;
+
+# ci indexed column is not optimal, should emit a warning
+CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value)) engine=rocksdb charset utf8;
+DROP TABLE t1;
+
+# ci non-indexed column is allowed
+CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text) engine=rocksdb charset utf8;
+# ci indexed column is not allowed, should emit a warning
+ALTER TABLE t1 ADD INDEX (value);
+DROP TABLE t1;
+
+# cs latin1_bin is allowed
+CREATE TABLE t1 (id varchar(20), value varchar(50), value2 varchar(50), value3 text, primary key (id), index(value, value2)) engine=rocksdb charset latin1 collate latin1_bin;
+# THIS SHOULD WARN BUT IT DOES NOT
+ALTER TABLE t1 collate=latin1_general_ci;
+DROP TABLE t1;
+
 # cleanup
-SET GLOBAL rocksdb_strict_collation_exceptions=@start_global_value;
+--source include/restart_mysqld.inc

--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_error_on_suboptimal_collation_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_error_on_suboptimal_collation_basic.result
@@ -1,0 +1,7 @@
+SET @start_global_value = @@global.ROCKSDB_ERROR_ON_SUBOPTIMAL_COLLATION;
+SELECT @start_global_value;
+@start_global_value
+1
+"Trying to set variable @@global.ROCKSDB_ERROR_ON_SUBOPTIMAL_COLLATION to 444. It should fail because it is readonly."
+SET @@global.ROCKSDB_ERROR_ON_SUBOPTIMAL_COLLATION   = 444;
+ERROR HY000: Variable 'rocksdb_error_on_suboptimal_collation' is a read only variable

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_error_on_suboptimal_collation_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_error_on_suboptimal_collation_basic.test
@@ -1,0 +1,6 @@
+--source include/have_rocksdb.inc
+
+--let $sys_var=ROCKSDB_ERROR_ON_SUBOPTIMAL_COLLATION
+--let $read_only=1
+--let $session=0
+--source ../include/rocksdb_sys_var.inc

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -492,6 +492,7 @@ static my_bool rocksdb_large_prefix = 0;
 static my_bool rocksdb_allow_to_start_after_corruption = 0;
 static uint32_t rocksdb_write_policy =
     rocksdb::TxnDBWritePolicy::WRITE_COMMITTED;
+static my_bool rocksdb_error_on_suboptimal_collation = 1;
 
 std::atomic<uint64_t> rocksdb_row_lock_deadlocks(0);
 std::atomic<uint64_t> rocksdb_row_lock_wait_timeouts(0);
@@ -1531,6 +1532,13 @@ static MYSQL_SYSVAR_BOOL(
     "detected.",
     nullptr, nullptr, FALSE);
 
+static MYSQL_SYSVAR_BOOL(error_on_suboptimal_collation,
+                         rocksdb_error_on_suboptimal_collation,
+                         PLUGIN_VAR_OPCMDARG | PLUGIN_VAR_READONLY,
+                         "Raise an error instead of warning if a sub-optimal "
+                         "collation is used",
+                         nullptr, nullptr, TRUE);
+
 static const int ROCKSDB_ASSUMED_KEY_VALUE_DISK_SIZE = 100;
 
 static struct st_mysql_sys_var *rocksdb_system_variables[] = {
@@ -1676,6 +1684,7 @@ static struct st_mysql_sys_var *rocksdb_system_variables[] = {
 
     MYSQL_SYSVAR(large_prefix),
     MYSQL_SYSVAR(allow_to_start_after_corruption),
+    MYSQL_SYSVAR(error_on_suboptimal_collation),
     nullptr};
 
 static rocksdb::WriteOptions
@@ -6382,11 +6391,22 @@ int ha_rocksdb::create_cfs(
             }
             collation_err += coll->name;
           }
-          my_error(ER_UNSUPPORTED_COLLATION, MYF(0),
-                   tbl_def_arg->full_tablename().c_str(),
-                   table_arg->key_info[i].key_part[part].field->field_name,
-                   collation_err.c_str());
-          DBUG_RETURN(HA_EXIT_FAILURE);
+
+          if (rocksdb_error_on_suboptimal_collation) {
+            my_error(ER_UNSUPPORTED_COLLATION, MYF(0),
+                     tbl_def_arg->full_tablename().c_str(),
+                     table_arg->key_info[i].key_part[part].field->field_name,
+                     collation_err.c_str());
+            DBUG_RETURN(HA_EXIT_FAILURE);
+          } else {
+            push_warning_printf(
+                ha_thd(), Sql_condition::WARN_LEVEL_WARN, ER_WRONG_ARGUMENTS,
+                "Unsupported collation on string indexed column %s.%s Use "
+                "binary collation (%s).",
+                tbl_def_arg->full_tablename().c_str(),
+                table_arg->key_info[i].key_part[part].field->field_name,
+                collation_err.c_str());
+          }
         }
       }
     }


### PR DESCRIPTION
New variable specifies whether to raise an error or a warning if an index is
created on a char field where the table has a sub-optimal collation (case
insensitive).

Default is TRUE. Variable is global read only.