### PR TITLE
FB8-54, FB8-55, FB8-70, FB8-101: Expose more information to audit plugin

### DIFF
--- a/include/mysql/plugin_audit.h
+++ b/include/mysql/plugin_audit.h
@@ -35,7 +35,7 @@
 #include "my_command.h"
 #include "my_sqlcommand.h"
 
-#define MYSQL_AUDIT_INTERFACE_VERSION 0x0401
+#define MYSQL_AUDIT_INTERFACE_VERSION 0x0402
 
 /**
  @enum mysql_event_class_t
@@ -138,6 +138,12 @@ struct mysql_event_general {
   MYSQL_LEX_CSTRING general_sql_command;
   MYSQL_LEX_CSTRING general_external_user;
   MYSQL_LEX_CSTRING general_ip;
+  /* Added in version 402 */
+  long long query_id;
+  MYSQL_LEX_CSTRING database;
+  long long affected_rows;
+  unsigned int port;
+  MYSQL_LEX_CSTRING connection_certificate;
 };
 
 /**

--- a/include/mysql/plugin_audit.h.pp
+++ b/include/mysql/plugin_audit.h.pp
@@ -379,6 +379,11 @@ struct mysql_event_general {
   MYSQL_LEX_CSTRING general_sql_command;
   MYSQL_LEX_CSTRING general_external_user;
   MYSQL_LEX_CSTRING general_ip;
+  long long query_id;
+  MYSQL_LEX_CSTRING database;
+  long long affected_rows;
+  unsigned int port;  
+  MYSQL_LEX_CSTRING connection_certificate;
 };
 typedef enum {
   MYSQL_AUDIT_CONNECTION_CONNECT = 1 << 0,

--- a/mysql-test/suite/audit_null/r/event_params.result
+++ b/mysql-test/suite/audit_null/r/event_params.result
@@ -1,0 +1,33 @@
+INSTALL PLUGIN null_audit SONAME 'adt_null.so';
+SET @@null_audit_extended_log = 1;
+CREATE TABLE foo (v INT);
+DROP TABLE foo;
+SHOW STATUS LIKE "Audit_null_generic_event_response";
+Variable_name	Value
+Audit_null_generic_event_response	database:test
+CREATE TABLE foo (v INT);
+SHOW STATUS LIKE "Audit_null_generic_event_response";
+Variable_name	Value
+Audit_null_generic_event_response	affected_rows:0
+INSERT INTO foo VALUES (1), (2);
+SHOW STATUS LIKE "Audit_null_generic_event_response";
+Variable_name	Value
+Audit_null_generic_event_response	affected_rows:2
+SELECT * FROM foo;
+v
+1
+2
+SHOW STATUS LIKE "Audit_null_generic_event_response";
+Variable_name	Value
+Audit_null_generic_event_response	affected_rows:-1
+DELETE FROM foo;
+SHOW STATUS LIKE "Audit_null_generic_event_response";
+Variable_name	Value
+Audit_null_generic_event_response	affected_rows:2
+DROP TABLE foo;
+SHOW STATUS LIKE "Audit_null_generic_event_response";
+Variable_name	Value
+Audit_null_generic_event_response	port:MYSQLD_PORT
+UNINSTALL PLUGIN null_audit;
+Warnings:
+Warning	1620	Plugin is busy and will be uninstalled on shutdown

--- a/mysql-test/suite/audit_null/r/event_params_cert.result
+++ b/mysql-test/suite/audit_null/r/event_params_cert.result
@@ -1,0 +1,16 @@
+INSTALL PLUGIN null_audit SONAME 'adt_null.so';
+CREATE USER cert_auth@localhost REQUIRE X509;
+GRANT SELECT ON test.* TO cert_auth@localhost;
+CREATE TABLE foo (i INT);
+FLUSH PRIVILEGES;
+SET @@null_audit_extended_log = 1;
+SELECT * FROM foo;
+i
+SHOW STATUS LIKE "Audit_null_generic_event_response";
+Variable_name	Value
+Audit_null_generic_event_response	connection_certificate:-----BEGIN CERTIFICATE-----\nMIIDyDCCArCgAwIBAgIJAOG0pVw936YVMA0GCSqGSIb3DQEBCwUAMGMxCzAJBgNV\nBAYTAlNFMRIwEAYDVQQIDAlTdG9ja2hvbG0xEjAQBgNVBAcMCVN0b2NraG9sbTEP\nMA0GA1UECgwGT3JhY2xlMQ4wDAYDVQQLDAVNeVNRTDELMAkGA1UEAwwCQ0EwHhcN\nMTQxMjA1MDQ0OTIzWhcNMjkxMjAxMDQ0OTIzWjBnMQswCQYDVQQGEwJTRTESMBAG\nA1UECAwJU3RvY2tob2xtMRIwEAYDVQQHDAlTdG9ja2hvbG0xDzANBgNVBAoMBk9y\nYWNsZTEOMAwGA1UECwwFTXlTUUwxDzANBgNVBAMMBkNsaWVudDCCASIwDQYJKoZI\nhvcNAQEBBQADggEPADCCAQoCggEBAMjRof6kjPMbF3EbdDUR4A5sQAr7wPfw67vJ\nHaHH17CK9vHP+mvQeWTru2mlDYAG31IU0oUyz7/OKkcoW80LKKu7BzPVi9O0csSm\ntcw3uQOoeFYlWB8XMHzRCrvsPKMDkJeZkkmus1eWXBrp6AIjrsjJBVBj5XehmnMG\ndA5GUCjYyU/EHDe4UhgLrxkr1OVmdKTz8No
+DROP USER cert_auth@localhost;
+DROP TABLE foo;
+UNINSTALL PLUGIN null_audit;
+Warnings:
+Warning	1620	Plugin is busy and will be uninstalled on shutdown

--- a/mysql-test/suite/audit_null/t/event_params-master.opt
+++ b/mysql-test/suite/audit_null/t/event_params-master.opt
@@ -1,0 +1,1 @@
+$AUDIT_NULL_OPT

--- a/mysql-test/suite/audit_null/t/event_params.test
+++ b/mysql-test/suite/audit_null/t/event_params.test
@@ -1,0 +1,44 @@
+--source include/have_null_audit_plugin.inc
+--source include/count_sessions.inc
+--source include/have_debug.inc
+
+eval INSTALL PLUGIN null_audit SONAME '$AUDIT_NULL';
+
+SET @@null_audit_extended_log = 1;
+
+## database name in generic event
+CREATE TABLE foo (v INT);
+DROP TABLE foo;
+
+--replace_regex /.*(database:[^;]*).*/\1/
+SHOW STATUS LIKE "Audit_null_generic_event_response";
+
+## affected_rows in generic event
+CREATE TABLE foo (v INT);
+--replace_regex /.*(affected_rows:[^;]*).*/\1/
+SHOW STATUS LIKE "Audit_null_generic_event_response";
+
+INSERT INTO foo VALUES (1), (2);
+--replace_regex /.*(affected_rows:[^;]*).*/\1/
+SHOW STATUS LIKE "Audit_null_generic_event_response";
+
+SELECT * FROM foo;
+--replace_regex /.*(affected_rows:[^;]*).*/\1/
+SHOW STATUS LIKE "Audit_null_generic_event_response";
+
+DELETE FROM foo;
+--replace_regex /.*(affected_rows:[^;]*).*/\1/
+SHOW STATUS LIKE "Audit_null_generic_event_response";
+
+DROP TABLE foo;
+
+## port
+let $MYSQLD_PORT= `SELECT @@port`;
+--replace_result $MYSQLD_PORT MYSQLD_PORT
+--replace_regex /.*(port:[^;]*).*/\1/
+SHOW STATUS LIKE "Audit_null_generic_event_response";
+
+
+UNINSTALL PLUGIN null_audit;
+
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/audit_null/t/event_params_cert-client.opt
+++ b/mysql-test/suite/audit_null/t/event_params_cert-client.opt
@@ -1,0 +1,4 @@
+--ssl-mode=VERIFY_CA
+--ssl-ca=$MYSQL_TEST_DIR/std_data/cacert.pem
+--ssl-cert=$MYSQL_TEST_DIR/std_data/client-cert.pem
+--ssl-key=$MYSQL_TEST_DIR/std_data/client-key.pem

