### PR TITLE
FB8-82: Removing unchanged columns from AI when when row image is not FULL

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_row_img_sanity.result
+++ b/mysql-test/suite/rpl/r/rpl_row_img_sanity.result
@@ -534,6 +534,9 @@ include/rpl_reset.inc
 include/sync_slave_sql_with_master.inc
 ####### MINIMAL OTHER PARTICULAR SCENARIO ######
 include/sync_slave_sql_with_master.inc
+####### MINIMAL AND COMPLETE PARTICULAR SCENARIO SETTING SAME VALUE ######
+include/sync_slave_sql_with_master.inc
+include/sync_slave_sql_with_master.inc
 CON: 'master', IMG: 'NOBLOB', RESTART SLAVE: 'N'
 Variable_name	Value
 binlog_row_image	NOBLOB
@@ -575,6 +578,9 @@ include/rpl_reset.inc
 include/sync_slave_sql_with_master.inc
 include/sync_slave_sql_with_master.inc
 include/rpl_reset.inc
+####### MINIMAL AND COMPLETE PARTICULAR SCENARIO SETTING SAME VALUE ######
+include/sync_slave_sql_with_master.inc
+include/sync_slave_sql_with_master.inc
 ################## SPECIAL CASES #########################
 include/rpl_reset.inc
 CON: 'master', IMG: 'NOBLOB', RESTART SLAVE: 'N'

