### PR TITLE
FB8-69: Don't force flush relay log info

### DIFF
--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -6151,7 +6151,8 @@ bool mts_checkpoint_routine(Relay_log_info *rli, bool force) {
          waiter: set wait_flag; waits....; drops wait_flag;
   */
 
-  error = rli->flush_info(true);
+  if (get_gtid_mode(GTID_MODE_LOCK_NONE) != GTID_MODE_ON)
+    error = rli->flush_info(true);
 
   mysql_cond_broadcast(&rli->data_cond);
   mysql_mutex_unlock(&rli->data_lock);


### PR DESCRIPTION
Summary:

With gtid enabled, flushing relay log info is not necessary. The force flushing is required to ensure recovery of MTS in non-gtid mode. The coordinator thread relies on positions in the relay log info repository during recovery. With GTID, this is not required and sql_thread doesn't even need to do any recovery. The slave (io_thread) uses auto-positioning directly.

JIRA: https://jira.percona.com/browse/FB8-69

Reference Patch: https://github.com/facebook/mysql-5.6/commit/ed39d49