--- a/mysql-test/suite/audit_null/t/event_params_cert-master.opt
+++ b/mysql-test/suite/audit_null/t/event_params_cert-master.opt
@@ -1,0 +1,1 @@
+$AUDIT_NULL_OPT

--- a/mysql-test/suite/audit_null/t/event_params_cert.test
+++ b/mysql-test/suite/audit_null/t/event_params_cert.test
@@ -1,0 +1,27 @@
+--source include/have_ssl.inc
+--source include/count_sessions.inc
+--source include/have_debug.inc
+
+eval INSTALL PLUGIN null_audit SONAME '$AUDIT_NULL';
+
+CREATE USER cert_auth@localhost REQUIRE X509;
+GRANT SELECT ON test.* TO cert_auth@localhost;
+CREATE TABLE foo (i INT);
+FLUSH PRIVILEGES;
+connect(con1,localhost,cert_auth,,,,,SSL);
+
+SET @@null_audit_extended_log = 1;
+
+SELECT * FROM foo;
+
+--replace_regex /.*(connection_certificate:[^;]*).*/\1/
+SHOW STATUS LIKE "Audit_null_generic_event_response";
+
+disconnect con1;
+connection default;
+DROP USER cert_auth@localhost;
+DROP TABLE foo;
+
+UNINSTALL PLUGIN null_audit;
+
+--source include/wait_until_count_sessions.inc

