### PR TITLE
Fix compile error on Ubuntu Bionic 18.04

### DIFF
--- a/sql/field.cc
+++ b/sql/field.cc
@@ -10012,7 +10012,7 @@ uint Field_document::get_key_image_double(uchar *buff, fbson::FbsonValue *pval)
     char* end = (char*)start + pval->size();
     int error;
     val = my_strtod(start, &end, &error);
-    if (error == OVERFLOW)
+    if (error == EOVERFLOW)
     {
       val = 0;
       return 0;


### PR DESCRIPTION
field.cc:10015:18: error: ‘OVERFLOW’ was not declared in this scope

The right constant is EOVERFLOW, see it being returned in
strings/dtoa.c:1628 *error= EOVERFLOW;