### PR TITLE
Portability: `unsigned long` instead of `ulong`

### DIFF
--- a/include/mysql.h
+++ b/include/mysql.h
@@ -670,8 +670,8 @@ unsigned int	STDCALL mysql_thread_safe(void);
 my_bool		STDCALL mysql_embedded(void);
 my_bool         STDCALL mysql_read_query_result(MYSQL *mysql);
 int             STDCALL mysql_reset_connection(MYSQL *mysql);
-ulong STDCALL cli_safe_read(MYSQL *mysql, my_bool *is_data_packet);
-net_async_status STDCALL cli_safe_read_nonblocking(MYSQL *mysql, ulong* res,
+unsigned long   STDCALL cli_safe_read(MYSQL *mysql, my_bool *is_data_packet);
+net_async_status STDCALL cli_safe_read_nonblocking(MYSQL *mysql, unsigned long *res,
                                                    my_bool *is_data_packet);
 
 

--- a/include/mysql.h.pp
+++ b/include/mysql.h.pp
@@ -727,8 +727,8 @@ unsigned int mysql_thread_safe(void);
 my_bool mysql_embedded(void);
 my_bool mysql_read_query_result(MYSQL *mysql);
 int mysql_reset_connection(MYSQL *mysql);
-ulong cli_safe_read(MYSQL *mysql, my_bool *is_data_packet);
-net_async_status cli_safe_read_nonblocking(MYSQL *mysql, ulong* res,
+unsigned long cli_safe_read(MYSQL *mysql, my_bool *is_data_packet);
+net_async_status cli_safe_read_nonblocking(MYSQL *mysql, unsigned long *res,
                                                    my_bool *is_data_packet);
 enum enum_mysql_stmt_state
 {


### PR DESCRIPTION
`ulong` is undefiend on macos, and otherwise unused. Blocks merging updates into HHVM.