### PR TITLE
Backporting WL#6355 Semisync AFTER_COMMIT

### DIFF
--- a/mysql-test/extra/rpl_tests/rpl_semi_sync_after_sync.test
+++ b/mysql-test/extra/rpl_tests/rpl_semi_sync_after_sync.test
@@ -1,0 +1,128 @@
+--echo #
+--echo # Test on AFTER_SYNC wait point
+--echo # #######################################################################
+--echo # Case 1: Single statement transaction
+--echo #
+--let $rpl_connection_name= server_1
+--source include/rpl_connection.inc
+--let $yes_tx= query_get_value(SHOW STATUS LIKE 'Rpl_semi_sync_master_yes_tx', Value, 1)
+show status like "rpl_semi_sync_master_yes_tx";
+SET DEBUG_SYNC= "after_call_after_sync_observer SIGNAL after_sync_done WAIT_FOR end";
+--send INSERT INTO t1 VALUES(1);
+
+--source include/rpl_connection_master.inc
+SET DEBUG_SYNC= "now WAIT_FOR after_sync_done";
+
+show status like "rpl_semi_sync_master_yes_tx";
+--let $assert_text= rpl_semi_sync_master_yes_tx increased 1
+--let $assert_cond= VARIABLE_VALUE = $yes_tx+1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = "rpl_semi_sync_master_yes_tx"
+--source include/assert.inc
+
+--let $assert_text= Table is empty right now.
+--let $assert_cond= COUNT(*) = 0 FROM t1
+--source include/assert.inc
+
+--sync_slave_with_master
+
+--let $assert_text= Table has 1 record
+--let $assert_cond= COUNT(*) = 1 FROM t1;
+--source include/assert.inc
+
+--source include/rpl_connection_master.inc
+SET DEBUG_SYNC= "now SIGNAL end";
+
+--let $rpl_connection_name= server_1
+--source include/rpl_connection.inc
+--reap
+
+# Varify that after_commit hook is not executed.
+--let $assert_text= rpl_semi_sync_master_yes_tx increased only 1
+--let $assert_cond= VARIABLE_VALUE = $yes_tx+1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = "rpl_semi_sync_master_yes_tx"
+--source include/assert.inc
+
+TRUNCATE t1;
+
+--echo #
+--echo # Test on AFTER_SYNC wait point
+--echo # #######################################################################
+--echo # Case 2: Real transaction
+--echo #
+
+--let $rpl_connection_name= server_1
+--source include/rpl_connection.inc
+--let $yes_tx= query_get_value(SHOW STATUS LIKE 'Rpl_semi_sync_master_yes_tx', Value, 1)
+
+SET DEBUG_SYNC= "after_call_after_sync_observer SIGNAL after_sync_done WAIT_FOR end";
+BEGIN;
+INSERT INTO t1 VALUES(1);
+INSERT INTO t1 VALUES(2);
+--send COMMIT
+
+--source include/rpl_connection_master.inc
+SET DEBUG_SYNC= "now WAIT_FOR after_sync_done";
+
+--let $assert_text= rpl_semi_sync_master_yes_tx increased 1
+--let $assert_cond= VARIABLE_VALUE = $yes_tx+1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = "rpl_semi_sync_master_yes_tx"
+--source include/assert.inc
+
+--let $assert_text= Table is empty right now.
+--let $assert_cond= COUNT(*) = 0 FROM t1
+--source include/assert.inc
+
+--sync_slave_with_master
+
+--let $assert_text= Table has two records
+--let $assert_cond= COUNT(*) = 2 FROM t1;
+--source include/assert.inc
+
+--source include/rpl_connection_master.inc
+SET DEBUG_SYNC= "now SIGNAL end";
+
+--let $rpl_connection_name= server_1
+--source include/rpl_connection.inc
+--reap
+
+# Varify that after_commit hook is not executed.
+--let $assert_text= rpl_semi_sync_master_yes_tx increased only 1
+--let $assert_cond= VARIABLE_VALUE = $yes_tx+1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = "rpl_semi_sync_master_yes_tx"
+--source include/assert.inc
+
+TRUNCATE t1;
+
+--echo #
+--echo # Test on AFTER_COMMIT wait point
+--echo # #######################################################################
+--echo # Verify after_sync hook will not be executed
+--echo #
+--let $yes_tx= query_get_value(SHOW STATUS LIKE 'Rpl_semi_sync_master_yes_tx', Value, 1)
+--let $no_tx= query_get_value(SHOW STATUS LIKE 'Rpl_semi_sync_master_no_tx', Value, 1)
+
+SET GLOBAL rpl_semi_sync_master_wait_point= AFTER_COMMIT;
+SET DEBUG_SYNC= "before_call_after_commit_observer SIGNAL engine_commit_done
+                 WAIT_FOR end";
+--send INSERT INTO t1 VALUES(1);
+
+--source include/rpl_connection_master.inc
+SET DEBUG_SYNC= "now WAIT_FOR engine_commit_done";
+
+--let $assert_text= Table is empty right now.
+--let $assert_cond= COUNT(*) = 1 FROM t1
+--source include/assert.inc
+
+--let $assert_text= rpl_semi_sync_master_yes_tx was not increased
+--let $assert_cond= VARIABLE_VALUE = $yes_tx FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = "rpl_semi_sync_master_yes_tx"
+--source include/assert.inc
+
+--let $assert_text= rpl_semi_sync_master_no_tx was not increased
+--let $assert_cond= VARIABLE_VALUE = $no_tx FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = "rpl_semi_sync_master_no_tx"
+--source include/assert.inc
+
+SET DEBUG_SYNC= "now SIGNAL end";
+SET DEBUG_SYNC= "RESET";
+--let $rpl_connection_name= server_1
+--source include/rpl_connection.inc
+--reap
+
+SET GLOBAL rpl_semi_sync_master_wait_point= AFTER_SYNC;
+TRUNCATE t1;
+--sync_slave_with_master

