### PR TITLE
FB8-134: Fix crash during shutdown in audit plugin code path

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -10440,6 +10440,7 @@ PSI_mutex_key key_LOCK_thd_data;
 PSI_mutex_key key_LOCK_thd_sysvar;
 PSI_mutex_key key_LOCK_thd_protocol;
 PSI_mutex_key key_LOCK_thd_db_read_only_hash;
+PSI_mutex_key key_LOCK_thd_audit_data;
 PSI_mutex_key key_LOG_LOCK_log;
 PSI_mutex_key key_master_info_data_lock;
 PSI_mutex_key key_master_info_run_lock;

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -454,6 +454,7 @@ extern PSI_mutex_key key_LOCK_thd_data;
 extern PSI_mutex_key key_LOCK_thd_sysvar;
 extern PSI_mutex_key key_LOCK_thd_protocol;
 extern PSI_mutex_key key_LOCK_thd_db_read_only_hash;
+extern PSI_mutex_key key_LOCK_thd_audit_data;
 extern PSI_mutex_key key_LOG_LOCK_log;
 extern PSI_mutex_key key_master_info_data_lock;
 extern PSI_mutex_key key_master_info_run_lock;

--- a/sql/sql_audit.cc
+++ b/sql/sql_audit.cc
@@ -26,6 +26,7 @@
 
 #include "lex_string.h"
 #include "m_ctype.h"
+#include "mutex_lock.h"  // MUTEX_LOCK
 #include "my_compiler.h"
 #include "my_dbug.h"
 #include "my_inttypes.h"
@@ -971,9 +972,11 @@ int mysql_audit_notify(THD *thd, mysql_event_authentication_subclass_t subclass,
 
   @return false is always returned.
 */
-static bool acquire_lookup_mask(THD *, plugin_ref plugin, void *arg) {
+static bool acquire_lookup_mask(THD *thd, plugin_ref plugin, void *arg) {
   st_mysql_subscribe_event *evt = static_cast<st_mysql_subscribe_event *>(arg);
   st_mysql_audit *audit = plugin_data<st_mysql_audit *>(plugin);
+
+  MUTEX_LOCK(lock, &thd->LOCK_thd_audit_data);
 
   /* Check if this plugin is interested in the event */
   if (!check_audit_mask(audit->class_mask[evt->event_class],
@@ -996,6 +999,8 @@ static bool acquire_lookup_mask(THD *, plugin_ref plugin, void *arg) {
 static bool acquire_plugins(THD *thd, plugin_ref plugin, void *arg) {
   st_mysql_subscribe_event *evt = static_cast<st_mysql_subscribe_event *>(arg);
   st_mysql_audit *data = plugin_data<st_mysql_audit *>(plugin);
+
+  MUTEX_LOCK(lock, &thd->LOCK_thd_audit_data);
 
   /* Check if this plugin is interested in the event */
   if (check_audit_mask(data->class_mask, evt->lookup_mask)) {
@@ -1084,6 +1089,7 @@ int mysql_audit_acquire_plugins(THD *thd, mysql_event_class_t event_class,
 */
 
 void mysql_audit_release(THD *thd) {
+  MUTEX_LOCK(lock, &thd->LOCK_thd_audit_data);
   plugin_ref *plugins, *plugins_last;
 
   if (!thd || thd->audit_class_plugins.empty()) return;
@@ -1118,6 +1124,7 @@ void mysql_audit_release(THD *thd) {
 */
 
 void mysql_audit_init_thd(THD *thd) {
+  MUTEX_LOCK(lock, &thd->LOCK_thd_audit_data);
   thd->audit_class_mask.clear();
   thd->audit_class_mask.resize(MYSQL_AUDIT_CLASS_MASK_SIZE);
 }
@@ -1318,11 +1325,16 @@ static int event_class_dispatch(THD *thd, mysql_event_class_t event_class,
                ? 1
                : 0;
   } else {
+    decltype(thd->audit_class_plugins) plugins_copy{PSI_NOT_INSTRUMENTED};
+    {
+      MUTEX_LOCK(lock, &thd->LOCK_thd_audit_data);
+      plugins_copy = thd->audit_class_plugins;
+    }
     plugin_ref *plugins, *plugins_last;
 
     /* Use the cached set of audit plugins */
-    plugins = thd->audit_class_plugins.begin();
-    plugins_last = thd->audit_class_plugins.end();
+    plugins = plugins_copy.begin();
+    plugins_last = plugins_copy.end();
 
     for (; plugins != plugins_last; plugins++)
       result |= plugins_dispatch(thd, *plugins, &event_generic);

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -483,6 +483,8 @@ THD::THD(bool enable_plugins)
 #ifndef DBUG_OFF
   dbug_sentry = THD_SENTRY_MAGIC;
 #endif
+  mysql_mutex_init(key_LOCK_thd_audit_data, &LOCK_thd_audit_data,
+                   MY_MUTEX_INIT_FAST);
   mysql_audit_init_thd(this);
   net.vio = 0;
   system_thread = NON_SYSTEM_THREAD;

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -993,6 +993,7 @@ class THD : public MDL_context_owner,
     Protects THD::db_read_only_hash.
   */
   mysql_mutex_t LOCK_thd_db_read_only_hash;
+  mysql_mutex_t LOCK_thd_audit_data;
 
   /**
     Protects query plan (SELECT/UPDATE/DELETE's) from being freed/changed


### PR DESCRIPTION
Jira ticket: https://jira.percona.com/browse/FB8-134

Reference patch: https://github.com/facebook/mysql-5.6/commit/0fc059a

------  0fc059a ------

On server shutdown, there exists a race condition that can trigger a segfault if an audit plugin is installed. The root cause because the `THD::audit_class_plugins` array is accessed concurrently without locks.

This is the sequence of actions that can trigger a crash:
1. The shutdown thread calls close_connections on all connected clients.
2. The connection thread will call into the audit plugin because it will receive a network error from `close_connections`, and will log the error into the audit plugin. The thread then adds the plugin to `THD::audit_class_plugins`, but it has not updated `audit_class_mask` yet.
3. The shutdown thread sees that `audit_class_mask` is not set, and also adds the plugin into `THD::audit_class_plugins`, but it has only extended the array, without setting the value of the 2nd element of the array.
4. The connection thread then goes ahead and updates `audit_class_mask` and finishes `acquire_plugins`. It then calls `mysql_audit_notify` and sees the array of size 2, and when it loops over the 2nd element, it segfaults because the value is uninitalized.

The fix is to add a lock per THD that protects these data structures. They should be relatively uncontended since the shutdown thread is the only thread that calls `acquire_plugins` on another THD.