--- a/plugin/audit_null/CMakeLists.txt
+++ b/plugin/audit_null/CMakeLists.txt
@@ -23,5 +23,7 @@
 MYSQL_ADD_PLUGIN(audit_null audit_null.cc
   MODULE_ONLY MODULE_OUTPUT_NAME "adt_null")
 
+INCLUDE_DIRECTORIES(SYSTEM ${BOOST_PATCHES_DIR} ${BOOST_INCLUDE_DIR})
+
 MYSQL_ADD_PLUGIN(test_security_context test_security_context.cc
   TEST_ONLY MODULE_ONLY)

--- a/plugin/audit_null/audit_null.cc
+++ b/plugin/audit_null/audit_null.cc
@@ -25,6 +25,8 @@
 #include <mysqld_error.h>
 #include <stdio.h>
 #include <sys/types.h>
+#include <sstream>
+#include <boost/algorithm/string/replace.hpp>
 
 #include "lex_string.h"
 #include "m_ctype.h"
@@ -130,6 +132,13 @@ static char *g_record_buffer;
 
 #undef AUDIT_NULL_VAR
 
+#ifndef DBUG_OFF
+static const constexpr size_t event_response_buffer_len = 1000;
+static char generic_event_response[event_response_buffer_len + 1] = {
+    0,
+};
+#endif
+
 /*
   Plugin status variables for SHOW STATUS
 */
@@ -143,6 +152,11 @@ static SHOW_VAR simple_status[] = {
 #include "plugin/audit_null/audit_null_variables.h"
 
 #undef AUDIT_NULL_VAR
+
+#ifndef DBUG_OFF
+    {"Audit_null_generic_event_response", (char *)generic_event_response,
+     SHOW_CHAR, SHOW_SCOPE_GLOBAL},
+#endif
 
     {0, 0, SHOW_UNDEF, SHOW_SCOPE_GLOBAL}};
 
