### PR TITLE
FB8-71: SHOW MASTER|BINARY LOGS [WITH GTID]

### DIFF
--- a/mysql-test/suite/rpl_gtid/r/binlog_gtid_index.result
+++ b/mysql-test/suite/rpl_gtid/r/binlog_gtid_index.result
@@ -1,0 +1,117 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+show binary logs with gtid;
+Log_name	File_size	Prev_gtid_set
+master-bin.000001	#	# [empty]
+create table t1 (a int);
+insert into t1 values(1);
+insert into t1 values(2);
+show binary logs with gtid;
+Log_name	File_size	Prev_gtid_set
+master-bin.000001	#	# [empty]
+FLUSH LOGS;
+show binary logs with gtid;
+Log_name	File_size	Prev_gtid_set
+master-bin.000001	#	# [empty]
+master-bin.000002	#	# uuid:1-3
+include/sync_slave_sql_with_master.inc
+include/stop_slave.inc
+insert into t1 values(3);
+insert into t1 values(4);
+show binary logs with gtid;
+Log_name	File_size	Prev_gtid_set
+master-bin.000001	#	# [empty]
+master-bin.000002	#	# uuid:1-3
+FLUSH LOGS;
+show binary logs with gtid;
+Log_name	File_size	Prev_gtid_set
+master-bin.000001	#	# [empty]
+master-bin.000002	#	# uuid:1-3
+master-bin.000003	#	# uuid:1-5
+include/start_slave.inc
+"GTID sets on master"
+select @@global.gtid_executed , @@global.gtid_purged;
+@@global.gtid_executed	@@global.gtid_purged
+UUID:1-5	
+show binary logs with gtid;
+Log_name	File_size	Prev_gtid_set
+master-bin.000001	#	# [empty]
+master-bin.000002	#	# uuid:1-3
+master-bin.000003	#	# uuid:1-5
+include/sync_slave_sql_with_master.inc
+"GTID sets on slave"
+select @@global.gtid_executed , @@global.gtid_purged;
+@@global.gtid_executed	@@global.gtid_purged
+UUID:1-5	
+show binary logs with gtid;
+Log_name	File_size	Prev_gtid_set
+slave-bin.000001	#	# [empty]
+include/stop_slave.inc
+show binary logs with gtid;
+Log_name	File_size	Prev_gtid_set
+master-bin.000001	#	# [empty]
+master-bin.000002	#	# uuid:1-3
+master-bin.000003	#	# uuid:1-5
+include/rpl_restart_server.inc [server_number=1 gtids=on]
+"GTID sets on master after first restart"
+select @@global.gtid_executed , @@global.gtid_purged;
+@@global.gtid_executed	@@global.gtid_purged
+UUID:1-5	
+show binary logs with gtid;
+Log_name	File_size	Prev_gtid_set
+master-bin.000001	#	# [empty]
+master-bin.000002	#	# uuid:1-3
+master-bin.000003	#	# uuid:1-5
+master-bin.000004	#	# uuid:1-5
+purge binary logs to 'master-bin.000002';
+show binary logs with gtid;
+Log_name	File_size	Prev_gtid_set
+master-bin.000002	#	# uuid:1-3
+master-bin.000003	#	# uuid:1-5
+master-bin.000004	#	# uuid:1-5
+"GTID sets on master after purge"
+select @@global.gtid_executed , @@global.gtid_purged;
+@@global.gtid_executed	@@global.gtid_purged
+UUID:1-5	UUID:1-3
+include/rpl_restart_server.inc [server_number=1 gtids=on]
+"GTID sets on master after second restart"
+select @@global.gtid_executed , @@global.gtid_purged;
+@@global.gtid_executed	@@global.gtid_purged
+UUID:1-5	UUID:1-3
+show binary logs with gtid;
+Log_name	File_size	Prev_gtid_set
+master-bin.000002	#	# uuid:1-3
+master-bin.000003	#	# uuid:1-5
+master-bin.000004	#	# uuid:1-5
+master-bin.000005	#	# uuid:1-5
+change master to master_auto_position=0;
+include/start_slave.inc
+drop table t1;
+create table t1 (a int);
+insert into t1 values(5);
+insert into t1 values(6);
+FLUSH LOGS;
+drop table t1;
+"GTID sets on master finally"
+select @@global.gtid_executed , @@global.gtid_purged;
+@@global.gtid_executed	@@global.gtid_purged
+UUID:1-10	UUID:1-3
+show binary logs with gtid;
+Log_name	File_size	Prev_gtid_set
+master-bin.000002	#	# uuid:1-3
+master-bin.000003	#	# uuid:1-5
+master-bin.000004	#	# uuid:1-5
+master-bin.000005	#	# uuid:1-5
+master-bin.000006	#	# uuid:1-9
+include/sync_slave_sql_with_master.inc
+"GTID sets on slave finally"
+select @@global.gtid_executed , @@global.gtid_purged;
+@@global.gtid_executed	@@global.gtid_purged
+UUID:1-10	
+show binary logs with gtid;
+Log_name	File_size	Prev_gtid_set
+slave-bin.000001	#	# [empty]
+include/rpl_end.inc

