### PR TITLE
Issue #881: Issue #809 still occurs for reverse scans on forward cfs

### DIFF
--- a/mysql-test/suite/rocksdb/r/bloomfilter5.result
+++ b/mysql-test/suite/rocksdb/r/bloomfilter5.result
@@ -59,4 +59,27 @@ insert into t4 values (1, 0xFFFF, 0xFFF, 12345);
 # This must not fail an assert:
 select * from t4 force index(kp1) where kp1=0xFFFFFFFF and kp2<=0xFFFFFFFF order by  kp2 desc;
 pk	kp1	kp2	col1
-drop table t1,t2,t3,t4;
+#
+#  Issue #881: Issue #809 still occurs for reverse scans on forward cfs
+#
+create table t5 (
+id1 bigint not null,
+id2 bigint not null,
+id3 varchar(100) not null,
+id4 int not null,
+id5 int not null,
+value bigint,
+value2 varchar(100),
+primary key (id1, id2, id3, id4) COMMENT 'bf5_1'
+) engine=ROCKSDB;
+insert into t5 select * from t1;
+set global rocksdb_force_flush_memtable_now=1;
+# An index scan starting from the end of the table:
+explain
+select * from t5 order by id1 desc,id2 desc, id3 desc, id4 desc limit 1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t5	index	NULL	PRIMARY	122	NULL	1	NULL
+select * from t5 order by id1 desc,id2 desc, id3 desc, id4 desc limit 1;
+id1	id2	id3	id4	id5	value	value2
+1000	2000	2000	10000	10000	1000	aaabbbccc
+drop table t1,t2,t3,t4,t5;

--- a/mysql-test/suite/rocksdb/t/bloomfilter5-master.opt
+++ b/mysql-test/suite/rocksdb/t/bloomfilter5-master.opt
@@ -1,3 +1,3 @@
 --rocksdb_default_cf_options=write_buffer_size=256k;block_based_table_factory={filter_policy=bloomfilter:10:false;whole_key_filtering=0;}
---rocksdb_override_cf_options=rev:bf5_1={prefix_extractor=capped:4};
+--rocksdb_override_cf_options=rev:bf5_1={prefix_extractor=capped:4};bf5_1={prefix_extractor=capped:4}
 

--- a/mysql-test/suite/rocksdb/t/bloomfilter5.test
+++ b/mysql-test/suite/rocksdb/t/bloomfilter5.test
@@ -56,6 +56,31 @@ insert into t4 values (1, 0xFFFF, 0xFFF, 12345);
 --echo # This must not fail an assert:
 select * from t4 force index(kp1) where kp1=0xFFFFFFFF and kp2<=0xFFFFFFFF order by  kp2 desc;
 
-drop table t1,t2,t3,t4;
 
+--echo #
+--echo #  Issue #881: Issue #809 still occurs for reverse scans on forward cfs
+--echo #
 
+# The same as t1 above but uses forward-ordered column family:
+
+create table t5 (
+  id1 bigint not null,
+  id2 bigint not null,
+  id3 varchar(100) not null,
+  id4 int not null,
+  id5 int not null,
+  value bigint,
+  value2 varchar(100),
+  primary key (id1, id2, id3, id4) COMMENT 'bf5_1'
+) engine=ROCKSDB;
+
+insert into t5 select * from t1;
+
+set global rocksdb_force_flush_memtable_now=1;
+
+--echo # An index scan starting from the end of the table:
+explain
+select * from t5 order by id1 desc,id2 desc, id3 desc, id4 desc limit 1;
+select * from t5 order by id1 desc,id2 desc, id3 desc, id4 desc limit 1;
+
+drop table t1,t2,t3,t4,t5;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -8788,11 +8788,7 @@ int ha_rocksdb::index_last_intern(uchar *const buf) {
   DBUG_ASSERT(key != nullptr);
 
   const Rdb_key_def &kd = *m_key_descr_arr[active_index];
-  if (kd.m_is_reverse_cf) {
-    kd.get_infimum_key(key, &key_size);
-  } else {
-    kd.get_supremum_key(key, &key_size);
-  }
+  int key_end_matching_bytes = kd.get_last_key(key, &key_size);
 
   rocksdb::Slice index_key((const char *)key, key_size);
 
@@ -8803,7 +8799,7 @@ int ha_rocksdb::index_last_intern(uchar *const buf) {
   // Loop as long as we get a deadlock error AND we end up creating the
   // snapshot here (i.e. it did not exist prior to this)
   for (;;) {
-    setup_scan_iterator(kd, &index_key, false, Rdb_key_def::INDEX_NUMBER_SIZE);
+    setup_scan_iterator(kd, &index_key, false, key_end_matching_bytes);
     m_scan_it->SeekForPrev(index_key);
     m_skip_scan_it_next_call = false;
 

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -256,6 +256,27 @@ public:
     return i;
   }
 
+  /*
+    The same as get_first_key, but get the key for the last entry in the index
+  */
+  inline int get_last_key(uchar *const key, uint *const size) const {
+    if (m_is_reverse_cf)
+      get_infimum_key(key, size);
+    else
+      get_supremum_key(key, size);
+
+    /* Find out how many bytes of infimum are the same as m_index_number */
+    uchar unmodified_key[INDEX_NUMBER_SIZE];
+    rdb_netbuf_store_index(unmodified_key, m_index_number);
+    int i;
+    for (i = 0; i < INDEX_NUMBER_SIZE; i++) {
+      if (key[i] != unmodified_key[i])
+        break;
+    }
+    return i;
+  }
+
+
   /* Make a key that is right after the given key. */
   static int successor(uchar *const packed_tuple, const uint &len);
 


### PR DESCRIPTION
When constructing a lookup key for reverse full index scan, pass the
correct eq_cond_len to setup_scan_iterator(). The code mirrors the
code in ha_rocksdb::index_first_intern().