### PR TITLE
FB8-77: Changed the behavior of purging logs. Now deleting logs first and then updating the index

### DIFF
--- a/mysql-test/suite/binlog/r/binlog_index.result
+++ b/mysql-test/suite/binlog/r/binlog_index.result
@@ -76,9 +76,9 @@ SELECT @index;
 binlog.000004
 binlog.000005
 
-# crash_purge_critical_after_update_index
+# crash_purge_critical_before_update_index
 flush logs;
-SET SESSION debug="+d,crash_purge_critical_after_update_index";
+SET SESSION debug="+d,crash_purge_critical_before_update_index";
 purge binary logs TO 'binlog.000006';
 ERROR HY000: Lost connection to MySQL server during query
 include/rpl_gen_binlog_index_file.inc
@@ -334,11 +334,9 @@ SET SESSION debug="+d,fault_injection_copy_part_file";
 purge binary logs TO 'binlog.000014';
 ERROR HY000: Lost connection to MySQL server during query
 # Restart the master server
-# Test the index file is complete, although is not purged successfully.
+# Test if both the index file and binlogs are in sync
 show binary logs;
 Log_name	File_size
-binlog.000012	#
-binlog.000013	#
 binlog.000014	#
 binlog.000015	#
 binlog.000016	#
@@ -353,12 +351,10 @@ call mtr.add_suppression("failed to move crash safe index file to index file");
 call mtr.add_suppression("failed to update the index file");
 PURGE BINARY LOGS TO 'binlog.000014';;
 ERROR HY000: I/O error reading log index file
-# Test the index file is complete, although is not purged successfully.
+# Test if both the index file and binlogs are in sync
 # Also this will indicate that binary logging is not disabled.
 show binary logs;
 Log_name	File_size
-binlog.000012	#
-binlog.000013	#
 binlog.000014	#
 binlog.000015	#
 binlog.000016	#
@@ -374,8 +370,6 @@ ERROR HY000: You are not using binary logging
 # restart
 show binary logs;
 Log_name	File_size
-binlog.000012	#
-binlog.000013	#
 binlog.000014	#
 binlog.000015	#
 binlog.000016	#
@@ -395,8 +389,6 @@ ERROR HY000: You are not using binary logging
 # restart
 show binary logs;
 Log_name	File_size
-binlog.000012	#
-binlog.000013	#
 binlog.000014	#
 binlog.000015	#
 binlog.000016	#

--- a/mysql-test/suite/binlog/t/binlog_index.test
+++ b/mysql-test/suite/binlog/t/binlog_index.test
@@ -147,11 +147,11 @@ file_exists $MYSQLD_DATADIR/binlog.000003;
 -- replace_regex /\.[\\\/]binlog/binlog/
 SELECT @index;
 
---echo # crash_purge_critical_after_update_index
+--echo # crash_purge_critical_before_update_index
 flush logs;
 
 --exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
-SET SESSION debug="+d,crash_purge_critical_after_update_index";
+SET SESSION debug="+d,crash_purge_critical_before_update_index";
 --error 2013
 purge binary logs TO 'binlog.000006';
 
@@ -443,9 +443,11 @@ purge binary logs TO 'binlog.000014';
 -- source include/wait_until_connected_again.inc
 -- disable_reconnect
 
--- echo # Test the index file is complete, although is not purged successfully.
+-- echo # Test if both the index file and binlogs are in sync
 -- source include/show_binary_logs.inc
+-- error 1
 file_exists $MYSQLD_DATADIR/binlog.000012;
+-- error 1
 file_exists $MYSQLD_DATADIR/binlog.000013;
 file_exists $MYSQLD_DATADIR/binlog.000014;
 
@@ -465,10 +467,12 @@ call mtr.add_suppression("failed to update the index file");
 -- error ER_IO_ERR_LOG_INDEX_READ
 -- eval PURGE BINARY LOGS TO 'binlog.000014';
 
--- echo # Test the index file is complete, although is not purged successfully.
+-- echo # Test if both the index file and binlogs are in sync
 -- echo # Also this will indicate that binary logging is not disabled.
 -- source include/show_binary_logs.inc
+-- error 1
 file_exists $MYSQLD_DATADIR/binlog.000012;
+-- error 1
 file_exists $MYSQLD_DATADIR/binlog.000013;
 file_exists $MYSQLD_DATADIR/binlog.000014;
 