--- a/mysql-test/suite/rpl/r/rpl_row_jsondiff_basic_nokey.result
+++ b/mysql-test/suite/rpl/r/rpl_row_jsondiff_basic_nokey.result
@@ -43,7 +43,7 @@ UPDATE `test`.`t` SET j='["a", 4]' WHERE i=1 AND j=CAST('[1, 2]' AS JSON) AND k=
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j='["a", 4]', k=k WHERE i=1 AND j=CAST('[1, 2]' AS JSON) AND k=CAST('[3, 4]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='["a", 4]', k=k WHERE i=1 AND j=CAST('[1, 2]' AS JSON) AND k=CAST('[3, 4]' AS JSON);
+UPDATE `test`.`t` SET j='["a", 4]' WHERE i=1 AND j=CAST('[1, 2]' AS JSON) AND k=CAST('[3, 4]' AS JSON);
 ---- 2. Update one row using full format (no JSON function used) ----
 include/rpl_row_jsondiff_scenario.inc
 * CREATE TABLE test.t (i INT , j JSON)
@@ -59,7 +59,7 @@ UPDATE `test`.`t` SET j='7' WHERE i=1 AND j=CAST('[1, 2]' AS JSON);
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j='7' WHERE i=1 AND j=CAST('[1, 2]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='7' WHERE i=1 AND j=CAST('[1, 2]' AS JSON);
+UPDATE `test`.`t` SET j='7' WHERE i=1 AND j=CAST('[1, 2]' AS JSON);
 ---- 3. Update one row using full format (wrong JSON function used (1)) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -76,7 +76,7 @@ UPDATE `test`.`t` SET j='[1, 2, 8]' WHERE i=1 AND j=CAST('[1, 2]' AS JSON);
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j='[1, 2, 8]' WHERE i=1 AND j=CAST('[1, 2]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='[1, 2, 8]' WHERE i=1 AND j=CAST('[1, 2]' AS JSON);
+UPDATE `test`.`t` SET j='[1, 2, 8]' WHERE i=1 AND j=CAST('[1, 2]' AS JSON);
 ---- 4. Update one row using full format (wrong JSON function used (2)) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -93,7 +93,7 @@ UPDATE `test`.`t` SET j='[3, 2, 8]' WHERE i=1 AND j=CAST('[1, 2]' AS JSON);
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j='[3, 2, 8]' WHERE i=1 AND j=CAST('[1, 2]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='[3, 2, 8]' WHERE i=1 AND j=CAST('[1, 2]' AS JSON);
+UPDATE `test`.`t` SET j='[3, 2, 8]' WHERE i=1 AND j=CAST('[1, 2]' AS JSON);
 ---- 5. Update one row using full format (wrong JSON function used (3)) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -110,7 +110,7 @@ UPDATE `test`.`t` SET j='[3, 2, 8]' WHERE i=1 AND j=CAST('[1, 2]' AS JSON);
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j='[3, 2, 8]' WHERE i=1 AND j=CAST('[1, 2]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='[3, 2, 8]' WHERE i=1 AND j=CAST('[1, 2]' AS JSON);
+UPDATE `test`.`t` SET j='[3, 2, 8]' WHERE i=1 AND j=CAST('[1, 2]' AS JSON);
 ---- 6. Update one row using full format (full smaller than partial) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -125,7 +125,7 @@ UPDATE `test`.`t` SET j='[3, 2]' WHERE i=1 AND j=CAST('[1, 2]' AS JSON);
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j='[3, 2]' WHERE i=1 AND j=CAST('[1, 2]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='[3, 2]' WHERE i=1 AND j=CAST('[1, 2]' AS JSON);
+UPDATE `test`.`t` SET j='[3, 2]' WHERE i=1 AND j=CAST('[1, 2]' AS JSON);
 ==== Single diffs ====
 ---- 7. Update one row (REPLACE using JSON_REPLACE in array) ----
 include/rpl_row_jsondiff_scenario.inc
@@ -141,7 +141,7 @@ UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', 7) WHERE i=1 AND j=CAST('[1, {"a
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_REPLACE(j, '$[0]', 7) WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_REPLACE(j, '$[0]', 7) WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
+UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', 7) WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
 ---- 8. Update one row (REPLACE using JSON_SET in array) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -156,7 +156,7 @@ UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', '7') WHERE i=1 AND j=CAST('[1, {
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_REPLACE(j, '$[0]', '7') WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_REPLACE(j, '$[0]', '7') WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
+UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', '7') WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
 ---- 9. Update one row (REPLACE using JSON_REPLACE in object) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -171,7 +171,7 @@ UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[1].a', CAST('[7]' AS JSON)) WHERE i=1
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_REPLACE(j, '$[1].a', CAST('[7]' AS JSON)) WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_REPLACE(j, '$[1].a', CAST('[7]' AS JSON)) WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
+UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[1].a', CAST('[7]' AS JSON)) WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
 ---- 10. Update one row (REPLACE using JSON_SET in object) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -186,7 +186,7 @@ UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[1].a', CAST('{"a": 7}' AS JSON)) WHER
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_REPLACE(j, '$[1].a', CAST('{"a": 7}' AS JSON)) WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_REPLACE(j, '$[1].a', CAST('{"a": 7}' AS JSON)) WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
+UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[1].a', CAST('{"a": 7}' AS JSON)) WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
 ---- 11. Update one row (INSERT using JSON_SET in array) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -201,7 +201,7 @@ UPDATE `test`.`t` SET j=JSON_SET(j, '$[2]', 3) WHERE i=1 AND j=CAST('[1, {"a": 2
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_SET(j, '$[2]', 3) WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_SET(j, '$[2]', 3) WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
+UPDATE `test`.`t` SET j=JSON_SET(j, '$[2]', 3) WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
 ---- 12. Update one row (INSERT using JSON_SET in object) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -216,7 +216,7 @@ UPDATE `test`.`t` SET j=JSON_SET(j, '$[1].b', 4) WHERE i=1 AND j=CAST('[1, {"a":
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_SET(j, '$[1].b', 4) WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_SET(j, '$[1].b', 4) WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
+UPDATE `test`.`t` SET j=JSON_SET(j, '$[1].b', 4) WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
 ---- 13. Update one row (REMOVE using JSON_REMOVE in array) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -231,7 +231,7 @@ UPDATE `test`.`t` SET j=JSON_REMOVE(j, '$[1]') WHERE i=1 AND j=CAST('[1, {"a": 2
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_REMOVE(j, '$[1]') WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_REMOVE(j, '$[1]') WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
+UPDATE `test`.`t` SET j=JSON_REMOVE(j, '$[1]') WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
 ---- 14. Update one row (REMOVE using JSON_REMOVE in object) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -246,7 +246,7 @@ UPDATE `test`.`t` SET j=JSON_REMOVE(j, '$[1].a') WHERE i=1 AND j=CAST('[1, {"a":
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_REMOVE(j, '$[1].a') WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_REMOVE(j, '$[1].a') WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
+UPDATE `test`.`t` SET j=JSON_REMOVE(j, '$[1].a') WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
 ==== Multiple diffs from one function call ====
 ---- 15. Update one row (many different update types, using JSON_SET) ----
 include/rpl_row_jsondiff_scenario.inc
@@ -262,7 +262,7 @@ UPDATE `test`.`t` SET j=JSON_SET( JSON_SET( JSON_REPLACE(j, '$[0]', 'one', '$[1]
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_SET( JSON_SET( JSON_REPLACE(j, '$[0]', 'one', '$[1]', 'two', '$[2].a', 'three', '$[2].b', 'four'), '$[2].c', 'five', '$[2].d', 'six'), '$[3]', 'seven', '$[4]', 'eight') WHERE i=1 AND j=CAST('[1, 2, {"a": 3, "b": 4, "a long string that ensures that the diff format is smaller than the full format": ""}]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_SET( JSON_SET( JSON_REPLACE(j, '$[0]', 'one', '$[1]', 'two', '$[2].a', 'three', '$[2].b', 'four'), '$[2].c', 'five', '$[2].d', 'six'), '$[3]', 'seven', '$[4]', 'eight') WHERE i=1 AND j=CAST('[1, 2, {"a": 3, "b": 4, "a long string that ensures that the diff format is smaller than the full format": ""}]' AS JSON);
+UPDATE `test`.`t` SET j=JSON_SET( JSON_SET( JSON_REPLACE(j, '$[0]', 'one', '$[1]', 'two', '$[2].a', 'three', '$[2].b', 'four'), '$[2].c', 'five', '$[2].d', 'six'), '$[3]', 'seven', '$[4]', 'eight') WHERE i=1 AND j=CAST('[1, 2, {"a": 3, "b": 4, "a long string that ensures that the diff format is smaller than the full format": ""}]' AS JSON);
 ---- 16. Update one row (many different update types, using JSON_REPLACE) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -277,7 +277,7 @@ UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', 'one', '$[1]', 'two', '$[0]', 'O
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_REPLACE(j, '$[0]', 'one', '$[1]', 'two', '$[0]', 'ONE', '$[1]', 'TWO') WHERE i=1 AND j=CAST('[1, 2, {"a": 3, "b": 4, "a long string that ensures that the diff format is smaller than the full format": ""}]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_REPLACE(j, '$[0]', 'one', '$[1]', 'two', '$[0]', 'ONE', '$[1]', 'TWO') WHERE i=1 AND j=CAST('[1, 2, {"a": 3, "b": 4, "a long string that ensures that the diff format is smaller than the full format": ""}]' AS JSON);
+UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', 'one', '$[1]', 'two', '$[0]', 'ONE', '$[1]', 'TWO') WHERE i=1 AND j=CAST('[1, 2, {"a": 3, "b": 4, "a long string that ensures that the diff format is smaller than the full format": ""}]' AS JSON);
 ---- 17. Update one row (using JSON_REMOVE) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -292,7 +292,7 @@ UPDATE `test`.`t` SET j=JSON_REMOVE(j, '$[1]', '$[0]') WHERE i=1 AND j=CAST('[1,
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_REMOVE(j, '$[1]', '$[0]') WHERE i=1 AND j=CAST('[1, 2, {"a": 3, "b": 4, "a long string that ensures that the diff format is smaller than the full format": ""}]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_REMOVE(j, '$[1]', '$[0]') WHERE i=1 AND j=CAST('[1, 2, {"a": 3, "b": 4, "a long string that ensures that the diff format is smaller than the full format": ""}]' AS JSON);
+UPDATE `test`.`t` SET j=JSON_REMOVE(j, '$[1]', '$[0]') WHERE i=1 AND j=CAST('[1, 2, {"a": 3, "b": 4, "a long string that ensures that the diff format is smaller than the full format": ""}]' AS JSON);
 ==== Multiple diffs from multiple function calls ====
 ---- 18. Update one row (using JSON_SET, JSON_REPLACE, and JSON_REMOVE) ----
 include/rpl_row_jsondiff_scenario.inc
@@ -308,7 +308,7 @@ UPDATE `test`.`t` SET j=JSON_REMOVE( JSON_SET( JSON_REPLACE(j, '$[0]', 'one', '$
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_REMOVE( JSON_SET( JSON_REPLACE(j, '$[0]', 'one', '$[1]', 'two', '$[2]', CAST('{"a": 1}' AS JSON)), '$[2].b', 2, '$[2].c', 3), '$[0]', '$[0]') WHERE i=1 AND j=CAST('[1, 2, 3, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_REMOVE( JSON_SET( JSON_REPLACE(j, '$[0]', 'one', '$[1]', 'two', '$[2]', CAST('{"a": 1}' AS JSON)), '$[2].b', 2, '$[2].c', 3), '$[0]', '$[0]') WHERE i=1 AND j=CAST('[1, 2, 3, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
+UPDATE `test`.`t` SET j=JSON_REMOVE( JSON_SET( JSON_REPLACE(j, '$[0]', 'one', '$[1]', 'two', '$[2]', CAST('{"a": 1}' AS JSON)), '$[2].b', 2, '$[2].c', 3), '$[0]', '$[0]') WHERE i=1 AND j=CAST('[1, 2, 3, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
 ==== NULL values ====
 ---- 19. Updating from non-NULL to NULL using JSON_SET ----
 include/rpl_row_jsondiff_scenario.inc
@@ -324,7 +324,7 @@ UPDATE `test`.`t` SET j=NULL WHERE i=1 AND j=CAST('[1, 2, 3, 4]' AS JSON);
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=NULL WHERE i=1 AND j=CAST('[1, 2, 3, 4]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=NULL WHERE i=1 AND j=CAST('[1, 2, 3, 4]' AS JSON);
+UPDATE `test`.`t` SET j=NULL WHERE i=1 AND j=CAST('[1, 2, 3, 4]' AS JSON);
 ---- 20. Updating from non-NULL to NULL using JSON_REPLACE ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -339,7 +339,7 @@ UPDATE `test`.`t` SET j=NULL WHERE i=1 AND j=CAST('[1, 2, 3, 4]' AS JSON);
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=NULL WHERE i=1 AND j=CAST('[1, 2, 3, 4]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=NULL WHERE i=1 AND j=CAST('[1, 2, 3, 4]' AS JSON);
+UPDATE `test`.`t` SET j=NULL WHERE i=1 AND j=CAST('[1, 2, 3, 4]' AS JSON);
 ---- 21. Updating from non-NULL to NULL using JSON_REMOVE ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -354,7 +354,7 @@ UPDATE `test`.`t` SET j=NULL WHERE i=1 AND j=CAST('[1, 2, 3, 4]' AS JSON);
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=NULL WHERE i=1 AND j=CAST('[1, 2, 3, 4]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=NULL WHERE i=1 AND j=CAST('[1, 2, 3, 4]' AS JSON);
+UPDATE `test`.`t` SET j=NULL WHERE i=1 AND j=CAST('[1, 2, 3, 4]' AS JSON);
 ---- 22. Updating from NULL to non-NULL using JSON_SET ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -369,7 +369,7 @@ UPDATE `test`.`t` SET j='{"a": "a", "b": null}' WHERE i=1 AND j IS NULL;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j='{"a": "a", "b": null}' WHERE i=1 AND j IS NULL;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='{"a": "a", "b": null}' WHERE i=1 AND j IS NULL;
+UPDATE `test`.`t` SET j='{"a": "a", "b": null}' WHERE i=1 AND j IS NULL;
 ---- 23. Updating from NULL to non-NULL using JSON_REPLACE ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -384,7 +384,7 @@ UPDATE `test`.`t` SET j='{"a": null}' WHERE i=1 AND j IS NULL;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j='{"a": null}' WHERE i=1 AND j IS NULL;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='{"a": null}' WHERE i=1 AND j IS NULL;
+UPDATE `test`.`t` SET j='{"a": null}' WHERE i=1 AND j IS NULL;
 ---- 24. Updating from NULL to non-NULL using JSON_REMOVE ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -399,7 +399,7 @@ UPDATE `test`.`t` SET j='{"a": "a", "b": "BB"}' WHERE i=1 AND j IS NULL;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j='{"a": "a", "b": "BB"}' WHERE i=1 AND j IS NULL;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='{"a": "a", "b": "BB"}' WHERE i=1 AND j IS NULL;
+UPDATE `test`.`t` SET j='{"a": "a", "b": "BB"}' WHERE i=1 AND j IS NULL;
 ==== No-op updates ====
 ---- 25. Making a no-op not mentioning the column ----
 include/rpl_row_jsondiff_scenario.inc
@@ -416,7 +416,7 @@ UPDATE `test`.`t` SET x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND 
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 ---- 26. Making a no-op setting the column to itself ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -427,11 +427,11 @@ UPDATE t SET x = 2, j = j WHERE i = 1
 i	j	x
 1	["a", {"b": "c"}]	2
 # Decoded rows
-UPDATE `test`.`t` SET j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 ---- 27. Making a no-op setting the column to its own value (1) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -442,11 +442,11 @@ UPDATE t SET x = 2, j = CONCAT(j, '') WHERE i = 1
 i	j	x
 1	["a", {"b": "c"}]	2
 # Decoded rows
-UPDATE `test`.`t` SET j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 ---- 28. Making a no-op setting the column to its own value (2) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -457,11 +457,11 @@ UPDATE t SET x = 2, j = '["a", {"b": "c"}]' WHERE i = 1
 i	j	x
 1	["a", {"b": "c"}]	2
 # Decoded rows
-UPDATE `test`.`t` SET j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 ---- 29. Making a no-op using JSON_SET inserting object in non-object or array element in non-array ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -476,7 +476,7 @@ UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[1]', CAST('[{"b": "c"}, 1]' AS JSON))
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_REPLACE(j, '$[1]', CAST('[{"b": "c"}, 1]' AS JSON)), x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_REPLACE(j, '$[1]', CAST('[{"b": "c"}, 1]' AS JSON)), x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
+UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[1]', CAST('[{"b": "c"}, 1]' AS JSON)), x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 ---- 30. Making a no-op using JSON_REPLACE with non-existing paths ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -487,11 +487,11 @@ UPDATE t SET x = 2, j = JSON_REPLACE(j, '$[9]', 0, '$.x', 1, '$[1].x', 2) WHERE 
 i	j	x
 1	["a", {"b": "c"}]	2
 # Decoded rows
-UPDATE `test`.`t` SET j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 ---- 31. Making a no-op removing a non-existing path, using JSON_REMOVE ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -506,7 +506,7 @@ UPDATE `test`.`t` SET j=JSON_REMOVE(j, '$[1]'), x=2 WHERE i=1 AND j=CAST('["a", 
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_REMOVE(j, '$[1]'), x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_REMOVE(j, '$[1]'), x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
+UPDATE `test`.`t` SET j=JSON_REMOVE(j, '$[1]'), x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 ---- 32. Making a no-op replacing a JSON value by itself, using JSON_SET ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -517,11 +517,11 @@ UPDATE t SET x = 2, j = JSON_SET(j, '$[0]', 'a', '$[1].b', 'c', '$[0]', 'a') WHE
 i	j	x
 1	["a", {"b": "c"}]	2
 # Decoded rows
-UPDATE `test`.`t` SET j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 ---- 33. Making a no-op replacing a JSON value by itself, using JSON_REPLACE ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -532,11 +532,11 @@ UPDATE t SET x = 2, j = JSON_REPLACE(j, '$[0]', 'a', '$[1].b', 'c', '$[0]', 'a')
 i	j	x
 1	["a", {"b": "c"}]	2
 # Decoded rows
-UPDATE `test`.`t` SET j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 ---- 34. Making a no-op update using JSON_SET, JSON_REPLACE, and JSON_REMOVE ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -550,11 +550,11 @@ UPDATE t SET x = 2, j = JSON_SET(JSON_REMOVE(JSON_REPLACE(j,
 i	j	x
 1	["a", {"b": "c"}]	2
 # Decoded rows
-UPDATE `test`.`t` SET j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 ==== Long paths ====
 ---- 35. Update using long path ----
 include/rpl_row_jsondiff_scenario.inc
@@ -571,7 +571,7 @@ UPDATE `test`.`t` SET j=JSON_SET(j, '$.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_SET(j, '$.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'ghi') WHERE i=1 AND j=CAST('{"abc": "def"}' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_SET(j, '$.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'ghi') WHERE i=1 AND j=CAST('{"abc": "def"}' AS JSON);
+UPDATE `test`.`t` SET j=JSON_SET(j, '$.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'ghi') WHERE i=1 AND j=CAST('{"abc": "def"}' AS JSON);
 ---- 36. Update using long document ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -586,7 +586,7 @@ UPDATE `test`.`t` SET j=JSON_SET(j, '$.ghi', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_SET(j, '$.ghi', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa') WHERE i=1 AND j=CAST('{"abc": "def"}' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_SET(j, '$.ghi', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa') WHERE i=1 AND j=CAST('{"abc": "def"}' AS JSON);
+UPDATE `test`.`t` SET j=JSON_SET(j, '$.ghi', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa') WHERE i=1 AND j=CAST('{"abc": "def"}' AS JSON);
 ---- 37. Update using very long document ----
 include/rpl_row_jsondiff_scenario.inc
 ==== Auto-wrapping ====
@@ -604,7 +604,7 @@ UPDATE `test`.`t` SET j='[{"a": 1}, 4711]' WHERE i=1 AND j=CAST('{"a": 1}' AS JS
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j='[{"a": 1}, 4711]' WHERE i=1 AND j=CAST('{"a": 1}' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='[{"a": 1}, 4711]' WHERE i=1 AND j=CAST('{"a": 1}' AS JSON);
+UPDATE `test`.`t` SET j='[{"a": 1}, 4711]' WHERE i=1 AND j=CAST('{"a": 1}' AS JSON);
 ==== Multi-row updates ====
 ---- 39. Update two rows: both partial ----
 include/rpl_row_jsondiff_scenario.inc
@@ -628,8 +628,8 @@ UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[
 UPDATE `test`.`t` SET i=2, j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=2 AND j=CAST('[4, 5, 6, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
 UPDATE `test`.`t` SET i=4, j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=4 AND j=CAST('[10, 11, 12, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=2, j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=2 AND j=CAST('[4, 5, 6, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
-UPDATE `test`.`t` SET i=4, j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=4 AND j=CAST('[10, 11, 12, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
+UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=2 AND j=CAST('[4, 5, 6, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
+UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=4 AND j=CAST('[10, 11, 12, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
 ---- 40. Update two rows: first partial, then full ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -652,8 +652,8 @@ UPDATE `test`.`t` SET j='[0, 8, 9]' WHERE i=3 AND j=CAST('[7, 8, 9]' AS JSON);
 UPDATE `test`.`t` SET i=2, j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=2 AND j=CAST('[4, 5, 6, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
 UPDATE `test`.`t` SET i=3, j='[0, 8, 9]' WHERE i=3 AND j=CAST('[7, 8, 9]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=2, j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=2 AND j=CAST('[4, 5, 6, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
-UPDATE `test`.`t` SET i=3, j='[0, 8, 9]' WHERE i=3 AND j=CAST('[7, 8, 9]' AS JSON);
+UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=2 AND j=CAST('[4, 5, 6, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
+UPDATE `test`.`t` SET j='[0, 8, 9]' WHERE i=3 AND j=CAST('[7, 8, 9]' AS JSON);
 ---- 41. Update two rows: first full, then partial ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -676,8 +676,8 @@ UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[
 UPDATE `test`.`t` SET i=1, j='[0, 2, 3]' WHERE i=1 AND j=CAST('[1, 2, 3]' AS JSON);
 UPDATE `test`.`t` SET i=2, j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=2 AND j=CAST('[4, 5, 6, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='[0, 2, 3]' WHERE i=1 AND j=CAST('[1, 2, 3]' AS JSON);
-UPDATE `test`.`t` SET i=2, j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=2 AND j=CAST('[4, 5, 6, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
+UPDATE `test`.`t` SET j='[0, 2, 3]' WHERE i=1 AND j=CAST('[1, 2, 3]' AS JSON);
+UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=2 AND j=CAST('[4, 5, 6, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
 ---- 42. Update two rows: both full ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -700,8 +700,8 @@ UPDATE `test`.`t` SET j='[0, 8, 9]' WHERE i=3 AND j=CAST('[7, 8, 9]' AS JSON);
 UPDATE `test`.`t` SET i=1, j='[0, 2, 3]' WHERE i=1 AND j=CAST('[1, 2, 3]' AS JSON);
 UPDATE `test`.`t` SET i=3, j='[0, 8, 9]' WHERE i=3 AND j=CAST('[7, 8, 9]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='[0, 2, 3]' WHERE i=1 AND j=CAST('[1, 2, 3]' AS JSON);
-UPDATE `test`.`t` SET i=3, j='[0, 8, 9]' WHERE i=3 AND j=CAST('[7, 8, 9]' AS JSON);
+UPDATE `test`.`t` SET j='[0, 2, 3]' WHERE i=1 AND j=CAST('[1, 2, 3]' AS JSON);
+UPDATE `test`.`t` SET j='[0, 8, 9]' WHERE i=3 AND j=CAST('[7, 8, 9]' AS JSON);
 ---- 43. Update four rows: full, partial, full, partial ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -728,10 +728,10 @@ UPDATE `test`.`t` SET i=2, j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz'
 UPDATE `test`.`t` SET i=3, j='[0, 8, 9]' WHERE i=3 AND j=CAST('[7, 8, 9]' AS JSON);
 UPDATE `test`.`t` SET i=4, j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=4 AND j=CAST('[10, 11, 12, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='[0, 2, 3]' WHERE i=1 AND j=CAST('[1, 2, 3]' AS JSON);
-UPDATE `test`.`t` SET i=2, j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=2 AND j=CAST('[4, 5, 6, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
-UPDATE `test`.`t` SET i=3, j='[0, 8, 9]' WHERE i=3 AND j=CAST('[7, 8, 9]' AS JSON);
-UPDATE `test`.`t` SET i=4, j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=4 AND j=CAST('[10, 11, 12, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
+UPDATE `test`.`t` SET j='[0, 2, 3]' WHERE i=1 AND j=CAST('[1, 2, 3]' AS JSON);
+UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=2 AND j=CAST('[4, 5, 6, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
+UPDATE `test`.`t` SET j='[0, 8, 9]' WHERE i=3 AND j=CAST('[7, 8, 9]' AS JSON);
+UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=4 AND j=CAST('[10, 11, 12, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
 ==== Invalid paths ====
 TODO
 ******** Multiple JSON columns ********
@@ -750,7 +750,7 @@ UPDATE `test`.`t` SET j=NULL, l=JSON_REPLACE(l, '$.d', 'DDD') WHERE i=1 AND j=CA
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=NULL, k=k, l=JSON_REPLACE(l, '$.d', 'DDD'), m=m WHERE i=1 AND j=CAST('[1, 2, 3, 4]' AS JSON) AND k=CAST('[5, 6, 7, 8]' AS JSON) AND l=CAST('{"a": 1, "b": 2, "c": 3, "d": 4}' AS JSON) AND m=CAST('{"e": 8, "f": 6, "g": 7}' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=NULL, k=k, l=JSON_REPLACE(l, '$.d', 'DDD'), m=m WHERE i=1 AND j=CAST('[1, 2, 3, 4]' AS JSON) AND k=CAST('[5, 6, 7, 8]' AS JSON) AND l=CAST('{"a": 1, "b": 2, "c": 3, "d": 4}' AS JSON) AND m=CAST('{"e": 8, "f": 6, "g": 7}' AS JSON);
+UPDATE `test`.`t` SET j=NULL, l=JSON_REPLACE(l, '$.d', 'DDD') WHERE i=1 AND j=CAST('[1, 2, 3, 4]' AS JSON) AND k=CAST('[5, 6, 7, 8]' AS JSON) AND l=CAST('{"a": 1, "b": 2, "c": 3, "d": 4}' AS JSON) AND m=CAST('{"e": 8, "f": 6, "g": 7}' AS JSON);
 ******** Differences between master and slave ********
 TODO: applies ok, does not apply, and mix
 ######## CLEAN UP ########

--- a/mysql-test/suite/rpl/r/rpl_row_jsondiff_basic_pk.result
+++ b/mysql-test/suite/rpl/r/rpl_row_jsondiff_basic_pk.result
@@ -43,7 +43,7 @@ UPDATE `test`.`t` SET j='["a", 4]' WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j='["a", 4]', k=k WHERE i=1 AND j=CAST('[1, 2]' AS JSON) AND k=CAST('[3, 4]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='["a", 4]', k=k WHERE i=1;
+UPDATE `test`.`t` SET j='["a", 4]' WHERE i=1;
 ---- 2. Update one row using full format (no JSON function used) ----
 include/rpl_row_jsondiff_scenario.inc
 * CREATE TABLE test.t (i INT PRIMARY KEY, j JSON)
@@ -59,7 +59,7 @@ UPDATE `test`.`t` SET j='7' WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j='7' WHERE i=1 AND j=CAST('[1, 2]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='7' WHERE i=1;
+UPDATE `test`.`t` SET j='7' WHERE i=1;
 ---- 3. Update one row using full format (wrong JSON function used (1)) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -76,7 +76,7 @@ UPDATE `test`.`t` SET j='[1, 2, 8]' WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j='[1, 2, 8]' WHERE i=1 AND j=CAST('[1, 2]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='[1, 2, 8]' WHERE i=1;
+UPDATE `test`.`t` SET j='[1, 2, 8]' WHERE i=1;
 ---- 4. Update one row using full format (wrong JSON function used (2)) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -93,7 +93,7 @@ UPDATE `test`.`t` SET j='[3, 2, 8]' WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j='[3, 2, 8]' WHERE i=1 AND j=CAST('[1, 2]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='[3, 2, 8]' WHERE i=1;
+UPDATE `test`.`t` SET j='[3, 2, 8]' WHERE i=1;
 ---- 5. Update one row using full format (wrong JSON function used (3)) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -110,7 +110,7 @@ UPDATE `test`.`t` SET j='[3, 2, 8]' WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j='[3, 2, 8]' WHERE i=1 AND j=CAST('[1, 2]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='[3, 2, 8]' WHERE i=1;
+UPDATE `test`.`t` SET j='[3, 2, 8]' WHERE i=1;
 ---- 6. Update one row using full format (full smaller than partial) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -125,7 +125,7 @@ UPDATE `test`.`t` SET j='[3, 2]' WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j='[3, 2]' WHERE i=1 AND j=CAST('[1, 2]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='[3, 2]' WHERE i=1;
+UPDATE `test`.`t` SET j='[3, 2]' WHERE i=1;
 ==== Single diffs ====
 ---- 7. Update one row (REPLACE using JSON_REPLACE in array) ----
 include/rpl_row_jsondiff_scenario.inc
@@ -141,7 +141,7 @@ UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', 7) WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_REPLACE(j, '$[0]', 7) WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_REPLACE(j, '$[0]', 7) WHERE i=1;
+UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', 7) WHERE i=1;
 ---- 8. Update one row (REPLACE using JSON_SET in array) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -156,7 +156,7 @@ UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', '7') WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_REPLACE(j, '$[0]', '7') WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_REPLACE(j, '$[0]', '7') WHERE i=1;
+UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', '7') WHERE i=1;
 ---- 9. Update one row (REPLACE using JSON_REPLACE in object) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -171,7 +171,7 @@ UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[1].a', CAST('[7]' AS JSON)) WHERE i=1
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_REPLACE(j, '$[1].a', CAST('[7]' AS JSON)) WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_REPLACE(j, '$[1].a', CAST('[7]' AS JSON)) WHERE i=1;
+UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[1].a', CAST('[7]' AS JSON)) WHERE i=1;
 ---- 10. Update one row (REPLACE using JSON_SET in object) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -186,7 +186,7 @@ UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[1].a', CAST('{"a": 7}' AS JSON)) WHER
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_REPLACE(j, '$[1].a', CAST('{"a": 7}' AS JSON)) WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_REPLACE(j, '$[1].a', CAST('{"a": 7}' AS JSON)) WHERE i=1;
+UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[1].a', CAST('{"a": 7}' AS JSON)) WHERE i=1;
 ---- 11. Update one row (INSERT using JSON_SET in array) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -201,7 +201,7 @@ UPDATE `test`.`t` SET j=JSON_SET(j, '$[2]', 3) WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_SET(j, '$[2]', 3) WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_SET(j, '$[2]', 3) WHERE i=1;
+UPDATE `test`.`t` SET j=JSON_SET(j, '$[2]', 3) WHERE i=1;
 ---- 12. Update one row (INSERT using JSON_SET in object) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -216,7 +216,7 @@ UPDATE `test`.`t` SET j=JSON_SET(j, '$[1].b', 4) WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_SET(j, '$[1].b', 4) WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_SET(j, '$[1].b', 4) WHERE i=1;
+UPDATE `test`.`t` SET j=JSON_SET(j, '$[1].b', 4) WHERE i=1;
 ---- 13. Update one row (REMOVE using JSON_REMOVE in array) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -231,7 +231,7 @@ UPDATE `test`.`t` SET j=JSON_REMOVE(j, '$[1]') WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_REMOVE(j, '$[1]') WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_REMOVE(j, '$[1]') WHERE i=1;
+UPDATE `test`.`t` SET j=JSON_REMOVE(j, '$[1]') WHERE i=1;
 ---- 14. Update one row (REMOVE using JSON_REMOVE in object) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -246,7 +246,7 @@ UPDATE `test`.`t` SET j=JSON_REMOVE(j, '$[1].a') WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_REMOVE(j, '$[1].a') WHERE i=1 AND j=CAST('[1, {"a": 2}]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_REMOVE(j, '$[1].a') WHERE i=1;
+UPDATE `test`.`t` SET j=JSON_REMOVE(j, '$[1].a') WHERE i=1;
 ==== Multiple diffs from one function call ====
 ---- 15. Update one row (many different update types, using JSON_SET) ----
 include/rpl_row_jsondiff_scenario.inc
@@ -262,7 +262,7 @@ UPDATE `test`.`t` SET j=JSON_SET( JSON_SET( JSON_REPLACE(j, '$[0]', 'one', '$[1]
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_SET( JSON_SET( JSON_REPLACE(j, '$[0]', 'one', '$[1]', 'two', '$[2].a', 'three', '$[2].b', 'four'), '$[2].c', 'five', '$[2].d', 'six'), '$[3]', 'seven', '$[4]', 'eight') WHERE i=1 AND j=CAST('[1, 2, {"a": 3, "b": 4, "a long string that ensures that the diff format is smaller than the full format": ""}]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_SET( JSON_SET( JSON_REPLACE(j, '$[0]', 'one', '$[1]', 'two', '$[2].a', 'three', '$[2].b', 'four'), '$[2].c', 'five', '$[2].d', 'six'), '$[3]', 'seven', '$[4]', 'eight') WHERE i=1;
+UPDATE `test`.`t` SET j=JSON_SET( JSON_SET( JSON_REPLACE(j, '$[0]', 'one', '$[1]', 'two', '$[2].a', 'three', '$[2].b', 'four'), '$[2].c', 'five', '$[2].d', 'six'), '$[3]', 'seven', '$[4]', 'eight') WHERE i=1;
 ---- 16. Update one row (many different update types, using JSON_REPLACE) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -277,7 +277,7 @@ UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', 'one', '$[1]', 'two', '$[0]', 'O
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_REPLACE(j, '$[0]', 'one', '$[1]', 'two', '$[0]', 'ONE', '$[1]', 'TWO') WHERE i=1 AND j=CAST('[1, 2, {"a": 3, "b": 4, "a long string that ensures that the diff format is smaller than the full format": ""}]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_REPLACE(j, '$[0]', 'one', '$[1]', 'two', '$[0]', 'ONE', '$[1]', 'TWO') WHERE i=1;
+UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', 'one', '$[1]', 'two', '$[0]', 'ONE', '$[1]', 'TWO') WHERE i=1;
 ---- 17. Update one row (using JSON_REMOVE) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -292,7 +292,7 @@ UPDATE `test`.`t` SET j=JSON_REMOVE(j, '$[1]', '$[0]') WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_REMOVE(j, '$[1]', '$[0]') WHERE i=1 AND j=CAST('[1, 2, {"a": 3, "b": 4, "a long string that ensures that the diff format is smaller than the full format": ""}]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_REMOVE(j, '$[1]', '$[0]') WHERE i=1;
+UPDATE `test`.`t` SET j=JSON_REMOVE(j, '$[1]', '$[0]') WHERE i=1;
 ==== Multiple diffs from multiple function calls ====
 ---- 18. Update one row (using JSON_SET, JSON_REPLACE, and JSON_REMOVE) ----
 include/rpl_row_jsondiff_scenario.inc
@@ -308,7 +308,7 @@ UPDATE `test`.`t` SET j=JSON_REMOVE( JSON_SET( JSON_REPLACE(j, '$[0]', 'one', '$
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_REMOVE( JSON_SET( JSON_REPLACE(j, '$[0]', 'one', '$[1]', 'two', '$[2]', CAST('{"a": 1}' AS JSON)), '$[2].b', 2, '$[2].c', 3), '$[0]', '$[0]') WHERE i=1 AND j=CAST('[1, 2, 3, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_REMOVE( JSON_SET( JSON_REPLACE(j, '$[0]', 'one', '$[1]', 'two', '$[2]', CAST('{"a": 1}' AS JSON)), '$[2].b', 2, '$[2].c', 3), '$[0]', '$[0]') WHERE i=1;
+UPDATE `test`.`t` SET j=JSON_REMOVE( JSON_SET( JSON_REPLACE(j, '$[0]', 'one', '$[1]', 'two', '$[2]', CAST('{"a": 1}' AS JSON)), '$[2].b', 2, '$[2].c', 3), '$[0]', '$[0]') WHERE i=1;
 ==== NULL values ====
 ---- 19. Updating from non-NULL to NULL using JSON_SET ----
 include/rpl_row_jsondiff_scenario.inc
@@ -324,7 +324,7 @@ UPDATE `test`.`t` SET j=NULL WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=NULL WHERE i=1 AND j=CAST('[1, 2, 3, 4]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=NULL WHERE i=1;
+UPDATE `test`.`t` SET j=NULL WHERE i=1;
 ---- 20. Updating from non-NULL to NULL using JSON_REPLACE ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -339,7 +339,7 @@ UPDATE `test`.`t` SET j=NULL WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=NULL WHERE i=1 AND j=CAST('[1, 2, 3, 4]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=NULL WHERE i=1;
+UPDATE `test`.`t` SET j=NULL WHERE i=1;
 ---- 21. Updating from non-NULL to NULL using JSON_REMOVE ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -354,7 +354,7 @@ UPDATE `test`.`t` SET j=NULL WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=NULL WHERE i=1 AND j=CAST('[1, 2, 3, 4]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=NULL WHERE i=1;
+UPDATE `test`.`t` SET j=NULL WHERE i=1;
 ---- 22. Updating from NULL to non-NULL using JSON_SET ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -369,7 +369,7 @@ UPDATE `test`.`t` SET j='{"a": "a", "b": null}' WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j='{"a": "a", "b": null}' WHERE i=1 AND j IS NULL;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='{"a": "a", "b": null}' WHERE i=1;
+UPDATE `test`.`t` SET j='{"a": "a", "b": null}' WHERE i=1;
 ---- 23. Updating from NULL to non-NULL using JSON_REPLACE ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -384,7 +384,7 @@ UPDATE `test`.`t` SET j='{"a": null}' WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j='{"a": null}' WHERE i=1 AND j IS NULL;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='{"a": null}' WHERE i=1;
+UPDATE `test`.`t` SET j='{"a": null}' WHERE i=1;
 ---- 24. Updating from NULL to non-NULL using JSON_REMOVE ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -399,7 +399,7 @@ UPDATE `test`.`t` SET j='{"a": "a", "b": "BB"}' WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j='{"a": "a", "b": "BB"}' WHERE i=1 AND j IS NULL;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='{"a": "a", "b": "BB"}' WHERE i=1;
+UPDATE `test`.`t` SET j='{"a": "a", "b": "BB"}' WHERE i=1;
 ==== No-op updates ====
 ---- 25. Making a no-op not mentioning the column ----
 include/rpl_row_jsondiff_scenario.inc
@@ -416,7 +416,7 @@ UPDATE `test`.`t` SET x=2 WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1;
 ---- 26. Making a no-op setting the column to itself ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -427,11 +427,11 @@ UPDATE t SET x = 2, j = j WHERE i = 1
 i	j	x
 1	["a", {"b": "c"}]	2
 # Decoded rows
-UPDATE `test`.`t` SET j=j, x=2 WHERE i=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1;
 ---- 27. Making a no-op setting the column to its own value (1) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -442,11 +442,11 @@ UPDATE t SET x = 2, j = CONCAT(j, '') WHERE i = 1
 i	j	x
 1	["a", {"b": "c"}]	2
 # Decoded rows
-UPDATE `test`.`t` SET j=j, x=2 WHERE i=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1;
 ---- 28. Making a no-op setting the column to its own value (2) ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -457,11 +457,11 @@ UPDATE t SET x = 2, j = '["a", {"b": "c"}]' WHERE i = 1
 i	j	x
 1	["a", {"b": "c"}]	2
 # Decoded rows
-UPDATE `test`.`t` SET j=j, x=2 WHERE i=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1;
 ---- 29. Making a no-op using JSON_SET inserting object in non-object or array element in non-array ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -476,7 +476,7 @@ UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[1]', CAST('[{"b": "c"}, 1]' AS JSON))
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_REPLACE(j, '$[1]', CAST('[{"b": "c"}, 1]' AS JSON)), x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_REPLACE(j, '$[1]', CAST('[{"b": "c"}, 1]' AS JSON)), x=2 WHERE i=1;
+UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[1]', CAST('[{"b": "c"}, 1]' AS JSON)), x=2 WHERE i=1;
 ---- 30. Making a no-op using JSON_REPLACE with non-existing paths ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -487,11 +487,11 @@ UPDATE t SET x = 2, j = JSON_REPLACE(j, '$[9]', 0, '$.x', 1, '$[1].x', 2) WHERE 
 i	j	x
 1	["a", {"b": "c"}]	2
 # Decoded rows
-UPDATE `test`.`t` SET j=j, x=2 WHERE i=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1;
 ---- 31. Making a no-op removing a non-existing path, using JSON_REMOVE ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -506,7 +506,7 @@ UPDATE `test`.`t` SET j=JSON_REMOVE(j, '$[1]'), x=2 WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_REMOVE(j, '$[1]'), x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_REMOVE(j, '$[1]'), x=2 WHERE i=1;
+UPDATE `test`.`t` SET j=JSON_REMOVE(j, '$[1]'), x=2 WHERE i=1;
 ---- 32. Making a no-op replacing a JSON value by itself, using JSON_SET ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -517,11 +517,11 @@ UPDATE t SET x = 2, j = JSON_SET(j, '$[0]', 'a', '$[1].b', 'c', '$[0]', 'a') WHE
 i	j	x
 1	["a", {"b": "c"}]	2
 # Decoded rows
-UPDATE `test`.`t` SET j=j, x=2 WHERE i=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1;
 ---- 33. Making a no-op replacing a JSON value by itself, using JSON_REPLACE ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -532,11 +532,11 @@ UPDATE t SET x = 2, j = JSON_REPLACE(j, '$[0]', 'a', '$[1].b', 'c', '$[0]', 'a')
 i	j	x
 1	["a", {"b": "c"}]	2
 # Decoded rows
-UPDATE `test`.`t` SET j=j, x=2 WHERE i=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1;
 ---- 34. Making a no-op update using JSON_SET, JSON_REPLACE, and JSON_REMOVE ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -550,11 +550,11 @@ UPDATE t SET x = 2, j = JSON_SET(JSON_REMOVE(JSON_REPLACE(j,
 i	j	x
 1	["a", {"b": "c"}]	2
 # Decoded rows
-UPDATE `test`.`t` SET j=j, x=2 WHERE i=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1 AND j=CAST('["a", {"b": "c"}]' AS JSON) AND x=1;
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=j, x=2 WHERE i=1;
+UPDATE `test`.`t` SET x=2 WHERE i=1;
 ==== Long paths ====
 ---- 35. Update using long path ----
 include/rpl_row_jsondiff_scenario.inc
@@ -571,7 +571,7 @@ UPDATE `test`.`t` SET j=JSON_SET(j, '$.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_SET(j, '$.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'ghi') WHERE i=1 AND j=CAST('{"abc": "def"}' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_SET(j, '$.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'ghi') WHERE i=1;
+UPDATE `test`.`t` SET j=JSON_SET(j, '$.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'ghi') WHERE i=1;
 ---- 36. Update using long document ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -586,7 +586,7 @@ UPDATE `test`.`t` SET j=JSON_SET(j, '$.ghi', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=JSON_SET(j, '$.ghi', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa') WHERE i=1 AND j=CAST('{"abc": "def"}' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=JSON_SET(j, '$.ghi', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa') WHERE i=1;
+UPDATE `test`.`t` SET j=JSON_SET(j, '$.ghi', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa') WHERE i=1;
 ---- 37. Update using very long document ----
 include/rpl_row_jsondiff_scenario.inc
 ==== Auto-wrapping ====
@@ -604,7 +604,7 @@ UPDATE `test`.`t` SET j='[{"a": 1}, 4711]' WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j='[{"a": 1}, 4711]' WHERE i=1 AND j=CAST('{"a": 1}' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='[{"a": 1}, 4711]' WHERE i=1;
+UPDATE `test`.`t` SET j='[{"a": 1}, 4711]' WHERE i=1;
 ==== Multi-row updates ====
 ---- 39. Update two rows: both partial ----
 include/rpl_row_jsondiff_scenario.inc
@@ -628,8 +628,8 @@ UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[
 UPDATE `test`.`t` SET i=2, j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=2 AND j=CAST('[4, 5, 6, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
 UPDATE `test`.`t` SET i=4, j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=4 AND j=CAST('[10, 11, 12, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=2, j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=2;
-UPDATE `test`.`t` SET i=4, j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=4;
+UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=2;
+UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=4;
 ---- 40. Update two rows: first partial, then full ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -652,8 +652,8 @@ UPDATE `test`.`t` SET j='[0, 8, 9]' WHERE i=3;
 UPDATE `test`.`t` SET i=2, j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=2 AND j=CAST('[4, 5, 6, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
 UPDATE `test`.`t` SET i=3, j='[0, 8, 9]' WHERE i=3 AND j=CAST('[7, 8, 9]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=2, j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=2;
-UPDATE `test`.`t` SET i=3, j='[0, 8, 9]' WHERE i=3;
+UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=2;
+UPDATE `test`.`t` SET j='[0, 8, 9]' WHERE i=3;
 ---- 41. Update two rows: first full, then partial ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -676,8 +676,8 @@ UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[
 UPDATE `test`.`t` SET i=1, j='[0, 2, 3]' WHERE i=1 AND j=CAST('[1, 2, 3]' AS JSON);
 UPDATE `test`.`t` SET i=2, j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=2 AND j=CAST('[4, 5, 6, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='[0, 2, 3]' WHERE i=1;
-UPDATE `test`.`t` SET i=2, j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=2;
+UPDATE `test`.`t` SET j='[0, 2, 3]' WHERE i=1;
+UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=2;
 ---- 42. Update two rows: both full ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -700,8 +700,8 @@ UPDATE `test`.`t` SET j='[0, 8, 9]' WHERE i=3;
 UPDATE `test`.`t` SET i=1, j='[0, 2, 3]' WHERE i=1 AND j=CAST('[1, 2, 3]' AS JSON);
 UPDATE `test`.`t` SET i=3, j='[0, 8, 9]' WHERE i=3 AND j=CAST('[7, 8, 9]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='[0, 2, 3]' WHERE i=1;
-UPDATE `test`.`t` SET i=3, j='[0, 8, 9]' WHERE i=3;
+UPDATE `test`.`t` SET j='[0, 2, 3]' WHERE i=1;
+UPDATE `test`.`t` SET j='[0, 8, 9]' WHERE i=3;
 ---- 43. Update four rows: full, partial, full, partial ----
 include/rpl_row_jsondiff_scenario.inc
 # Before update
@@ -728,10 +728,10 @@ UPDATE `test`.`t` SET i=2, j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz'
 UPDATE `test`.`t` SET i=3, j='[0, 8, 9]' WHERE i=3 AND j=CAST('[7, 8, 9]' AS JSON);
 UPDATE `test`.`t` SET i=4, j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=4 AND j=CAST('[10, 11, 12, "a long string that ensures that the diff format is smaller than the full format"]' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j='[0, 2, 3]' WHERE i=1;
-UPDATE `test`.`t` SET i=2, j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=2;
-UPDATE `test`.`t` SET i=3, j='[0, 8, 9]' WHERE i=3;
-UPDATE `test`.`t` SET i=4, j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=4;
+UPDATE `test`.`t` SET j='[0, 2, 3]' WHERE i=1;
+UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=2;
+UPDATE `test`.`t` SET j='[0, 8, 9]' WHERE i=3;
+UPDATE `test`.`t` SET j=JSON_REPLACE(j, '$[0]', 'abcdefghijklmnopqrstuvxyz', '$[0]', 0) WHERE i=4;
 ==== Invalid paths ====
 TODO
 ******** Multiple JSON columns ********
@@ -750,7 +750,7 @@ UPDATE `test`.`t` SET j=NULL, l=JSON_REPLACE(l, '$.d', 'DDD') WHERE i=1;
 # Decoded rows, full image
 UPDATE `test`.`t` SET i=1, j=NULL, k=k, l=JSON_REPLACE(l, '$.d', 'DDD'), m=m WHERE i=1 AND j=CAST('[1, 2, 3, 4]' AS JSON) AND k=CAST('[5, 6, 7, 8]' AS JSON) AND l=CAST('{"a": 1, "b": 2, "c": 3, "d": 4}' AS JSON) AND m=CAST('{"e": 8, "f": 6, "g": 7}' AS JSON);
 # Decoded rows, minimal image when master has full image
-UPDATE `test`.`t` SET i=1, j=NULL, k=k, l=JSON_REPLACE(l, '$.d', 'DDD'), m=m WHERE i=1;
+UPDATE `test`.`t` SET j=NULL, l=JSON_REPLACE(l, '$.d', 'DDD') WHERE i=1;
 ******** Differences between master and slave ********
 TODO: applies ok, does not apply, and mix
 ######## CLEAN UP ########

--- a/mysql-test/suite/rpl/t/rpl_row_img_sanity.test
+++ b/mysql-test/suite/rpl/t/rpl_row_img_sanity.test
@@ -304,7 +304,7 @@ while (`SELECT HEX(@img_types) != HEX('')`)
     #      1. columns that are set to default value are in AI
     #
     #    UPDATE/MINIMAL:
-    #      2. columns that are set to the same value are in AI
+    #      2. columns that are set to the same value are not in AI
     #      3. columns that are not in WHERE clause but in PKE are in BI
     #      4. on slave, columns that are not in master's BI but are in slave's
     #         PKE are in slave's BI
@@ -330,11 +330,11 @@ while (`SELECT HEX(@img_types) != HEX('')`)
     -- source include/rpl_row_img_parts_master_slave.inc
 
     -- let $row_img_query= UPDATE t SET c2=100, c3=1000 WHERE c2=100;
-    #   2. columns that are set to the same value are in AI
+    #   2. columns that are set to the same value are not in AI
     #   3. columns that are not in WHERE clause but in PKE are in BI
     #   4. on slave, columns that are not in master's BI but are in slave's PKE are in slave's BI
-    -- let $row_img_expected_master= 1:1 | 2:100 3:1000
-    -- let $row_img_expected_slave = 2:100 3:1 | 2:100 3:1000
+    -- let $row_img_expected_master= 1:1 | 3:1000
+    -- let $row_img_expected_slave = 2:100 3:1 | 3:1000
     -- source include/rpl_row_img_parts_master_slave.inc
 
     -- let $row_img_query= DELETE FROM t WHERE c1=1
@@ -381,6 +381,54 @@ while (`SELECT HEX(@img_types) != HEX('')`)
     --source include/sync_slave_sql_with_master.inc
   }
 
+  if (`SELECT @@binlog_row_image = "MINIMAL" OR (SELECT @@binlog_row_image = "COMPLETE")`)
+  {
+    -- echo ####### MINIMAL AND COMPLETE PARTICULAR SCENARIO SETTING SAME VALUE ######
+
+    # ASSERTIONS:
+    #    1. columns that are set to the same value are not in AI
+    #    2. columns that are set to the same value by INSERT ... DUPLICATE KEY
+    #       are not in AI
+    #
+
+    -- connection master
+    CREATE TABLE t (c1 int, c2 int, c3 blob, primary key(c1));
+    INSERT INTO t VALUES (1,2,"a");
+
+
+    --source include/sync_slave_sql_with_master.inc
+    -- connection master
+
+    # Issue some statements
+    -- let $row_img_query= UPDATE t SET c1 = 1, c2 = 4 WHERE c3 = "a";
+    if (`SELECT @@binlog_row_image = "MINIMAL"`)
+    {
+      -- let $row_img_expected_master= 1:1 | 2:4
+    }
+    if (`SELECT @@binlog_row_image = "COMPLETE"`)
+    {
+      -- let $row_img_expected_master= 1:1 2:2 3:'a' | 2:4
+    }
+    -- let $row_img_expected_slave = $row_img_expected_master
+    -- source include/rpl_row_img_parts_master_slave.inc
+
+    -- let $row_img_query= INSERT INTO t VALUES (1, 4, "a") ON DUPLICATE KEY UPDATE c2 = c2 + 2, c3 = values(c3);
+    if (`SELECT @@binlog_row_image = "MINIMAL"`)
+    {
+      -- let $row_img_expected_master= 1:1 | 2:6
+    }
+    if (`SELECT @@binlog_row_image = "COMPLETE"`)
+    {
+      -- let $row_img_expected_master= 1:1 2:4 3:'a' | 2:6
+    }
+    -- let $row_img_expected_slave = $row_img_expected_master
+    -- source include/rpl_row_img_parts_master_slave.inc
+
+    -- connection master
+    DROP TABLE t;
+    --source include/sync_slave_sql_with_master.inc
+  }
+
   if (`SELECT @@binlog_row_image = "NOBLOB"`)
   {
     -- echo ####### NOBLOB PARTICULAR SCENARIO ######
@@ -390,19 +438,17 @@ while (`SELECT HEX(@img_types) != HEX('')`)
     #      1 non-blob columns that are set to default value are in AI
     #    
     #    UPDATE/NOBLOB:
-    #      2 non-blob columns that are set to default value are in AI
-    #      3 blob columns that are set to default value are in AI
-    #      4 blob columns that are in WHERE clause but not in PKE are not in BI
-    #      5 blob columns that are in NON-NULL UK but not in PK are not in BI
-    #      6 on slave, blob columns that are in master's BI clause but not in
+    #      2 blob columns that are in WHERE clause but not in PKE are not in BI
+    #      3 blob columns that are in NON-NULL UK but not in PK are not in BI
+    #      4 on slave, blob columns that are in master's BI clause but not in
     #        slave's PKE are not in BI
     #
     #    DELETE
-    #      7 non-blob columns that are not in WHERE clause but in PKE are in BI
-    #      8 blob columns that are used in WHERE clause but not in PKE are not
+    #      5 non-blob columns that are not in WHERE clause but in PKE are in BI
+    #      6 blob columns that are used in WHERE clause but not in PKE are not
     #        in BI
-    #      9 blob columns that are NOT NULL UK but not in PK are not in BI
-    #     10 on slave, blob columns that are in master's BI but not in slave's PKE
+    #      7 blob columns that are NOT NULL UK but not in PK are not in BI
+    #      8 on slave, blob columns that are in master's BI but not in slave's PKE
     #        are not in slave's BI
 
     -- connection master
@@ -425,23 +471,21 @@ while (`SELECT HEX(@img_types) != HEX('')`)
     -- connection master
     -- let $row_img_query= UPDATE t SET c2='aaa', c3=1000, c5=10000 WHERE c1=1 AND c4='bbb'
     # asserts that:
-    #  2. non-blob columns that are set to default value are in AI
-    #  3. blob columns that are set to default value are in AI
-    #  4. blob columns that are in WHERE clause but not in PKE are not in BI
-    #  5. blob columns that are in NON-NULL UK but not in PK are not in BI
-    #  6. on slave, blob columns that are in master's BI clause but not in
+    #  2. blob columns that are in WHERE clause but not in PKE are not in BI
+    #  3. blob columns that are in NON-NULL UK but not in PK are not in BI
+    #  4. on slave, blob columns that are in master's BI clause but not in
     #     slave's PKE are not in BI
-    -- let $row_img_expected_master= 1:1 2:'aaa' 3:1000 5:1 | 1:1 2:'aaa' 3:1000 5:10000
-    -- let $row_img_expected_slave = 1:1 3:1000 5:1 | 1:1 2:'aaa' 3:1000 5:10000
+    -- let $row_img_expected_master= 1:1 2:'aaa' 3:1000 5:1 | 1:1 3:1000 5:10000
+    -- let $row_img_expected_slave = 1:1 3:1000 5:1 | 1:1 3:1000 5:10000
     -- source include/rpl_row_img_parts_master_slave.inc
 
     -- connection master
     -- let $row_img_query= DELETE FROM t WHERE c1=1 AND c4='bbb'
     # asserts that:
-    #   7. non-blob columns that are not in WHERE clause but in PKE are in BI
-    #   8. blob columns that are used in WHERE clause but not in PKE are not n BI
-    #   9. blob columns that are NOT NULL UK but not in PK are not in BI
-    #  10. on slave, blob columns that are in master's BI but not in slave's PKE are not in slave's BI
+    #   5. non-blob columns that are not in WHERE clause but in PKE are in BI
+    #   6. blob columns that are used in WHERE clause but not in PKE are not n BI
+    #   7. blob columns that are NOT NULL UK but not in PK are not in BI
+    #   8. on slave, blob columns that are in master's BI but not in slave's PKE are not in slave's BI
     -- let $row_img_expected_master= 1:1 2:'aaa' 3:1000 5:10000 | 
     -- let $row_img_expected_slave = 1:1 3:1000 5:10000 | 
     -- source include/rpl_row_img_parts_master_slave.inc

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -10676,7 +10676,7 @@ int THD::binlog_update_row(TABLE *table, bool is_trans,
      not needed for binlogging. This is done according to the:
      binlog-row-image option.
    */
-  binlog_prepare_row_images(table);
+  binlog_prepare_row_images(table, true);
 
   Row_data_memory row_data(table, before_record, after_record,
                            variables.binlog_row_value_options);
@@ -10731,7 +10731,7 @@ int THD::binlog_delete_row(TABLE *table, bool is_trans, uchar const *record,
      not needed for binlogging. This is done according to the:
      binlog-row-image option.
    */
-  binlog_prepare_row_images(table);
+  binlog_prepare_row_images(table, false);
 
   /*
      Pack records into format for transfer. We are allocating more
@@ -10762,10 +10762,10 @@ int THD::binlog_delete_row(TABLE *table, bool is_trans, uchar const *record,
   return error;
 }
 
-void THD::binlog_prepare_row_images(TABLE *table) {
+void THD::binlog_prepare_row_images(TABLE *table, bool is_update) {
   DBUG_ENTER("THD::binlog_prepare_row_images");
   /**
-    Remove from read_set spurious columns. The write_set has been
+    Remove spurious columns. The write_set has been partially
     handled before in table->mark_columns_needed_for_update.
    */
 
@@ -10773,6 +10773,7 @@ void THD::binlog_prepare_row_images(TABLE *table) {
                     table->read_set);
   THD *thd = table->in_use;
 
+  /* Handle the read set */
   /**
     if there is a primary key in the table (ie, user declared PK or a
     non-null unique index) and we dont want to ship the entire image,
@@ -10815,6 +10816,39 @@ void THD::binlog_prepare_row_images(TABLE *table) {
 
     /* set the temporary read_set */
     table->column_bitmaps_set_no_signal(&table->tmp_set, table->write_set);
+  }
+
+  /* Now, handle the write set */
+  if (is_update && thd->variables.binlog_row_image != BINLOG_ROW_IMAGE_FULL &&
+      !ha_check_storage_engine_flag(table->s->db_type(),
+                                    HTON_NO_BINLOG_ROW_OPT)) {
+    /**
+      Just to be sure that tmp_write_set is currently not in use as
+      the write_set already.
+    */
+    DBUG_ASSERT(table->write_set != &table->tmp_write_set);
+
+    bitmap_copy(&table->tmp_write_set, table->write_set);
+
+    for (Field **ptr = table->field; *ptr; ptr++) {
+      Field *field = (*ptr);
+      if (bitmap_is_set(&table->tmp_write_set, field->field_index)) {
+        /* When image type is NOBLOB, we prune only BLOB fields */
+        if (thd->variables.binlog_row_image == BINLOG_ROW_IMAGE_NOBLOB &&
+            field->type() != MYSQL_TYPE_BLOB)
+          continue;
+
+        /* compare null bit */
+        if (field->is_null() && field->is_null_in_record(table->record[1]))
+          bitmap_clear_bit(&table->tmp_write_set, field->field_index);
+
+        /* compare content, only if fields are not set to NULL */
+        else if (!field->is_null() &&
+                 !field->cmp_binary_offset(table->s->rec_buff_length))
+          bitmap_clear_bit(&table->tmp_write_set, field->field_index);
+      }
+    }
+    table->column_bitmaps_set_no_signal(table->read_set, &table->tmp_write_set);
   }
 
   DBUG_PRINT_BITSET("debug", "table->read_set (after preparing): %s",

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -1361,7 +1361,7 @@ class THD : public MDL_context_owner,
   int binlog_update_row(TABLE *table, bool is_transactional,
                         const uchar *old_data, const uchar *new_data,
                         const uchar *extra_row_info);
-  void binlog_prepare_row_images(TABLE *table);
+  void binlog_prepare_row_images(TABLE *table, bool is_update);
 
   void set_server_id(uint32 sid) { server_id = sid; }
 

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -2952,7 +2952,7 @@ int open_table_from_share(THD *thd, TABLE_SHARE *share, const char *alias,
   */
 
   bitmap_size = share->column_bitmap_size;
-  if (!(bitmaps = (uchar *)alloc_root(root, bitmap_size * 7))) goto err;
+  if (!(bitmaps = (uchar *)alloc_root(root, bitmap_size * 8))) goto err;
   bitmap_init(&outparam->def_read_set, (my_bitmap_map *)bitmaps, share->fields,
               false);
   bitmap_init(&outparam->def_write_set,
@@ -2969,6 +2969,9 @@ int open_table_from_share(THD *thd, TABLE_SHARE *share, const char *alias,
               false);
   bitmap_init(&outparam->pack_row_tmp_set,
               (my_bitmap_map *)(bitmaps + bitmap_size * 6), share->fields,
+              false);
+  bitmap_init(&outparam->tmp_write_set,
+              (my_bitmap_map *)(bitmaps + bitmap_size * 7), share->fields,
               false);
   outparam->default_column_bitmaps();
 

--- a/sql/table.h
+++ b/sql/table.h
@@ -1379,7 +1379,8 @@ struct TABLE {
       nullptr};  ///< Saved null_flags while null_row is true
 
   /* containers */
-  MY_BITMAP def_read_set, def_write_set, tmp_set, pack_row_tmp_set;
+  MY_BITMAP def_read_set, def_write_set, tmp_set, tmp_write_set,
+      pack_row_tmp_set;
   /*
     Bitmap of fields that one or more query condition refers to. Only
     used if optimizer_condition_fanout_filter is turned 'on'.


### PR DESCRIPTION
JIRA: https://jira.percona.com/browse/FB8-82

Reference Patch: https://github.com/facebook/mysql-5.6/commit/b1fec60

Summary:
Some update and upsert (insert ... on duplicate key update) queries
used to log columns which have not changed in the after image (when using RBR)
even when the image format is not FULL.

Test Plan: Extended rpl_row_img_sanity to check these special cases