### PR TITLE
Optimize MyRocks Replace Into Statement

### DIFF
--- a/mysql-test/suite/rocksdb/r/optimize_myrocks_replace_into_base.result
+++ b/mysql-test/suite/rocksdb/r/optimize_myrocks_replace_into_base.result
@@ -1,66 +1,82 @@
---source include/have_rocksdb.inc
---source include/master-slave.inc
-
-connection master;
 SET @prior_rocksdb_perf_context_level = @@rocksdb_perf_context_level;
 SET GLOBAL rocksdb_perf_context_level=3;
-
 create table t1(c1 int,c2 int, primary key (c1)) engine=rocksdb;
 insert into t1 values(1,1),(2,2),(3,3);
 select * from t1;
-
-sync_slave_with_master;
---echo connect slave
-select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
-
-
-connection master;
---echo connect master
+c1	c2
+1	1
+2	2
+3	3
 select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
 replace into t1 values(1,11);
-replace into t1 values(2,22);
-replace into t1 values(3,33);
 select case when value-@c > 0 then 'false' else 'true' end as read_free from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+read_free
+true
+drop table t1;
+create table t1(c1 int,c2 int, primary key (c1)) engine=rocksdb;
+create trigger trg before insert on t1 for each row set @a:=1;
+insert into t1 values(1,1),(2,2),(3,3);
 select * from t1;
-
-sync_slave_with_master;
---echo connect slave
-select case when value-@c > 0 then 'false' else 'true' end as read_free from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
-select * from t1;
-
-
+c1	c2
+1	1
+2	2
+3	3
 select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
-
-connection master;
---echo connect master
-select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
-replace into t1 values(2,44),(3,55);
-select case when value-@g > 0 then 'false' else 'true' end as read_free from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
-select * from t1;
-
-sync_slave_with_master;
---echo connect slave
+replace into t1 values(1,11);
 select case when value-@c > 0 then 'false' else 'true' end as read_free from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+read_free
+false
+drop table t1;
+create table t1(c1 int,c2 int) engine=rocksdb;
+insert into t1 values(1,1),(2,2),(3,3);
 select * from t1;
-
+c1	c2
+1	1
+2	2
+3	3
 select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
-
-connection master;
---echo connect master
+replace into t1 values(1,11);
+select case when value-@c > 0 then 'false' else 'true' end as read_free from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+read_free
+false
+drop table t1;
+create table t1(c1 int,c2 int unique) engine=rocksdb;
+insert into t1 values(1,1),(2,2),(3,3);
+select * from t1;
+c1	c2
+1	1
+2	2
+3	3
 select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
-update t1 set c2=66 where c1=3;
+replace into t1 values(1,11);
 select case when value-@c > 0 then 'false' else 'true' end as read_free from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+read_free
+false
+drop table t1;
+create table t1(c1 int primary key,c2 int unique) engine=rocksdb;
+insert into t1 values(1,1),(2,2),(3,3);
 select * from t1;
-
---source include/show_binlog_events.inc
-
-sync_slave_with_master;
---echo connect slave
+c1	c2
+1	1
+2	2
+3	3
+select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+replace into t1 values(1,11);
 select case when value-@c > 0 then 'false' else 'true' end as read_free from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+read_free
+false
+drop table t1;
+create table t1(c1 int primary key,c2 int, key idx1(c2)) engine=rocksdb;
+insert into t1 values(1,1),(2,2),(3,3);
 select * from t1;
-
-connection master;
+c1	c2
+1	1
+2	2
+3	3
+select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+replace into t1 values(1,11);
+select case when value-@c > 0 then 'false' else 'true' end as read_free from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+read_free
+false
 drop table t1;
 SET GLOBAL rocksdb_perf_context_level = @prior_rocksdb_perf_context_level;
-
---source include/rpl_end.inc

--- a/mysql-test/suite/rocksdb/r/optimize_myrocks_replace_into_lock.result
+++ b/mysql-test/suite/rocksdb/r/optimize_myrocks_replace_into_lock.result
@@ -1,0 +1,32 @@
+create table t1(c1 int,c2 int, primary key (c1)) engine=rocksdb;
+insert into t1 values(1,1),(2,2),(3,3);
+select * from t1;
+c1	c2
+1	1
+2	2
+3	3
+begin;
+replace into t1 values(1,11);
+begin;
+update t1 set c2=22 where c1=1;
+commit;
+# Reap update.
+commit;
+select * from t1;
+c1	c2
+1	22
+2	2
+3	3
+begin;
+update t1 set c2=55 where c1=1;
+begin;
+replace into t1 values(1,66);
+commit;
+# Reap replace into.
+commit;
+select * from t1;
+c1	c2
+1	66
+2	2
+3	3
+drop table t1;