--- a/mysql-test/suite/rpl/r/rpl_semi_sync_after_sync.result
+++ b/mysql-test/suite/rpl/r/rpl_semi_sync_after_sync.result
@@ -1,0 +1,142 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+include/install_semisync.inc
+CREATE TABLE t1(c1 INT) ENGINE=InnoDB;
+#
+# Test on AFTER_SYNC wait point
+# #######################################################################
+# Case 1: Single statement transaction
+#
+[connection server_1]
+show status like "rpl_semi_sync_master_yes_tx";
+Variable_name	Value
+Rpl_semi_sync_master_yes_tx	1
+SET DEBUG_SYNC= "after_call_after_sync_observer SIGNAL after_sync_done WAIT_FOR end";
+INSERT INTO t1 VALUES(1);;
+[connection master]
+SET DEBUG_SYNC= "now WAIT_FOR after_sync_done";
+show status like "rpl_semi_sync_master_yes_tx";
+Variable_name	Value
+Rpl_semi_sync_master_yes_tx	2
+include/assert.inc [rpl_semi_sync_master_yes_tx increased 1]
+include/assert.inc [Table is empty right now.]
+include/assert.inc [Table has 1 record]
+[connection master]
+SET DEBUG_SYNC= "now SIGNAL end";
+[connection server_1]
+include/assert.inc [rpl_semi_sync_master_yes_tx increased only 1]
+TRUNCATE t1;
+#
+# Test on AFTER_SYNC wait point
+# #######################################################################
+# Case 2: Real transaction
+#
+[connection server_1]
+SET DEBUG_SYNC= "after_call_after_sync_observer SIGNAL after_sync_done WAIT_FOR end";
+BEGIN;
+INSERT INTO t1 VALUES(1);
+INSERT INTO t1 VALUES(2);
+COMMIT;
+[connection master]
+SET DEBUG_SYNC= "now WAIT_FOR after_sync_done";
+include/assert.inc [rpl_semi_sync_master_yes_tx increased 1]
+include/assert.inc [Table is empty right now.]
+include/assert.inc [Table has two records]
+[connection master]
+SET DEBUG_SYNC= "now SIGNAL end";
+[connection server_1]
+include/assert.inc [rpl_semi_sync_master_yes_tx increased only 1]
+TRUNCATE t1;
+#
+# Test on AFTER_COMMIT wait point
+# #######################################################################
+# Verify after_sync hook will not be executed
+#
+SET GLOBAL rpl_semi_sync_master_wait_point= AFTER_COMMIT;
+SET DEBUG_SYNC= "before_call_after_commit_observer SIGNAL engine_commit_done
+                 WAIT_FOR end";
+INSERT INTO t1 VALUES(1);;
+[connection master]
+SET DEBUG_SYNC= "now WAIT_FOR engine_commit_done";
+include/assert.inc [Table is empty right now.]
+include/assert.inc [rpl_semi_sync_master_yes_tx was not increased]
+include/assert.inc [rpl_semi_sync_master_no_tx was not increased]
+SET DEBUG_SYNC= "now SIGNAL end";
+SET DEBUG_SYNC= "RESET";
+[connection server_1]
+SET GLOBAL rpl_semi_sync_master_wait_point= AFTER_SYNC;
+TRUNCATE t1;
+[connection master]
+SET GLOBAL binlog_order_commits = OFF;
+#
+# Test on AFTER_SYNC wait point
+# #######################################################################
+# Case 1: Single statement transaction
+#
+[connection server_1]
+show status like "rpl_semi_sync_master_yes_tx";
+Variable_name	Value
+Rpl_semi_sync_master_yes_tx	7
+SET DEBUG_SYNC= "after_call_after_sync_observer SIGNAL after_sync_done WAIT_FOR end";
+INSERT INTO t1 VALUES(1);;
+[connection master]
+SET DEBUG_SYNC= "now WAIT_FOR after_sync_done";
+show status like "rpl_semi_sync_master_yes_tx";
+Variable_name	Value
+Rpl_semi_sync_master_yes_tx	8
+include/assert.inc [rpl_semi_sync_master_yes_tx increased 1]
+include/assert.inc [Table is empty right now.]
+include/assert.inc [Table has 1 record]
+[connection master]
+SET DEBUG_SYNC= "now SIGNAL end";
+[connection server_1]
+include/assert.inc [rpl_semi_sync_master_yes_tx increased only 1]
+TRUNCATE t1;
+#
+# Test on AFTER_SYNC wait point
+# #######################################################################
+# Case 2: Real transaction
+#
+[connection server_1]
+SET DEBUG_SYNC= "after_call_after_sync_observer SIGNAL after_sync_done WAIT_FOR end";
+BEGIN;
+INSERT INTO t1 VALUES(1);
+INSERT INTO t1 VALUES(2);
+COMMIT;
+[connection master]
+SET DEBUG_SYNC= "now WAIT_FOR after_sync_done";
+include/assert.inc [rpl_semi_sync_master_yes_tx increased 1]
+include/assert.inc [Table is empty right now.]
+include/assert.inc [Table has two records]
+[connection master]
+SET DEBUG_SYNC= "now SIGNAL end";
+[connection server_1]
+include/assert.inc [rpl_semi_sync_master_yes_tx increased only 1]
+TRUNCATE t1;
+#
+# Test on AFTER_COMMIT wait point
+# #######################################################################
+# Verify after_sync hook will not be executed
+#
+SET GLOBAL rpl_semi_sync_master_wait_point= AFTER_COMMIT;
+SET DEBUG_SYNC= "before_call_after_commit_observer SIGNAL engine_commit_done
+                 WAIT_FOR end";
+INSERT INTO t1 VALUES(1);;
+[connection master]
+SET DEBUG_SYNC= "now WAIT_FOR engine_commit_done";
+include/assert.inc [Table is empty right now.]
+include/assert.inc [rpl_semi_sync_master_yes_tx was not increased]
+include/assert.inc [rpl_semi_sync_master_no_tx was not increased]
+SET DEBUG_SYNC= "now SIGNAL end";
+SET DEBUG_SYNC= "RESET";
+[connection server_1]
+SET GLOBAL rpl_semi_sync_master_wait_point= AFTER_SYNC;
+TRUNCATE t1;
+[connection master]
+SET GLOBAL binlog_order_commits= 1;
+DROP TABLE t1;
+include/uninstall_semisync.inc
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/r/rpl_semi_sync_group_commit_deadlock.result
+++ b/mysql-test/suite/rpl/r/rpl_semi_sync_group_commit_deadlock.result
@@ -7,6 +7,7 @@ include/install_semisync.inc
 SET @max_binlog_size_save= @@GLOBAL.MAX_BINLOG_SIZE;
 SET @@GLOBAL.MAX_BINLOG_SIZE= 4096;
 SET GLOBAL rpl_semi_sync_master_timeout= 600000;
