### PR TITLE
FB8-84: Add global variable `max_nonsuper_connections`

### DIFF
--- a/mysql-test/r/max_nonsuper_connections.result
+++ b/mysql-test/r/max_nonsuper_connections.result
@@ -1,0 +1,82 @@
+create user test_user@localhost;
+grant all on test to test_user@localhost;
+create user super_user@localhost;
+grant all on *.* to super_user@localhost with grant option;
+SET @start_value = @@global.max_nonsuper_connections;
+SET @@global.max_nonsuper_connections = 10;
+SELECT @@global.max_nonsuper_connections;
+@@global.max_nonsuper_connections
+10
+connection default;
+connect  con$i, localhost, test_user,,test;
+connect  con$i, localhost, test_user,,test;
+connect  con$i, localhost, test_user,,test;
+connect  con$i, localhost, test_user,,test;
+connect  con$i, localhost, test_user,,test;
+connect  con$i, localhost, test_user,,test;
+connect  con$i, localhost, test_user,,test;
+connect  con$i, localhost, test_user,,test;
+connect  con$i, localhost, test_user,,test;
+connect  con$i, localhost, test_user,,test;
+ERROR 08004: Too many connections
+connect  con_root, localhost, root,,test;
+# connection con_root
+connection con_root;
+SELECT @@global.max_nonsuper_connections;
+@@global.max_nonsuper_connections
+10
+disconnect con_root;
+connection default;
+connect  con_super, localhost, super_user,,test;
+connection con_super;
+SELECT @@global.max_nonsuper_connections;
+@@global.max_nonsuper_connections
+10
+mysqltest: At line 1: Query 'change_user test_user' failed.
+ERROR 1040 (08004): Too many connections
+disconnect con_super;
+connection con10;
+connect  con11, localhost, test_user,,test;
+disconnect con11;
+connection con10;
+ERROR 08004: Too many connections
+connection default;
+disconnect con10;
+disconnect con9;
+disconnect con8;
+disconnect con7;
+disconnect con6;
+disconnect con5;
+disconnect con4;
+disconnect con3;
+disconnect con2;
+disconnect con1;
+connection default;
+connect  con$i, localhost, test_user,,test;
+connect  con$i, localhost, test_user,,test;
+connect  con$i, localhost, test_user,,test;
+connect  con$i, localhost, test_user,,test;
+connect  con$i, localhost, test_user,,test;
+connect  con$i, localhost, test_user,,test;
+connect  con$i, localhost, test_user,,test;
+connect  con$i, localhost, test_user,,test;
+connect  con$i, localhost, test_user,,test;
+connect  con$i, localhost, test_user,,test;
+ERROR 08004: Too many connections
+connection default;
+SET @@global.max_nonsuper_connections = @start_value;
+SELECT @@global.max_nonsuper_connections;
+@@global.max_nonsuper_connections
+0
+drop user test_user@localhost;
+drop user super_user@localhost;
+disconnect con10;
+disconnect con9;
+disconnect con8;
+disconnect con7;
+disconnect con6;
+disconnect con5;
+disconnect con4;
+disconnect con3;
+disconnect con2;
+disconnect con1;

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -608,6 +608,9 @@ The following options may be given as the first argument:
  max_join_size records return an error
  --max-length-for-sort-data=# 
  Max number of bytes in sorted records
