### PR TITLE
Fix issue #878: Descending scans from reverse cf return no results

### DIFF
--- a/mysql-test/suite/rocksdb/r/iterator_bounds.result
+++ b/mysql-test/suite/rocksdb/r/iterator_bounds.result
@@ -1,13 +1,15 @@
+create table t (i int primary key) engine=rocksdb;
+drop table t;
 create table t (i int primary key, j int, key(j) comment 'rev:bf5_2') engine=rocksdb;
-select *, hex(index_number) from information_schema.rocksdb_ddl where table_name = 't';
-TABLE_SCHEMA	TABLE_NAME	PARTITION_NAME	INDEX_NAME	COLUMN_FAMILY	INDEX_NUMBER	INDEX_TYPE	KV_FORMAT_VERSION	TTL_DURATION	INDEX_FLAGS	CF	AUTO_INCREMENT	hex(index_number)
-test	t	NULL	PRIMARY	0	766	1	13	0	0	default	NULL	2FE
-test	t	NULL	j	2	767	2	13	0	0	rev:bf5_2	NULL	2FF
-create table u (i int primary key, j int, key(j) comment 'rev:bf5_2') engine=rocksdb;
+select RIGHT(HEX(index_number), 2) from information_schema.rocksdb_ddl where table_name = 't';
+RIGHT(HEX(index_number), 2)
+FE
+FF
 insert into t values (1, 1);
-insert into u values (1, 1);
+select j from t order by j asc;
+j
+1
 select j from t order by j desc;
 j
 1
 drop table t;
-drop table u;

--- a/mysql-test/suite/rocksdb/r/iterator_bounds.result
+++ b/mysql-test/suite/rocksdb/r/iterator_bounds.result
@@ -1,9 +1,9 @@
-create table t (i int primary key, j int, key(j) comment 'rev:bf5_2');
+create table t (i int primary key, j int, key(j) comment 'rev:bf5_2') engine=rocksdb;
 select *, hex(index_number) from information_schema.rocksdb_ddl where table_name = 't';
 TABLE_SCHEMA	TABLE_NAME	PARTITION_NAME	INDEX_NAME	COLUMN_FAMILY	INDEX_NUMBER	INDEX_TYPE	KV_FORMAT_VERSION	TTL_DURATION	INDEX_FLAGS	CF	AUTO_INCREMENT	hex(index_number)
 test	t	NULL	PRIMARY	0	766	1	13	0	0	default	NULL	2FE
 test	t	NULL	j	2	767	2	13	0	0	rev:bf5_2	NULL	2FF
-create table u (i int primary key, j int, key(j) comment 'rev:bf5_2');
+create table u (i int primary key, j int, key(j) comment 'rev:bf5_2') engine=rocksdb;
 insert into t values (1, 1);
 insert into u values (1, 1);
 select j from t order by j desc;

--- a/mysql-test/suite/rocksdb/r/iterator_bounds.result
+++ b/mysql-test/suite/rocksdb/r/iterator_bounds.result
@@ -1,0 +1,13 @@
+create table t (i int primary key, j int, key(j) comment 'rev:bf5_2');
+select *, hex(index_number) from information_schema.rocksdb_ddl where table_name = 't';
+TABLE_SCHEMA	TABLE_NAME	PARTITION_NAME	INDEX_NAME	COLUMN_FAMILY	INDEX_NUMBER	INDEX_TYPE	KV_FORMAT_VERSION	TTL_DURATION	INDEX_FLAGS	CF	AUTO_INCREMENT	hex(index_number)
+test	t	NULL	PRIMARY	0	766	1	13	0	0	default	NULL	2FE
+test	t	NULL	j	2	767	2	13	0	0	rev:bf5_2	NULL	2FF
+create table u (i int primary key, j int, key(j) comment 'rev:bf5_2');
+insert into t values (1, 1);
+insert into u values (1, 1);
+select j from t order by j desc;
+j
+1
+drop table t;
+drop table u;

