### PR TITLE
Fix FB8-210 (innodb_row_recreations InnoDB global status variable is always equal to innodb_row_recreation_steps)

### DIFF
--- a/storage/innobase/srv/srv0mon.cc
+++ b/storage/innobase/srv/srv0mon.cc
@@ -1627,6 +1627,7 @@ void srv_mon_process_existing_counter(
     /* innodb_row_recreations, the total number of row recreations. */
     case MONITOR_OVLD_ROW_RECREATIONS:
       value = srv_stats.row_recreations;
+      break;
 
     /* innodb_row_recreation_steps, the total number of row recreation
     steps. */


### PR DESCRIPTION
https://jira.percona.com/browse/FB8-210

Added missing 'break;' statement which should have been introduced as part
of the commit 89fe9bb.

This PR fixes Issue #921 

Squash with D8882644