### PR TITLE
Disable bloomfilter when seeking to index+1

### DIFF
--- a/mysql-test/suite/rocksdb/r/bloomfilter5.result
+++ b/mysql-test/suite/rocksdb/r/bloomfilter5.result
@@ -1,0 +1,53 @@
+CREATE TABLE t1 (
+`id1` bigint NOT NULL,
+`id2` bigint NOT NULL,
+`id3` varchar(100) NOT NULL,
+`id4` int NOT NULL,
+`id5` int NOT NULL,
+`value` bigint,
+`value2` varchar(100),
+PRIMARY KEY (id1, id2, id3, id4) COMMENT 'rev:cf_short_prefix',
+INDEX id2 (id2) COMMENT 'rev:cf_short_prefix',
+INDEX id2_id1 (id2, id1) COMMENT 'rev:cf_short_prefix',
+INDEX id2_id3 (id2, id3) COMMENT 'rev:cf_short_prefix',
+INDEX id2_id4 (id2, id4) COMMENT 'rev:cf_short_prefix',
+INDEX id2_id3_id1_id4 (id2, id3, id1, id4) COMMENT 'rev:cf_short_prefix',
+INDEX id3_id2 (id3, id2) COMMENT 'rev:cf_short_prefix'
+) ENGINE=RocksDB;
+CREATE TABLE t2 (
+`id1` bigint NOT NULL,
+`id2` bigint NOT NULL,
+`id3` varchar(100) NOT NULL,
+`id4` int NOT NULL,
+`id5` int NOT NULL,
+`value` bigint,
+`value2` varchar(100),
+PRIMARY KEY (id4) COMMENT 'rev:cf_short_prefix',
+INDEX id2 (id2) COMMENT 'rev:cf_short_prefix',
+INDEX id2_id3 (id2, id3) COMMENT 'rev:cf_short_prefix',
+INDEX id2_id4 (id2, id4) COMMENT 'rev:cf_short_prefix',
+INDEX id2_id4_id5 (id2, id4, id5) COMMENT 'rev:cf_short_prefix',
+INDEX id3_id4 (id3, id4) COMMENT 'rev:cf_short_prefix',
+INDEX id3_id5 (id3, id5) COMMENT 'rev:cf_short_prefix'
+) ENGINE=RocksDB;
+CREATE TABLE ten(a int) ENGINE=MYISAM;
+INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+CREATE TABLE ten_k(seq int);
+INSERT INTO ten_k select 1+ A.a + B.a* 10 + C.a * 100 + D.a * 1000 from ten A, ten B, ten C, ten D;
+INSERT t1
+SELECT (seq+9) div 10, (seq+4) div 5, (seq+4) div 5, seq, seq, 1000, "aaabbbccc"
+  FROM ten_k;
+INSERT t2 select * from t1;
+SELECT count(*) from t1;
+count(*)
+10000
+CHECKSUM TABLE t1;
+Table	Checksum
+test.t1	2625466469
+SELECT count(*) from t2;
+count(*)
+10000
+CHECKSUM TABLE t2;
+Table	Checksum
+test.t2	2625466469
+DROP TABLE t1, t2, ten, ten_k;

--- a/mysql-test/suite/rocksdb/t/bloomfilter5-master.opt
+++ b/mysql-test/suite/rocksdb/t/bloomfilter5-master.opt
@@ -1,0 +1,2 @@
+--rocksdb_default_cf_options=write_buffer_size=256k;block_based_table_factory={filter_policy=bloomfilter:10:false;whole_key_filtering=0;};prefix_extractor=capped:20
+--rocksdb_override_cf_options=cf_short_prefix={prefix_extractor=capped:4};rev:cf_short_prefix={prefix_extractor=capped:4};cf_long_prefix={prefix_extractor=capped:240};rev:cf_long_prefix={prefix_extractor=capped:240}

