### PR TITLE
FB8-102 : Add posix_fadvise(FADV_DONTNEED) to flush buffered pages

### DIFF
--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -5428,6 +5428,13 @@ void os_file_set_nocache(int fd MY_ATTRIBUTE((unused)),
                               << strerror(errno_save) << ", continuing anyway.";
     }
   }
+
+#ifdef POSIX_FADV_DONTNEED
+  /* Request the filesystem to flush cached pages. Otherwise,
+  DIRECTIO requests are serialized. */
+  posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED);
+#endif /* POSIX_FADV_DONTNEED  */
+
 #endif /* defined(UNIV_SOLARIS) && defined(DIRECTIO_ON) */
 }
 


### PR DESCRIPTION
JIRA : https://jira.percona.com/browse/FB8-102

Referenced patch : https://github.com/facebook/mysql-5.6/commit/ab9d60b

When InnoDB opens a .ibd or log file in O_DIRECT mode, request the os to
flush the buffer cache. Otherwise, direct IO is serialized when buffered
pages for the file existing within the filesystem cache.

Originally Reviewed By: alxyang