--- a/mysql-test/suite/rocksdb/t/optimize_myrocks_replace_into_base.test
+++ b/mysql-test/suite/rocksdb/t/optimize_myrocks_replace_into_base.test
@@ -1,0 +1,79 @@
+--source include/have_rocksdb.inc
+SET @prior_rocksdb_perf_context_level = @@rocksdb_perf_context_level;
+SET GLOBAL rocksdb_perf_context_level=3;
+
+#
+# cast 1: table only with primary key, support replace blind write
+#
+create table t1(c1 int,c2 int, primary key (c1)) engine=rocksdb;
+insert into t1 values(1,1),(2,2),(3,3);
+select * from t1;
+
+select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+replace into t1 values(1,11);
+select case when value-@c > 0 then 'false' else 'true' end as read_free from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+drop table t1;
+
+#
+# cast 2: table only with primary key but with trigger, not support replace blind write
+#
+create table t1(c1 int,c2 int, primary key (c1)) engine=rocksdb;
+create trigger trg before insert on t1 for each row set @a:=1;
+insert into t1 values(1,1),(2,2),(3,3);
+select * from t1;
+
+select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+replace into t1 values(1,11);
+select case when value-@c > 0 then 'false' else 'true' end as read_free from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+drop table t1;
+
+
+#
+# cast 3: table without primary key, not support replace blind write
+#
+
+create table t1(c1 int,c2 int) engine=rocksdb;
+insert into t1 values(1,1),(2,2),(3,3);
+select * from t1;
+
+select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+replace into t1 values(1,11);
+select case when value-@c > 0 then 'false' else 'true' end as read_free from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+drop table t1;
+
+
+create table t1(c1 int,c2 int unique) engine=rocksdb;
+insert into t1 values(1,1),(2,2),(3,3);
+select * from t1;
+
+select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+replace into t1 values(1,11);
+select case when value-@c > 0 then 'false' else 'true' end as read_free from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+drop table t1;
+
+
+
+#
+# cast 4: table with primary key and secondary key, not support replace blind write
+#
+create table t1(c1 int primary key,c2 int unique) engine=rocksdb;
+insert into t1 values(1,1),(2,2),(3,3);
+select * from t1;
+
+select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+replace into t1 values(1,11);
+select case when value-@c > 0 then 'false' else 'true' end as read_free from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+drop table t1;
+
+
+create table t1(c1 int primary key,c2 int, key idx1(c2)) engine=rocksdb;
+insert into t1 values(1,1),(2,2),(3,3);
+select * from t1;
+
+select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+replace into t1 values(1,11);
+select case when value-@c > 0 then 'false' else 'true' end as read_free from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+drop table t1;
+
+SET GLOBAL rocksdb_perf_context_level = @prior_rocksdb_perf_context_level;
+

--- a/mysql-test/suite/rocksdb/t/optimize_myrocks_replace_into_lock.test
+++ b/mysql-test/suite/rocksdb/t/optimize_myrocks_replace_into_lock.test
@@ -1,0 +1,75 @@
+connect (con1,localhost,root,,);
+connect (con2,localhost,root,,);
+
+
+
+create table t1(c1 int,c2 int, primary key (c1)) engine=rocksdb;
+insert into t1 values(1,1),(2,2),(3,3);
+select * from t1;
+
+#
+# cast 1: update is blocked by replace into 
+#
+connection con1;
+begin;
+replace into t1 values(1,11);
+
+
+connection con2;
+begin;
+send update t1 set c2=22 where c1=1;
+
+
+connection default;
+# Check that the above update is blocked
+let $wait_condition=
+  select count(*) = 1 from information_schema.processlist
+    where state = 'Waiting for row lock' and
+          info = 'update t1 set c2=22 where c1=1';
+--source include/wait_condition.inc
+
+
+connection con1;
+commit;
+
+connection con2;
+--echo # Reap update.
+--reap
+commit;
+select * from t1;
+
+
+#
+# cast 2: replace into is blocked by update
+#
+
+connection con1;
+begin;
+update t1 set c2=55 where c1=1;
+
+connection con2;
+begin;
+send replace into t1 values(1,66);
+
+
+connection default;
+# Check that the above replace into is blocked
+let $wait_condition=
+  select count(*) = 1 from information_schema.processlist
+    where state = 'Waiting for row lock' and
+          info = 'replace into t1 values(1,66)';
+--source include/wait_condition.inc
+
+
+connection con1;
+commit;
+
+connection con2;
+--echo # Reap replace into.
+--reap
+commit;
+select * from t1;
+
+connection default;
+drop table t1;
+

