### PR TITLE
FB8-56: Create a new mode SEMI_STRICT for slave_exec_mode

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_slave_exec_mode_semi_strict.result
+++ b/mysql-test/suite/rpl/r/rpl_slave_exec_mode_semi_strict.result
@@ -1,0 +1,14 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+CREATE TABLE t1 (a INT PRIMARY KEY, b int) ENGINE=Innodb;
+INSERT INTO t1 VALUES(1, 2);
+include/sync_slave_sql_with_master.inc
+DELETE FROM t1 WHERE a=1;
+DELETE FROM t1 WHERE a=1;
+include/sync_slave_sql_with_master.inc
+include/assert.inc [Check if Rbr_unsafe_queries is increased by 1]
+DROP TABLE t1;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_slave_exec_mode_semi_strict-slave.opt
+++ b/mysql-test/suite/rpl/t/rpl_slave_exec_mode_semi_strict-slave.opt
@@ -1,0 +1,1 @@
+--slave_exec_mode=SEMI_STRICT

--- a/mysql-test/suite/rpl/t/rpl_slave_exec_mode_semi_strict.test
+++ b/mysql-test/suite/rpl/t/rpl_slave_exec_mode_semi_strict.test
@@ -1,0 +1,24 @@
+source include/have_binlog_format_row.inc;
+source include/master-slave.inc;
+connection master;
+
+CREATE TABLE t1 (a INT PRIMARY KEY, b int) ENGINE=Innodb;
+INSERT INTO t1 VALUES(1, 2);
+
+--source include/sync_slave_sql_with_master.inc
+--let $unsafe_queries_before= query_get_value(SHOW GLOBAL STATUS LIKE 'Rbr_unsafe_queries', Value, 1)
+DELETE FROM t1 WHERE a=1;
+
+connection master;
+DELETE FROM t1 WHERE a=1;
+--source include/sync_slave_sql_with_master.inc
+
+--let $unsafe_queries_after= query_get_value(SHOW GLOBAL STATUS LIKE 'Rbr_unsafe_queries', Value, 1)
+--let $assert_text= Check if Rbr_unsafe_queries is increased by 1
+--let $assert_cond= $unsafe_queries_after - $unsafe_queries_before = 1
+--source include/assert.inc
+
+connection master;
+DROP TABLE t1;
+source include/rpl_end.inc;
+

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -8310,10 +8310,18 @@ int Rows_log_event::handle_idempotent_and_ignored_errors(
     int actual_error = convert_handler_error(error, thd, m_table);
     bool idempotent_error = (idempotent_error_code(error) &&
                              (rbr_exec_mode == RBR_EXEC_MODE_IDEMPOTENT));
-    bool ignored_error =
-        (idempotent_error == 0 ? ignored_error_code(actual_error) : 0);
+    bool ignore_delete_error =
+        (rbr_exec_mode == RBR_EXEC_MODE_SEMI_STRICT &&
+         (error == HA_ERR_RECORD_CHANGED || error == HA_ERR_KEY_NOT_FOUND));
+    bool ignored_error = ((idempotent_error == 0 && !ignore_delete_error)
+                              ? ignored_error_code(actual_error)
+                              : 0);
 
-    if (idempotent_error || ignored_error) {
+    if (ignore_delete_error) {
+      ++rbr_unsafe_queries;
+    }
+
+    if (idempotent_error || ignored_error || ignore_delete_error) {
       loglevel ll;
       if (idempotent_error)
         ll = WARNING_LEVEL;
@@ -8326,7 +8334,7 @@ int Rows_log_event::handle_idempotent_and_ignored_errors(
       thd->get_stmt_da()->reset_condition_info(thd);
       clear_all_errors(thd, const_cast<Relay_log_info *>(rli));
       *err = 0;
-      if (idempotent_error == 0) return ignored_error;
+      if (idempotent_error == 0 && !ignore_delete_error) return ignored_error;
     }
   }
 

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1011,6 +1011,8 @@ mysql_mutex_t LOCK_mandatory_roles;
 mysql_mutex_t LOCK_password_history;
 mysql_mutex_t LOCK_password_reuse_interval;
 
+ulonglong rbr_unsafe_queries = 0;
+
 /* Number of times the IO thread connected to the master */
 ulong relay_io_connected = 0;
 
@@ -8687,6 +8689,8 @@ SHOW_VAR status_vars[] = {
     {"Queries", (char *)&show_queries, SHOW_FUNC, SHOW_SCOPE_ALL},
     {"Questions", (char *)offsetof(System_status_var, questions),
      SHOW_LONGLONG_STATUS, SHOW_SCOPE_ALL},
+    {"Rbr_unsafe_queries", (char *)&rbr_unsafe_queries, SHOW_LONGLONG,
+     SHOW_SCOPE_GLOBAL},
     {"Relay_log_io_connected", (char *)&relay_io_connected, SHOW_LONG,
      SHOW_SCOPE_GLOBAL},
     {"Relay_log_io_events", (char *)&relay_io_events, SHOW_LONG,

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -321,6 +321,7 @@ extern const char *binlog_error_action_list[];
 
 extern bool opt_log_slow_extra;
 
+extern ulonglong rbr_unsafe_queries;
 extern ulong relay_io_connected;
 extern ulong relay_io_events, relay_sql_events;
 extern ulonglong relay_io_bytes, relay_sql_bytes;

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -3376,7 +3376,8 @@ static Sys_var_bool Sys_slave_compressed_protocol(
     GLOBAL_VAR(opt_slave_compressed_protocol), CMD_LINE(OPT_ARG),
     DEFAULT(false));
 
-static const char *slave_exec_mode_names[] = {"STRICT", "IDEMPOTENT", 0};
+static const char *slave_exec_mode_names[] = {"STRICT", "IDEMPOTENT",
+                                              "SEMI_STRICT", 0};
 static Sys_var_enum Slave_exec_mode(
     "slave_exec_mode",
     "Modes for how replication events should be executed. Legal values "

--- a/sql/system_variables.h
+++ b/sql/system_variables.h
@@ -53,6 +53,7 @@ enum enum_binlog_format {
 enum enum_rbr_exec_mode {
   RBR_EXEC_MODE_STRICT,
   RBR_EXEC_MODE_IDEMPOTENT,
+  RBR_EXEC_MODE_SEMI_STRICT,
   RBR_EXEC_MODE_LAST_BIT
 };
 


### PR DESCRIPTION
JIRA: https://jira.percona.com/browse/FB8-56

Reference Patch: https://github.com/facebook/mysql-5.6/commit/9d97282

Summary:
Create a new mode SEMI_STRICT which ignores HA_ERR_RECORD_CHANGED and HA_ERR_KEY_NOT_FOUND errors.
A new status counter will track the usage of this new mode. Logging a warning/error message may cause error log to get flooded with same error message, so I decided against it.

Test Plan: mtr