@@ -174,6 +188,12 @@ static MYSQL_THDVAR_INT(event_order_started, PLUGIN_VAR_RQCMDARG,
 static MYSQL_THDVAR_INT(event_order_check_exact, PLUGIN_VAR_RQCMDARG,
                         "Plugin checks exact event order.", NULL, NULL, 1, 0, 1,
                         0);
+
+#ifndef DBUG_OFF
+static MYSQL_THDVAR_INT(extended_log, PLUGIN_VAR_RQCMDARG,
+                        "Provide extended debug information with audit_null.",
+                        NULL, NULL, 1, 0, 1, 0);
+#endif
 
 static MYSQL_THDVAR_STR(event_record_def,
                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_MEMALLOC,
@@ -411,6 +431,45 @@ static int process_command(MYSQL_THD thd, LEX_CSTRING event_command,
   return 0;
 }
 
+#ifndef DBUG_OFF
+/*
+ * Exposes a generic audit log event in a status variable
+ */
+static void log_event(const mysql_event_general *event) {
+#define EVENT_PARAM(name) event_str << #name ":" << event->name << ";";
+#define EVENT_PARAM_STR(name)                             \
+  {                                                       \
+    std::string tmp(event->name.str, event->name.length); \
+    boost::replace_all(tmp, "\n", "\\n");                 \
+    event_str << #name ":" << tmp << ";";                 \
+  }
+  std::stringstream event_str;
+  EVENT_PARAM(event_subclass);
+  EVENT_PARAM(general_error_code);
+  // skipping general_thread_id
+  EVENT_PARAM_STR(general_user);
+  EVENT_PARAM_STR(general_command);
+  EVENT_PARAM_STR(general_query);
+  // EVENT_PARAM_STR(general_charset);
+  EVENT_PARAM(general_time);
+  EVENT_PARAM(general_rows);
+  EVENT_PARAM_STR(general_host);
+  EVENT_PARAM_STR(general_sql_command);
+  EVENT_PARAM_STR(general_external_user);
+  EVENT_PARAM_STR(general_ip);
+  EVENT_PARAM(query_id);
+  EVENT_PARAM_STR(database);
+  EVENT_PARAM(affected_rows);
+  EVENT_PARAM(port);
+  EVENT_PARAM_STR(connection_certificate);
+#undef EVENT_PARAM
+#undef EVENT_PARAM_STR
+
+  const std::string str = event_str.str();
+  strncpy(generic_event_response, str.c_str(), event_response_buffer_len);
+}
+#endif
+
 /**
   @brief Plugin function handler.
 
@@ -454,9 +513,16 @@ static int audit_null_notify(MYSQL_THD thd, mysql_event_class_t event_class,
       case MYSQL_AUDIT_GENERAL_RESULT:
         number_of_calls_general_result++;
         break;
-      case MYSQL_AUDIT_GENERAL_STATUS:
+      case MYSQL_AUDIT_GENERAL_STATUS: {
+#ifndef DBUG_OFF
+        const int extended_info = static_cast<int>(THDVAR(thd, extended_log));
+        if (extended_info != 0) {
+          log_event(static_cast<const mysql_event_general *>(event));
+        }
+#endif
         number_of_calls_general_status++;
         break;
+      }
       default:
         break;
     }
@@ -767,6 +833,9 @@ static SYS_VAR *system_variables[] = {
     MYSQL_SYSVAR(event_order_check_consume_ignore_count),
     MYSQL_SYSVAR(event_order_started),
     MYSQL_SYSVAR(event_order_check_exact),
+#ifndef DBUG_OFF
+    MYSQL_SYSVAR(extended_log),
+#endif
 
     MYSQL_SYSVAR(event_record_def),
     MYSQL_SYSVAR(event_record),

--- a/sql/auth/sql_authentication.cc
+++ b/sql/auth/sql_authentication.cc
@@ -1382,9 +1382,9 @@ static bool send_server_handshake_packet(MPVIO_EXT *mpvio, const char *data,
 
   end = my_stpnmov(end, server_version, SERVER_VERSION_LENGTH);
   end = my_stpcpy(end, " ");
-  end = my_stpnmov(end,
-                   MYSQL_COMPILATION_COMMENT,
-                   SERVER_VERSION_LENGTH - (end - buff - 1)) + 1;
+  end = my_stpnmov(end, MYSQL_COMPILATION_COMMENT,
+                   SERVER_VERSION_LENGTH - (end - buff - 1)) +
+        1;
 
   DBUG_ASSERT(sizeof(my_thread_id) == 4);
   int4store((uchar *)end, mpvio->thread_id);
@@ -1844,11 +1844,14 @@ static bool read_client_connect_attrs(char **ptr, size_t *max_bytes_available,
   return false;
 }
 
+typedef std::string Sql_string_t;
+static Sql_string_t x509_cert_write(X509 *cert);
+
 static bool acl_check_ssl(THD *thd, const ACL_USER *acl_user) {
 #if defined(HAVE_OPENSSL)
   Vio *vio = thd->get_protocol_classic()->get_vio();
   SSL *ssl = (SSL *)vio->ssl_arg;
-  X509 *cert;
+  X509 *cert = nullptr;
 #endif /* HAVE_OPENSSL */
 
   /*
@@ -1875,6 +1878,7 @@ static bool acl_check_ssl(THD *thd, const ACL_USER *acl_user) {
       if (vio_type(vio) == VIO_TYPE_SSL &&
           SSL_get_verify_result(ssl) == X509_V_OK &&
           (cert = SSL_get_peer_certificate(ssl))) {
+        thd->set_connection_certificate(x509_cert_write(cert));
         X509_free(cert);
         return 0;
       }
@@ -1924,6 +1928,7 @@ static bool acl_check_ssl(THD *thd, const ACL_USER *acl_user) {
         }
         OPENSSL_free(ptr);
       }
+      thd->set_connection_certificate(x509_cert_write(cert));
       X509_free(cert);
       return 0;
 #else  /* HAVE_OPENSSL */
@@ -4128,8 +4133,6 @@ static MYSQL_SYSVAR_BOOL(
 static SYS_VAR *sha256_password_sysvars[] = {
     MYSQL_SYSVAR(private_key_path), MYSQL_SYSVAR(public_key_path),
     MYSQL_SYSVAR(auto_generate_rsa_keys), 0};
-
-typedef std::string Sql_string_t;
 
 /**
   Exception free resize

--- a/sql/sql_audit.cc
+++ b/sql/sql_audit.cc
@@ -371,10 +371,17 @@ int mysql_audit_notify(THD *thd, mysql_event_general_subclass_t subclass,
   event.general_user.str = user_buff;
   event.general_user.length = make_user_name(sctx, user_buff);
   event.general_ip = sctx->ip();
+  event.database.str = thd->db().str;
+  event.database.length = thd->db().length;
+  event.query_id = thd->query_id;
   event.general_host = sctx->host();
   event.general_external_user = sctx->external_user();
   event.general_rows = thd->get_stmt_da()->current_row_for_condition();
   event.general_sql_command = sql_statement_names[thd->lex->sql_command];
+  event.affected_rows = thd->get_row_count_func();
+  event.port = mysqld_port;
+  event.connection_certificate.str = thd->connection_certificate().c_str();
+  event.connection_certificate.length = thd->connection_certificate().size();
 
   thd_get_audit_query(thd, &event.general_query,
                       (const CHARSET_INFO **)&event.general_charset);

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -863,6 +863,8 @@ void THD::cleanup_connection(void) {
   sp_cache_clear(&sp_proc_cache);
   sp_cache_clear(&sp_func_cache);
 
+  m_connection_certificate = "";
+
   clear_error();
   // clear the warnings
   get_stmt_da()->reset_condition_info(this);
@@ -891,6 +893,15 @@ void THD::cleanup_connection(void) {
   }
     /* DEBUG code only (end) */
 #endif
+}
+
+void THD::set_connection_certificate(std::string const &cert) {
+  DBUG_ASSERT(m_connection_certificate.empty());
+  m_connection_certificate = cert;
+}
+
+std::string const &THD::connection_certificate() const noexcept {
+  return m_connection_certificate;
 }
 
 /*
@@ -1057,6 +1068,8 @@ void THD::release_resources() {
   mysql_audit_free_thd(this);
 
   if (current_thd == this) restore_globals();
+
+  m_connection_certificate = "";
 
   m_release_resources_done = true;
 }

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -3323,6 +3323,11 @@ class THD : public MDL_context_owner,
   Gtid_set owned_gtid_set;
 #endif
 
+  std::string m_connection_certificate;
+
+  std::string const &connection_certificate() const noexcept;
+  void set_connection_certificate(std::string const &cert);
+
   /*
    Replication related context.
 
@@ -4032,6 +4037,7 @@ class THD : public MDL_context_owner,
     m_persist_variables_init = is_init;
   }
   bool is_persist_variables_init() { return m_persist_variables_init; }
+
  private:
   bool m_persist_variables_init = false;
 };


### PR DESCRIPTION
Summary:
This commit adds the following fields to the generic event in audit log:
* query_id
* database
* affected_rows
* connection_certificate

Reference Patch: https://github.com/facebook/mysql-5.6/commit/1def6b7
Reference Patch: https://github.com/facebook/mysql-5.6/commit/ce95a09
Reference Patch: https://github.com/facebook/mysql-5.6/commit/588be34
Reference Patch: https://github.com/facebook/mysql-5.6/commit/ba03c70
Reference Patch: https://github.com/facebook/mysql-5.6/commit/be8c587
Reference Patch: https://github.com/facebook/mysql-5.6/commit/22b2508

We need some extra info for the shadowing and security logging. This is a
simple first step of info that MariaDB actually also exposes.
Now we would have the `query_id` and the database name for general events.
Making as few changes as possible to accomplish it, so I'm just taking the
information from the TDH and exposing it through `mysql_event_general`
struct and as a argument to disconnect.

Forward the connection certificate to the audit plugin. The connection certificate can then be parsed by the audit plugin and handled appropriately. It made more sense for the certificate to live in the connection events, since they generally don't change between every general event, so the move was done.

This is done by caching a BUF_MEM struct on the THD object. Since it's not possible to change certificates on the same connection, this caching should be correct. The BUF_MEM is released on THD::release_resources.

If upstream bumps the MYSQL_AUDIT_INTERFACE_VERSION, we should bump ours to be greater or equal to it.

Expose the port current mysqld is running on for the audit plugin. If no port, 0 is used.

Test Plan:
This commit also introduces changes to the audit_null plugin, which makes
the fields, and further similar changes testable.
The audit_null plugin now has the "extended_log" variable, which can be
turned on. When it's ON, the plugin logs the last generic event log
into the Audit_null_generic_event_response system variable.
This can be easily verified in MTR tests, which is done in the new
audit_null.event_params testcase.