+SET GLOBAL rpl_semi_sync_master_wait_point= AFTER_COMMIT;
 # Disable diff_table test
 # Test tables with MyISAM engine when disabling diff_table and
 # simulating flush error
@@ -34,5 +35,6 @@ include/diff_tables.inc [master:t9, slave:t9]
 include/diff_tables.inc [master:t10, slave:t10]
 include/sync_slave_sql_with_master.inc
 SET @@GLOBAL.MAX_BINLOG_SIZE= @max_binlog_size_save;
+SET GLOBAL rpl_semi_sync_master_wait_point= AFTER_SYNC;
 include/uninstall_semisync.inc
 include/rpl_end.inc

--- a/mysql-test/suite/rpl/r/rpl_semi_sync_non_group_commit_deadlock.result
+++ b/mysql-test/suite/rpl/r/rpl_semi_sync_non_group_commit_deadlock.result
@@ -8,6 +8,7 @@ SET @max_binlog_size_save= @@GLOBAL.MAX_BINLOG_SIZE;
 SET @@GLOBAL.MAX_BINLOG_SIZE= 4096;
 SET @@GLOBAL.BINLOG_ORDER_COMMITS= FALSE;
 SET GLOBAL rpl_semi_sync_master_timeout= 600000;
+SET GLOBAL rpl_semi_sync_master_wait_point= AFTER_COMMIT;
 # Disable diff_table test
 # Test tables with MyISAM engine when disabling diff_table and
 # simulating flush error
