### PR TITLE
FB8-97: Add mtr suppression rule for rpl.rpl_gtid_skip_writing_previous_gtid_set test

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_gtid_skip_writing_previous_gtid_set.result
+++ b/mysql-test/suite/rpl/r/rpl_gtid_skip_writing_previous_gtid_set.result
@@ -10,8 +10,10 @@ insert into t1 values(1);
 insert into t1 values(2);
 FLUSH LOGS;
 include/assert.inc [gtid set on master.]
+include/stop_slave.inc
 include/rpl_restart_server.inc [server_number=1 gtids=on parameters: --debug=d,skip_writing_previous_gtids_log_event]
 include/rpl_restart_server.inc [server_number=1 gtids=on]
+include/start_slave.inc
 include/assert.inc [gtid set on master after restart with skip_writing_previous_gtids_log_event.]
 include/start_slave.inc
 include/assert.inc [gtid set on slave.]

--- a/mysql-test/suite/rpl/t/rpl_gtid_skip_writing_previous_gtid_set.test
+++ b/mysql-test/suite/rpl/t/rpl_gtid_skip_writing_previous_gtid_set.test
@@ -3,6 +3,14 @@
 -- source include/rpl_reset.inc
 -- source include/have_debug.inc
 
+--disable_query_log
+connection slave;
+SET @save_sql_log_bin=@@sql_log_bin;
+SET sql_log_bin=0;
+CALL mtr.add_suppression("Slave SQL:*Request to stop slave SQL Thread received while applying a group that has non-transactional changes");
+SET sql_log_bin=@save_sql_log_bin;
+--enable_query_log
+
 -- connection master
 -- let $master_uuid= `SELECT @@SERVER_UUID`
 create table t1(a int);
@@ -14,12 +22,18 @@ FLUSH LOGS;
 -- let $assert_cond= GTID_IS_EQUAL(@@GLOBAL.GTID_EXECUTED, "$master_uuid:1-3")
 -- source include/assert.inc
 
+connection slave;
+source include/stop_slave.inc;
+-- connection master
 -- let $rpl_server_number= 1
 -- let $rpl_start_with_gtids= 1
 -- let $rpl_server_parameters= --debug=d,skip_writing_previous_gtids_log_event
 -- source include/rpl_restart_server.inc
 -- let $rpl_server_parameters=
 -- source include/rpl_restart_server.inc
+connection slave;
+source include/start_slave.inc;
+-- connection master
 
 -- let $assert_text = gtid set on master after restart with skip_writing_previous_gtids_log_event.
 -- let $assert_cond= GTID_IS_EQUAL(@@GLOBAL.GTID_EXECUTED, "$master_uuid:1-3")


### PR DESCRIPTION
Summary:

JIRA: https://jira.percona.com/browse/FB8-97

Reference Patch: https://github.com/facebook/mysql-5.6/commit/eaabc64
Reference Patch: https://github.com/facebook/mysql-5.6/commit/62c3073

Add mtr suppression rule for rpl.rpl_gtid_skip_writing_previous_gtid_set test

Adding slave start/stop calls to the
rpl.rpl_gtid_skip_writing_previous_gtid_set test can sometimes trigger a
warning message in the log. Add a new suppression rule for this warning
message since it does not cause the test to fail.

A flaky warning `failed registering on master` may happen in this rpl test,
when the master restarts twice in a row. The slave may still try to connect to
the master while the master restarts again. Adding stop/start slaves when
master restarts.

Test Plan:
mtr.

Also stressed with `--repeat=32 --parallel=32` and passed.