### PR TITLE
FB8-86: Delete crash safe index file if index file exists

### DIFF
--- a/share/errmsg-utf8.txt
+++ b/share/errmsg-utf8.txt
@@ -18706,6 +18706,9 @@ ER_BINLOG_INDEX_PREV_GTID_OUTOFMEMORY
 ER_BINLOG_INDEX_PREV_GTID_CORRUPT
   eng "MYSQL_BINLOG::init_gtid_sets failed because previous gtid set of binlog %s is corrupted in the index file"
 
+ER_BINLOG_CANT_DELETE_TMP_INDEX
+  eng "%s failed to delete the crash safe index file."
+
 #
 # End of 8.0 FB MySQL error messages.
 # (Please read comments from the header of this section before adding error


### PR DESCRIPTION
JIRA: https://jira.percona.com/browse/FB8-86

Reference Patch: https://github.com/facebook/mysql-5.6/commit/78fa270

Summary:
Crash safe index file is created when any change is made to the index
file. The index file is first copied over to the crash safe one and then stuff
is added/removed from the crash safe index file. Finally, the old index file is
deleted and crash safe index file is renamed to the index file. There might be a
scenario where mysql crashes after stuff is changed in the crash safe file
but before the old index file is deleted. In this case we should delete the
crash safe index file at restart. If we don't delete it subsequent changes to
the index file can corrupt it because it can be copied to the old crash safe
file which already has some data in it.