--- a/share/errmsg-utf8.txt
+++ b/share/errmsg-utf8.txt
@@ -18706,6 +18706,12 @@ ER_BINLOG_INDEX_PREV_GTID_OUTOFMEMORY
 ER_BINLOG_INDEX_PREV_GTID_CORRUPT
   eng "MYSQL_BINLOG::init_gtid_sets failed because previous gtid set of binlog %s is corrupted in the index file"
 
+ER_BINLOG_CANT_READ_INDEX
+  eng "%s failed while reading log index file."
+
+ER_RPL_FAILED_IN_RLI_INIT_INFO
+  eng "Failed in %s called from Relay_log_info::rli_init_info()."
+
 #
 # End of 8.0 FB MySQL error messages.
 # (Please read comments from the header of this section before adding error

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -3634,12 +3634,9 @@ bool MYSQL_BIN_LOG::open_index_file(const char *index_file_name_arg,
 
   /*
     Sync the index by purging any binary log file that is not registered.
-    In other words, either purge binary log files that were removed from
-    the index but not purged from the file system due to a crash or purge
-    any binary log file that was created but not register in the index
-    due to a crash.
+    In other words, purge any binary log file that was created but not
+    register in the index due to a crash.
   */
-
   if (set_purge_index_file_name(index_file_name_arg) ||
       open_purge_index_file(false) || purge_index_entry(NULL, NULL, false) ||
       close_purge_index_file() ||
@@ -3652,6 +3649,57 @@ bool MYSQL_BIN_LOG::open_index_file(const char *index_file_name_arg,
 end:
   if (need_lock_index) mysql_mutex_unlock(&LOCK_index);
   return error;
+}
+
+/**
+  Remove logs from index that are not present on disk
+  NOTE: this method will not update index with arbitrarily
+  deleted logs. It will only remove entries of logs which
+  are deleted from the beginning of the sequence
+  @param need_lock_index        Need to lock index?
+  @param need_update_threads    If we want to update the log coordinates
+                                of all threads. False for relay logs,
+                                true otherwise.
+  @retval
+   0    ok
+  @retval
+    LOG_INFO_IO    Got IO error while reading/writing file
+    LOG_INFO_EOF   log-index-file is empty
+*/
+int MYSQL_BIN_LOG::remove_deleted_logs_from_index(bool need_lock_index,
+                                                  bool need_update_threads) {
+  int error;
+  int no_of_log_files_purged = 0;
+  LOG_INFO log_info;
+
+  DBUG_ENTER("remove_deleted_logs_from_index");
+
+  if (need_lock_index) mysql_mutex_lock(&LOCK_index);
+
+  if ((error = find_log_pos(&log_info, NullS, false /*need_lock_index=false*/)))
+    goto err;
+
+  while (true) {
+    if (my_access(log_info.log_file_name, F_OK) == 0) break;
+
+    int ret = find_next_log(&log_info, false /*need_lock_index=false*/);
+    if (ret == LOG_INFO_EOF) {
+      break;
+    } else if (ret == LOG_INFO_IO) {
+      LogErr(ERROR_LEVEL, ER_BINLOG_CANT_READ_INDEX,
+             "MYSQL_BIN_LOG::remove_deleted_logs_from_index");
+      goto err;
+    }
+
+    ++no_of_log_files_purged;
+  }
+
+  error = remove_logs_from_index(&log_info, need_update_threads);
+  DBUG_PRINT("info", ("num binlogs deleted = %d", no_of_log_files_purged));
+
+err:
+  if (need_lock_index) mysql_mutex_unlock(&LOCK_index);
+  DBUG_RETURN(error);
 }
 
 /**
@@ -5577,20 +5625,24 @@ err:
   @retval
     0			ok
   @retval
-    LOG_INFO_EOF		to_log not found
-    LOG_INFO_EMFILE             too many files opened
-    LOG_INFO_FATAL              if any other than ENOENT error from
+    LOG_INFO_EOF          to_log not found
+    LOG_INFO_EMFILE       Too many files opened
+    LOG_INFO_IO           Got IO error while reading/writing file
+    LOG_INFO_FATAL        If any other than ENOENT error from
                                 mysql_file_stat() or mysql_file_delete()
 */
 
 int MYSQL_BIN_LOG::purge_logs(const char *to_log, bool included,
                               bool need_lock_index, bool need_update_threads,
                               ulonglong *decrease_log_space, bool auto_purge) {
-  int error = 0, no_of_log_files_to_purge = 0, no_of_log_files_purged = 0;
+  int error = 0, error_index = 0, no_of_log_files_to_purge = 0,
+      no_of_log_files_purged = 0;
   int no_of_threads_locking_log = 0;
   bool exit_loop = 0;
   LOG_INFO log_info;
   THD *thd = current_thd;
+  log_file_name_container delete_list;
+
   DBUG_ENTER("purge_logs");
   DBUG_PRINT("info", ("to_log= %s", to_log));
 
@@ -5606,11 +5658,6 @@ int MYSQL_BIN_LOG::purge_logs(const char *to_log, bool included,
   }
 
   no_of_log_files_to_purge = log_info.entry_index;
-
-  if ((error = open_purge_index_file(true))) {
-    LogErr(ERROR_LEVEL, ER_BINLOG_PURGE_LOGS_CANT_SYNC_INDEX_FILE);
-    goto err;
-  }
 
   /*
     File name exists in index file; delete until we find this file
@@ -5639,11 +5686,7 @@ int MYSQL_BIN_LOG::purge_logs(const char *to_log, bool included,
     }
     no_of_log_files_purged++;
 
-    if ((error = register_purge_index_entry(log_info.log_file_name))) {
-      LogErr(ERROR_LEVEL, ER_BINLOG_PURGE_LOGS_CANT_COPY_TO_REGISTER_FILE,
-             log_info.log_file_name);
-      goto err;
-    }
+    delete_list.emplace_back(log_info.log_file_name);
 
     if (find_next_log(&log_info, false /*need_lock_index=false*/) || exit_loop)
       break;
@@ -5651,16 +5694,21 @@ int MYSQL_BIN_LOG::purge_logs(const char *to_log, bool included,
 
   DBUG_EXECUTE_IF("crash_purge_before_update_index", DBUG_SUICIDE(););
 
-  if ((error = sync_purge_index_file())) {
-    LogErr(ERROR_LEVEL, ER_BINLOG_PURGE_LOGS_CANT_FLUSH_REGISTER_FILE);
-    goto err;
-  }
+  /* Read each entry from the list and delete the file. */
+  if ((error_index = purge_logs_in_list(delete_list, thd, decrease_log_space,
+                                        false /*need_lock_index=false*/)))
+    LogErr(ERROR_LEVEL, ER_BINLOG_PURGE_LOGS_FAILED_TO_PURGE_LOG);
+
+  DBUG_EXECUTE_IF("crash_purge_critical_before_update_index", DBUG_SUICIDE(););
 
   /* We know how many files to delete. Update index file. */
   if ((error = remove_logs_from_index(&log_info, need_update_threads))) {
     LogErr(ERROR_LEVEL, ER_BINLOG_PURGE_LOGS_CANT_UPDATE_INDEX_FILE);
     goto err;
   }
+
+  DBUG_EXECUTE_IF("crash_purge_non_critical_after_update_index",
+                  DBUG_SUICIDE(););
 
   // Update gtid_state->lost_gtids
   if (!is_relay_log) {
@@ -5670,34 +5718,16 @@ int MYSQL_BIN_LOG::purge_logs(const char *to_log, bool included,
         opt_master_verify_checksum, false /*false=don't need lock*/,
         NULL /*trx_parser*/, NULL /*partial_trx*/);
     global_sid_lock->unlock();
-    if (error) goto err;
   }
 
-  DBUG_EXECUTE_IF("crash_purge_critical_after_update_index", DBUG_SUICIDE(););
-
 err:
-
-  int error_index = 0, close_error_index = 0;
-  /* Read each entry from purge_index_file and delete the file. */
-  if (!error && is_inited_purge_index_file() &&
-      (error_index = purge_index_entry(thd, decrease_log_space,
-                                       false /*need_lock_index=false*/)))
-    LogErr(ERROR_LEVEL, ER_BINLOG_PURGE_LOGS_FAILED_TO_PURGE_LOG);
-
-  close_error_index = close_purge_index_file();
-
-  DBUG_EXECUTE_IF("crash_purge_non_critical_after_update_index",
-                  DBUG_SUICIDE(););
-
   if (need_lock_index) mysql_mutex_unlock(&LOCK_index);
 
   /*
     Error codes from purge logs take precedence.
     Then error codes from purging the index entry.
-    Finally, error codes from closing the purge index file.
   */
-  error = error ? error : (error_index ? error_index : close_error_index);
-
+  error = error ? error : error_index;
   DBUG_RETURN(error);
 }
 
@@ -5786,10 +5816,10 @@ int MYSQL_BIN_LOG::register_create_index_entry(const char *entry) {
 
 int MYSQL_BIN_LOG::purge_index_entry(THD *thd, ulonglong *decrease_log_space,
                                      bool need_lock_index) {
-  MY_STAT s;
   int error = 0;
   LOG_INFO log_info;
   LOG_INFO check_log_info;
+  log_file_name_container delete_list;
 
   DBUG_ENTER("MYSQL_BIN_LOG:purge_index_entry");
 
@@ -5818,7 +5848,70 @@ int MYSQL_BIN_LOG::purge_index_entry(THD *thd, ulonglong *decrease_log_space,
     /* Get rid of the trailing '\n' */
     log_info.log_file_name[length - 1] = 0;
 
-    if (!mysql_file_stat(m_key_file_log, log_info.log_file_name, &s, MYF(0))) {
+    if ((error = find_log_pos(&check_log_info, log_info.log_file_name,
+                              need_lock_index))) {
+      if (error != LOG_INFO_EOF) {
+        if (thd) {
+          push_warning_printf(thd, Sql_condition::SL_WARNING,
+                              ER_BINLOG_PURGE_FATAL_ERR,
+                              "a problem with deleting %s and "
+                              "reading the binlog index file",
+                              log_info.log_file_name);
+        } else {
+          LogErr(INFORMATION_LEVEL,
+                 ER_BINLOG_CANT_DELETE_FILE_AND_READ_BINLOG_INDEX,
+                 log_info.log_file_name);
+        }
+        break;
+      }
+
+      error = 0;
+      if (!need_lock_index) {
+        /*
+          This is to avoid triggering an error in NDB.
+
+          @todo: This is weird, what does NDB errors have to do with
+          need_lock_index? Explain better or refactor /Sven
+        */
+        ha_binlog_index_purge_file(current_thd, log_info.log_file_name);
+      }
+
+      delete_list.emplace_back(log_info.log_file_name);
+    }
+  }
+
+  if (!error)
+    error = purge_logs_in_list(delete_list, thd, decrease_log_space,
+                               need_lock_index);
+
+err:
+  DBUG_RETURN(error);
+}
+
+/**
+  Deletes logs sepecified in a list if they exist on the file system
+  @param delete_list         The list of log files to delete
+  @param thd                 Pointer to the THD object
+  @param decrease_log_space  Amount of space freed
+  @param need_lock_index     Need to lock the index?
+  @retval
+    0                        ok
+  @retval
+    LOG_INFO_EMFILE          Too many files opened
+    LOG_INFO_FATAL           If any other than ENOENT error from
+                             mysql_file_stat() or mysql_file_delete()
+*/
+int MYSQL_BIN_LOG::purge_logs_in_list(
+    const log_file_name_container &delete_list, THD *thd,
+    ulonglong *decrease_log_space,
+    bool need_lock_index MY_ATTRIBUTE((unused))) {
+  MY_STAT s;
+  int error = 0;
+
+  DBUG_ENTER("MYSQL_BIN_LOG:purge_logs_in_list");
+
+  for (const auto &log_file_name : delete_list) {
+    if (!mysql_file_stat(m_key_file_log, log_file_name.c_str(), &s, MYF(0))) {
       if (my_errno() == ENOENT) {
         /*
           It's not fatal if we can't stat a log file that does not exist;
@@ -5827,9 +5920,9 @@ int MYSQL_BIN_LOG::purge_index_entry(THD *thd, ulonglong *decrease_log_space,
         if (thd) {
           push_warning_printf(
               thd, Sql_condition::SL_WARNING, ER_LOG_PURGE_NO_FILE,
-              ER_THD(thd, ER_LOG_PURGE_NO_FILE), log_info.log_file_name);
+              ER_THD(thd, ER_LOG_PURGE_NO_FILE), log_file_name.c_str());
         }
-        LogErr(INFORMATION_LEVEL, ER_CANT_STAT_FILE, log_info.log_file_name);
+        LogErr(INFORMATION_LEVEL, ER_CANT_STAT_FILE, log_file_name.c_str());
         set_my_errno(0);
       } else {
         /*
@@ -5842,87 +5935,55 @@ int MYSQL_BIN_LOG::purge_index_entry(THD *thd, ulonglong *decrease_log_space,
                               "consider examining correspondence "
                               "of your binlog index file "
                               "to the actual binlog files",
-                              log_info.log_file_name);
+                              log_file_name.c_str());
         } else {
           LogErr(INFORMATION_LEVEL,
                  ER_BINLOG_CANT_DELETE_LOG_FILE_DOES_INDEX_MATCH_FILES,
-                 log_info.log_file_name);
+                 log_file_name.c_str());
         }
         error = LOG_INFO_FATAL;
-        goto err;
+        break;
       }
     } else {
-      if ((error = find_log_pos(&check_log_info, log_info.log_file_name,
-                                need_lock_index))) {
-        if (error != LOG_INFO_EOF) {
+      DBUG_PRINT("info", ("purging %s", log_file_name.c_str()));
+      if (!mysql_file_delete(key_file_binlog, log_file_name.c_str(), MYF(0))) {
+        if (decrease_log_space) *decrease_log_space -= s.st_size;
+      } else {
+        if (my_errno() == ENOENT) {
+          if (thd) {
+            push_warning_printf(
+                thd, Sql_condition::SL_WARNING, ER_LOG_PURGE_NO_FILE,
+                ER_THD(thd, ER_LOG_PURGE_NO_FILE), log_file_name.c_str());
+          }
+          LogErr(INFORMATION_LEVEL, ER_BINLOG_CANT_DELETE_FILE,
+                 log_file_name.c_str());
+          set_my_errno(0);
+        } else {
           if (thd) {
             push_warning_printf(thd, Sql_condition::SL_WARNING,
                                 ER_BINLOG_PURGE_FATAL_ERR,
-                                "a problem with deleting %s and "
-                                "reading the binlog index file",
-                                log_info.log_file_name);
+                                "a problem with deleting %s; "
+                                "consider examining correspondence "
+                                "of your binlog index file "
+                                "to the actual binlog files",
+                                log_file_name.c_str());
           } else {
             LogErr(INFORMATION_LEVEL,
-                   ER_BINLOG_CANT_DELETE_FILE_AND_READ_BINLOG_INDEX,
-                   log_info.log_file_name);
+                   ER_BINLOG_CANT_DELETE_LOG_FILE_DOES_INDEX_MATCH_FILES,
+                   log_file_name.c_str());
           }
-          goto err;
-        }
-
-        error = 0;
-        if (!need_lock_index) {
-          /*
-            This is to avoid triggering an error in NDB.
-
-            @todo: This is weird, what does NDB errors have to do with
-            need_lock_index? Explain better or refactor /Sven
-          */
-          ha_binlog_index_purge_file(current_thd, log_info.log_file_name);
-        }
-
-        DBUG_PRINT("info", ("purging %s", log_info.log_file_name));
-        if (!mysql_file_delete(key_file_binlog, log_info.log_file_name,
-                               MYF(0))) {
-          if (decrease_log_space) *decrease_log_space -= s.st_size;
-        } else {
-          if (my_errno() == ENOENT) {
-            if (thd) {
-              push_warning_printf(
-                  thd, Sql_condition::SL_WARNING, ER_LOG_PURGE_NO_FILE,
-                  ER_THD(thd, ER_LOG_PURGE_NO_FILE), log_info.log_file_name);
-            }
-            LogErr(INFORMATION_LEVEL, ER_BINLOG_CANT_DELETE_FILE,
-                   log_info.log_file_name);
-            set_my_errno(0);
-          } else {
-            if (thd) {
-              push_warning_printf(thd, Sql_condition::SL_WARNING,
-                                  ER_BINLOG_PURGE_FATAL_ERR,
-                                  "a problem with deleting %s; "
-                                  "consider examining correspondence "
-                                  "of your binlog index file "
-                                  "to the actual binlog files",
-                                  log_info.log_file_name);
-            } else {
-              LogErr(INFORMATION_LEVEL,
-                     ER_BINLOG_CANT_DELETE_LOG_FILE_DOES_INDEX_MATCH_FILES,
-                     log_info.log_file_name);
-            }
-            if (my_errno() == EMFILE) {
-              DBUG_PRINT("info", ("my_errno: %d, set ret = LOG_INFO_EMFILE",
-                                  my_errno()));
-              error = LOG_INFO_EMFILE;
-              goto err;
-            }
-            error = LOG_INFO_FATAL;
-            goto err;
+          if (my_errno() == EMFILE) {
+            DBUG_PRINT("info",
+                       ("my_errno: %d, set ret = LOG_INFO_EMFILE", my_errno()));
+            error = LOG_INFO_EMFILE;
+            break;
           }
+          error = LOG_INFO_FATAL;
+          break;
         }
       }
     }
   }
-
-err:
   DBUG_RETURN(error);
 }
 

--- a/sql/binlog.h
+++ b/sql/binlog.h
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 #include <time.h>
 #include <atomic>
+#include <list>
 #include <utility>
 
 #include "binlog_event.h"  // enum_binlog_checksum_alg
@@ -69,6 +70,8 @@ class Binlog_cache_storage;
 struct Gtid;
 
 typedef int64 query_id_t;
+
+using log_file_name_container = std::list<std::string>;
 
 /*
   Maximum unique log filename extension.
@@ -807,6 +810,8 @@ class MYSQL_BIN_LOG : public TC_LOG {
   void make_log_name(char *buf, const char *log_ident);
   bool is_active(const char *log_file_name);
   int remove_logs_from_index(LOG_INFO *linfo, bool need_update_threads);
+  int remove_deleted_logs_from_index(bool need_lock_index,
+                                     bool need_update_threads);
   int rotate(bool force_rotate, bool *check_purge);
   void purge();
   int rotate_and_purge(THD *thd, bool force_rotate);
@@ -847,6 +852,8 @@ class MYSQL_BIN_LOG : public TC_LOG {
   int register_create_index_entry(const char *entry);
   int purge_index_entry(THD *thd, ulonglong *decrease_log_space,
                         bool need_lock_index);
+  int purge_logs_in_list(const log_file_name_container &delete_list, THD *thd,
+                         ulonglong *decrease_log_space, bool need_lock_index);
   bool reset_logs(THD *thd, bool delete_only = false);
   void close(uint exiting, bool need_lock_log, bool need_lock_index);
 

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5182,6 +5182,14 @@ static int init_server_components() {
         mysql_bin_log.open_index_file(opt_binlog_index_name, ln, true)) {
       unireg_abort(MYSQLD_ABORT_EXIT);
     }
+    /*
+      Remove entries of logs from the index that were deleted from
+      the file system but not from the index due to a crash.
+    */
+    if (!opt_help && mysql_bin_log.remove_deleted_logs_from_index(true, true) ==
+                         LOG_INFO_IO) {
+      unireg_abort(MYSQLD_ABORT_EXIT);
+    }
   }
 
   if (opt_bin_log) {

--- a/sql/rpl_rli.cc
+++ b/sql/rpl_rli.cc
@@ -1607,6 +1607,15 @@ int Relay_log_info::rli_init_info() {
       LogErr(ERROR_LEVEL, ER_RPL_OPEN_INDEX_FILE_FAILED);
       DBUG_RETURN(1);
     }
+    /*
+      Remove entries of logs from the index that were deleted from
+      the file system but not from the index due to a crash.
+    */
+    if (relay_log.remove_deleted_logs_from_index(true, false) == LOG_INFO_IO) {
+      LogErr(ERROR_LEVEL, ER_RPL_FAILED_IN_RLI_INIT_INFO,
+             "remove_deleted_logs_from_index()");
+      DBUG_RETURN(1);
+    }
 
     if (!gtid_retrieved_initialized) {
       /* Store the GTID of a transaction spanned in multiple relay log files */


### PR DESCRIPTION
Summary: 
JIRA: https://jira.percona.com/browse/FB8-77

Reference Patch: https://github.com/facebook/mysql-5.6/commit/832be30
Reference Patch: https://github.com/facebook/mysql-5.6/commit/0d85250
Reference Patch: https://github.com/facebook/mysql-5.6/commit/e8be5be

Changed the behavior of purging logs. Now deleting logs first and then updating the index.

Previously when purging logs, the index was updated before deleting the logs. This creates problems the disk is full. We should first delete logs to free up disk and then update index.

Test Plan: Modified existing test cases to test the change in order of operations.