--- a/mysql-test/suite/rocksdb/t/optimize_myrocks_replace_into_lock.test
+++ b/mysql-test/suite/rocksdb/t/optimize_myrocks_replace_into_lock.test
@@ -1,7 +1,6 @@
+--source include/have_rocksdb.inc
 connect (con1,localhost,root,,);
 connect (con2,localhost,root,,);
-
-
 
 create table t1(c1 int,c2 int, primary key (c1)) engine=rocksdb;
 insert into t1 values(1,1),(2,2),(3,3);
@@ -73,3 +72,5 @@ select * from t1;
 connection default;
 drop table t1;
 
+disconnect con1;
+disconnect con2;

--- a/mysql-test/suite/rocksdb_rpl/r/optimize_myrocks_replace_into.result
+++ b/mysql-test/suite/rocksdb_rpl/r/optimize_myrocks_replace_into.result
@@ -1,0 +1,70 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+SET GLOBAL rocksdb_perf_context_level=3;
+create table t1(c1 int,c2 int, primary key (c1)) engine=rocksdb;
+insert into t1 values(1,1),(2,2),(3,3);
+select * from t1;
+c1	c2
+1	1
+2	2
+3	3
+select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+replace into t1 values(1,11);
+replace into t1 values(2,22);
+replace into t1 values(3,33);
+select case when value-@c > 0 then 'false' else 'true' end as read_free from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+read_free
+true
+select * from t1;
+c1	c2
+1	11
+2	22
+3	33
+select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+replace into t1 values(2,44),(3,55);
+select case when value-@g > 0 then 'false' else 'true' end as read_free from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+read_free
+true
+select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+update t1 set c2=66 where c1=3;
+select case when value-@c > 0 then 'false' else 'true' end as read_free from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+read_free
+false
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Query	#	#	use `test`; create table t1(c1 int,c2 int, primary key (c1)) engine=rocksdb
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000001	#	Update_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+select * from t1;
+c1	c2
+1	11
+2	44
+3	66
+drop table t1;
+SET GLOBAL rocksdb_perf_context_level=DEFAULT;
+include/rpl_end.inc

--- a/mysql-test/suite/rocksdb_rpl/r/optimize_myrocks_replace_into.result
+++ b/mysql-test/suite/rocksdb_rpl/r/optimize_myrocks_replace_into.result
@@ -3,6 +3,7 @@ Warnings:
 Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
 Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
 [connection master]
+SET @prior_rocksdb_perf_context_level = @@rocksdb_perf_context_level;
 SET GLOBAL rocksdb_perf_context_level=3;
 create table t1(c1 int,c2 int, primary key (c1)) engine=rocksdb;
 insert into t1 values(1,1),(2,2),(3,3);
@@ -11,6 +12,9 @@ c1	c2
 1	1
 2	2
 3	3
+connect slave
+select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+connect master
 select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
 replace into t1 values(1,11);
 replace into t1 values(2,22);
@@ -23,16 +27,48 @@ c1	c2
 1	11
 2	22
 3	33
+connect slave
+select case when value-@c > 0 then 'false' else 'true' end as read_free from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+read_free
+true
+select * from t1;
+c1	c2
+1	11
+2	22
+3	33
+select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+connect master
 select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
 replace into t1 values(2,44),(3,55);
 select case when value-@g > 0 then 'false' else 'true' end as read_free from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
 read_free
 true
