### PR TITLE
FB8-129 Bug#26997096: RELAY_LOG_SPACE IS INACCURATE AND LEAKS

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_relay_log_space_synchronization.result
+++ b/mysql-test/suite/rpl/r/rpl_relay_log_space_synchronization.result
@@ -1,0 +1,23 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+CREATE TABLE t1 (i INT);
+include/sync_slave_sql_with_master.inc
+include/stop_slave_sql.inc
+SET GLOBAL debug='+d,wait_in_purge_index_entry';
+FLUSH LOCAL RELAY LOGS;
+START SLAVE SQL_THREAD;
+SET DEBUG_SYNC="now WAIT_FOR in_purge_index_entry";
+[connection master]
+INSERT INTO t1 VALUES (1);
+[connection slave]
+include/assert.inc [IO Thread is waiting for Relay_log_info::log_space_lock.]
+SET DEBUG_SYNC="now SIGNAL go_ahead_sql";
+[connection master]
+DROP TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL debug='-d,wait_in_purge_index_entry';
+SET DEBUG_SYNC="RESET";
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_relay_log_space_synchronization.test
+++ b/mysql-test/suite/rpl/t/rpl_relay_log_space_synchronization.test
@@ -1,0 +1,64 @@
+# === Purpose ===
+#
+# This test verifies that SQL and IO threads update the
+# rli->relay_log_space_total variable in a synchronized manner.
+#
+# === Implementation ===
+#
+# 1. On Slave, make the SQL thread to purge relay logs and halt
+#    the SQL thread in MYSQL_BIN_LOG::purge_index_entry function
+#    using debug sync utility.
+# 2. Do a DML on master so that IO thread calls queue_event and
+#    updates rli->relay_log_space_total.
+# 3. Verify that IO thread is waiting rli->log_space_lock until it is released
+#    by SQL thread.
+#
+# === References ===
+#
+# Bug#26997096 RELAY_LOG_SPACE IS INACCURATE AND LEAKS
+
+# This test case is binlog_format agnostic
+--source include/have_binlog_format_row.inc
+# This test case uses debug_sync
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+--source include/master-slave.inc
+
+CREATE TABLE t1 (i INT);
+
+--source include/sync_slave_sql_with_master.inc
+--source include/stop_slave_sql.inc
+SET GLOBAL debug='+d,wait_in_purge_index_entry';
+
+# Create a new relay log so the START SLAVE SQL_THREAD tries
+# to purge the old relay logs and hits the debug point.
+FLUSH LOCAL RELAY LOGS;
+START SLAVE SQL_THREAD;
+SET DEBUG_SYNC="now WAIT_FOR in_purge_index_entry";
+
+# Do a DML on master so that IO thread calls queue_event and
+# updates rli->relay_log_space_total.
+--source include/rpl_connection_master.inc
+INSERT INTO t1 VALUES (1);
+--source include/rpl_connection_slave.inc
+
+# Wait until IO thread tries to take a log_space_lock.
+--let $io_thread_id = `SELECT THREAD_ID FROM performance_schema.threads WHERE NAME like '%slave_io%'`
+--let $wait_condition= SELECT EVENT_NAME= 'wait/synch/mutex/sql/Relay_log_info::log_space_lock' FROM performance_schema.events_waits_current WHERE THREAD_ID=$io_thread_id
+--source include/wait_condition.inc
+
+# Since SQL thread has taken the rli->log_space_lock, IO thread should wait until
+# the lock is released. Assert that IO thread is waiting for rli->log_space_lock.
+--let $assert_text= IO Thread is waiting for Relay_log_info::log_space_lock.
+--let $assert_cond= "[SELECT EVENT_NAME FROM performance_schema.events_waits_current WHERE THREAD_ID=$io_thread_id]" = "wait/synch/mutex/sql/Relay_log_info::log_space_lock"
+--source include/assert.inc
+
+SET DEBUG_SYNC="now SIGNAL go_ahead_sql";
+
+# Cleanup
+--source include/rpl_connection_master.inc
+DROP TABLE t1;
+--source include/sync_slave_sql_with_master.inc
+SET GLOBAL debug='-d,wait_in_purge_index_entry';
+SET DEBUG_SYNC="RESET";
+--source include/rpl_end.inc

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -5883,6 +5883,13 @@ int MYSQL_BIN_LOG::purge_index_entry(THD *thd, ulonglong *decrease_log_space,
         DBUG_PRINT("info", ("purging %s", log_info.log_file_name));
         if (!mysql_file_delete(key_file_binlog, log_info.log_file_name,
                                MYF(0))) {
+          DBUG_EXECUTE_IF("wait_in_purge_index_entry", {
+            const char action[] =
+                "now SIGNAL in_purge_index_entry WAIT_FOR go_ahead_sql";
+            DBUG_ASSERT(!debug_sync_set_action(thd, STRING_WITH_LEN(action)));
+            DBUG_SET("-d,wait_in_purge_index_entry");
+          };);
+
           if (decrease_log_space) *decrease_log_space -= s.st_size;
         } else {
           if (my_errno() == ENOENT) {
@@ -6426,7 +6433,7 @@ bool MYSQL_BIN_LOG::after_write_to_relay_log(Master_info *mi) {
   lock_binlog_end_pos();
   mi->rli->ign_master_log_name_end[0] = 0;
   update_binlog_end_pos(false /*need_lock*/);
-  harvest_bytes_written(&mi->rli->log_space_total);
+  harvest_bytes_written(mi->rli, true /*need_log_space_lock=true*/);
   unlock_binlog_end_pos();
 
   DBUG_RETURN(error);
@@ -7368,6 +7375,26 @@ void MYSQL_BIN_LOG::close(
 
   if (need_lock_log) mysql_mutex_unlock(&LOCK_log);
 
+  DBUG_VOID_RETURN;
+}
+
+void MYSQL_BIN_LOG::harvest_bytes_written(Relay_log_info *rli,
+                                          bool need_log_space_lock) {
+#ifndef DBUG_OFF
+  char buf1[22], buf2[22];
+#endif
+
+  DBUG_ENTER("harvest_bytes_written");
+  if (need_log_space_lock)
+    mysql_mutex_lock(&rli->log_space_lock);
+  else
+    mysql_mutex_assert_owner(&rli->log_space_lock);
+  rli->log_space_total += bytes_written;
+  DBUG_PRINT("info",
+             ("relay_log_space: %s  bytes_written: %s",
+              llstr(rli->log_space_total, buf1), llstr(bytes_written, buf2)));
+  bytes_written = 0;
+  if (need_log_space_lock) mysql_mutex_unlock(&rli->log_space_lock);
   DBUG_VOID_RETURN;
 }
 

--- a/sql/binlog.h
+++ b/sql/binlog.h
@@ -697,17 +697,7 @@ class MYSQL_BIN_LOG : public TC_LOG {
 #endif /* defined(MYSQL_SERVER) */
   void add_bytes_written(ulonglong inc) { bytes_written += inc; }
   void reset_bytes_written() { bytes_written = 0; }
-  void harvest_bytes_written(ulonglong *counter) {
-#ifndef DBUG_OFF
-    char buf1[22], buf2[22];
-#endif
-    DBUG_ENTER("harvest_bytes_written");
-    (*counter) += bytes_written;
-    DBUG_PRINT("info", ("counter: %s  bytes_written: %s", llstr(*counter, buf1),
-                        llstr(bytes_written, buf2)));
-    bytes_written = 0;
-    DBUG_VOID_RETURN;
-  }
+  void harvest_bytes_written(Relay_log_info *rli, bool need_log_space_lock);
   void set_max_size(ulong max_size_arg);
   void signal_update() {
     DBUG_ENTER("MYSQL_BIN_LOG::signal_update");

--- a/sql/rpl_rli.cc
+++ b/sql/rpl_rli.cc
@@ -30,6 +30,7 @@
 
 #include "binlog_event.h"
 #include "m_ctype.h"
+#include "mutex_lock.h"  // Mutex_lock
 #include "my_dbug.h"
 #include "my_dir.h"  // MY_STAT
 #include "my_sqlcommand.h"
@@ -440,6 +441,7 @@ err:
 static inline int add_relay_log(Relay_log_info *rli, LOG_INFO *linfo) {
   MY_STAT s;
   DBUG_ENTER("add_relay_log");
+  mysql_mutex_assert_owner(&rli->log_space_lock);
   if (!mysql_file_stat(key_file_relaylog, linfo->log_file_name, &s, MYF(0))) {
     LogErr(ERROR_LEVEL, ER_RPL_FAILED_TO_STAT_LOG_IN_INDEX,
            linfo->log_file_name);
@@ -456,6 +458,7 @@ static inline int add_relay_log(Relay_log_info *rli, LOG_INFO *linfo) {
 int Relay_log_info::count_relay_log_space() {
   LOG_INFO flinfo;
   DBUG_ENTER("Relay_log_info::count_relay_log_space");
+  MUTEX_LOCK(lock, &log_space_lock);
   log_space_total = 0;
   if (relay_log.find_log_pos(&flinfo, NullS, 1)) {
     LogErr(ERROR_LEVEL, ER_RPL_LOG_NOT_FOUND_WHILE_COUNTING_RELAY_LOG_SPACE);
@@ -1756,7 +1759,7 @@ void Relay_log_info::end_info() {
   inited = 0;
   relay_log.close(LOG_CLOSE_INDEX | LOG_CLOSE_STOP_EVENT,
                   true /*need_lock_log=true*/, true /*need_lock_index=true*/);
-  relay_log.harvest_bytes_written(&log_space_total);
+  relay_log.harvest_bytes_written(this, true /*need_log_space_lock=true*/);
   /*
     Delete the slave's temporary tables from memory.
     In the future there will be other actions than this, to ensure persistance

--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -2889,7 +2889,7 @@ static bool wait_for_relay_log_space(Relay_log_info *rli) {
     }
 #endif
     if (rli->sql_force_rotate_relay) {
-      rotate_relay_log(mi);
+      rotate_relay_log(mi, true, true, false);
       rli->sql_force_rotate_relay = false;
     }
 
@@ -6981,7 +6981,7 @@ static int process_io_rotate(Master_info *mi, Rotate_log_event *rev) {
     Master will send a FD event immediately after the Roate event, so don't log
     the current FD event.
   */
-  int ret = rotate_relay_log(mi, false, false);
+  int ret = rotate_relay_log(mi, false, false, true);
 
   mysql_mutex_lock(&mi->data_lock);
   /* Safe copy as 'rev' has been "sanitized" in Rotate_log_event's ctor */
@@ -7921,7 +7921,8 @@ static int safe_reconnect(THD *thd, MYSQL *mysql, Master_info *mi,
   is void).
 */
 
-int rotate_relay_log(Master_info *mi, bool log_master_fd, bool need_lock) {
+int rotate_relay_log(Master_info *mi, bool log_master_fd, bool need_lock,
+                     bool need_log_space_lock) {
   DBUG_ENTER("rotate_relay_log");
 
   Relay_log_info *rli = mi->rli;
@@ -7964,7 +7965,7 @@ int rotate_relay_log(Master_info *mi, bool log_master_fd, bool need_lock) {
     If the log is closed, then this will just harvest the last writes, probably
     0 as they probably have been harvested.
   */
-  rli->relay_log.harvest_bytes_written(&rli->log_space_total);
+  rli->relay_log.harvest_bytes_written(rli, need_log_space_lock);
 end:
   if (need_lock) mysql_mutex_unlock(rli->relay_log.get_log_lock());
   DBUG_RETURN(error);

--- a/sql/rpl_slave.h
+++ b/sql/rpl_slave.h
@@ -482,7 +482,7 @@ void init_thread_mask(int *mask, Master_info *mi, bool inverse);
 void set_slave_thread_options(THD *thd);
 void set_slave_thread_default_charset(THD *thd, Relay_log_info const *rli);
 int rotate_relay_log(Master_info *mi, bool log_master_fd = true,
-                     bool need_lock = true);
+                     bool need_lock = true, bool need_log_space_lock = true);
 typedef enum {
   QUEUE_EVENT_OK = 0,
   QUEUE_EVENT_ERROR_QUEUING,


### PR DESCRIPTION
Problem
-------
The Relay_Log_Space variable shown in SHOW SLAVE STATUS is
sometimes much higher than the actual disk space used by relay
logs.

Analysis
--------
This is because we are not writing to
Relay_log_info::log_space_total in a synchronized manner. i.e, no
lock is being taken by the IO thread while updating the variable.

Fix
---
The Relay_log_info::log_space_total is now guarded by the
Relay_log_info::log_space_lock and this protects concurrent
update on Relay_log_info::log_space_total.

This solves https://jira.percona.com/browse/FB8-129

Reference Patch: https://github.com/mysql/mysql-server/commit/14c10add4
Resolves https://bugs.mysql.com/bug.php?id=87832, which is fixed in 8.0.14, where this patch can be dropped.