--- a/mysql-test/suite/rocksdb/t/bloomfilter5.test
+++ b/mysql-test/suite/rocksdb/t/bloomfilter5.test
@@ -1,0 +1,55 @@
+--source include/have_rocksdb.inc
+
+# Test for https://github.com/facebook/mysql-5.6/issues/809
+# Testing for reverse column families and 4 byte bloomfilters
+
+CREATE TABLE t1 (
+  `id1` bigint NOT NULL,
+  `id2` bigint NOT NULL,
+  `id3` varchar(100) NOT NULL,
+  `id4` int NOT NULL,
+  `id5` int NOT NULL,
+  `value` bigint,
+  `value2` varchar(100),
+  PRIMARY KEY (id1, id2, id3, id4) COMMENT 'rev:cf_short_prefix',
+  INDEX id2 (id2) COMMENT 'rev:cf_short_prefix',
+  INDEX id2_id1 (id2, id1) COMMENT 'rev:cf_short_prefix',
+  INDEX id2_id3 (id2, id3) COMMENT 'rev:cf_short_prefix',
+  INDEX id2_id4 (id2, id4) COMMENT 'rev:cf_short_prefix',
+  INDEX id2_id3_id1_id4 (id2, id3, id1, id4) COMMENT 'rev:cf_short_prefix',
+  INDEX id3_id2 (id3, id2) COMMENT 'rev:cf_short_prefix'
+) ENGINE=RocksDB;
+CREATE TABLE t2 (
+  `id1` bigint NOT NULL,
+  `id2` bigint NOT NULL,
+  `id3` varchar(100) NOT NULL,
+  `id4` int NOT NULL,
+  `id5` int NOT NULL,
+  `value` bigint,
+  `value2` varchar(100),
+  PRIMARY KEY (id4) COMMENT 'rev:cf_short_prefix',
+  INDEX id2 (id2) COMMENT 'rev:cf_short_prefix',
+  INDEX id2_id3 (id2, id3) COMMENT 'rev:cf_short_prefix',
+  INDEX id2_id4 (id2, id4) COMMENT 'rev:cf_short_prefix',
+  INDEX id2_id4_id5 (id2, id4, id5) COMMENT 'rev:cf_short_prefix',
+  INDEX id3_id4 (id3, id4) COMMENT 'rev:cf_short_prefix',
+  INDEX id3_id5 (id3, id5) COMMENT 'rev:cf_short_prefix'
+) ENGINE=RocksDB;
+
+CREATE TABLE ten(a int) ENGINE=MYISAM;
+INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+
+CREATE TABLE ten_k(seq int);
+INSERT INTO ten_k select 1+ A.a + B.a* 10 + C.a * 100 + D.a * 1000 from ten A, ten B, ten C, ten D;
+
+INSERT t1
+SELECT (seq+9) div 10, (seq+4) div 5, (seq+4) div 5, seq, seq, 1000, "aaabbbccc"
+  FROM ten_k;
+
+INSERT t2 select * from t1;
+SELECT count(*) from t1;
+CHECKSUM TABLE t1;
+SELECT count(*) from t2;
+CHECKSUM TABLE t2;
+
+DROP TABLE t1, t2, ten, ten_k;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -12533,7 +12533,7 @@ bool ha_rocksdb::can_use_bloom_filter(THD *thd, const Rdb_key_def &kd,
                                       const bool use_all_keys) {
   bool can_use = false;
 
-  if (THDVAR(thd, skip_bloom_filter_on_read)) {
+  if (THDVAR(thd, skip_bloom_filter_on_read) || !kd.covers_key(eq_cond)) {
     return can_use;
   }
 


### PR DESCRIPTION
Summary:

https://github.com/facebook/mysql-5.6/issues/809

When seeking to a infimum or supremum records of an index, the record's
index value might be different from the key definition. If the
bloomfilter is also set to 4 bytes cap, bloomfilters would be enabled.

i.e. Key definition index value is 260, but we seek to the supremum
record with index value 261. Since bloomfilter ends up being enabled,
Seek(261) would use 261 as the matching key and none of the keys in the
table starting with index value 260 would be found. The result is
selecting those rows fail.