+ --max-nonsuper-connections=# 
+ The maximum number of total active connections for
+ non-super user (0 = no limit)
  --max-points-in-geometry[=#] 
  Maximum number of points in a geometry
  --max-prepared-stmt-count=# 
@@ -1546,6 +1549,7 @@ max-execution-time 0
 max-heap-table-size 16777216
 max-join-size 18446744073709551615
 max-length-for-sort-data 4096
+max-nonsuper-connections 0
 max-points-in-geometry 65536
 max-prepared-stmt-count 16382
 max-relay-log-size 0

--- a/mysql-test/suite/sys_vars/r/max_nonsuper_connections_basic.result
+++ b/mysql-test/suite/sys_vars/r/max_nonsuper_connections_basic.result
@@ -1,0 +1,100 @@
+SET @start_value = @@global.max_nonsuper_connections;
+SELECT @start_value;
+@start_value
+0
+SET @@global.max_nonsuper_connections = DEFAULT;
+SELECT @@global.max_nonsuper_connections;
+@@global.max_nonsuper_connections
+0
+SET @@global.max_nonsuper_connections = 100000;
+SELECT @@global.max_nonsuper_connections;
+@@global.max_nonsuper_connections
+100000
+SET @@global.max_nonsuper_connections = 99999;
+SELECT @@global.max_nonsuper_connections;
+@@global.max_nonsuper_connections
+99999
+SET @@global.max_nonsuper_connections = 65536;
+SELECT @@global.max_nonsuper_connections;
+@@global.max_nonsuper_connections
+65536
+SET @@global.max_nonsuper_connections = 1;
+SELECT @@global.max_nonsuper_connections;
+@@global.max_nonsuper_connections
+1
+SET @@global.max_nonsuper_connections = 2;
+SELECT @@global.max_nonsuper_connections;
+@@global.max_nonsuper_connections
+2
+SET @@global.max_nonsuper_connections = TRUE;
+SELECT @@global.max_nonsuper_connections;
+@@global.max_nonsuper_connections
+1
+SET @@global.max_nonsuper_connections = FALSE;
+SELECT @@global.max_nonsuper_connections;
+@@global.max_nonsuper_connections
+0
+SET @@global.max_nonsuper_connections = -1;
+Warnings:
+Warning	1292	Truncated incorrect max_nonsuper_connections value: '-1'
+SELECT @@global.max_nonsuper_connections;
+@@global.max_nonsuper_connections
+0
+SET @@global.max_nonsuper_connections = 100000000000;
+SELECT @@global.max_nonsuper_connections;
+@@global.max_nonsuper_connections
+100000000000
+SET @@global.max_nonsuper_connections = 10000.01;
+ERROR 42000: Incorrect argument type to variable 'max_nonsuper_connections'
+SELECT @@global.max_nonsuper_connections;
+@@global.max_nonsuper_connections
+100000000000
+SET @@global.max_nonsuper_connections = -1024;
+Warnings:
+Warning	1292	Truncated incorrect max_nonsuper_connections value: '-1024'
+SELECT @@global.max_nonsuper_connections;
+@@global.max_nonsuper_connections
+0
+SET @@global.max_nonsuper_connections = ON;
+ERROR 42000: Incorrect argument type to variable 'max_nonsuper_connections'
+SELECT @@global.max_nonsuper_connections;
+@@global.max_nonsuper_connections
+0
+SET @@global.max_nonsuper_connections = 'test';
+ERROR 42000: Incorrect argument type to variable 'max_nonsuper_connections'
+SELECT @@global.max_nonsuper_connections;
+@@global.max_nonsuper_connections
+0
+SET @@session.max_nonsuper_connections = 4096;
+ERROR HY000: Variable 'max_nonsuper_connections' is a GLOBAL variable and should be set with SET GLOBAL
+SELECT @@session.max_nonsuper_connections;
+ERROR HY000: Variable 'max_nonsuper_connections' is a GLOBAL variable
+SET max_nonsuper_connections = 6000;
+ERROR HY000: Variable 'max_nonsuper_connections' is a GLOBAL variable and should be set with SET GLOBAL
+SELECT @@max_nonsuper_connections;
+@@max_nonsuper_connections
+0
+SET local.max_nonsuper_connections = 7000;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'local.max_nonsuper_connections = 7000' at line 1
+SELECT local.max_nonsuper_connections;
+ERROR 42S02: Unknown table 'local' in field list
+SET global.max_nonsuper_connections = 8000;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'global.max_nonsuper_connections = 8000' at line 1
+SELECT global.max_nonsuper_connections;
+ERROR 42S02: Unknown table 'global' in field list
+SELECT max_nonsuper_connections = @@session.max_nonsuper_connections;
+ERROR 42S22: Unknown column 'max_nonsuper_connections' in 'field list'
+SELECT @@global.max_nonsuper_connections = VARIABLE_VALUE
+FROM performance_schema.global_variables
+WHERE VARIABLE_NAME='max_nonsuper_connections';
+@@global.max_nonsuper_connections = VARIABLE_VALUE
+1
+SELECT @@max_nonsuper_connections = VARIABLE_VALUE
+FROM performance_schema.session_variables
+WHERE VARIABLE_NAME='max_nonsuper_connections';
+@@max_nonsuper_connections = VARIABLE_VALUE
+1
+SET @@global.max_nonsuper_connections = @start_value;
+SELECT @@global.max_nonsuper_connections;
+@@global.max_nonsuper_connections
+0

--- a/mysql-test/suite/sys_vars/t/max_nonsuper_connections_basic.test
+++ b/mysql-test/suite/sys_vars/t/max_nonsuper_connections_basic.test
@@ -1,0 +1,95 @@
+--source include/load_sysvars.inc
+
+#
+# save original value
+#
+SET @start_value = @@global.max_nonsuper_connections;
+SELECT @start_value;
+
+
+#
+# set default value
+#
+SET @@global.max_nonsuper_connections = DEFAULT;
+SELECT @@global.max_nonsuper_connections;
+
+
+#
+# set various values
+#
+SET @@global.max_nonsuper_connections = 100000;
+SELECT @@global.max_nonsuper_connections;
+SET @@global.max_nonsuper_connections = 99999;
+SELECT @@global.max_nonsuper_connections;
+SET @@global.max_nonsuper_connections = 65536;
+SELECT @@global.max_nonsuper_connections;
+SET @@global.max_nonsuper_connections = 1;
+SELECT @@global.max_nonsuper_connections;
+SET @@global.max_nonsuper_connections = 2;
+SELECT @@global.max_nonsuper_connections;
+SET @@global.max_nonsuper_connections = TRUE;
+SELECT @@global.max_nonsuper_connections;
+SET @@global.max_nonsuper_connections = FALSE;
+SELECT @@global.max_nonsuper_connections;
+
+
+#
+# set invalid values
+#
+# Value truncated
+SET @@global.max_nonsuper_connections = -1;
+SELECT @@global.max_nonsuper_connections;
+# Value truncated
+SET @@global.max_nonsuper_connections = 100000000000;
+SELECT @@global.max_nonsuper_connections;
+--Error ER_WRONG_TYPE_FOR_VAR
+SET @@global.max_nonsuper_connections = 10000.01;
+SELECT @@global.max_nonsuper_connections;
+# Value truncated
+SET @@global.max_nonsuper_connections = -1024;
+SELECT @@global.max_nonsuper_connections;
+
+--Error ER_WRONG_TYPE_FOR_VAR
+SET @@global.max_nonsuper_connections = ON;
+SELECT @@global.max_nonsuper_connections;
+--Error ER_WRONG_TYPE_FOR_VAR
+SET @@global.max_nonsuper_connections = 'test';
+SELECT @@global.max_nonsuper_connections;
+
+--Error ER_GLOBAL_VARIABLE
+SET @@session.max_nonsuper_connections = 4096;
+--Error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.max_nonsuper_connections;
+
+--Error ER_GLOBAL_VARIABLE
+SET max_nonsuper_connections = 6000;
+SELECT @@max_nonsuper_connections;
+--Error ER_PARSE_ERROR
+SET local.max_nonsuper_connections = 7000;
+--Error ER_UNKNOWN_TABLE
+SELECT local.max_nonsuper_connections;
+--Error ER_PARSE_ERROR
+SET global.max_nonsuper_connections = 8000;
+--Error ER_UNKNOWN_TABLE
+SELECT global.max_nonsuper_connections;
+--Error ER_BAD_FIELD_ERROR
+SELECT max_nonsuper_connections = @@session.max_nonsuper_connections;
+
+
+#
+# Check if the value in GLOBAL & SESSION Tables matches values in variable
+#
+SELECT @@global.max_nonsuper_connections = VARIABLE_VALUE
+FROM performance_schema.global_variables
+WHERE VARIABLE_NAME='max_nonsuper_connections';
+
+SELECT @@max_nonsuper_connections = VARIABLE_VALUE
+FROM performance_schema.session_variables
+WHERE VARIABLE_NAME='max_nonsuper_connections';
+
+
+#
+# restore
+#
+SET @@global.max_nonsuper_connections = @start_value;
+SELECT @@global.max_nonsuper_connections;

--- a/mysql-test/t/max_nonsuper_connections.test
+++ b/mysql-test/t/max_nonsuper_connections.test
@@ -1,0 +1,131 @@
+# Save the initial number of concurrent sessions
+--source include/count_sessions.inc
+
+create user test_user@localhost;
+grant all on test to test_user@localhost;
+
+create user super_user@localhost;
+grant all on *.* to super_user@localhost with grant option;
+
+SET @start_value = @@global.max_nonsuper_connections;
+
+SET @@global.max_nonsuper_connections = 10;
+SELECT @@global.max_nonsuper_connections;
+
+enable_connect_log;
+connection default;
+
+#
+# fill up max_nonsuper_connections
+#
+let $i = 10;
+while ($i)
+{
+  connect (con$i, localhost, test_user,,test);
+  dec $i;
+}
+
+#
+# New non-admin connection will be rejected
+#
+disable_query_log;
+--error ER_CON_COUNT_ERROR
+connect (con11, localhost, test_user,,test);
+enable_query_log;
+
+#
+# admin user connection is not limited by max_nonsuper_connections
+#
+connect (con_root, localhost, root,,test);
+--echo # connection con_root
+connection con_root;
+SELECT @@global.max_nonsuper_connections;
+disconnect con_root;
+connection default;
+
+#
+# Test another admin super_user
+#
+connect (con_super, localhost, super_user,,test);
+connection con_super;
+SELECT @@global.max_nonsuper_connections;
+
+#
+# change admin user to regular user in the current connection will fail
+# because max_total_user_connection is already reached
+#
+--error 1
+--exec echo "--change_user test_user" | $MYSQL_TEST 2>&1
+
+#
+# change user to root is OK
+#
+change_user root;
+disconnect con_super;
+
+#
+# change regular user to root will free up the nonsuper_connections
+# so we will be able to connect another regular user
+#
+connection con10;
+change_user root;
+connect (con11, localhost, test_user,,test);
+disconnect con11;
+
+#
+# change con10 back to regular user
+#
+connection con10;
+# wait for con11 to be disconnected
+let $wait_condition=
+  select count(*)=9 from information_schema.processlist where user='test_user';
+source include/wait_condition.inc;
+# now change user in con10
+change_user test_user;
+disable_query_log;
+# no new regular connection can be accepted
+--error ER_CON_COUNT_ERROR
+connect (con11, localhost, test_user,,test);
+enable_query_log;
+
+#
+# decrement user connection counts
+#
+connection default;
+let $i= 10;
+while ($i)
+{
+  disconnect con$i;
+  dec $i;
+}
+
+# able to refill up max_nonsuper_connections
+connection default;
+let $i = 10;
+while ($i)
+{
+  connect (con$i, localhost, test_user,,test);
+  dec $i;
+}
+disable_query_log;
+--error ER_CON_COUNT_ERROR
+connect (con11, localhost, test_user,,test);
+enable_query_log;
+
+#
+# restore
+#
+connection default;
+SET @@global.max_nonsuper_connections = @start_value;
+SELECT @@global.max_nonsuper_connections;
+drop user test_user@localhost;
+drop user super_user@localhost;
+let $i= 10;
+while ($i)
+{
+  disconnect con$i;
+  dec $i;
+}
+
+# Wait till all disconnects are completed
+--source include/wait_until_count_sessions.inc

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1124,6 +1124,7 @@ ulong specialflag = 0;
 ulong binlog_cache_use = 0, binlog_cache_disk_use = 0;
 ulong binlog_stmt_cache_use = 0, binlog_stmt_cache_disk_use = 0;
 ulong max_connections, max_connect_errors;
+ulong max_nonsuper_connections = 0, nonsuper_connections = 0;
 ulong rpl_stop_slave_timeout = LONG_TIMEOUT;
 bool log_bin_use_v1_row_events = 0;
 bool thread_cache_size_specified = false;

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -287,6 +287,7 @@ extern ulong tablespace_def_size;
 extern MYSQL_PLUGIN_IMPORT ulong max_connections;
 extern ulong max_digest_length;
 extern ulong max_connect_errors, connect_timeout;
+extern ulong max_nonsuper_connections, nonsuper_connections;
 extern bool opt_slave_allow_batching;
 extern ulong slave_trans_retries;
 extern uint slave_net_timeout;

--- a/sql/sql_connect.cc
+++ b/sql/sql_connect.cc
@@ -274,6 +274,13 @@ void release_user_connection(THD *thd) {
   const USER_CONN *uc = thd->get_user_connect();
   DBUG_ENTER("release_user_connection");
 
+  if (!thd->m_main_security_ctx.check_access(SUPER_ACL)) {
+    mysql_mutex_lock(&LOCK_user_conn);
+    // this is non-super user, decrement nonsuper_connections
+    nonsuper_connections--;
+    mysql_mutex_unlock(&LOCK_user_conn);
+  }
+
   if (uc) {
     mysql_mutex_lock(&LOCK_user_conn);
     DBUG_ASSERT(uc->connections > 0);

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1678,6 +1678,12 @@ bool dispatch_command(THD *thd, const COM_DATA *com_data,
         PSI_THREAD_CALL(notify_session_change_user)(thd->get_psi());
 #endif /* HAVE_PSI_THREAD_INTERFACE */
 
+        if (!save_security_ctx.check_access(SUPER_ACL)) {
+          mysql_mutex_lock(&LOCK_user_conn);
+          // previous user was a non-super user, decrement nonsuper_connections
+          nonsuper_connections--;
+          mysql_mutex_unlock(&LOCK_user_conn);
+        }
         if (save_user_connect) decrease_user_connections(save_user_connect);
         mysql_mutex_lock(&thd->LOCK_thd_data);
         my_free(const_cast<char *>(save_db.str));

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -2458,6 +2458,14 @@ static Sys_var_ulong Sys_max_binlog_size(
     BLOCK_SIZE(IO_SIZE), NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(0),
     ON_UPDATE(fix_max_binlog_size));
 
+static Sys_var_ulong Sys_max_nonsuper_connections(
+    "max_nonsuper_connections",
+    "The maximum number of total active connections for non-super user "
+    "(0 = no limit)",
+    GLOBAL_VAR(max_nonsuper_connections), CMD_LINE(REQUIRED_ARG),
+    VALID_RANGE(0, ULONG_MAX), DEFAULT(0), BLOCK_SIZE(1), NO_MUTEX_GUARD,
+    NOT_IN_BINLOG);
+
 static Sys_var_ulong Sys_max_connections(
     "max_connections", "The number of simultaneous clients allowed",
     GLOBAL_VAR(max_connections), CMD_LINE(REQUIRED_ARG), VALID_RANGE(1, 100000),


### PR DESCRIPTION
Because of conflicts I removed changes in `mysql-test/t/all_persisted_variables.test`. This test has to be modified at `let $total_persistent_vars=XXX;` (+1 increase) and it should be re-recorded.

```
JIRA: https://jira.percona.com/browse/FB8-84

Reference Patch: https://github.com/facebook/mysql-5.6/commit/478fa2a

The new global variable `max_nonsuper_connections` will enforce the limit for
the sum of all non-admin connections. This will be useful to limit regular user
connections while still allow super users to connect to server.
```