--- a/mysql-test/suite/rpl_gtid/t/binlog_gtid_index.test
+++ b/mysql-test/suite/rpl_gtid/t/binlog_gtid_index.test
@@ -1,0 +1,120 @@
+-- source include/master-slave.inc
+
+connection master;
+let $master_uuid=`select @@server_uuid;`;
+replace_result $master_uuid uuid; replace_column 2 #;
+show binary logs with gtid;
+create table t1 (a int);
+
+insert into t1 values(1);
+insert into t1 values(2);
+
+replace_result $master_uuid uuid; replace_column 2 #;
+show binary logs with gtid;
+
+FLUSH LOGS;
+
+replace_result $master_uuid uuid; replace_column 2 #;
+show binary logs with gtid;
+
+-- source include/sync_slave_sql_with_master.inc
+-- source include/stop_slave.inc
+
+connection master;
+insert into t1 values(3);
+insert into t1 values(4);
+
+replace_result $master_uuid uuid; replace_column 2 #;
+show binary logs with gtid;
+
+FLUSH LOGS;
+
+replace_result $master_uuid uuid; replace_column 2 #;
+show binary logs with gtid;
+
+connection slave;
+-- source include/start_slave.inc
+
+connection master;
+
+-- echo "GTID sets on master"
+-- replace_regex /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/UUID/
+select @@global.gtid_executed , @@global.gtid_purged;
+replace_result $master_uuid uuid; replace_column 2 #;
+show binary logs with gtid;
+
+-- source include/sync_slave_sql_with_master.inc
+
+-- echo "GTID sets on slave"
+-- replace_regex /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/UUID/
+select @@global.gtid_executed , @@global.gtid_purged;
+
+replace_result $master_uuid uuid; replace_column 2 #;
+show binary logs with gtid;
+
+-- source include/stop_slave.inc
+
+
+connection master;
+
+replace_result $master_uuid uuid; replace_column 2 #;
+show binary logs with gtid;
+
+-- let $rpl_server_number= 1
+-- let $rpl_start_with_gtids= 1
+-- source include/rpl_restart_server.inc
+
+-- echo "GTID sets on master after first restart"
+-- replace_regex /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/UUID/
+select @@global.gtid_executed , @@global.gtid_purged;
+
+replace_result $master_uuid uuid; replace_column 2 #;
+show binary logs with gtid;
+
+purge binary logs to 'master-bin.000002';
+replace_result $master_uuid uuid; replace_column 2 #;
+show binary logs with gtid;
+
+-- echo "GTID sets on master after purge"
+-- replace_regex /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/UUID/
+select @@global.gtid_executed , @@global.gtid_purged;
+
+-- let $rpl_server_number= 1
+-- let $rpl_start_with_gtids= 1
+-- source include/rpl_restart_server.inc
+
+-- echo "GTID sets on master after second restart"
+-- replace_regex /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/UUID/
+select @@global.gtid_executed , @@global.gtid_purged;
+replace_result $master_uuid uuid; replace_column 2 #;
+show binary logs with gtid;
+
+connection slave;
+change master to master_auto_position=0;
+-- source include/start_slave.inc
+
+connection master;
+drop table t1;
+create table t1 (a int);
+insert into t1 values(5);
+insert into t1 values(6);
+FLUSH LOGS;
+
+drop table t1;
+
+-- echo "GTID sets on master finally"
+-- replace_regex /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/UUID/
+select @@global.gtid_executed , @@global.gtid_purged;
+replace_result $master_uuid uuid; replace_column 2 #;
+show binary logs with gtid;
+
+-- source include/sync_slave_sql_with_master.inc
+
+-- echo "GTID sets on slave finally"
+-- replace_regex /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/UUID/
+select @@global.gtid_executed , @@global.gtid_purged;
+replace_result $master_uuid uuid; replace_column 2 #;
+show binary logs with gtid;
+
+connection master;
+-- source include/rpl_end.inc

