### PR TITLE
Issue-895 : rocksdb/env/io_posix.cc:449: rocksdb::PosixMmapReadableFi…

### DIFF
--- a/mysql-test/suite/rocksdb/include/use_direct_io_option.inc
+++ b/mysql-test/suite/rocksdb/include/use_direct_io_option.inc
@@ -1,0 +1,39 @@
+# Common test pattern for options that control direct i/o
+#
+# Required input:
+#   $io_option - name and assignment to enable on server command line
+
+--perl
+use Cwd 'abs_path';
+
+open(FILE, ">", "$ENV{MYSQL_TMP_DIR}/data_in_shm.inc") or die;
+my $real_path= abs_path($ENV{'MYSQLTEST_VARDIR'});
+my $in_shm= index($real_path, "/dev/shm") != -1;
+print FILE "let \$DATA_IN_SHM= $in_shm;\n";
+close FILE;
+EOF
+
+--source $MYSQL_TMP_DIR/data_in_shm.inc
+--remove_file $MYSQL_TMP_DIR/data_in_shm.inc
+
+if ($DATA_IN_SHM)
+{
+  --skip DATADIR is in /dev/shm, possibly due to --mem
+}
+
+--echo Checking direct reads
+--let $_mysqld_option=$io_option
+--source include/restart_mysqld_with_option.inc
+
+CREATE TABLE t1 (pk INT PRIMARY KEY DEFAULT '0', a INT(11), b CHAR(8)) ENGINE=rocksdb;
+SHOW CREATE TABLE t1;
+INSERT INTO t1 VALUES (1, 1,'a');
+INSERT INTO t1 (a,b) VALUES (2,'b');
+set global rocksdb_force_flush_memtable_now=1;
+--sorted_result
+SELECT a,b FROM t1;
+DROP TABLE t1;
+
+# cleanup
+--let _$mysqld_option=
+--source include/restart_mysqld.inc

--- a/mysql-test/suite/rocksdb/r/use_direct_io_for_flush_and_compaction.result
+++ b/mysql-test/suite/rocksdb/r/use_direct_io_for_flush_and_compaction.result
@@ -1,0 +1,18 @@
+Checking direct reads
+CREATE TABLE t1 (pk INT PRIMARY KEY DEFAULT '0', a INT(11), b CHAR(8)) ENGINE=rocksdb;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `pk` int(11) NOT NULL DEFAULT '0',
+  `a` int(11) DEFAULT NULL,
+  `b` char(8) DEFAULT NULL,
+  PRIMARY KEY (`pk`)
+) ENGINE=ROCKSDB DEFAULT CHARSET=latin1
+INSERT INTO t1 VALUES (1, 1,'a');
+INSERT INTO t1 (a,b) VALUES (2,'b');
+set global rocksdb_force_flush_memtable_now=1;
+SELECT a,b FROM t1;
+a	b
+1	a
+2	b
+DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/t/use_direct_io_for_flush_and_compaction.test
+++ b/mysql-test/suite/rocksdb/t/use_direct_io_for_flush_and_compaction.test
@@ -1,5 +1,5 @@
 --source include/have_rocksdb.inc
 
---let $io_option=--rocksdb_use_direct_reads=1
+--let $io_option=--rocksdb_use_direct_io_for_flush_and_compaction=1
 
 --source ../include/use_direct_io_option.inc

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -4673,7 +4673,8 @@ static int rocksdb_init_func(void *const p) {
   }
 
   // Check whether the filesystem backing rocksdb_datadir allows O_DIRECT
-  if (rocksdb_db_options->use_direct_reads) {
+  if (rocksdb_db_options->use_direct_reads ||
+      rocksdb_db_options->use_direct_io_for_flush_and_compaction) {
     rocksdb::EnvOptions soptions;
     rocksdb::Status check_status;
     rocksdb::Env *const env = rocksdb_db_options->env;


### PR DESCRIPTION
…le::PosixMmapReadableFile(int, const string&, void*, size_t, const rocksdb::EnvOptions&): Assertion `!options.use_direct_reads' failed.

- Extended previous fix fo Issue 778 to also check if
  rocksdb_use_direct_io_for_flush_and_compaction=1 is being used on tmpfs.
  Duplicated simple test that skips when on tmpfs.