@@ -36,5 +37,6 @@ include/diff_tables.inc [master:t10, slave:t10]
 include/sync_slave_sql_with_master.inc
 SET @@GLOBAL.BINLOG_ORDER_COMMITS= TRUE;
 SET @@GLOBAL.MAX_BINLOG_SIZE= @max_binlog_size_save;
+SET GLOBAL rpl_semi_sync_master_wait_point= AFTER_SYNC;
 include/uninstall_semisync.inc
 include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_semi_sync_after_sync.test
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_after_sync.test
@@ -1,0 +1,31 @@
+################################################################################
+# It verifies the feature that semisync waits after binlog sync and before
+# transaction commit(WL#6355).
+#
+# Two wait points are there for semisync. AFTER_SYNC and AFTER_COMMIT
+# The main differece is that Other sessions could NOT see the data before it
+# replicated to slave if waiting at AFTER_SYNC wait point. In contrast, when
+# waiting at AFTER_COMMIT, other sessions could see the data before it is
+# replicated to slave.
+#################################################################################
+--source include/have_innodb.inc
+--source include/have_debug_sync.inc
+--source include/master-slave.inc
+--source include/install_semisync.inc
+
+CREATE TABLE t1(c1 INT) ENGINE=InnoDB;
+--sync_slave_with_master
+--source extra/rpl_tests/rpl_semi_sync_after_sync.test
+
+--source include/rpl_connection_master.inc
+--let $saved_binlog_order_commits= `SELECT @@GLOBAL.binlog_order_commits`
+SET GLOBAL binlog_order_commits = OFF;
+
+--source extra/rpl_tests/rpl_semi_sync_after_sync.test
+
+--source include/rpl_connection_master.inc
+eval SET GLOBAL binlog_order_commits= $saved_binlog_order_commits;
+
+DROP TABLE t1;
+--source include/uninstall_semisync.inc
+--source include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_semi_sync_group_commit_deadlock.test
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_group_commit_deadlock.test
@@ -15,6 +15,7 @@
 SET @max_binlog_size_save= @@GLOBAL.MAX_BINLOG_SIZE;
 SET @@GLOBAL.MAX_BINLOG_SIZE= 4096;
 SET GLOBAL rpl_semi_sync_master_timeout= 600000;
