### PR TITLE
FB8-214 clang-format fb-mysql-8.0.13 branch

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -183,11 +183,10 @@ static char *opt_bind_addr = NULL;
 static int connect_flag = CLIENT_INTERACTIVE;
 static bool opt_binary_mode = false;
 static bool opt_connect_expired_password = false;
-static char *current_host, *current_db,
-    *current_user = 0, *opt_password = 0, *current_prompt = 0,
-    *delimiter_str = 0,
-    *default_charset = (char *)"latin1",
-    *opt_init_command = 0;
+static char *current_host, *current_db, *current_user = 0, *opt_password = 0,
+                                        *current_prompt = 0, *delimiter_str = 0,
+                                        *default_charset = (char *)"latin1",
+                                        *opt_init_command = 0;
 static char *histfile;
 static char *histfile_tmp;
 static char *opt_histignore = NULL;

--- a/client/mysqldump.cc
+++ b/client/mysqldump.cc
@@ -1675,13 +1675,12 @@ static int connect_to_db(char *host, char *user, char *passwd) {
               my_progname);
     } else {
       if (opt_lra_sleep) {
-        snprintf(buff, sizeof(buff), "SET innodb_lra_sleep=%lu",
-                    opt_lra_sleep);
+        snprintf(buff, sizeof(buff), "SET innodb_lra_sleep=%lu", opt_lra_sleep);
         if (mysql_query_with_error_report(mysql, 0, buff)) DBUG_RETURN(1);
       }
       if (opt_lra_pages_before_sleep) {
         snprintf(buff, sizeof(buff), "SET innodb_lra_pages_before_sleep=%lu",
-                    opt_lra_pages_before_sleep);
+                 opt_lra_pages_before_sleep);
         if (mysql_query_with_error_report(mysql, 0, buff)) DBUG_RETURN(1);
       }
     }
@@ -1689,9 +1688,9 @@ static int connect_to_db(char *host, char *user, char *passwd) {
 
   if (opt_timeout) {
     snprintf(buff, sizeof(buff),
-                "SET wait_timeout=%lu, "
-                "net_write_timeout=%lu",
-                opt_timeout, opt_timeout);
+             "SET wait_timeout=%lu, "
+             "net_write_timeout=%lu",
+             opt_timeout, opt_timeout);
     if (mysql_query_with_error_report(mysql, 0, buff)) DBUG_RETURN(1);
   }
 
@@ -4213,8 +4212,7 @@ static void dump_table(char *table, char *db) {
       check_io(md_result_file);
     }
     mysql_free_result(res);