+select * from t1;
+c1	c2
+1	11
+2	44
+3	55
+connect slave
+select case when value-@c > 0 then 'false' else 'true' end as read_free from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+read_free
+true
+select * from t1;
+c1	c2
+1	11
+2	44
+3	55
+select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+connect master
 select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
 update t1 set c2=66 where c1=3;
 select case when value-@c > 0 then 'false' else 'true' end as read_free from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
 read_free
 false
+select * from t1;
+c1	c2
+1	11
+2	44
+3	66
 include/show_binlog_events.inc
 Log_name	Pos	Event_type	Server_id	End_log_pos	Info
 master-bin.000001	#	Query	#	#	use `test`; create table t1(c1 int,c2 int, primary key (c1)) engine=rocksdb
@@ -60,11 +96,15 @@ master-bin.000001	#	Query	#	#	BEGIN
 master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
 master-bin.000001	#	Update_rows	#	#	table_id: # flags: STMT_END_F
 master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+connect slave
+select case when value-@c > 0 then 'false' else 'true' end as read_free from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+read_free
+true
 select * from t1;
 c1	c2
 1	11
 2	44
 3	66
 drop table t1;
-SET GLOBAL rocksdb_perf_context_level=DEFAULT;
+SET GLOBAL rocksdb_perf_context_level = @prior_rocksdb_perf_context_level;
 include/rpl_end.inc

--- a/mysql-test/suite/rocksdb_rpl/t/optimize_myrocks_replace_into.test
+++ b/mysql-test/suite/rocksdb_rpl/t/optimize_myrocks_replace_into.test
@@ -1,0 +1,38 @@
+--source include/have_rocksdb.inc
+--source include/master-slave.inc
+--source include/have_binlog_format_row.inc
+
+connection master;
+SET GLOBAL rocksdb_perf_context_level=3;
+
+create table t1(c1 int,c2 int, primary key (c1)) engine=rocksdb;
+insert into t1 values(1,1),(2,2),(3,3);
+select * from t1;
+
+
+select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+replace into t1 values(1,11);
+replace into t1 values(2,22);
+replace into t1 values(3,33);
+select case when value-@c > 0 then 'false' else 'true' end as read_free from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+
+select * from t1;
+
+select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+replace into t1 values(2,44),(3,55);
+select case when value-@g > 0 then 'false' else 'true' end as read_free from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+
+select value into @c from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+update t1 set c2=66 where c1=3;
+select case when value-@c > 0 then 'false' else 'true' end as read_free from information_schema.rocksdb_perf_context where table_schema='test' and table_name='t1' and stat_type='GET_FROM_MEMTABLE_COUNT';
+--source include/show_binlog_events.inc
+
+sync_slave_with_master;
+
+select * from t1;
+
+connection master;
+drop table t1;
+SET GLOBAL rocksdb_perf_context_level=DEFAULT;
+
+--source include/rpl_end.inc

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -13834,6 +13834,10 @@ Write_rows_log_event::Write_rows_log_event(THD *thd_arg, TABLE *tbl_arg,
                    WRITE_ROWS_EVENT,
                    extra_row_info)
 {
+  if (thd_arg && thd_arg->lex->can_optimize_replace_into)
+  {
+    set_replace_into_event();
+  }
 }
 #endif
 