+SET GLOBAL rpl_semi_sync_master_wait_point= AFTER_COMMIT;
 
 --let $connections= 11
 --let $loops= 500
@@ -36,5 +37,6 @@ SET GLOBAL rpl_semi_sync_master_timeout= 600000;
 
 --connection master
 SET @@GLOBAL.MAX_BINLOG_SIZE= @max_binlog_size_save;
+SET GLOBAL rpl_semi_sync_master_wait_point= AFTER_SYNC;
 --source include/uninstall_semisync.inc
 --source include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_semi_sync_non_group_commit_deadlock.test
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_non_group_commit_deadlock.test
@@ -16,6 +16,7 @@ SET @max_binlog_size_save= @@GLOBAL.MAX_BINLOG_SIZE;
 SET @@GLOBAL.MAX_BINLOG_SIZE= 4096;
 SET @@GLOBAL.BINLOG_ORDER_COMMITS= FALSE;
 SET GLOBAL rpl_semi_sync_master_timeout= 600000;
+SET GLOBAL rpl_semi_sync_master_wait_point= AFTER_COMMIT;
 
 --let $connections= 11
 --let $loops= 500
@@ -38,6 +39,7 @@ SET GLOBAL rpl_semi_sync_master_timeout= 600000;
 --connection master
 SET @@GLOBAL.BINLOG_ORDER_COMMITS= TRUE;
 SET @@GLOBAL.MAX_BINLOG_SIZE= @max_binlog_size_save;
+SET GLOBAL rpl_semi_sync_master_wait_point= AFTER_SYNC;
 
 --source include/uninstall_semisync.inc
 --source include/rpl_end.inc