-    print_comment(md_result_file, 0,
-                  "\n--\n-- Rows found for %s: %lu\n--\n",
+    print_comment(md_result_file, 0, "\n--\n-- Rows found for %s: %lu\n--\n",
                   table, rownr);
     if (opt_enable_checksum_table) {
       print_comment(md_result_file, 0, "\n--\n-- Checksum for %s: %u\n--\n\n",
@@ -6042,8 +6040,7 @@ int main(int argc, char **argv) {
 
   if (opt_slave_data && do_stop_slave_sql(mysql)) goto err;
 
-  if ((opt_lock_all_tables ||
-       (opt_single_transaction && flush_logs)) &&
+  if ((opt_lock_all_tables || (opt_single_transaction && flush_logs)) &&
       do_flush_tables_read_lock(mysql))
     goto err;
 

--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -6178,7 +6178,7 @@ void dump_timed_out_connection_socket_buffer(struct st_connection *con) {
   } else {
     const char *err_str = "Error message is wrong: ";
     dynstr_append_mem(&ds, err_str, std::strlen(err_str));
-    dynstr_append_line(&ds, reinterpret_cast<char*>(&buf[8]), sz - 8);
+    dynstr_append_line(&ds, reinterpret_cast<char *>(&buf[8]), sz - 8);
   }
   log_file.write(&ds);
   log_file.flush();

--- a/include/violite.h
+++ b/include/violite.h
@@ -345,8 +345,8 @@ struct Vio {
 
   timeout_t read_timeout = {UINT_MAX};  /* Timeout value (ms) for read ops. */
   timeout_t write_timeout = {UINT_MAX}; /* Timeout value (ms) for write ops. */
-  int retry_count = {1};    /* Retry count */
-  bool inactive = {false};  /* Connection has been shutdown */
+  int retry_count = {1};                /* Retry count */
+  bool inactive = {false};              /* Connection has been shutdown */
 
   struct sockaddr_storage local;  /* Local internet address */
   struct sockaddr_storage remote; /* Remote internet address */

--- a/libmysql/mysql_trace.cc
+++ b/libmysql/mysql_trace.cc
@@ -53,8 +53,8 @@
   hooks within libmysql code.
 */
 
-#include <mysql_com.h>
 #include "mysql_trace.h"
+#include <mysql_com.h>
 #include "my_dbug.h"
 #include "my_inttypes.h"
 #include "my_sys.h"

--- a/mysys/my_compress.cc
+++ b/mysys/my_compress.cc
@@ -37,7 +37,6 @@
 #include <zstd.h>
 #include <algorithm>
 
-
 #include "my_compiler.h"
 #include "my_dbug.h"
 #include "my_inttypes.h"
@@ -45,7 +44,6 @@
 #include "mysql/service_mysql_alloc.h"
 #include "mysql_com.h"
 #include "mysys/mysys_priv.h"
-
 
 #ifdef MYSQL_SERVER
 extern uint zstd_net_compression_level;

--- a/plugin/auth/qa_auth_client.cc
+++ b/plugin/auth/qa_auth_client.cc
@@ -20,8 +20,8 @@
     along with this program; if not, write to the Free Software
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
-#include <mysql_com.h>
 #include <mysql/client_plugin.h>
+#include <mysql_com.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/plugin/auth/qa_auth_interface.cc
+++ b/plugin/auth/qa_auth_interface.cc
@@ -20,9 +20,9 @@
     along with this program; if not, write to the Free Software
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
-#include <mysql_com.h>
 #include <mysql/client_plugin.h>
 #include <mysql/plugin_auth.h>
+#include <mysql_com.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/plugin/auth/qa_auth_server.cc
+++ b/plugin/auth/qa_auth_server.cc
@@ -20,9 +20,9 @@
     along with this program; if not, write to the Free Software
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
-#include <mysql_com.h>
 #include <mysql/client_plugin.h>
 #include <mysql/plugin_auth.h>
+#include <mysql_com.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/plugin/auth/test_plugin.cc
+++ b/plugin/auth/test_plugin.cc
@@ -33,11 +33,11 @@
 
 #define LOG_COMPONENT_TAG "test_plugin_server"
 
-#include <mysql_com.h>
 #include <mysql/client_plugin.h>
 #include <mysql/components/my_service.h>
 #include <mysql/components/services/log_builtins.h>
 #include <mysql/plugin_auth.h>
+#include <mysql_com.h>
 #include <mysqld_error.h>
 
 #include <stdio.h>

--- a/plugin/test_service_sql_api/test_sql_stmt.cc
+++ b/plugin/test_service_sql_api/test_sql_stmt.cc
@@ -712,7 +712,7 @@ static char *fieldflags2str(uint f) {
 }
 
 static void set_query_in_com_data(union COM_DATA *cmd, const char *query) {
-  *cmd = COM_DATA(); // will initialize 'com_query' member of the union
+  *cmd = COM_DATA();  // will initialize 'com_query' member of the union
   cmd->com_query.query = (char *)query;
   cmd->com_query.length = strlen(query);
 }
@@ -1128,7 +1128,7 @@ static void test_4(MYSQL_SESSION session, void *p) {
     d_data++;
   }
 
-  cmd = COM_DATA(); // will initialize 'com_query' member of the union
+  cmd = COM_DATA();  // will initialize 'com_query' member of the union
   set_query_in_com_data(&cmd, "SELECT * FROM t2");
   run_cmd(session, COM_QUERY, &cmd, &ctx, false, p);
 

--- a/sql-common/client.cc
+++ b/sql-common/client.cc
@@ -1018,12 +1018,9 @@ net_async_status cli_safe_read_with_ok_nonblocking(MYSQL *mysql, bool parse_ok,
   DBUG_RETURN(NET_ASYNC_COMPLETE);
 }
 
-ulong
-cli_safe_read_with_ok_complete(MYSQL *mysql,
-                               bool parse_ok,
-                               bool *is_data_packet,
-                               ulong len) {
-  NET *net= &mysql->net;
+ulong cli_safe_read_with_ok_complete(MYSQL *mysql, bool parse_ok,
+                                     bool *is_data_packet, ulong len) {
+  NET *net = &mysql->net;
   DBUG_ENTER(__func__);
   if (len == packet_error || len == 0) {
     if (net->vio != 0) {
@@ -5375,9 +5372,8 @@ static mysql_state_machine_status authsm_handle_first_authenticate_user(
   After the first authenticate_user comes a call to read the result of the
   implied change_user.
 */
-static mysql_state_machine_status
-authsm_read_change_user_result(mysql_authsm_context *ctx)
-{
+static mysql_state_machine_status authsm_read_change_user_result(
+    mysql_authsm_context *ctx) {
   DBUG_ENTER(__func__);
   MYSQL *mysql = ctx->mysql;
   /* read the OK packet (or use the cached value in mysql->net.read_pos */

--- a/sql-common/client_plugin.cc
+++ b/sql-common/client_plugin.cc
@@ -41,8 +41,8 @@
 
 #include "my_config.h"
 
-#include <mysql_com.h>
 #include <mysql/client_plugin.h>
+#include <mysql_com.h>
 #include <stdarg.h>
 #include <stdlib.h>
 #include <sys/types.h>

--- a/sql-common/net_serv.cc
+++ b/sql-common/net_serv.cc
@@ -600,8 +600,9 @@ static int begin_packet_write_state(NET *net, uchar command,
     // If we have a payload to compress, then compress_packet will
     // add compression headers for us. This is what we have at this point where
     // each line is an iovec.
-    // | len              |cpn|uncompress len| len                                    | pn | command |
-    // | prefix + command |  0|             0| total_len = command + prefix + payload |  0 |   COM_* |
+    // | len              |cpn|uncompress len| len | pn | command | | prefix +
+    // command |  0|             0| total_len = command + prefix + payload |  0
+    // |   COM_* |
     //
     // | prefix |
     // | ...    |
@@ -610,8 +611,9 @@ static int begin_packet_write_state(NET *net, uchar command,
     // | ...     |
     //
     // We want to transform into this:
-    // | len              |cpn|uncompress len| len                                    | pn | command |
-    // | prefix + command |  0|             0| total_len = command + prefix + payload |  0 |   COM_* |
+    // | len              |cpn|uncompress len| len | pn | command | | prefix +
+    // command |  0|             0| total_len = command + prefix + payload |  0
+    // |   COM_* |
     //
     // | prefix |
     // | ...    |
@@ -1540,7 +1542,7 @@ static net_async_status net_read_packet_header_nonblock(NET *net,
     The local packet counter must be truncated since its not reset.
   */
   if (pkt_nr != (uchar)net->pkt_nr) {
-    /* Not a NET error on the client. XXX: why? */
+  /* Not a NET error on the client. XXX: why? */
 #if defined(MYSQL_SERVER)
     my_error(ER_NET_PACKETS_OUT_OF_ORDER, MYF(0));
 #elif defined(EXTRA_DEBUG)

--- a/sql/auth/sql_authentication.cc
+++ b/sql/auth/sql_authentication.cc
@@ -1382,9 +1382,9 @@ static bool send_server_handshake_packet(MPVIO_EXT *mpvio, const char *data,
 
   end = my_stpnmov(end, server_version, SERVER_VERSION_LENGTH);
   end = my_stpcpy(end, " ");
-  end = my_stpnmov(end,
-                   MYSQL_COMPILATION_COMMENT,
-                   SERVER_VERSION_LENGTH - (end - buff - 1)) + 1;
+  end = my_stpnmov(end, MYSQL_COMPILATION_COMMENT,
+                   SERVER_VERSION_LENGTH - (end - buff - 1)) +
+        1;
 
   DBUG_ASSERT(sizeof(my_thread_id) == 4);
   int4store((uchar *)end, mpvio->thread_id);

--- a/sql/dd/types/schema.h
+++ b/sql/dd/types/schema.h
@@ -26,8 +26,8 @@
 #include "my_inttypes.h"
 #include "sql/dd/impl/raw/object_keys.h"  // IWYU pragma: keep
 #include "sql/dd/properties.h"
-#include "sql/dd/sdi_fwd.h"               // RJ_Document
-#include "sql/dd/types/entity_object.h"   // dd::Entity_object
+#include "sql/dd/sdi_fwd.h"              // RJ_Document
+#include "sql/dd/types/entity_object.h"  // dd::Entity_object
 
 class THD;
 

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -2312,8 +2312,7 @@ static bool snapshot_handlerton(THD *thd, plugin_ref plugin, void *arg) {
     info->error = false;
 
     if (hton->start_consistent_snapshot(hton, thd, info->binlog_file,
-                                        info->binlog_pos,
-                                        info->gtid_executed,
+                                        info->binlog_pos, info->gtid_executed,
                                         info->gtid_executed_length)) {
       my_printf_error(ER_UNKNOWN_ERROR,
                       "Cannot start InnoDB transaction or binlog disabled",

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -1162,9 +1162,9 @@ typedef int (*panic_t)(handlerton *hton, enum ha_panic_function flag);
 
 typedef int (*start_consistent_snapshot_t)(handlerton *hton, THD *thd,
                                            char *binlog_file,
-                                           ulonglong* binlog_pos,
+                                           ulonglong *binlog_pos,
                                            char **gtid_executed,
-                                           int* gtid_executed_length);
+                                           int *gtid_executed_length);
 
 /**
   Flush the log(s) of storage engine(s).

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -1358,13 +1358,13 @@ bool Query_logger::slow_log_write(
   bool error = false;
   for (Log_event_handler **current_handler = slow_log_handler_list;
        *current_handler;) {
-    error |= (*current_handler++)
-                 ->log_slow(thd, current_utime,
-                            (thd->start_time.tv_sec * 1000000ULL) +
-                                thd->start_time.tv_usec,
-                            user_host_buff, user_host_len, query_utime,
-                            lock_utime, is_command, query, query_length,
-                            query_start_status);
+    error |=
+        (*current_handler++)
+            ->log_slow(
+                thd, current_utime,
+                (thd->start_time.tv_sec * 1000000ULL) + thd->start_time.tv_usec,
+                user_host_buff, user_host_len, query_utime, lock_utime,
+                is_command, query, query_length, query_start_status);
   }
 
   mysql_rwlock_unlock(&LOCK_logger);
@@ -1756,7 +1756,7 @@ bool log_slow_applicable(THD *thd) {
   DBUG_RETURN(false);
 }
 
-void log_slow_do(THD *thd, struct System_status_var* query_start_status) {
+void log_slow_do(THD *thd, struct System_status_var *query_start_status) {
   THD_STAGE_INFO(thd, stage_logging_slow_query);
   thd->status_var.long_query_count++;
 

--- a/sql/log.h
+++ b/sql/log.h
@@ -472,7 +472,7 @@ bool log_slow_applicable(THD *thd);
 
   @param thd              thread handle
 */
-void log_slow_do(THD *thd, struct System_status_var* query_start_status);
+void log_slow_do(THD *thd, struct System_status_var *query_start_status);
 
 /**
   Check whether we need to write the current statement to the slow query
@@ -486,7 +486,7 @@ void log_slow_do(THD *thd, struct System_status_var* query_start_status);
 
   @param thd              thread handle
 */
-void log_slow_statement(THD *thd, struct System_status_var* query_start_status);
+void log_slow_statement(THD *thd, struct System_status_var *query_start_status);
 
 /**
   @class Log_throttle

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -2361,14 +2361,14 @@ void Log_event::print_base64(IO_CACHE *file, PRINT_EVENT_INFO *print_event_info,
   if (print_event_info->base64_output_mode != BASE64_OUTPUT_DECODE_ROWS) {
     if (my_b_tell(file) == 0) {
       my_b_printf(file, "\nBINLOG '\n");
-      print_event_info->inside_binlog= true;
+      print_event_info->inside_binlog = true;
     }
 
     my_b_printf(file, "%s\n", tmp_str);
 
     if (!more) {
       my_b_printf(file, "'%s\n", print_event_info->delimiter);
-      print_event_info->inside_binlog= false;
+      print_event_info->inside_binlog = false;
     }
   }
 
@@ -2409,12 +2409,11 @@ void Log_event::print_base64(IO_CACHE *file, PRINT_EVENT_INFO *print_event_info,
     }
 
     if (print_event_info->inside_binlog) {
-      if (ev)
-        print_event_info->verbose_events.push_back(ev);
+      if (ev) print_event_info->verbose_events.push_back(ev);
     } else {
-      std::vector<Rows_log_event *> &evs= print_event_info->verbose_events;
-      for (size_t i= 0; i < evs.size(); ++i) {
-        Rows_log_event *rle= evs.at(i);
+      std::vector<Rows_log_event *> &evs = print_event_info->verbose_events;
+      for (size_t i = 0; i < evs.size(); ++i) {
+        Rows_log_event *rle = evs.at(i);
         rle->print_verbose(file, print_event_info);
         delete rle;
       }

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -101,8 +101,8 @@ class Basic_ostream;
 #endif
 
 #ifndef MYSQL_SERVER
-#include "sql/rpl_tblmap.h"  // table_mapping
 #include <vector>
+#include "sql/rpl_tblmap.h"  // table_mapping
 
 #endif
 

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5338,7 +5338,6 @@ static int init_server_components() {
       LogErr(WARNING_LEVEL, ER_RPL_INFINITY_IGNORED);
   }
 
-
   {
   /*
     We have to call a function in log_resource.cc, or its references
@@ -8482,7 +8481,7 @@ static int show_ssl_get_server_not_after(THD *, SHOW_VAR *var, char *buff) {
       return 1;
     }
   } else {
-    var->value= empty_c_string;
+    var->value = empty_c_string;
     mysql_rwlock_unlock(&LOCK_use_ssl);
   }
   return 0;

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -61,10 +61,10 @@
 #include "mysql_com.h"  // SERVER_VERSION_LENGTH
 #ifdef _WIN32
 #include "sql/nt_servc.h"
-#endif  // _WIN32
+#endif                    // _WIN32
+#include "sql/set_var.h"  // enum_var_type
 #include "sql/sql_bitmap.h"
 #include "sql/sql_const.h"  // UUID_LENGTH
-#include "sql/set_var.h"  // enum_var_type
 #include "sql/system_variables.h"
 #include "sql/thr_malloc.h"
 

--- a/sql/protocol_classic.cc
+++ b/sql/protocol_classic.cc
@@ -434,7 +434,7 @@
 #include <limits>
 
 #include "decimal.h"
-#include "errmsg.h" // CR_*
+#include "errmsg.h"  // CR_*
 #include "lex_string.h"
 #include "m_ctype.h"
 #include "m_string.h"

--- a/sql/rpl_binlog_sender.cc
+++ b/sql/rpl_binlog_sender.cc
@@ -22,12 +22,12 @@
 
 #include "sql/rpl_binlog_sender.h"
 
+#include <errno.h>
 #include <stdio.h>
+#include <sys/socket.h>
 #include <algorithm>
 #include <atomic>
-#include <errno.h>
 #include <memory>
-#include <sys/socket.h>
 #include <unordered_map>
 #include <utility>
 
@@ -187,7 +187,7 @@ void Binlog_sender::init() {
   }
   m_transmit_started = true;
 
-  NET *net= thd->get_protocol_classic()->get_net();
+  NET *net = thd->get_protocol_classic()->get_net();
   if (rpl_send_buffer_size &&
       (setsockopt(net->vio->mysql_socket.fd, SOL_SOCKET, SO_SNDBUF,
                   &rpl_send_buffer_size, sizeof(rpl_send_buffer_size)) == -1

--- a/sql/rpl_gtid.h
+++ b/sql/rpl_gtid.h
@@ -24,8 +24,8 @@
 #define RPL_GTID_H_INCLUDED
 
 #include <atomic>
-#include <map>
 #include <list>
+#include <map>
 #include <string>
 
 #include "libbinlogevents/include/uuid.h"

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -4032,6 +4032,7 @@ class THD : public MDL_context_owner,
     m_persist_variables_init = is_init;
   }
   bool is_persist_variables_init() { return m_persist_variables_init; }
+
  private:
   bool m_persist_variables_init = false;
 };

--- a/sql/sql_db.cc
+++ b/sql/sql_db.cc
@@ -80,7 +80,7 @@
 #include "sql/log.h"        // log_*()
 #include "sql/log_event.h"  // Query_log_event
 #include "sql/mdl.h"
-#include "sql/mysqld.h"          // key_file_misc
+#include "sql/mysqld.h"  // key_file_misc
 #include "sql/mysqld_thd_manager.h"
 #include "sql/psi_memory_key.h"  // key_memory_THD_db
 #include "sql/rpl_gtid.h"

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1263,7 +1263,8 @@ bool do_command(THD *thd) {
   thd->get_protocol_classic()->get_output_packet()->shrink(
       thd->variables.net_buffer_length);
   /* Restore read timeout value */
-  my_net_set_read_timeout(net, timeout_from_seconds(thd->variables.net_read_timeout));
+  my_net_set_read_timeout(
+      net, timeout_from_seconds(thd->variables.net_read_timeout));
 
   return_value = dispatch_command(thd, &com_data, command);
   thd->get_protocol_classic()->get_output_packet()->shrink(
@@ -1519,7 +1520,7 @@ bool dispatch_command(THD *thd, const COM_DATA *com_data,
     query_start_status = thd->status_var;
   }
 
-  /* SHOW PROFILE instrumentation, begin */
+    /* SHOW PROFILE instrumentation, begin */
 #if defined(ENABLED_PROFILING)
   thd->profiling->start_new_query();
 #endif
@@ -2923,8 +2924,8 @@ int mysql_execute_command(THD *thd, bool first_level) {
       memcpy(cross_db_query_log + prefix_len, thd->query().str,
              thd->query().length);
       cross_db_query_log[log_len] = 0;
-      query_logger.slow_log_write(thd, cross_db_query_log,
-                                  log_len, &(thd->status_var));
+      query_logger.slow_log_write(thd, cross_db_query_log, log_len,
+                                  &(thd->status_var));
       my_free(cross_db_query_log);
     }
     if (ret == 2) /* For LOG_WARN */
@@ -3282,8 +3283,7 @@ int mysql_execute_command(THD *thd, bool first_level) {
       break;
     }
     case SQLCOM_SHOW_MEMORY_STATUS: {
-      if (check_global_access(thd, PROCESS_ACL))
-        goto error;
+      if (check_global_access(thd, PROCESS_ACL)) goto error;
 
       res = show_memory_status(thd);
       break;

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -2327,7 +2327,7 @@ void reset_status_vars() {
     if (ptr->type == SHOW_LONG || ptr->type == SHOW_SIGNED_LONG)
       *(ulong *)ptr->value = 0;
     else if (ptr->type == SHOW_TIMER)
-      *(ulonglong *) ptr->value= 0;
+      *(ulonglong *)ptr->value = 0;
   }
 }
 
@@ -2523,12 +2523,11 @@ const char *get_one_variable_ext(THD *running_thd, THD *target_thd,
       value_charset = system_charset_info;
       break;
 
-    case SHOW_TIMER:
-    {
+    case SHOW_TIMER: {
       /* 6 is the default precision for '%f' in sprintf() */
-      double tmp_val = my_timer_to_seconds(*(longlong*) value);
-      end= buff + my_fcvt(tmp_val, 6, buff, NULL);
-      value_charset= system_charset_info;
+      double tmp_val = my_timer_to_seconds(*(longlong *)value);
+      end = buff + my_fcvt(tmp_val, 6, buff, NULL);
+      value_charset = system_charset_info;
       break;
     }
     case SHOW_LONG_STATUS:

--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -3848,7 +3848,7 @@ ibool buf_page_optimistic_get(
     /* In the case of a first access, and logical read ahead
     is not set, try to apply linear read-ahead */
     buf_read_ahead_linear(block->page.id, block->page.size, ibuf_inside(mtr));
-	}
+  }
 
 #ifdef UNIV_IBUF_COUNT_DEBUG
   ut_a(ibuf_count_get(block->page.id) == 0);

--- a/storage/innobase/buf/buf0dblwr.cc
+++ b/storage/innobase/buf/buf0dblwr.cc
@@ -386,15 +386,15 @@ static void buf_dblwr_reset(ulint doublewrite_mode) {
 
   ut_free(page_unaligned);
 }
-/****************************************************************//**
-At a database startup initializes the doublewrite buffer memory structure if
-we already have a doublewrite buffer created in the data files. If we are
-upgrading to an InnoDB version which supports multiple tablespaces, then this
-function performs the necessary update operations. If we are in a crash
-recovery, this function loads the pages from double write buffer into memory.
-@param[in]	file		File handle
-@param[in]	path		Path name of file
-@return DB_SUCCESS or error code */
+/****************************************************************/ /**
+ At a database startup initializes the doublewrite buffer memory structure if
+ we already have a doublewrite buffer created in the data files. If we are
+ upgrading to an InnoDB version which supports multiple tablespaces, then this
+ function performs the necessary update operations. If we are in a crash
+ recovery, this function loads the pages from double write buffer into memory.
+ @param[in]	file		File handle
+ @param[in]	path		Path name of file
+ @return DB_SUCCESS or error code */
 dberr_t buf_dblwr_init_or_load_pages(pfs_os_file_t file, const char *path) {
   byte *buf;
   byte *page;
@@ -507,10 +507,9 @@ dberr_t buf_dblwr_init_or_load_pages(pfs_os_file_t file, const char *path) {
   if (header_found) {
     byte *ptr = page + FIL_PAGE_DATA;
     ut_a(!reset_space_ids);
-    const page_size_t &header_page_size = page_size_t(
-				BUF_DBLWR_HEADER_SIZE,
-				BUF_DBLWR_HEADER_SIZE,
-				true/* use compressed as original checksum
+    const page_size_t &header_page_size =
+        page_size_t(BUF_DBLWR_HEADER_SIZE, BUF_DBLWR_HEADER_SIZE,
+                    true /* use compressed as original checksum
 				was calculated using #calc_zip_checksum*/);
     BlockReporter block(false, page, header_page_size, false);
     if (block.is_corrupted()) {

--- a/storage/innobase/dict/mem.cc
+++ b/storage/innobase/dict/mem.cc
@@ -151,8 +151,7 @@ static const char *innobase_system_databases[] = {
 
 /** Determines if a table belongs to a system database
  @return */
-static bool dict_mem_table_is_system(
-    char *name) /*!< in: table name */
+static bool dict_mem_table_is_system(char *name) /*!< in: table name */
 {
   ut_ad(name);
 

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -1559,7 +1559,6 @@ class Fil_system {
   Fil_system &operator=(const Fil_system &) = delete;
 
   friend class Fil_shard;
-
 };
 
 /** The tablespace memory cache. This variable is nullptr before the module is
@@ -7470,8 +7469,8 @@ void fil_aio_wait(ulint segment) {
 @retval DB_SUCCESS on success
 @retval DB_TABLESPACE_DELETED if the tablespace does not exist */
 dberr_t _fil_io(const IORequest &type, bool sync, const page_id_t &page_id,
-               const page_size_t &page_size, ulint byte_offset, ulint len,
-               void *buf, void *message, bool should_buffer) {
+                const page_size_t &page_size, ulint byte_offset, ulint len,
+                void *buf, void *message, bool should_buffer) {
   auto shard = fil_system->shard_by_id(page_id.space());
 
   return (shard->do_io(type, sync, page_id, page_size, byte_offset, len, buf,
@@ -7648,7 +7647,7 @@ void Fil_shard::space_flush(space_id_t space_id) {
         srv_unix_file_flush_method == SRV_UNIX_O_DIRECT &&
         file.flush_size == file.size) {
       skip_flush = true;
-  }
+    }
 #endif
 
     while (file.n_pending_flushes > 0 && !skip_flush) {
@@ -9205,7 +9204,6 @@ bool Fil_system::check_missing_tablespaces() {
   buffer pages. If not then print a warning. */
 
   for (auto &page : dblwr.deferred) {
-
     /* If the tablespace was in the missing IDs then we
     know that the problem is elsewhere. If a file deleted
     record was not found in the redo log and the tablespace
@@ -10519,7 +10517,7 @@ void Fil_path::convert_to_lower_case(std::string &path) {
 
 /*************************************************************************
 Print tablespace data for SHOW INNODB STATUS. */
-void fil_print(FILE* file) {
+void fil_print(FILE *file) {
   fprintf(file,
           "fsync callers: %lu other, %lu checkpoint, %lu log aio,"
           " %lu log sync, %lu doublwrite\n",

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -1419,12 +1419,12 @@ static void innodb_pre_dd_shutdown(handlerton *) {
  have one.
  @return 0 */
 static int innobase_start_trx_and_assign_read_view(
-    handlerton *hton, /* in: InnoDB handlerton */
-    THD *thd,         /* in: MySQL thread handle of the
-                      user for whom the transaction should
-                      be committed */
-    char *binlog_file,      /* out: binlog file for last commit */
-    ulonglong *binlog_pos,  /* out: binlog pos for last commit */
+    handlerton *hton,           /* in: InnoDB handlerton */
+    THD *thd,                   /* in: MySQL thread handle of the
+                                user for whom the transaction should
+                                be committed */
+    char *binlog_file,          /* out: binlog file for last commit */
+    ulonglong *binlog_pos,      /* out: binlog pos for last commit */
     char **gtid_executed,       /* out: Gtids logged until last commit */
     int *gtid_executed_length); /* out: Length of gtid_executed string */
 /** Flush InnoDB redo logs to the file system.
@@ -4838,13 +4838,13 @@ void innobase_commit_low(trx_t *trx) /*!< in: transaction handle */
  have one.
  @return 0 */
 static int innobase_start_trx_and_assign_read_view(
-    handlerton *hton, /*!< in: InnoDB handlerton */
-    THD *thd,         /*!< in: MySQL thread handle of the user for
-                      whom the transaction should be committed */
-    char *binlog_file,      /* out: binlog file for last commit */
-    ulonglong *binlog_pos,  /* out: binlog pos for last commit */
-    char **gtid_executed,       /* out: Gtids logged until last commit */
-    int *gtid_executed_length)  /* out: Length of gtid_executed string */
+    handlerton *hton,          /*!< in: InnoDB handlerton */
+    THD *thd,                  /*!< in: MySQL thread handle of the user for
+                               whom the transaction should be committed */
+    char *binlog_file,         /* out: binlog file for last commit */
+    ulonglong *binlog_pos,     /* out: binlog pos for last commit */
+    char **gtid_executed,      /* out: Gtids logged until last commit */
+    int *gtid_executed_length) /* out: Length of gtid_executed string */
 {
   DBUG_ENTER("innobase_start_trx_and_assign_read_view");
   DBUG_ASSERT(hton == innodb_hton_ptr);

--- a/storage/innobase/include/fil0fil.h
+++ b/storage/innobase/include/fil0fil.h
@@ -1349,8 +1349,8 @@ dberr_t fil_redo_io(const IORequest &type, const page_id_t &page_id,
 @retval DB_SUCCESS on success
 @retval DB_TABLESPACE_DELETED if the tablespace does not exist */
 dberr_t _fil_io(const IORequest &type, bool sync, const page_id_t &page_id,
-               const page_size_t &page_size, ulint byte_offset, ulint len,
-               void *buf, void *message, bool should_buffer)
+                const page_size_t &page_size, ulint byte_offset, ulint len,
+                void *buf, void *message, bool should_buffer)
     MY_ATTRIBUTE((warn_unused_result));
 
 #define fil_io(type, sync, page_id, page_size, byte_offset, len, buf, message) \
@@ -1810,6 +1810,6 @@ void fil_space_update_name(fil_space_t *space, const char *name);
 Print tablespace data for SHOW INNODB STATUS. */
 void fil_print(
     /*=======*/
-    FILE* file);	/* in: print results to this */
+    FILE *file); /* in: print results to this */
 
 #endif /* fil0fil_h */

--- a/storage/innobase/include/os0file.h
+++ b/storage/innobase/include/os0file.h
@@ -69,7 +69,6 @@ extern ulint os_n_pending_reads;
 /** Number of pending write operations */
 extern ulint os_n_pending_writes;
 
-
 /* Flush after each os_fsync_threshold bytes */
 extern unsigned long long os_fsync_threshold;
 

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -872,9 +872,9 @@ void srv_wake_master_thread(void);
  @return false if not all information printed
  due to failure to obtain necessary mutex */
 ibool srv_printf_innodb_monitor(
-    FILE *file,       /*!< in: output stream */
-    ibool nowait,     /*!< in: whether to wait for the
-                      lock_sys_t::mutex */
+    FILE *file,          /*!< in: output stream */
+    ibool nowait,        /*!< in: whether to wait for the
+                         lock_sys_t::mutex */
     ibool include_trxs); /*!< in: include per-transaction output */
 
 /** Output for SHOW INNODB TRANSACTION STATUS */
@@ -1054,7 +1054,7 @@ struct export_var_t {
   ulint innodb_outstanding_aio_requests;
 #ifdef UNIV_DEBUG
   ulint innodb_max_outstanding_aio_requests;
-#endif /* UNIV_DEBUG */
+#endif                                         /* UNIV_DEBUG */
   ulint innodb_logical_read_ahead_misses;      /*!< total number of pages that
                                                logical-read-ahead missed
                                                during a table scan.  The

--- a/storage/innobase/include/trx0trx.h
+++ b/storage/innobase/include/trx0trx.h
@@ -53,8 +53,8 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef UNIV_HOTBACKUP
 #include "fts0fts.h"
 #endif /* !UNIV_HOTBACKUP */
-#include "srv0srv.h"
 #include "btr0types.h"
+#include "srv0srv.h"
 
 // Forward declaration
 struct mtr_t;
@@ -633,65 +633,65 @@ struct page_no_holder_struct {
 };
 
 struct lra_t {
-  ulint lra_size;     /* Total size (in MBs) of the
-                      pages that will be prefetched by
-                      logical read ahead. */
-  ulint lra_n_pages;  /* Number of pages that lra prefetches
-                      every time. This is computed using
-                      lra_size and the currently scanned
-                      table's block size */
-  ulint lra_n_spaces; /* Number of times space id can change
-                      before lra is disabled during
-                      transaction execution. */
+  ulint lra_size;           /* Total size (in MBs) of the
+                            pages that will be prefetched by
+                            logical read ahead. */
+  ulint lra_n_pages;        /* Number of pages that lra prefetches
+                            every time. This is computed using
+                            lra_size and the currently scanned
+                            table's block size */
+  ulint lra_n_spaces;       /* Number of times space id can change
+                            before lra is disabled during
+                            transaction execution. */
   ulint lra_count_n_spaces; /* Number of times space id changes during
                             transaction execution. */
-  ulint lra_space_id; /* The last space id that the scanning
-                      transaction accessed. If the scanning
-                      trx accesses multiple tables, we need
-                      to reset the data structures that lra
-                      uses. */
-  ulint lra_page_no;  /* The last page that was visited
-                      by the trx. Used by the
-                      logical-read-ahead algorithm to
-                      determine if a new prefetch should be
-                      performed. */
+  ulint lra_space_id;       /* The last space id that the scanning
+                            transaction accessed. If the scanning
+                            trx accesses multiple tables, we need
+                            to reset the data structures that lra
+                            uses. */
+  ulint lra_page_no;        /* The last page that was visited
+                            by the trx. Used by the
+                            logical-read-ahead algorithm to
+                            determine if a new prefetch should be
+                            performed. */
   hash_table_t *lra_ht1;
-  hash_table_t *lra_ht2;      /* Hash tables store the leaf page
-                              numbers for the already prefetched
-                              pages. Each hash table will typically
-                              have lra_n_pages pages and when the
-                              scanning trx visits all lra_n_pages
-                              pages in one of them, we will empty
-                              that one and prefetch another batch of
-                              lra_n_pages pages. */
-  hash_table_t *lra_ht;       /* Points to lra_ht1 and lra_ht2
-                              alternatingly. */
-  ulint lra_n_pages_since;    /* number of leaf pages visited since the last
-                              prefetch operation. We require that no prefetch
-                              be done until the scanning trx scans lra_n_pages
-                              pages. */
-  ulint *lra_sort_arr;        /* Array used for sorting the page
-                              numbers before issuing the read
-                              requests */
-  page_no_holder_t *lra_arr1; /* Pre-allocated array of
-                              page_no_holder objects which are used
-                              by the logical-read-ahead algorithm for
-                              lra_ht1. */
-  page_no_holder_t *lra_arr2; /* Pre-allocated array of
-                              page_no_holder objects which are used
-                              by the logical-read-ahead algorithm for
-                              lra_ht2. */
-  btr_pcur_t *lra_cur;        /* The persistent cursor that points
-                              to the first node pointer record for
-                              which the associated leaf page is not
-                              prefetched by LRA. */
+  hash_table_t *lra_ht2;        /* Hash tables store the leaf page
+                                numbers for the already prefetched
+                                pages. Each hash table will typically
+                                have lra_n_pages pages and when the
+                                scanning trx visits all lra_n_pages
+                                pages in one of them, we will empty
+                                that one and prefetch another batch of
+                                lra_n_pages pages. */
+  hash_table_t *lra_ht;         /* Points to lra_ht1 and lra_ht2
+                                alternatingly. */
+  ulint lra_n_pages_since;      /* number of leaf pages visited since the last
+                                prefetch operation. We require that no prefetch
+                                be done until the scanning trx scans lra_n_pages
+                                pages. */
+  ulint *lra_sort_arr;          /* Array used for sorting the page
+                                numbers before issuing the read
+                                requests */
+  page_no_holder_t *lra_arr1;   /* Pre-allocated array of
+                                page_no_holder objects which are used
+                                by the logical-read-ahead algorithm for
+                                lra_ht1. */
+  page_no_holder_t *lra_arr2;   /* Pre-allocated array of
+                                page_no_holder objects which are used
+                                by the logical-read-ahead algorithm for
+                                lra_ht2. */
+  btr_pcur_t *lra_cur;          /* The persistent cursor that points
+                                to the first node pointer record for
+                                which the associated leaf page is not
+                                prefetched by LRA. */
   ulint lra_pages_before_sleep; /* Number of node pointer records traversed
                                 while holding the index lock before releasing
                                 the index lock and sleeping for a short period
                                 of time so that the other threads get a chance
                                 to x-latch the index lock. */
-  ulint lra_sleep;            /* Sleep time in milliseconds. */
-  ulint lra_tree_height;      /* Tree height. */
+  ulint lra_sleep;              /* Sleep time in milliseconds. */
+  ulint lra_tree_height;        /* Tree height. */
 };
 
 /** Frees data structures related to logical-read-ahead. */

--- a/storage/innobase/log/log0chkp.cc
+++ b/storage/innobase/log/log0chkp.cc
@@ -474,8 +474,7 @@ static void log_checkpoint(log_t &log) {
     case SRV_WIN_IO_UNBUFFERED:
       break;
     case SRV_WIN_IO_NORMAL:
-      fil_flush_file_spaces(to_int(FIL_TYPE_TABLESPACE),
-                            FLUSH_FROM_CHECKPOINT);
+      fil_flush_file_spaces(to_int(FIL_TYPE_TABLESPACE), FLUSH_FROM_CHECKPOINT);
       break;
   }
 #else  /* !_WIN32 */
@@ -489,8 +488,7 @@ static void log_checkpoint(log_t &log) {
     case SRV_UNIX_LITTLESYNC:
     case SRV_UNIX_O_DIRECT:
     case SRV_UNIX_O_DIRECT_NO_FSYNC:
-      fil_flush_file_spaces(to_int(FIL_TYPE_TABLESPACE),
-                            FLUSH_FROM_CHECKPOINT);
+      fil_flush_file_spaces(to_int(FIL_TYPE_TABLESPACE), FLUSH_FROM_CHECKPOINT);
   }
 #endif /* _WIN32 */
 

--- a/storage/innobase/row/row0sel.cc
+++ b/storage/innobase/row/row0sel.cc
@@ -39,8 +39,8 @@ this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "row0sel.h"
 
-#include <algorithm>
 #include <sys/types.h>
+#include <algorithm>
 
 #include "btr0btr.h"
 #include "btr0cur.h"
@@ -5994,7 +5994,7 @@ next_rec:
       if (trx &&
           row_read_ahead_logical(pcur, index, &mtr, trx, offsets, &heap)) {
         goto rec_loop;
-			}
+      }
       move = btr_pcur_move_to_next(pcur, &mtr);
     }
 

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -1248,10 +1248,10 @@ void srv_printf_innodb_transaction(FILE *file) /*!< in: output stream */
  @return false if not all information printed
  due to failure to obtain necessary mutex */
 ibool srv_printf_innodb_monitor(
-    FILE *file,           /*!< in: output stream */
-    ibool nowait,         /*!< in: whether to wait for the
-                          lock_sys_t:: mutex */
-    ibool include_trxs)   /*!< in: include per-transaction output */
+    FILE *file,         /*!< in: output stream */
+    ibool nowait,       /*!< in: whether to wait for the
+                        lock_sys_t:: mutex */
+    ibool include_trxs) /*!< in: include per-transaction output */
 {
   double time_elapsed;
   time_t current_time;

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -37,6 +37,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <sql_thd_internal_api.h>
 
+#include "btr0pcur.h"
 #include "btr0sea.h"
 #include "dict0dd.h"
 #include "fsp0sysspace.h"
@@ -61,7 +62,6 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #include "ut0new.h"
 #include "ut0pool.h"
 #include "ut0vec.h"
-#include "btr0pcur.h"
 
 #include "my_dbug.h"
 
@@ -157,21 +157,21 @@ void trx_lra_free(lra_t *lra) /*!< in: lra structure */
 /** Creates or frees data structures related to logical-read-ahead.
  based on the value of lra_size. */
 void trx_lra_reset(
-    trx_t *trx,                     /*!< in: transaction */
-    ulint lra_size,                 /*!< in: lra_size in MB. If 0, the fields
-                                    that are related to logical-read-ahead will
-                                    be freed if they were initialized. */
-    ulint lra_pages_before_sleep,   /*!< in: The number of node pointer records
-                                    traversed while holding the index lock
-                                    before releasing the index lock and
-                                    sleeping for a short period of time so that
-                                    the other threads get a chance to x-latch
-                                    the index lock. */
-    ulint lra_sleep,                /*!< in: Sleep time in milliseconds. */
-    ulint lra_n_spaces,             /*!< in: Number of space switches before
-                                    lra is disabled. */
-    bool reset_lra_count_n_spaces)  /*!< in: whether to reset
-                                    lra_count_n_spaces.  */
+    trx_t *trx,                    /*!< in: transaction */
+    ulint lra_size,                /*!< in: lra_size in MB. If 0, the fields
+                                   that are related to logical-read-ahead will
+                                   be freed if they were initialized. */
+    ulint lra_pages_before_sleep,  /*!< in: The number of node pointer records
+                                   traversed while holding the index lock
+                                   before releasing the index lock and
+                                   sleeping for a short period of time so that
+                                   the other threads get a chance to x-latch
+                                   the index lock. */
+    ulint lra_sleep,               /*!< in: Sleep time in milliseconds. */
+    ulint lra_n_spaces,            /*!< in: Number of space switches before
+                                   lra is disabled. */
+    bool reset_lra_count_n_spaces) /*!< in: whether to reset
+                                   lra_count_n_spaces.  */
 {
 #ifndef UNIV_LINUX
   if (lra_size) {

--- a/vio/viosocket.cc
+++ b/vio/viosocket.cc
@@ -253,8 +253,7 @@ int vio_set_blocking(Vio *vio, bool status) {
 #else
   {
 #ifdef DBUG_OFF
-    if (vio->is_blocking_flag == status)
-      DBUG_RETURN(0);
+    if (vio->is_blocking_flag == status) DBUG_RETURN(0);
 #endif
 
     int flags;

--- a/vio/viossl.cc
+++ b/vio/viossl.cc
@@ -573,12 +573,12 @@ static int ssl_do(struct st_VioSSLFd *ptr, Vio *vio, long timeout,
     }
 #endif
 
-    /*
-      Since yaSSL does not support non-blocking send operations, use
-      special transport functions that properly handles non-blocking
-      sockets. These functions emulate the behavior of blocking I/O
-      operations by waiting for I/O to become available.
-    */
+      /*
+        Since yaSSL does not support non-blocking send operations, use
+        special transport functions that properly handles non-blocking
+        sockets. These functions emulate the behavior of blocking I/O
+        operations by waiting for I/O to become available.
+      */
 #ifdef HAVE_WOLFSSL
     /* Set first argument of the transport functions. */
     wolfSSL_SetIOReadCtx(ssl, vio);


### PR DESCRIPTION
JIRA: https://jira.percona.com/browse/FB8-214

Upstream now uses git filters to do code formatting using clang-format
This patch fixes the formatting issues detected in fb-mysql-8.0.13
branch.

When git clean filters are enabled, formatting issues prevent from
doing git pull, checkout etc

Only clang-format version 5.0 should be used.