--- a/mysql-test/suite/rocksdb/t/iterator_bounds-master.opt
+++ b/mysql-test/suite/rocksdb/t/iterator_bounds-master.opt
@@ -1,0 +1,2 @@
+--rocksdb_default_cf_options=write_buffer_size=256k;block_based_table_factory={filter_policy=bloomfilter:10:false;whole_key_filtering=0;}
+--rocksdb_override_cf_options=rev:bf5_1={prefix_extractor=capped:12};

--- a/mysql-test/suite/rocksdb/t/iterator_bounds.test
+++ b/mysql-test/suite/rocksdb/t/iterator_bounds.test
@@ -1,0 +1,27 @@
+#
+# Issue #878: Descending scans from reverse column families return no results
+# due to iterator bounds
+#
+
+create table t (i int primary key, j int, key(j) comment 'rev:bf5_2');
+
+let $i=253;
+while ($i)
+{
+  --disable_query_log
+  truncate table t;
+  --enable_query_log
+  dec $i;
+}
+
+select *, hex(index_number) from information_schema.rocksdb_ddl where table_name = 't';
+
+create table u (i int primary key, j int, key(j) comment 'rev:bf5_2');
+
+insert into t values (1, 1);
+insert into u values (1, 1);
+
+select j from t order by j desc;
+
+drop table t;
+drop table u;

--- a/mysql-test/suite/rocksdb/t/iterator_bounds.test
+++ b/mysql-test/suite/rocksdb/t/iterator_bounds.test
@@ -3,7 +3,7 @@
 # due to iterator bounds
 #
 
-create table t (i int primary key, j int, key(j) comment 'rev:bf5_2');
+create table t (i int primary key, j int, key(j) comment 'rev:bf5_2') engine=rocksdb;
 
 let $i=253;
 while ($i)
@@ -16,7 +16,7 @@ while ($i)
 
 select *, hex(index_number) from information_schema.rocksdb_ddl where table_name = 't';
 
-create table u (i int primary key, j int, key(j) comment 'rev:bf5_2');
+create table u (i int primary key, j int, key(j) comment 'rev:bf5_2') engine=rocksdb;
 
 insert into t values (1, 1);
 insert into u values (1, 1);

--- a/mysql-test/suite/rocksdb/t/iterator_bounds.test
+++ b/mysql-test/suite/rocksdb/t/iterator_bounds.test
@@ -3,25 +3,27 @@
 # due to iterator bounds
 #
 
-create table t (i int primary key, j int, key(j) comment 'rev:bf5_2') engine=rocksdb;
+create table t (i int primary key) engine=rocksdb;
 
-let $i=253;
-while ($i)
+let $cond=1;
+while ($cond)
 {
   --disable_query_log
   truncate table t;
   --enable_query_log
-  dec $i;
+  let $cond=`select RIGHT(HEX(index_number), 2) != "FD" from information_schema.rocksdb_ddl where table_name = 't'`;
 }
 
-select *, hex(index_number) from information_schema.rocksdb_ddl where table_name = 't';
+# Index id is now at FD. Create a table with primary and secondary key, so
+# that the secondary key index id ends in 0xFF.
 
-create table u (i int primary key, j int, key(j) comment 'rev:bf5_2') engine=rocksdb;
+drop table t;
+create table t (i int primary key, j int, key(j) comment 'rev:bf5_2') engine=rocksdb;
+select RIGHT(HEX(index_number), 2) from information_schema.rocksdb_ddl where table_name = 't';
 
 insert into t values (1, 1);
-insert into u values (1, 1);
 
+select j from t order by j asc;
 select j from t order by j desc;
 
 drop table t;