--- a/mysql-test/suite/sys_vars/r/rpl_semi_sync_master_wait_point_basic.result
+++ b/mysql-test/suite/sys_vars/r/rpl_semi_sync_master_wait_point_basic.result
@@ -1,0 +1,64 @@
+#
+# Verify it can set selected and showed correctly
+#
+SELECT @@GLOBAL.rpl_semi_sync_master_wait_point;
+@@GLOBAL.rpl_semi_sync_master_wait_point
+AFTER_SYNC
+SHOW GLOBAL VARIABLES LIKE 'rpl_semi_sync_master_wait_point';
+Variable_name	Value
+rpl_semi_sync_master_wait_point	AFTER_SYNC
+SELECT * FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE
+VARIABLE_NAME = 'rpl_semi_sync_master_wait_point';
+VARIABLE_NAME	VARIABLE_VALUE
+RPL_SEMI_SYNC_MASTER_WAIT_POINT	AFTER_SYNC
+#
+# Verify it is not a session variable
+#
+SELECT @@SESSION.rpl_semi_sync_master_wait_point;
+ERROR HY000: Variable 'rpl_semi_sync_master_wait_point' is a GLOBAL variable
+SHOW SESSION VARIABLES LIKE 'rpl_semi_sync_master_wait_point';
+Variable_name	Value
+rpl_semi_sync_master_wait_point	AFTER_SYNC
+SELECT * FROM INFORMATION_SCHEMA.SESSION_VARIABLES WHERE
+VARIABLE_NAME ='rpl_semi_sync_master_wait_point';
+VARIABLE_NAME	VARIABLE_VALUE
+RPL_SEMI_SYNC_MASTER_WAIT_POINT	AFTER_SYNC
+#
+# Verify it can be set correctly
+#
+SET GLOBAL rpl_semi_sync_master_wait_point = AFTER_COMMIT;
+SELECT @@GLOBAL.rpl_semi_sync_master_wait_point;
+@@GLOBAL.rpl_semi_sync_master_wait_point
+AFTER_COMMIT
+SET GLOBAL rpl_semi_sync_master_wait_point = AFTER_SYNC;
+SELECT @@GLOBAL.rpl_semi_sync_master_wait_point;
+@@GLOBAL.rpl_semi_sync_master_wait_point
+AFTER_SYNC
+SET GLOBAL rpl_semi_sync_master_wait_point = 1;
+SELECT @@GLOBAL.rpl_semi_sync_master_wait_point;
+@@GLOBAL.rpl_semi_sync_master_wait_point
+AFTER_COMMIT
+SET GLOBAL rpl_semi_sync_master_wait_point = 0;
+SELECT @@GLOBAL.rpl_semi_sync_master_wait_point;
+@@GLOBAL.rpl_semi_sync_master_wait_point
+AFTER_SYNC
+SET SESSION rpl_semi_sync_master_wait_point = AFTER_COMMIT;
+ERROR HY000: Variable 'rpl_semi_sync_master_wait_point' is a GLOBAL variable and should be set with SET GLOBAL
+SHOW SESSION VARIABLES LIKE 'rpl_semi_sync_master_wait_point';
+Variable_name	Value
+rpl_semi_sync_master_wait_point	AFTER_SYNC
+#
+# Verify it could not bet set with invalid values
+#
+SET GLOBAL rpl_semi_sync_master_wait_point = 2;
+ERROR 42000: Variable 'rpl_semi_sync_master_wait_point' can't be set to the value of '2'
+SET GLOBAL rpl_semi_sync_master_wait_point = blabla;
+ERROR 42000: Variable 'rpl_semi_sync_master_wait_point' can't be set to the value of 'blabla'
+SET GLOBAL rpl_semi_sync_master_wait_point = "blabla";
+ERROR 42000: Variable 'rpl_semi_sync_master_wait_point' can't be set to the value of 'blabla'
+SET GLOBAL rpl_semi_sync_master_wait_point = "";
+ERROR 42000: Variable 'rpl_semi_sync_master_wait_point' can't be set to the value of ''
+SET GLOBAL rpl_semi_sync_master_wait_point = NULL;
+ERROR 42000: Variable 'rpl_semi_sync_master_wait_point' can't be set to the value of 'NULL'
+SET GLOBAL rpl_semi_sync_master_wait_point = 0.1;
+ERROR 42000: Incorrect argument type to variable 'rpl_semi_sync_master_wait_point'

