### PR TITLE
Add cahce_high_pri_pool_ratio option and cache_index_and_filter_blocks_with_high_priority

### DIFF
--- a/mysql-test/r/mysqld--help-notwin-profiling.result
+++ b/mysql-test/r/mysqld--help-notwin-profiling.result
@@ -1137,10 +1137,15 @@ The following options may be given as the first argument:
  Max #records in a batch for bulk-load mode
  --rocksdb-bytes-per-sync=# 
  DBOptions::bytes_per_sync for RocksDB
+ --rocksdb-cache-high-pri-pool-ratio=# 
+ Specify the size of block cache high-pri pool
  --rocksdb-cache-index-and-filter-blocks 
  BlockBasedTableOptions::cache_index_and_filter_blocks for
  RocksDB
  (Defaults to on; use --skip-rocksdb-cache-index-and-filter-blocks to disable.)
+ --rocksdb-cache-index-and-filter-blocks-with-high-priority 
+ Cache index and filter blocks as high-pri cache entry
+ (Defaults to on; use --skip-rocksdb-cache-index-and-filter-blocks-with-high-priority to disable.)
  --rocksdb-cf-options[=name] 
  Enable or disable ROCKSDB_CF_OPTIONS plugin. Possible
  values are ON, OFF, FORCE (don't start if the plugin
@@ -2155,7 +2160,9 @@ rocksdb-bulk-load-allow-sk FALSE
 rocksdb-bulk-load-allow-unsorted FALSE
 rocksdb-bulk-load-size 1000
 rocksdb-bytes-per-sync 0
+rocksdb-cache-high-pri-pool-ratio 0
 rocksdb-cache-index-and-filter-blocks TRUE
+rocksdb-cache-index-and-filter-blocks-with-high-priority TRUE
 rocksdb-cf-options ON
 rocksdb-cfstats ON
 rocksdb-checksums-pct 100

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -1135,10 +1135,15 @@ The following options may be given as the first argument:
  Max #records in a batch for bulk-load mode
  --rocksdb-bytes-per-sync=# 
  DBOptions::bytes_per_sync for RocksDB
+ --rocksdb-cache-high-pri-pool-ratio=# 
+ Specify the size of block cache high-pri pool
  --rocksdb-cache-index-and-filter-blocks 
  BlockBasedTableOptions::cache_index_and_filter_blocks for
  RocksDB
  (Defaults to on; use --skip-rocksdb-cache-index-and-filter-blocks to disable.)
+ --rocksdb-cache-index-and-filter-blocks-with-high-priority 
+ Cache index and filter blocks as high-pri cache entry
+ (Defaults to on; use --skip-rocksdb-cache-index-and-filter-blocks-with-high-priority to disable.)
  --rocksdb-cf-options[=name] 
  Enable or disable ROCKSDB_CF_OPTIONS plugin. Possible
  values are ON, OFF, FORCE (don't start if the plugin
@@ -2152,7 +2157,9 @@ rocksdb-bulk-load-allow-sk FALSE
 rocksdb-bulk-load-allow-unsorted FALSE
 rocksdb-bulk-load-size 1000
 rocksdb-bytes-per-sync 0
+rocksdb-cache-high-pri-pool-ratio 0
 rocksdb-cache-index-and-filter-blocks TRUE
+rocksdb-cache-index-and-filter-blocks-with-high-priority TRUE
 rocksdb-cf-options ON
 rocksdb-cfstats ON
 rocksdb-checksums-pct 100

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -870,7 +870,9 @@ rocksdb_bulk_load_allow_sk	OFF
 rocksdb_bulk_load_allow_unsorted	OFF
 rocksdb_bulk_load_size	1000
 rocksdb_bytes_per_sync	0
+rocksdb_cache_high_pri_pool_ratio	0.000000
 rocksdb_cache_index_and_filter_blocks	ON
+rocksdb_cache_index_and_filter_blocks_with_high_priority	ON
 rocksdb_checksums_pct	100
 rocksdb_collect_sst_properties	ON
 rocksdb_commit_in_the_middle	OFF

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -1227,7 +1227,7 @@ static MYSQL_SYSVAR_BOOL(
     *reinterpret_cast<my_bool *>(
         &rocksdb_tbl_options->cache_index_and_filter_blocks_with_high_priority),
     PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
-    "BlockBasedTableOptions::cache_index_and_filter_blocks_with_high_priority for RocksDB",
+    "Cache index and filter blocks as high-pri cache entry",
     nullptr, nullptr, true);
 
 // When pin_l0_filter_and_index_blocks_in_cache is true, RocksDB will  use the
@@ -4592,9 +4592,9 @@ static int rocksdb_init_func(void *const p) {
     std::shared_ptr<rocksdb::Cache> block_cache = rocksdb_use_clock_cache
       ? rocksdb::NewClockCache(rocksdb_block_cache_size)
       : rocksdb::NewLRUCache(rocksdb_block_cache_size,
-                             -1 /*num_shard_bits*/,
-                             false /*strict_capcity_limit*/,
-                             rocksdb_cache_high_pri_pool_ratio);
+                            -1 /*num_shard_bits*/,
+                            false /*strict_capcity_limit*/,
+                            rocksdb_cache_high_pri_pool_ratio);
     if (rocksdb_sim_cache_size > 0) {
       // Simulated cache enabled
       // Wrap block cache inside a simulated cache and pass it to RocksDB

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -1211,7 +1211,7 @@ static MYSQL_SYSVAR_DOUBLE(
     cache_high_pri_pool_ratio,
     rocksdb_cache_high_pri_pool_ratio,
     PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
-    "Use ClockCache instead of default LRUCache for RocksDB",
+    "Specify the size of block cache high-pri pool",
     nullptr, nullptr, /* default */ 0.0, /* min */ 0.0, /* max */ 1.0, 0);
 
 static MYSQL_SYSVAR_BOOL(

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -493,6 +493,7 @@ static void rocksdb_set_wal_bytes_per_sync(THD *thd,
 static long long rocksdb_block_cache_size;
 static long long rocksdb_sim_cache_size;
 static my_bool rocksdb_use_clock_cache;
+static double rocksdb_cache_high_pri_pool_ratio;
 /* Use unsigned long long instead of uint64_t because of MySQL compatibility */
 static unsigned long long  // NOLINT(runtime/int)
     rocksdb_rate_limiter_bytes_per_sec;
@@ -1206,12 +1207,27 @@ static MYSQL_SYSVAR_BOOL(
     "Use ClockCache instead of default LRUCache for RocksDB",
     nullptr, nullptr, false);
 
+static MYSQL_SYSVAR_DOUBLE(
+    cache_high_pri_pool_ratio,
+    rocksdb_cache_high_pri_pool_ratio,
+    PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
+    "Use ClockCache instead of default LRUCache for RocksDB",
+    nullptr, nullptr, /* default */ 0.0, /* min */ 0.0, /* max */ 1.0, 0);
+
 static MYSQL_SYSVAR_BOOL(
     cache_index_and_filter_blocks,
     *reinterpret_cast<my_bool *>(
         &rocksdb_tbl_options->cache_index_and_filter_blocks),
     PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
     "BlockBasedTableOptions::cache_index_and_filter_blocks for RocksDB",
+    nullptr, nullptr, true);
+
+static MYSQL_SYSVAR_BOOL(
+    cache_index_and_filter_blocks_with_high_priority,
+    *reinterpret_cast<my_bool *>(
+        &rocksdb_tbl_options->cache_index_and_filter_blocks_with_high_priority),
+    PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
+    "BlockBasedTableOptions::cache_index_and_filter_blocks_with_high_priority for RocksDB",
     nullptr, nullptr, true);
 
 // When pin_l0_filter_and_index_blocks_in_cache is true, RocksDB will  use the
@@ -1686,7 +1702,9 @@ static struct st_mysql_sys_var *rocksdb_system_variables[] = {
     MYSQL_SYSVAR(block_cache_size),
     MYSQL_SYSVAR(sim_cache_size),
     MYSQL_SYSVAR(use_clock_cache),
+    MYSQL_SYSVAR(cache_high_pri_pool_ratio),
     MYSQL_SYSVAR(cache_index_and_filter_blocks),
+    MYSQL_SYSVAR(cache_index_and_filter_blocks_with_high_priority),
     MYSQL_SYSVAR(pin_l0_filter_and_index_blocks_in_cache),
     MYSQL_SYSVAR(index_type),
     MYSQL_SYSVAR(hash_index_allow_collision),
@@ -4573,7 +4591,10 @@ static int rocksdb_init_func(void *const p) {
   if (!rocksdb_tbl_options->no_block_cache) {
     std::shared_ptr<rocksdb::Cache> block_cache = rocksdb_use_clock_cache
       ? rocksdb::NewClockCache(rocksdb_block_cache_size)
-      : rocksdb::NewLRUCache(rocksdb_block_cache_size);
+      : rocksdb::NewLRUCache(rocksdb_block_cache_size,
+                             -1 /*num_shard_bits*/,
+                             false /*strict_capcity_limit*/,
+                             rocksdb_cache_high_pri_pool_ratio);
     if (rocksdb_sim_cache_size > 0) {
       // Simulated cache enabled
       // Wrap block cache inside a simulated cache and pass it to RocksDB


### PR DESCRIPTION
Summary:
Adding rocksdb options cahce_high_pri_pool_ratio and cache_index_and_filter_blocks_with_high_priority. I'm adding LRU cache midpoint insertion with rocksdb PR https://github.com/facebook/rocksdb/pull/3877. My preliminary db_bench shows some latency and throughput drop for a read only workload when background full table scan presents (See the PR for more details). To enable the midpoint insertion strategy, high_pri_pool_ratio needs to be set to set the location for the midpoint. cache_index_and_filter_blocks_with_high_priority can be enabled so that index and filter blocks don't insert to the midpoint, but the tail of the full list.

Test Plan:
What are the test I need to run with myrocks?