-drop table u;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -9715,10 +9715,7 @@ void ha_rocksdb::setup_iterator_bounds(
     kd.get_supremum_key(upper_bound, &size);
     DBUG_ASSERT(size == Rdb_key_def::INDEX_NUMBER_SIZE);
   } else {
-    // Right now, if eq_cond.size() > Rdb_key_def::INDEX_NUMBER_SIZE, then
-    // bound_len should always equal eq_cond.size(). This also implies that
-    // bound_len > Rdb_key_def::INDEX_NUMBER_SIZE
-    DBUG_ASSERT(bound_len == eq_cond.size());
+    DBUG_ASSERT(bound_len <= eq_cond.size());
     memcpy(upper_bound, eq_cond.data(), bound_len);
     kd.successor(upper_bound, bound_len);
     memcpy(lower_bound, eq_cond.data(), bound_len);

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -9721,7 +9721,7 @@ void ha_rocksdb::setup_iterator_bounds(
     DBUG_ASSERT(size == Rdb_key_def::INDEX_NUMBER_SIZE);
     len = Rdb_key_def::INDEX_NUMBER_SIZE;
   } else {
-    auto len = eq_cond.size();
+    len = eq_cond.size();
     memcpy(upper_bound, eq_cond.data(), len);
     kd.successor(upper_bound, len);
     memcpy(lower_bound, eq_cond.data(), len);

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -9719,6 +9719,10 @@ void ha_rocksdb::setup_iterator_bounds(
     kd.get_supremum_key(upper_bound, &size);
     DBUG_ASSERT(size == Rdb_key_def::INDEX_NUMBER_SIZE);
   } else {
+    // Right now, if eq_cond.size() >= Rdb_key_def::INDEX_NUMBER_SIZE, then
+    // bound_len should always equal eq_cond.size(). If this changes, then use
+    // std::min to only copy up to the shorter string.
+    DBUG_ASSERT(bound_len == eq_cond.size());
     memcpy(upper_bound, eq_cond.data(), bound_len);
     kd.successor(upper_bound, bound_len);
     memcpy(lower_bound, eq_cond.data(), bound_len);

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -9705,18 +9705,35 @@ void ha_rocksdb::setup_iterator_bounds(
     const Rdb_key_def &kd, const rocksdb::Slice &eq_cond, size_t bound_len,
     uchar *const lower_bound, uchar *const upper_bound,
     rocksdb::Slice *lower_bound_slice, rocksdb::Slice *upper_bound_slice) {
-  uint min_len = std::min(eq_cond.size(), bound_len);
-  memcpy(upper_bound, eq_cond.data(), min_len);
-  kd.successor(upper_bound, min_len);
-  memcpy(lower_bound, eq_cond.data(), min_len);
-  kd.predecessor(lower_bound, min_len);
+  // bound_len represents the lower_bound and upper_bound buffer size. It
+  // should always be greater than Rdb_key_def::INDEX_NUMBER_SIZE because
+  // callers either with a local buffer of size Rdb_key_def::INDEX_NUMBER_SIZE
+  // or it is called with m_scan_it_lower_bound.
+  DBUG_ASSERT(bound_len >= Rdb_key_def::INDEX_NUMBER_SIZE);
+  uint len;
+  // If eq_cond is shorter than Rdb_key_def::INDEX_NUMBER_SIZE, we should be
+  // able to get better bounds just by using index id directly.
+  if (eq_cond.size() < Rdb_key_def::INDEX_NUMBER_SIZE) {
+    uint size;
+    kd.get_infimum_key(lower_bound, &size);
+    DBUG_ASSERT(size == Rdb_key_def::INDEX_NUMBER_SIZE);
+    kd.get_supremum_key(upper_bound, &size);
+    DBUG_ASSERT(size == Rdb_key_def::INDEX_NUMBER_SIZE);
+    len = Rdb_key_def::INDEX_NUMBER_SIZE;
+  } else {
+    auto len = eq_cond.size();
+    memcpy(upper_bound, eq_cond.data(), len);
+    kd.successor(upper_bound, len);
+    memcpy(lower_bound, eq_cond.data(), len);
+    kd.predecessor(lower_bound, len);
+  }
 
   if (kd.m_is_reverse_cf) {
-    *upper_bound_slice = rocksdb::Slice((const char *)lower_bound, min_len);
-    *lower_bound_slice = rocksdb::Slice((const char *)upper_bound, min_len);
+    *upper_bound_slice = rocksdb::Slice((const char *)lower_bound, len);
+    *lower_bound_slice = rocksdb::Slice((const char *)upper_bound, len);
   } else {
-    *upper_bound_slice = rocksdb::Slice((const char *)upper_bound, min_len);
-    *lower_bound_slice = rocksdb::Slice((const char *)lower_bound, min_len);
+    *upper_bound_slice = rocksdb::Slice((const char *)upper_bound, len);
+    *lower_bound_slice = rocksdb::Slice((const char *)lower_bound, len);
   }
 }
 
@@ -9735,8 +9752,17 @@ void ha_rocksdb::setup_scan_iterator(const Rdb_key_def &kd,
   bool skip_bloom = true;
 
   const rocksdb::Slice eq_cond(slice->data(), eq_cond_len);
+  // The size of m_scan_it_lower_bound (and upper) is technically
+  // max_packed_sk_len as calculated in ha_rocksdb::alloc_key_buffers.  Rather
+  // than recalculating that number, we pass in the max of eq_cond_len and
+  // Rdb_key_def::INDEX_NUMBER_SIZE which is guaranteed to be smaller than
+  // max_packed_sk_len, hence ensuring no buffer overrun.
+  //
+  // See ha_rocksdb::setup_iterator_bounds on how the bound_len parameter is
+  // used.
   if (check_bloom_and_set_bounds(
-          ha_thd(), kd, eq_cond, use_all_keys, eq_cond_len,
+          ha_thd(), kd, eq_cond, use_all_keys,
+          std::max(eq_cond_len, (uint)Rdb_key_def::INDEX_NUMBER_SIZE),
           m_scan_it_lower_bound, m_scan_it_upper_bound,
           &m_scan_it_lower_bound_slice, &m_scan_it_upper_bound_slice)) {
     skip_bloom = false;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -9710,7 +9710,6 @@ void ha_rocksdb::setup_iterator_bounds(
   // callers either with a local buffer of size Rdb_key_def::INDEX_NUMBER_SIZE
   // or it is called with m_scan_it_lower_bound.
   DBUG_ASSERT(bound_len >= Rdb_key_def::INDEX_NUMBER_SIZE);
-  uint len;
   // If eq_cond is shorter than Rdb_key_def::INDEX_NUMBER_SIZE, we should be
   // able to get better bounds just by using index id directly.
   if (eq_cond.size() < Rdb_key_def::INDEX_NUMBER_SIZE) {
@@ -9719,21 +9718,19 @@ void ha_rocksdb::setup_iterator_bounds(
     DBUG_ASSERT(size == Rdb_key_def::INDEX_NUMBER_SIZE);
     kd.get_supremum_key(upper_bound, &size);
     DBUG_ASSERT(size == Rdb_key_def::INDEX_NUMBER_SIZE);
-    len = Rdb_key_def::INDEX_NUMBER_SIZE;
   } else {
-    len = eq_cond.size();
-    memcpy(upper_bound, eq_cond.data(), len);
-    kd.successor(upper_bound, len);
-    memcpy(lower_bound, eq_cond.data(), len);
-    kd.predecessor(lower_bound, len);
+    memcpy(upper_bound, eq_cond.data(), bound_len);
+    kd.successor(upper_bound, bound_len);
+    memcpy(lower_bound, eq_cond.data(), bound_len);
+    kd.predecessor(lower_bound, bound_len);
   }
 
   if (kd.m_is_reverse_cf) {
-    *upper_bound_slice = rocksdb::Slice((const char *)lower_bound, len);
-    *lower_bound_slice = rocksdb::Slice((const char *)upper_bound, len);
+    *upper_bound_slice = rocksdb::Slice((const char *)lower_bound, bound_len);
+    *lower_bound_slice = rocksdb::Slice((const char *)upper_bound, bound_len);
   } else {
-    *upper_bound_slice = rocksdb::Slice((const char *)upper_bound, len);
-    *lower_bound_slice = rocksdb::Slice((const char *)lower_bound, len);
+    *upper_bound_slice = rocksdb::Slice((const char *)upper_bound, bound_len);
+    *lower_bound_slice = rocksdb::Slice((const char *)lower_bound, bound_len);
   }
 }
 


### PR DESCRIPTION
Currently, `Rdb_key_def::predecessor` can underflow during `ha_rocksdb::setup_iterator_bounds` if eq_cond being passed in is too short. The fix is to use index id directly in that case, instead of relying on eq_cond.

Fixes https://github.com/facebook/mysql-5.6/issues/878