### PR TITLE
FB8-64: Fix time granularity in dump thread

### DIFF
--- a/sql/rpl_binlog_sender.h
+++ b/sql/rpl_binlog_sender.h
@@ -87,7 +87,7 @@ class Binlog_sender : Gtid_mode_copy {
   binary_log::enum_binlog_checksum_alg m_event_checksum_alg;
   binary_log::enum_binlog_checksum_alg m_slave_checksum_alg;
   ulonglong m_heartbeat_period;
-  time_t m_last_event_sent_ts;
+  timespec m_last_event_sent_ts;
   /*
     For mysqlbinlog(server_id is 0), it will stop immediately without waiting
     if it already reads all events.


### PR DESCRIPTION
Summary:
Dump thread used second granularity to decide whether
heartbeat needs to be sent to slaves. With milli-second heartbeat
configuration on slaves, this caused dump thread to send heartbeat
events for every skipped event. This significantly increases slave
start time. Fix this by increasing the granularity.

JIRA: https://jira.percona.com/browse/FB8-64

Fixes upstream bug: https://bugs.mysql.com/bug.php?id=81164

Reference patch: https://github.com/facebook/mysql-5.6/commit/1ac73cf

Test Plan:
The MTR changes done by the original patch doesn't result in measurable slave start time increase.
The change was verified manually with traces for 8.0:
with modified (millisecond) heartbeat_period in some rpl MTR testcases, the number of heartbeats is significatly lower with the patch applied.