### PR TITLE
Issue #904: Crash in rocksdb::IOStatsContext::Reset, this=NULL

### DIFF
--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -47,10 +47,15 @@ CHECK_CXX_SOURCE_COMPILES("
 #endif
 int main() {
   static __thread int tls;
+  tls=0;
+  return tls;
 }
 " HAVE_THREAD_LOCAL)
 if(HAVE_THREAD_LOCAL)
   ADD_DEFINITIONS(-DROCKSDB_SUPPORT_THREAD_LOCAL)
+else()
+  MESSAGE(SEND_ERROR "The compiler failed the check for ROCKSDB_SUPPORT_THREAD_LOCAL. "
+                     "MyRocks requires that feature.")
 endif()
 
 SET(ROCKSDB_SOURCES


### PR DESCRIPTION
Fix both code paths:
- Change the test source code so it doesn't cause the "Unused variable"
  warning (which -Werror converted into error and caused CMake not to set
  HAVE_THREAD_LOCAL)

- If the system doesn't seem to support HAVE_THREAD_LOCAL, refuse to
  compile (rather than producing a binary that crashes for some tests)