### PR TITLE
Update AUTO_INCREMENT in the UPDATE statement

### DIFF
--- a/mysql-test/suite/rocksdb/r/autoinc_vars.result
+++ b/mysql-test/suite/rocksdb/r/autoinc_vars.result
@@ -151,3 +151,11 @@ CREATE TABLE t0(c0 BLOB) ENGINE=ROCKSDB;
 INSERT INTO t0 VALUES(0);
 ALTER TABLE t0 AUTO_INCREMENT=0;
 DROP TABLE t0;
+#----------------------------------
+# Issue #869 Crash in autoincrement
+#----------------------------------
+CREATE TABLE t1 (pk INT AUTO_INCREMENT, a INT, PRIMARY KEY(pk)) ENGINE=RocksDB;
+INSERT INTO t1 (a) VALUES (1);
+UPDATE t1 SET pk = 3;
+ALTER TABLE t1 AUTO_INCREMENT 2;
+DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/t/autoinc_vars.test
+++ b/mysql-test/suite/rocksdb/t/autoinc_vars.test
@@ -114,3 +114,13 @@ CREATE TABLE t0(c0 BLOB) ENGINE=ROCKSDB;
 INSERT INTO t0 VALUES(0);
 ALTER TABLE t0 AUTO_INCREMENT=0;
 DROP TABLE t0;
+
+--echo #----------------------------------
+--echo # Issue #869 Crash in autoincrement
+--echo #----------------------------------
+
+CREATE TABLE t1 (pk INT AUTO_INCREMENT, a INT, PRIMARY KEY(pk)) ENGINE=RocksDB;
+INSERT INTO t1 (a) VALUES (1);
+UPDATE t1 SET pk = 3;
+ALTER TABLE t1 AUTO_INCREMENT 2;
+DROP TABLE t1;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -9410,7 +9410,7 @@ int ha_rocksdb::update_pk(const Rdb_key_def &kd,
     }
   }
 
-  if (table->next_number_field) {
+  if (table->found_next_number_field) {
     update_auto_incr_val_from_field();
   }
 


### PR DESCRIPTION
Currently RocksDB engine doesn't update AUTO_INCREMENT in the UPDATE statement.
For example,

CREATE TABLE t1 (pk INT AUTO_INCREMENT, a INT, PRIMARY KEY(pk)) ENGINE=RocksDB;
INSERT INTO t1 (a) VALUES (1);
UPDATE t1 SET pk = 3; ==> AUTO_INCREMENT should be updated to 4.

Without this fix, it hits the Assertion `dd_val >= last_val' failed in
myrocks::ha_rocksdb::load_auto_incr_value_from_index.

Please see detail at:
https://jira.mariadb.org/browse/MDEV-16703