### PR TITLE
issue-884 : Prefixed PK and index_merge causes "ERROR 1032 (HY000): C…

### DIFF
--- a/mysql-test/suite/rocksdb/r/ha_extra_keyread.result
+++ b/mysql-test/suite/rocksdb/r/ha_extra_keyread.result
@@ -1,0 +1,10 @@
+CREATE TABLE t1 (a INT, b CHAR(8), KEY ab(a, b)) ENGINE=rocksdb DEFAULT CHARSET utf8mb4 COLLATE utf8mb4_bin;
+INSERT INTO t1 (a,b) VALUES (76,'bar');
+INSERT INTO t1 (a,b) VALUES (35,'foo');
+INSERT INTO t1 (a,b) VALUES (77,'baz');
+SET debug="+d,dbug.rocksdb.HA_EXTRA_KEYREAD";
+SELECT b FROM t1 FORCE INDEX(ab) WHERE a=35;
+b
+foo
+SET debug="-d,dbug.rocksdb.HA_EXTRA_KEYREAD";
+DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/r/issue884.result
+++ b/mysql-test/suite/rocksdb/r/issue884.result
@@ -1,0 +1,79 @@
+create table test (
+a bigint(20) not null,
+b bigint(20) not null,
+c varchar(500) not null,
+d bigint(20) not null,
+e bigint(20) not null,
+f varchar(500) not null,
+g varchar(500) not null,
+h varchar(500) not null,
+i varchar(1000) not null,
+j varchar(16384) not null,
+k varchar(200) not null,
+l varchar(500) not null,
+m varchar(100) not null,
+n bigint(20) not null,
+primary key (a, b, m, c(100), l(100), d, e, f(100), g(100), h(100), n),
+key n (n),
+key d (d, a)
+) engine = rocksdb default charset = latin1;
+Table	Op	Msg_type	Msg_text
+test.test	analyze	status	OK
+explain
+select * from test where d = 10 and a = 10 and b = 2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	test	index_merge	PRIMARY,d	d,PRIMARY	24,16	NULL	#	Using intersect(d,PRIMARY); Using where
+select * from test where d = 10 and a = 10 and b = 2;
+a	b	c	d	e	f	g	h	i	j	k	l	m	n
+10	2	i	10	950	f	g	h	i	j	k	l	m	950
+10	2	i	10	951	f	g	h	i	j	k	l	m	951
+10	2	i	10	952	f	g	h	i	j	k	l	m	952
+10	2	i	10	953	f	g	h	i	j	k	l	m	953
+10	2	i	10	954	f	g	h	i	j	k	l	m	954
+10	2	i	10	955	f	g	h	i	j	k	l	m	955
+10	2	i	10	956	f	g	h	i	j	k	l	m	956
+10	2	i	10	957	f	g	h	i	j	k	l	m	957
+10	2	i	10	958	f	g	h	i	j	k	l	m	958
+10	2	i	10	959	f	g	h	i	j	k	l	m	959
+10	2	i	10	960	f	g	h	i	j	k	l	m	960
+10	2	i	10	961	f	g	h	i	j	k	l	m	961
+10	2	i	10	962	f	g	h	i	j	k	l	m	962
+10	2	i	10	963	f	g	h	i	j	k	l	m	963
+10	2	i	10	964	f	g	h	i	j	k	l	m	964
+10	2	i	10	965	f	g	h	i	j	k	l	m	965
+10	2	i	10	966	f	g	h	i	j	k	l	m	966
+10	2	i	10	967	f	g	h	i	j	k	l	m	967
+10	2	i	10	968	f	g	h	i	j	k	l	m	968
+10	2	i	10	969	f	g	h	i	j	k	l	m	969
+10	2	i	10	970	f	g	h	i	j	k	l	m	970
+10	2	i	10	971	f	g	h	i	j	k	l	m	971
+10	2	i	10	972	f	g	h	i	j	k	l	m	972
+10	2	i	10	973	f	g	h	i	j	k	l	m	973
+10	2	i	10	974	f	g	h	i	j	k	l	m	974
+10	2	i	10	975	f	g	h	i	j	k	l	m	975
+10	2	i	10	976	f	g	h	i	j	k	l	m	976
+10	2	i	10	977	f	g	h	i	j	k	l	m	977
+10	2	i	10	978	f	g	h	i	j	k	l	m	978
+10	2	i	10	979	f	g	h	i	j	k	l	m	979
+10	2	i	10	980	f	g	h	i	j	k	l	m	980
+10	2	i	10	981	f	g	h	i	j	k	l	m	981
+10	2	i	10	982	f	g	h	i	j	k	l	m	982
+10	2	i	10	983	f	g	h	i	j	k	l	m	983
+10	2	i	10	984	f	g	h	i	j	k	l	m	984
+10	2	i	10	985	f	g	h	i	j	k	l	m	985
+10	2	i	10	986	f	g	h	i	j	k	l	m	986
+10	2	i	10	987	f	g	h	i	j	k	l	m	987
+10	2	i	10	988	f	g	h	i	j	k	l	m	988
+10	2	i	10	989	f	g	h	i	j	k	l	m	989
+10	2	i	10	990	f	g	h	i	j	k	l	m	990
+10	2	i	10	991	f	g	h	i	j	k	l	m	991
+10	2	i	10	992	f	g	h	i	j	k	l	m	992
+10	2	i	10	993	f	g	h	i	j	k	l	m	993
+10	2	i	10	994	f	g	h	i	j	k	l	m	994
+10	2	i	10	995	f	g	h	i	j	k	l	m	995
+10	2	i	10	996	f	g	h	i	j	k	l	m	996
+10	2	i	10	997	f	g	h	i	j	k	l	m	997
+10	2	i	10	998	f	g	h	i	j	k	l	m	998
+10	2	i	10	999	f	g	h	i	j	k	l	m	999
+10	2	i	10	1000	f	g	h	i	j	k	l	m	1000
+drop table test;

