### PR TITLE
Fixing slow_log_extra_big.test failure

### DIFF
--- a/mysql-test/r/slow_log_extra_big.result
+++ b/mysql-test/r/slow_log_extra_big.result
@@ -43,6 +43,5 @@ Rows_sent	Rows_examined	Errno	Killed	Bytes_received	Bytes_sent	Read_first	Read_l
 1	1	0	0	0	314	0	0	1	0	0	0	0	0	0	0	0	0	0	0	0
 1	15000	0	0	0	67	0	0	1	15000	0	0	0	0	0	0	0	0	0	0	0
 1	20000	0	0	0	67	1	0	1	20000	0	0	0	0	0	0	0	0	0	0	0
-1	15000	0	0	0	67	0	0	1	15000	0	0	0	0	0	0	0	0	0	0	0
 if the following is not 1 you need to adjust the file_lines_count variable
 1

--- a/mysql-test/t/slow_log_extra_big.test
+++ b/mysql-test/t/slow_log_extra_big.test
@@ -65,7 +65,7 @@ select count(*) from big_table_slow where id >10000;
 query_attrs_delete traceid;
 
 # Wait for all output lines to show up in the slow log file
-let $file_lines_count= 7;
+let $file_lines_count= 6;
 let $file_lines_pattern= ^# Query_time;
 let $file_lines_filename=
     $MYSQLTEST_VARDIR/mysqld.1/data/slow_log_extra_big-slow.log;


### PR DESCRIPTION
Summary: slow_log_extra_big.test was incorrect
and caused test failures. This diff fixes it.

Test Plan: slow_log_extra_big.test