### PR TITLE
issue 900 : Segentation fault in myrocks::Rdb_string_reader::read

### DIFF
--- a/mysql-test/suite/rocksdb/r/issue900.result
+++ b/mysql-test/suite/rocksdb/r/issue900.result
@@ -1,0 +1,11 @@
+CREATE TABLE t1(c1 VARCHAR(1) CHARACTER SET 'utf8' COLLATE 'utf8_bin', c2 YEAR, c3 REAL(1,0) UNSIGNED, PRIMARY KEY(c1)) ENGINE=RocksDB;
+INSERT INTO t1 VALUES(0,'0','0');
+INSERT INTO t1 VALUES('{0}','0','0');
+Warnings:
+Warning	1265	Data truncated for column 'c1' at row 1
+INSERT INTO t1 VALUES('1','0','1');
+ALTER TABLE t1 ADD INDEX(c3), ADD UNIQUE (c3);
+ERROR 23000: Duplicate entry '0' for key 'c3_2'
+SELECT c3 FROM t1 FORCE INDEX(c3) ORDER BY c3;
+ERROR 42000: Key 'c3' doesn't exist in table 't1'
+DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/t/issue900.test
+++ b/mysql-test/suite/rocksdb/t/issue900.test
@@ -1,0 +1,13 @@
+--source include/have_rocksdb.inc
+
+# Issue 900 : Segmentation fault in myrocks::Rdb_string_reader::read
+CREATE TABLE t1(c1 VARCHAR(1) CHARACTER SET 'utf8' COLLATE 'utf8_bin', c2 YEAR, c3 REAL(1,0) UNSIGNED, PRIMARY KEY(c1)) ENGINE=RocksDB;
+INSERT INTO t1 VALUES(0,'0','0');
+INSERT INTO t1 VALUES('{0}','0','0');
+INSERT INTO t1 VALUES('1','0','1');
+# Would segfault here
+--error ER_DUP_ENTRY
+ALTER TABLE t1 ADD INDEX(c3), ADD UNIQUE (c3);
+--error ER_KEY_DOES_NOT_EXITS
+SELECT c3 FROM t1 FORCE INDEX(c3) ORDER BY c3;
+DROP TABLE t1;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -12051,7 +12051,7 @@ int ha_rocksdb::inplace_populate_sk(
             the duplicate record.
           */
           if (index->unpack_record(new_table_arg, new_table_arg->record[0],
-                                   &merge_key, nullptr,
+                                   &merge_key, &merge_val,
                                    m_verify_row_debug_checksums)) {
             /* Should never reach here */
             DBUG_ASSERT(0);


### PR DESCRIPTION
- Inplace ALTER TABLE .. ADD UNIQUE during uniqueness checks needs to unpack
  secondary but code was not passing in unpack info to index->unpack_record.
  Fixed to pass unpack info (value) to unack_record.

- Created simple test that reproduced initial segfault.