@@ -14093,6 +14097,9 @@ Write_rows_log_event::write_row(const Relay_log_info *const rli,
   int error;
   int UNINIT_VAR(keynum);
   auto_afree_ptr<char> key(NULL);
+
+  if (is_replace_into_event())
+    thd->lex->duplicates= DUP_REPLACE;
 
   const bool invoke_triggers =
     slave_run_triggers_for_rbr && !master_had_triggers && table->triggers;

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -651,6 +651,10 @@ struct sql_ex_info
 
 
 /**
+  flag for myrocks replace into
+ */
+#define LOG_EVENT_DUP_REPLACE_F 0x400
+/**
   @def OPTIONS_WRITTEN_TO_BIN_LOG
 
   OPTIONS_WRITTEN_TO_BIN_LOG are the bits of thd->options which must
@@ -1414,10 +1418,12 @@ public:
   virtual bool is_valid() const = 0;
   void set_artificial_event() { flags |= LOG_EVENT_ARTIFICIAL_F; }
   void set_relay_log_event() { flags |= LOG_EVENT_RELAY_LOG_F; }
+  void set_replace_into_event() { flags |= LOG_EVENT_DUP_REPLACE_F; }
   bool is_artificial_event() const { return flags & LOG_EVENT_ARTIFICIAL_F; }
   bool is_relay_log_event() const { return flags & LOG_EVENT_RELAY_LOG_F; }
   bool is_ignorable_event() const { return flags & LOG_EVENT_IGNORABLE_F; }
   bool is_no_filter_event() const { return flags & LOG_EVENT_NO_FILTER_F; }
+  bool is_replace_into_event() const { return flags & LOG_EVENT_DUP_REPLACE_F; }
   inline bool is_using_trans_cache() const
   {
     return (event_cache_type == EVENT_TRANSACTIONAL_CACHE);

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -477,6 +477,7 @@ void lex_start(THD *thd)
   lex->expr_allows_subselect= TRUE;
   lex->use_only_table_context= FALSE;
   lex->contains_plaintext_password= false;
+  lex->can_optimize_replace_into= false;
 
   lex->name.str= 0;
   lex->name.length= 0;

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -2479,6 +2479,7 @@ struct LEX: public Query_tables_list
   */
   bool is_set_password_sql;
   bool contains_plaintext_password;
+  bool can_optimize_replace_into;
 
   ulong thread_id_opt; //thread id option
 

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -8728,6 +8728,20 @@ bool ha_rocksdb::skip_unique_check() const {
           m_tbl_def->m_key_count == 1);
 }
 
+bool ha_rocksdb::can_optimize_replace_into() const {
+  /*
+    optimize replace into can only works if:
+      1) table only have primary key but no hidden primary key,
+         with any other secondary indexes
+      2) no triggers
+  */
+  THD *thd = ha_thd();
+  return (thd->lex->duplicates == DUP_REPLACE &&
+	  table->s->keys == 1 &&
+	  !has_hidden_pk(table) &&
+	  !table->triggers);
+}
+
 void ha_rocksdb::set_force_skip_unique_check(bool skip) {
   DBUG_ENTER_FUNC();
 
@@ -8968,6 +8982,8 @@ int ha_rocksdb::check_and_lock_unique_pk(const uint &key_id,
   DBUG_ASSERT(found != nullptr);
   DBUG_ASSERT(pk_changed != nullptr);
 
+  bool ignore_get = false;
+
   *pk_changed = false;
 
   /*
@@ -8986,6 +9002,9 @@ int ha_rocksdb::check_and_lock_unique_pk(const uint &key_id,
     *pk_changed = true;
   }
 
+  ignore_get = can_optimize_replace_into();
+  if (ignore_get)
+    ha_thd()->lex->can_optimize_replace_into = true;
   /*
     Perform a read to determine if a duplicate entry exists. For primary
     keys, a point lookup will be sufficient.
@@ -9007,13 +9026,13 @@ int ha_rocksdb::check_and_lock_unique_pk(const uint &key_id,
   */
   const rocksdb::Status s =
       get_for_update(row_info.tx, m_pk_descr->get_cf(), row_info.new_pk_slice,
-                     &m_retrieved_record);
+                     ignore_get ? nullptr : &m_retrieved_record);
   if (!s.ok() && !s.IsNotFound()) {
     return row_info.tx->set_status_error(
         table->in_use, s, *m_key_descr_arr[key_id], m_tbl_def, m_table_handler);
   }
 
-  *found = !s.IsNotFound();
+  *found = ignore_get ? false : !s.IsNotFound() ;
   return HA_EXIT_SUCCESS;
 }
 

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -687,6 +687,7 @@ class ha_rocksdb : public my_core::handler {
       MY_ATTRIBUTE((__warn_unused_result__));
   bool is_blind_delete_enabled();
   bool skip_unique_check() const MY_ATTRIBUTE((__warn_unused_result__));
+  bool can_optimize_replace_into() const MY_ATTRIBUTE((__warn_unused_result__));
   void set_force_skip_unique_check(bool skip) override;
   bool commit_in_the_middle() MY_ATTRIBUTE((__warn_unused_result__));
   bool do_bulk_commit(Rdb_transaction *const tx)


### PR DESCRIPTION
Summary:
When rocksdb tables only have primary key and without secondary indexes,
Replace Into can use Insert Into instead and this insert into no
need to check unique constraint.