### PR TITLE
FB8-96: Remove special formatting for user name when writing to audit plugin log

### DIFF
--- a/sql/sql_audit.cc
+++ b/sql/sql_audit.cc
@@ -354,7 +354,6 @@ int mysql_audit_notify(THD *thd, mysql_event_general_subclass_t subclass,
                        const char *subclass_name, int error_code,
                        const char *msg, size_t msg_len) {
   mysql_event_general event;
-  char user_buff[MAX_USER_HOST_SIZE];
 
   DBUG_ASSERT(thd);
 
@@ -368,8 +367,8 @@ int mysql_audit_notify(THD *thd, mysql_event_general_subclass_t subclass,
 
   Security_context *sctx = thd->security_context();
 
-  event.general_user.str = user_buff;
-  event.general_user.length = make_user_name(sctx, user_buff);
+  event.general_user.str = thd->security_context()->user().str;
+  event.general_user.length = thd->security_context()->user().str ? thd->security_context()->user().length : 0;
   event.general_ip = sctx->ip();
   event.general_host = sctx->host();
   event.general_external_user = sctx->external_user();


### PR DESCRIPTION
Jira issue: https://jira.percona.com/browse/FB8-96

Reference patch: https://github.com/facebook/mysql-5.6/commit/3b47dae
Reference patch: https://github.com/facebook/mysql-5.6/commit/87e0683