### PR TITLE
issue-661 : rocksdb_sys_vars.rocksdb_update_cf_options_basic is unstable

### DIFF
--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_update_cf_options_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_update_cf_options_basic.result
@@ -114,6 +114,10 @@ ERROR 42000: Variable 'rocksdb_update_cf_options' can't be set to the value of '
 SELECT @@global.rocksdb_update_cf_options;
 @@global.rocksdb_update_cf_options
 cf1={target_file_size_base=24m};foo={max_bytes_for_level_multiplier=8};
+SET @@global.rocksdb_update_cf_options = 'default={write_buffer_size=67108864;target_file_size_base=67108864};';
+SET @@global.rocksdb_update_cf_options = 'cf1={write_buffer_size=67108864;target_file_size_base=67108864};';
+SET @@global.rocksdb_update_cf_options = 'cf2={write_buffer_size=67108864;target_file_size_base=67108864;max_bytes_for_level_multiplier=10.000000};';
+SET @@global.rocksdb_update_cf_options = 'cf3={write_buffer_size=67108864;target_file_size_base=67108864};';
 SET @@global.rocksdb_update_cf_options = NULL;
 SELECT @@global.rocksdb_update_cf_options;
 @@global.rocksdb_update_cf_options

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_update_cf_options_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_update_cf_options_basic.test
@@ -54,6 +54,11 @@ SELECT @@global.rocksdb_update_cf_options;
 SELECT * FROM ROCKSDB_CF_OPTIONS WHERE CF_NAME='default' AND OPTION_TYPE='WRITE_BUFFER_SIZE';
 SELECT * FROM ROCKSDB_CF_OPTIONS WHERE CF_NAME='default' AND OPTION_TYPE='TARGET_FILE_SIZE_BASE';
 
+# Save these off to reset later
+--let $ORIG_WRITE_BUFFER_SIZE=`SELECT VALUE FROM ROCKSDB_CF_OPTIONS WHERE CF_NAME='default' AND OPTION_TYPE='WRITE_BUFFER_SIZE'`
+--let $ORIG_TARGET_FILE_SIZE_BASE=`SELECT VALUE FROM ROCKSDB_CF_OPTIONS WHERE CF_NAME='default' AND OPTION_TYPE='TARGET_FILE_SIZE_BASE'`
+--let $ORIG_MAX_BYTES_FOR_LEVEL_MULTIPLIER=`SELECT VALUE FROM ROCKSDB_CF_OPTIONS WHERE CF_NAME='default' AND OPTION_TYPE='MAX_BYTES_FOR_LEVEL_MULTIPLIER'`
+
 # All good. Use default CF.
 SET @@global.rocksdb_update_cf_options = 'default={write_buffer_size=8m;target_file_size_base=2m};';
 SELECT @@global.rocksdb_update_cf_options;
@@ -98,6 +103,12 @@ SELECT * FROM ROCKSDB_CF_OPTIONS WHERE CF_NAME='cf1' AND OPTION_TYPE='TARGET_FIL
 --Error ER_WRONG_VALUE_FOR_VAR
 --eval SET @@global.rocksdb_update_cf_options = 'default={foo=bar};';
 SELECT @@global.rocksdb_update_cf_options;
+
+# Reset the cf options so the test passes with --repeat=2
+--eval SET @@global.rocksdb_update_cf_options = 'default={write_buffer_size=$ORIG_WRITE_BUFFER_SIZE;target_file_size_base=$ORIG_TARGET_FILE_SIZE_BASE};'
+--eval SET @@global.rocksdb_update_cf_options = 'cf1={write_buffer_size=$ORIG_WRITE_BUFFER_SIZE;target_file_size_base=$ORIG_TARGET_FILE_SIZE_BASE};'
+--eval SET @@global.rocksdb_update_cf_options = 'cf2={write_buffer_size=$ORIG_WRITE_BUFFER_SIZE;target_file_size_base=$ORIG_TARGET_FILE_SIZE_BASE;max_bytes_for_level_multiplier=$ORIG_MAX_BYTES_FOR_LEVEL_MULTIPLIER};'
+--eval SET @@global.rocksdb_update_cf_options = 'cf3={write_buffer_size=$ORIG_WRITE_BUFFER_SIZE;target_file_size_base=$ORIG_TARGET_FILE_SIZE_BASE};'
 
 SET @@global.rocksdb_update_cf_options = NULL;
 SELECT @@global.rocksdb_update_cf_options;


### PR DESCRIPTION
- Test was failing to reset specific column family options back to their
  starting point which would cause the test to fail if run with --repeat=2
  and the server instance is not restarted.  Added harvesting of original
  cf options and reset on all column families at end of test.