### PR TITLE
Issue #885: Can't locate lib/mtr_process.pl in @INC on Ubuntu 18.04.1

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -101,6 +101,8 @@ use mtr_results;
 use IO::Socket::INET;
 use IO::Select;
 
+push @INC, ".";
+
 require "lib/mtr_process.pl";
 require "lib/mtr_io.pl";
 require "lib/mtr_gcov.pl";


### PR DESCRIPTION
Add "." to @INC array like upstream does.