--- a/mysql-test/suite/sys_vars/t/rpl_semi_sync_master_wait_point_basic.test
+++ b/mysql-test/suite/sys_vars/t/rpl_semi_sync_master_wait_point_basic.test
@@ -1,0 +1,74 @@
+################################################################################
+# rpl_semi_sync_master
+#
+# It is a global variable only and can be set dynamically.
+# It has ENUM type and only accepts 'AFTER_COMMIT' and 'AFTER_SYNC' two values.
+#
+# This test verifies the variable can be set, selected and showed correctly.
+################################################################################
+source include/not_embedded.inc;
+
+--echo #
+--echo # Verify it can set selected and showed correctly
+--echo #
+SELECT @@GLOBAL.rpl_semi_sync_master_wait_point;
+
+SHOW GLOBAL VARIABLES LIKE 'rpl_semi_sync_master_wait_point';
+
+SELECT * FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE
+  VARIABLE_NAME = 'rpl_semi_sync_master_wait_point';
+
+--echo #
+--echo # Verify it is not a session variable
+--echo #
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@SESSION.rpl_semi_sync_master_wait_point;
+
+SHOW SESSION VARIABLES LIKE 'rpl_semi_sync_master_wait_point';
+
+SELECT * FROM INFORMATION_SCHEMA.SESSION_VARIABLES WHERE
+  VARIABLE_NAME ='rpl_semi_sync_master_wait_point';
+
+--echo #
+--echo # Verify it can be set correctly
+--echo #
+SET GLOBAL rpl_semi_sync_master_wait_point = AFTER_COMMIT;
+SELECT @@GLOBAL.rpl_semi_sync_master_wait_point;
+
+SET GLOBAL rpl_semi_sync_master_wait_point = AFTER_SYNC;
+SELECT @@GLOBAL.rpl_semi_sync_master_wait_point;
+
+# 1 is same to AFTER_COMMIT
+SET GLOBAL rpl_semi_sync_master_wait_point = 1;
+SELECT @@GLOBAL.rpl_semi_sync_master_wait_point;
+
+# 0 is same to AFTER_SYNC
+SET GLOBAL rpl_semi_sync_master_wait_point = 0;
+SELECT @@GLOBAL.rpl_semi_sync_master_wait_point;
+
+--error ER_GLOBAL_VARIABLE
+SET SESSION rpl_semi_sync_master_wait_point = AFTER_COMMIT;
+SHOW SESSION VARIABLES LIKE 'rpl_semi_sync_master_wait_point';
+
+--echo #
+--echo # Verify it could not bet set with invalid values
+--echo #
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL rpl_semi_sync_master_wait_point = 2;
+
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL rpl_semi_sync_master_wait_point = blabla;
+
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL rpl_semi_sync_master_wait_point = "blabla";
+
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL rpl_semi_sync_master_wait_point = "";
+
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL rpl_semi_sync_master_wait_point = NULL;
+
+--error ER_WRONG_TYPE_FOR_VAR
+SET GLOBAL rpl_semi_sync_master_wait_point = 0.1;
+
+

--- a/sql/binlog.h
+++ b/sql/binlog.h
@@ -585,6 +585,7 @@ private:
   std::pair<bool, bool> sync_binlog_file(bool force, bool async);
   void process_semisync_stage_queue(THD *queue_head);
   void process_commit_stage_queue(THD *thd, THD *queue, bool async);