--- a/mysql-test/suite/rpl_nogtid/r/binlog_nogtid_index.result
+++ b/mysql-test/suite/rpl_nogtid/r/binlog_nogtid_index.result
@@ -1,0 +1,23 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+create table t1 (a int);
+insert into t1 values(1);
+insert into t1 values(2);
+SHOW BINARY LOGS WITH GTID;
+Log_name	File_size	Prev_gtid_set
+master-bin.000001	#	# [empty]
+FLUSH LOGS;
+insert into t1 values(3);
+SHOW BINARY LOGS WITH GTID;
+Log_name	File_size	Prev_gtid_set
+master-bin.000001	#	# [empty]
+master-bin.000002	#	# [empty]
+drop table t1;
+SHOW BINARY LOGS WITH GTID;
+Log_name	File_size	Prev_gtid_set
+master-bin.000001	#	# [empty]
+master-bin.000002	#	# [empty]
+include/rpl_end.inc

--- a/mysql-test/suite/rpl_nogtid/t/binlog_nogtid_index.test
+++ b/mysql-test/suite/rpl_nogtid/t/binlog_nogtid_index.test
@@ -1,0 +1,17 @@
+source include/master-slave.inc;
+
+connection master;
+let $master_uuid=`select @@server_uuid;`;
+create table t1 (a int);
+insert into t1 values(1);
+insert into t1 values(2);
+replace_result $master_uuid uuid; replace_column 2 #;
+SHOW BINARY LOGS WITH GTID;
+FLUSH LOGS;
+insert into t1 values(3);
+replace_result $master_uuid uuid; replace_column 2 #;
+SHOW BINARY LOGS WITH GTID;
+drop table t1;
+replace_result $master_uuid uuid; replace_column 2 #;
+SHOW BINARY LOGS WITH GTID;
+source include/rpl_end.inc;

