### PR TITLE
Aborting on Background Thread I/O errors as well

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -12760,6 +12760,9 @@ void rdb_handle_io_error(const rocksdb::Status status,
     }
     case RDB_IO_ERROR_BG_THREAD: {
       rdb_log_status_error(status, "BG thread failed to write to RocksDB");
+      /* NO_LINT_DEBUG */
+      sql_print_error("MyRocks: aborting on BG write error.");
+      abort();
       break;
     }
     case RDB_IO_ERROR_GENERAL: {


### PR DESCRIPTION
Summary: When hitting rocksdb::Status != ok, MyRocks aborted
on non-background threads, but did not abort when BG threads hit it.
This may result in data loss, when BG thread hit EIO on fsync but
did succeeded in following attempts. This diff changes the behavior
so that MyRocks aborts as well on BG errors.