+  void process_after_commit_stage_queue(THD *thd, THD *first, bool async);
   int process_flush_stage_queue(my_off_t *total_bytes_var, bool *rotate_var,
                                 THD **out_queue_var, bool async);
   int ordered_commit(THD *thd, bool all, bool skip_commit = false,

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -1552,9 +1552,12 @@ end:
                    issued by DDL. Is not set when called
                    at the end of statement, even if
                    autocommit=1.
+  @param[in]  run_after_commit
+                   True by default, otherwise, does not execute
+                   the after_commit hook in the function.
 */
 
-int ha_commit_low(THD *thd, bool all, bool async)
+int ha_commit_low(THD *thd, bool all, bool async, bool run_after_commit)
 {
   int error=0;
   THD_TRANS *trans=all ? &thd->transaction.all : &thd->transaction.stmt;
@@ -1604,6 +1607,19 @@ int ha_commit_low(THD *thd, bool all, bool async)
     was called.
   */
   thd->transaction.flags.commit_low= false;
+  if (run_after_commit && thd->transaction.flags.run_hooks)
+  {
+    /*
+       If commit succeeded, we call the after_commit hook.
+
+       TODO: Investigate if this can be refactored so that there is
+             only one invocation of this hook in the code (in
+             MYSQL_LOG_BIN::finish_commit).
+    */
+    if (!error)
+      (void) RUN_HOOK(transaction, after_commit, (thd, all));
+    thd->transaction.flags.run_hooks= false;
+  }
   DBUG_RETURN(error);
 }
 

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -3746,7 +3746,7 @@ int ha_recover(HASH *commit_list, char *binlog_file = NULL,
  intended to be used by the transaction coordinators to
  commit/prepare/rollback transactions in the engines.
 */
-int ha_commit_low(THD *thd, bool all, bool async);
+int ha_commit_low(THD *thd, bool all, bool async, bool run_after_commit= true);
 int ha_prepare_low(THD *thd, bool all, bool async);
 int ha_rollback_low(THD *thd, bool all);
 

--- a/sql/rpl_handler.cc
+++ b/sql/rpl_handler.cc
@@ -21,6 +21,7 @@
 #include "rpl_filter.h"
 #include <my_dir.h>
 #include "rpl_handler.h"
+#include "debug_sync.h"
 
 Trans_delegate *transaction_delegate;
 Binlog_storage_delegate *binlog_storage_delegate;
@@ -233,6 +234,8 @@ int Trans_delegate::before_commit(THD *thd, bool all)
 
   int ret= 0;
   FOREACH_OBSERVER(ret, before_commit, thd, (&param));
+
+  DEBUG_SYNC(thd, "after_call_after_sync_observer");
   DBUG_RETURN(ret);
 }
 
@@ -248,6 +251,7 @@ int Trans_delegate::after_commit(THD *thd, bool all)
   thd->get_trans_fixed_pos(&param.log_file, &param.log_pos);
 
   DBUG_PRINT("enter", ("log_file: %s, log_pos: %llu", param.log_file, param.log_pos));
+  DEBUG_SYNC(thd, "before_call_after_commit_observer");
 
   int ret= 0;
   FOREACH_OBSERVER(ret, after_commit, thd, (&param));

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -2890,7 +2890,7 @@ public:
       bool xid_written;               // The session wrote an XID
       bool real_commit;               // Is this a "real" commit?
       bool commit_low;                // see MYSQL_BIN_LOG::ordered_commit
-      bool run_hooks;                 // Call the before_commit hook
+      bool run_hooks;                 // Call the after_commit hook
 #ifndef DBUG_OFF
       bool ready_preempt;             // internal in MYSQL_BIN_LOG::ordered_commit
 #endif


### PR DESCRIPTION
Summary: This diff backports WL#6335 -- "Semisync: externalize
transactions only after ACK received" from MySQL 5.7.
FB MySQL implemented Enhanced Semisync
(https://github.com/facebook/mysql-5.6/commit/29f245ac81296128c377d14a26a6fdb705260528),
which is equivalent to rpl_semi_sync_master_wait_point=AFTER_SYNC,
but it removed rpl_semi_sync_master_wait_point=AFTER_COMMIT equivalent
feature.
This diff backports rpl_semi_sync_master_wait_point variable and
supports both AFTER_SYNC and AFTER_COMMIT.

This diff basically restores deleted code from FB MySQL
29f245ac81296128c377d14a26a6fdb705260528 for supporting AFTER_COMMIT,
and backports 5.7 semisync diffs to support a new variable
(1cec0be51ef35274c8a31c002aa9ba288d80b09c and
c548bbfcec64d9145e94c0c21c0d22391cbf057a from mysql-server).

Benchmark results were the followings. With 0.18ms semisync latency,
AFTER_SYNC showed ~5000/s commits (auto committed inserts) with single
thread, AFTER_COMMIT showed about ~5500/s. With 100 clients,
commit throughput was around 70000/s for both. When updating the same
row from 100 clients, AFTER_SYNC was about 5200/s and AFTER_COMMIT was
about 7800/s. AFTER_COMMIT showed better throughput because it released
engine row locks earlier. The update throughput difference was higher
when semisync latency was longer -- when semisync latency was 65ms,
update throughput with 100 clients were 16/s with AFTER_SYNC and
500/s with AFTER_COMMIT.
All of these numbers were not worse without this diff (AFTER_SYNC
equivalent).

Test Plan: mtr