--- a/mysql-test/suite/rocksdb/t/ha_extra_keyread.test
+++ b/mysql-test/suite/rocksdb/t/ha_extra_keyread.test
@@ -1,0 +1,15 @@
+--source include/have_debug.inc
+--source include/have_rocksdb.inc
+
+CREATE TABLE t1 (a INT, b CHAR(8), KEY ab(a, b)) ENGINE=rocksdb DEFAULT CHARSET utf8mb4 COLLATE utf8mb4_bin;
+INSERT INTO t1 (a,b) VALUES (76,'bar');
+INSERT INTO t1 (a,b) VALUES (35,'foo');
+INSERT INTO t1 (a,b) VALUES (77,'baz');
+
+SET debug="+d,dbug.rocksdb.HA_EXTRA_KEYREAD";
+
+SELECT b FROM t1 FORCE INDEX(ab) WHERE a=35;
+
+
+SET debug="-d,dbug.rocksdb.HA_EXTRA_KEYREAD";
+DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/t/issue884.test
+++ b/mysql-test/suite/rocksdb/t/issue884.test
@@ -1,0 +1,43 @@
+--source include/have_rocksdb.inc
+
+create table test (
+  a bigint(20) not null,
+  b bigint(20) not null,
+  c varchar(500) not null,
+  d bigint(20) not null,
+  e bigint(20) not null,
+  f varchar(500) not null,
+  g varchar(500) not null,
+  h varchar(500) not null,
+  i varchar(1000) not null,
+  j varchar(16384) not null,
+  k varchar(200) not null,
+  l varchar(500) not null,
+  m varchar(100) not null,
+  n bigint(20) not null,
+  primary key (a, b, m, c(100), l(100), d, e, f(100), g(100), h(100), n),
+  key n (n),
+  key d (d, a)
+) engine = rocksdb default charset = latin1;
+
+--disable_query_log
+let $i = 1000;
+while ($i) {
+  --eval insert into test values (10, 1, "i", $i / 100, $i, "f", "g", "h", "i", "j", "k", "l", "m", $i);
+  --eval insert into test values (10, 2, "i", $i / 100, $i, "f", "g", "h", "i", "j", "k", "l", "m", $i);
+  --eval insert into test values (10, 3, "i", $i / 100, $i, "f", "g", "h", "i", "j", "k", "l", "m", $i);
+  --eval insert into test values (10, 4, "i", $i / 100, $i, "f", "g", "h", "i", "j", "k", "l", "m", $i);
+  --eval insert into test values (10, 5, "i", $i / 100, $i, "f", "g", "h", "i", "j", "k", "l", "m", $i);
+  dec $i;
+}
+set global rocksdb_force_flush_memtable_now = true;
+analyze table test;
+--enable_query_log
+
+--replace_column 9 #
+explain
+select * from test where d = 10 and a = 10 and b = 2;
+select * from test where d = 10 and a = 10 and b = 2;
+
+
+drop table test;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -7748,8 +7748,18 @@ int ha_rocksdb::read_row_from_secondary_key(uchar *const buf,
   const rocksdb::Slice &rkey = m_scan_it->key();
   const rocksdb::Slice &value = m_scan_it->value();
 
-  bool covered_lookup =
-      m_keyread_only || kd.covers_lookup(table, &value, &m_lookup_bitmap);
+#ifndef NDEBUG
+  bool save_keyread_only = m_keyread_only;
+#endif
+  DBUG_EXECUTE_IF("dbug.rocksdb.HA_EXTRA_KEYREAD", { m_keyread_only = true; });
+
+  bool covered_lookup = (m_keyread_only && kd.can_cover_lookup()) ||
+                        kd.covers_lookup(table, &value, &m_lookup_bitmap);
+
+#ifndef NDEBUG
+  m_keyread_only = save_keyread_only;
+#endif
+
   if (covered_lookup && m_lock_rows == RDB_LOCK_NONE) {
     pk_size =
         kd.get_primary_key_tuple(table, *m_pk_descr, &rkey, m_pk_packed_tuple);
@@ -7869,8 +7879,9 @@ int ha_rocksdb::secondary_index_read(const int keyno, uchar *const buf) {
 
       rocksdb::Slice value = m_scan_it->value();
       bool covered_lookup =
-          m_keyread_only || m_key_descr_arr[keyno]->covers_lookup(
-                                table, &value, &m_lookup_bitmap);
+          (m_keyread_only && m_key_descr_arr[keyno]->can_cover_lookup()) ||
+          m_key_descr_arr[keyno]->covers_lookup(table, &value,
+                                                &m_lookup_bitmap);
       if (covered_lookup && m_lock_rows == RDB_LOCK_NONE) {
         rc = m_key_descr_arr[keyno]->unpack_record(
             table, buf, &key, &value, m_verify_row_debug_checksums);

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -939,6 +939,15 @@ bool Rdb_key_def::covers_lookup(TABLE *const table,
   return bitmap_is_subset(lookup_bitmap, &covered_bitmap);
 }
 
+/* Indicates that all key parts can be unpacked to cover a secondary lookup */
+bool Rdb_key_def::can_cover_lookup() const {
+  for (uint i = 0; i < m_key_parts; i++) {
+    if (!m_pack_info[i].m_covered)
+      return false;
+  }
+  return true;
+}
+
 uchar *Rdb_key_def::pack_field(Field *const field, Rdb_field_packing *pack_info,
                                uchar *tuple, uchar *const packed_tuple,
                                uchar *const pack_buffer,

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -316,6 +316,9 @@ public:
            m_kv_format_version >= SECONDARY_FORMAT_VERSION_UPDATE3;
   }
 
+  /* Indicates that all key parts can be unpacked to cover a secondary lookup */
+  bool can_cover_lookup() const;
+
   /*
     Return true if the passed mem-comparable key
     - is from this index, and


### PR DESCRIPTION
…an't find record in ..."

PS-4593 : MyRocks 8.0 inserts/returns incorrect data for tables with no explicit primary key

- Fix for PS-4593 backported from Percona Server 5.7 to Facebook-MySQL 5.6.35
  and issue-884 mtr test integrated into patch.

- This appears as a real issue in 8.0 as it is passing HA_EXTRA_KEYREAD more
  aggressively. The core issue is that the logic in MyRocks to perform a
  secondary key read directly does not check to see if the packed key can be
  properly unpacked to satisfy the read. When this happens, the previous value
  for Field is left and no error returned, leading to incorrect query results.
  This is difficult to reproduce in 5.7 to for a test case, some DBUG trickery
  is needed to force the same situation that happens naturally in 8.0.

- The fix is quite simple and that is to validate that all key parts are marked
  as 'covering', meaning that they are known to be able to be unpacked, with the
  predicate for HA_EXTRA_KEYREAD.