--- a/sql/rpl_gtid.h
+++ b/sql/rpl_gtid.h
@@ -3878,7 +3878,7 @@ class Gtid_mode_copy {
 */
 class binlog_cmp {
  public:
-  bool operator()(std::string s1, std::string s2) {
+  bool operator()(const std::string &s1, const std::string &s2) const noexcept {
     return (s1.length() != s2.length()) ? (s1.length() < s2.length())
                                         : (s1 < s2);
   }

--- a/sql/rpl_master.cc
+++ b/sql/rpl_master.cc
@@ -1328,11 +1328,12 @@ bool show_master_status(THD *thd) {
 
   @param thd Pointer to THD object for the client thread executing the
   statement.
+  @param with_gtid Whether to include previous_gtid_set (default false)
 
   @retval false success
   @retval true failure
 */
-bool show_binlogs(THD *thd) {
+bool show_binlogs(THD *thd, bool with_gtid) {
   IO_CACHE *index_file;
   LOG_INFO cur;
   File file;
@@ -1351,6 +1352,10 @@ bool show_binlogs(THD *thd) {
   field_list.push_back(new Item_empty_string("Log_name", 255));
   field_list.push_back(
       new Item_return_int("File_size", 20, MYSQL_TYPE_LONGLONG));
+  if (with_gtid)
+    field_list.push_back(
+        new Item_empty_string("Prev_gtid_set",
+                              0));  // max_size seems not to matter
   if (thd->send_result_metadata(&field_list,
                                 Protocol::SEND_NUM_ROWS | Protocol::SEND_EOF))
     DBUG_RETURN(true);
@@ -1397,6 +1402,25 @@ bool show_binlogs(THD *thd) {
       }
     }
     protocol->store(file_length);
+
+    if (with_gtid) {
+      const auto previous_gtid_set_map =
+          mysql_bin_log.get_previous_gtid_set_map();
+      Sid_map sid_map(nullptr);
+      Gtid_set gtid_set(&sid_map, nullptr);
+      const auto gtid_str_it = previous_gtid_set_map->find(fname);
+      if (gtid_str_it != previous_gtid_set_map->end() &&
+          !gtid_str_it->second.empty()) {  // if GTID enabled
+        gtid_set.add_gtid_encoding((const uchar *)gtid_str_it->second.c_str(),
+                                   gtid_str_it->second.length(), nullptr);
+        char *buf;
+        gtid_set.to_string(&buf, false, &Gtid_set::commented_string_format);
+        protocol->store(buf, strlen(buf), &my_charset_bin);
+        my_free(buf);
+      } else {
+        protocol->store("", 0, &my_charset_bin);
+      }
+    }
     if (protocol->end_row()) {
       DBUG_PRINT(
           "info",

--- a/sql/rpl_master.h
+++ b/sql/rpl_master.h
@@ -60,7 +60,7 @@ bool show_master_offset(THD *thd, const char *file, ulonglong pos,
                         const char *gtid_executed, int gtid_executed_length,
                         bool *need_ok);
 bool show_master_status(THD *thd);
-bool show_binlogs(THD *thd);
+bool show_binlogs(THD *thd, bool with_gtid = false);
 void kill_zombie_dump_threads(THD *thd);
 
 uint find_gtid_position_helper(const char *gtid_string, char *log_name,

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -2993,6 +2993,10 @@ class Query_tables_list {
 
   void set_using_match() { using_match = true; }
   bool get_using_match() { return using_match; }
+  /**
+    for SHOW BINARY|MASTER LOGS, true if WITH GTID specified
+  */
+  bool with_gtid;
 
  private:
   /**

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -3474,7 +3474,7 @@ int mysql_execute_command(THD *thd, bool first_level) {
     }
     case SQLCOM_SHOW_BINLOGS: {
       if (check_global_access(thd, SUPER_ACL | REPL_CLIENT_ACL)) goto error;
-      res = show_binlogs(thd);
+      res = show_binlogs(thd, lex->with_gtid);
       break;
     }
     case SQLCOM_SHOW_CREATE:

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -12426,7 +12426,7 @@ show_param:
             lex->sql_command= SQLCOM_SHOW_FIELDS;
             MAKE_CMD(p);
           }
-        | master_or_binary LOGS_SYM
+        | master_or_binary LOGS_SYM gtid_bool
           {
             Lex->sql_command = SQLCOM_SHOW_BINLOGS;
           }
@@ -12715,6 +12715,16 @@ show_param:
             lex->grant_user=$3;
           }
         ;
+
+gtid_bool:
+         /* empty */
+         {
+           Lex->with_gtid = false;
+         }
+         | WITH GTID_SYM
+         {
+           Lex->with_gtid = true;
+         }
 
 show_engine_param:
           STATUS_SYM


### PR DESCRIPTION
Jira ticket: https://jira.percona.com/browse/FB8-71

Reference Patch: https://github.com/facebook/mysql-5.6/commit/4bb6dfa
Reference Patch: https://github.com/facebook/mysql-5.6/commit/ee92950

adds option to show last set GTID in SHOW MASTER LOGS command
Unconditionally send gtid in SHOW BINARY LOGS WITH GTID

Test Plan: binlog.binlog_gtid_index, binlog.binlog_nogtid_index

Originally Reviewed By: santoshb, lth