### PR TITLE
FB8-85: Copy and move index file only when there are changes

### DIFF
--- a/mysql-test/suite/binlog/r/binlog_index.result
+++ b/mysql-test/suite/binlog/r/binlog_index.result
@@ -350,7 +350,6 @@ call mtr.add_suppression("Failed to delete the existing index file");
 call mtr.add_suppression("failed to move crash safe index file to index file");
 call mtr.add_suppression("failed to update the index file");
 PURGE BINARY LOGS TO 'binlog.000014';;
-ERROR HY000: I/O error reading log index file
 # Test if both the index file and binlogs are in sync
 # Also this will indicate that binary logging is not disabled.
 show binary logs;

--- a/mysql-test/suite/binlog/t/binlog_index.test
+++ b/mysql-test/suite/binlog/t/binlog_index.test
@@ -462,9 +462,7 @@ call mtr.add_suppression("Failed to delete the existing index file");
 call mtr.add_suppression("failed to move crash safe index file to index file");
 call mtr.add_suppression("failed to update the index file");
 
-# When index file cannot be recreated during purge binary logs command,
-# it should throw error but it should not disable binary logging.
--- error ER_IO_ERR_LOG_INDEX_READ
+# PURGE BINARY LOGS COMMAND doesn't throw ER_IO_ERR_LOG_INDEX_READ when delete_list.size() == 0
 -- eval PURGE BINARY LOGS TO 'binlog.000014';
 
 -- echo # Test if both the index file and binlogs are in sync

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -3706,7 +3706,8 @@ int MYSQL_BIN_LOG::remove_deleted_logs_from_index(bool need_lock_index,
     ++no_of_log_files_purged;
   }
 
-  error = remove_logs_from_index(&log_info, need_update_threads);
+  if (no_of_log_files_purged)
+    error = remove_logs_from_index(&log_info, need_update_threads);
   DBUG_PRINT("info", ("num binlogs deleted = %d", no_of_log_files_purged));
 
 err:
@@ -5653,8 +5654,7 @@ err:
 int MYSQL_BIN_LOG::purge_logs(const char *to_log, bool included,
                               bool need_lock_index, bool need_update_threads,
                               ulonglong *decrease_log_space, bool auto_purge) {
-  int error = 0, error_index = 0, no_of_log_files_to_purge = 0,
-      no_of_log_files_purged = 0;
+  int error = 0, error_index = 0, no_of_log_files_to_purge = 0;
   int no_of_threads_locking_log = 0;
   bool exit_loop = 0;
   LOG_INFO log_info;
@@ -5699,10 +5699,9 @@ int MYSQL_BIN_LOG::purge_logs(const char *to_log, bool included,
                             ER_WARN_PURGE_LOG_IN_USE,
                             ER_THD(thd, ER_WARN_PURGE_LOG_IN_USE),
                             log_info.log_file_name, no_of_threads_locking_log,
-                            no_of_log_files_purged, no_of_log_files_to_purge);
+                            delete_list.size(), no_of_log_files_to_purge);
       break;
     }
-    no_of_log_files_purged++;
 
     delete_list.emplace_back(log_info.log_file_name);
 
@@ -5720,7 +5719,8 @@ int MYSQL_BIN_LOG::purge_logs(const char *to_log, bool included,
   DBUG_EXECUTE_IF("crash_purge_critical_before_update_index", DBUG_SUICIDE(););
 
   /* We know how many files to delete. Update index file. */
-  if ((error = remove_logs_from_index(&log_info, need_update_threads))) {
+  if (delete_list.size() &&
+      (error = remove_logs_from_index(&log_info, need_update_threads))) {
     LogErr(ERROR_LEVEL, ER_BINLOG_PURGE_LOGS_CANT_UPDATE_INDEX_FILE);
     goto err;
   }


### PR DESCRIPTION
Jira ticket: https://jira.percona.com/browse/FB8-85

Reference Patch: https://github.com/facebook/mysql-5.6/commit/4a1823a

Can be squashed with FB8-77 `Changed the behavior of purging logs. Now deleting logs first and then updating the index.`:
https://jira.percona.com/browse/FB8-77
https://github.com/facebook/mysql-5.6/commit/97ae20bd3aa24aee6d3ad87ec7833931c451d887

When index file is updated, it is first copied to a crash safe index
file, updates are made to the crash safe file and finally the crash safe file is
renamed. During purge, all this should happen only when at least one log is
being removed.

Squash with D13930811