### PR TITLE
Make rocksdb.issue255 test stable

### DIFF
--- a/mysql-test/suite/rocksdb/r/issue255.result
+++ b/mysql-test/suite/rocksdb/r/issue255.result
@@ -46,7 +46,7 @@ pk
 127
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	10	Fixed	2	15	30	0	0	0	127	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	#	Fixed	2	#	#	#	#	#	127	NULL	NULL	NULL	latin1_swedish_ci	NULL		
 INSERT INTO t1 VALUES ();
 ERROR 23000: Duplicate entry '127' for key 'PRIMARY'
 SELECT * FROM t1;

--- a/mysql-test/suite/rocksdb/t/issue255.test
+++ b/mysql-test/suite/rocksdb/t/issue255.test
@@ -32,8 +32,8 @@ INSERT INTO t1 VALUES (5);
 SHOW TABLE STATUS LIKE 't1';
 
 INSERT INTO t1 VALUES (1000);
---replace_column 3 # 6 # 7 # 8 # 9 # 10 #
 SELECT * FROM t1;
+--replace_column 3 # 6 # 7 # 8 # 9 # 10 #
 SHOW TABLE STATUS LIKE 't1';
 
 --error ER_DUP_ENTRY


### PR DESCRIPTION
Fix an obvious typo: replace_column should apply to SHOW TABLE STATUS,
not to SELECT * FROM t1.