### PR TITLE
[MyRocks] Flushing on deleting chunks after fast index creation

### DIFF
--- a/storage/rocksdb/rdb_index_merge.cc
+++ b/storage/rocksdb/rdb_index_merge.cc
@@ -52,6 +52,11 @@ Rdb_index_merge::~Rdb_index_merge() {
       }
 
       my_sleep(m_merge_tmp_file_removal_delay * 1000);
+      // Not aborting on fsync error since the tmp file is not used anymore
+      if (mysql_file_sync(m_merge_file.m_fd, MYF(MY_WME))) {
+        // NO_LINT_DEBUG
+        sql_print_error("Error flushing truncated MyRocks merge buffer.");
+      }
       curr_size -= m_merge_buf_size;
     }
   }


### PR DESCRIPTION
Summary: MyRocks fast index creation process deletes a large
temporary merge file in the end. The deletion was done by
deleting chunks one by one, with short sleep
(rocksdb_merge_tmp_file_removal_delay_ms). This was for avoiding
burst TRIM stalls on Flash. The graceful delete actually did
not work as expected, because all deletions were done in kernel buffer
only. Burst TRIM happened when kernel BG thread flushed to storage.
This diff explicitly calls fsync for each chunk deletion.

Test Plan: Fast index creation on large table. Prior to this diff
one second 1GB/s burst write happened. After this diff it changed
to 64MB/s consistent writes.