### PR TITLE
FB8-136: Wait on disk full for binlog cache

### DIFF
--- a/mysql-test/suite/binlog/r/binlog_cache_disk_full.result
+++ b/mysql-test/suite/binlog/r/binlog_cache_disk_full.result
@@ -1,0 +1,17 @@
+call mtr.add_suppression("OS errno 28 - No space left on device");
+CREATE TABLE t1(f1 TEXT) ENGINE = InnoDB;
+SET SESSION debug="+d,simulate_disk_full_at_binlog_cache_write";
+BEGIN;
+INSERT INTO t1 VALUES(md5(1));
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+include/assert_grep.inc [Found the expected error: No space left on device.]
+COMMIT;
+SET SESSION debug="-d,simulate_disk_full_at_binlog_cache_write";
+DROP TABLE t1;

--- a/mysql-test/suite/binlog/t/binlog_cache_disk_full-master.opt
+++ b/mysql-test/suite/binlog/t/binlog_cache_disk_full-master.opt
@@ -1,0 +1,1 @@
+--binlog_cache_size=4096

--- a/mysql-test/suite/binlog/t/binlog_cache_disk_full.test
+++ b/mysql-test/suite/binlog/t/binlog_cache_disk_full.test
@@ -1,0 +1,39 @@
+--source include/have_log_bin.inc
+--source include/have_binlog_format_row.inc
+--source include/have_debug.inc
+
+call mtr.add_suppression("OS errno 28 - No space left on device");
+
+CREATE TABLE t1(f1 TEXT) ENGINE = InnoDB;
+
+# Simulate disk full during writing binlog cache
+# The property affects only single round of waiting for MY_WAIT_IF_FULL
+# It prints error message in the log, sleep for 1 second and continue
+SET SESSION debug="+d,simulate_disk_full_at_binlog_cache_write";
+
+# we need to generate huge transaction to hit binlog_cache_size
+BEGIN;
+INSERT INTO t1 VALUES(md5(1));
+let $i = 0;
+# binlog_cache_disk_full-master.opt sets binlog_cache_size to 4K so the
+# following number of insert is required to overflow the cache to hit disk
+let $NUMBER_OF_ITERATIONS = 8;
+while ($i < $NUMBER_OF_ITERATIONS)
+{
+    INSERT INTO t1 SELECT * FROM t1;
+    inc $i;
+}
+
+# after the loop we expect to hit binlog_cache_size and generate the warnings
+# telling us that we entered into MY_WAIT_IF_FULL mode
+--let $assert_file= $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $assert_only_after = CURRENT_TEST: binlog.binlog_cache_disk_full
+--let $assert_count = 1
+--let $assert_select = Disk is full writing .* \(OS errno 28 - No space left on device\). Waiting for someone to free space...
+--let $assert_text = Found the expected error: No space left on device.
+--source include/assert_grep.inc
+
+COMMIT;
+
+SET SESSION debug="-d,simulate_disk_full_at_binlog_cache_write";
+DROP TABLE t1;

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -1317,24 +1317,19 @@ int binlog_cache_data::write_event(Log_event *ev) {
   DBUG_ENTER("binlog_cache_data::write_event");
 
   if (ev != NULL) {
-    DBUG_EXECUTE_IF("simulate_disk_full_at_flush_pending",
-                    { DBUG_SET("+d,simulate_file_write_error"); });
+    DBUG_EXECUTE_IF("simulate_disk_full_at_binlog_cache_write",
+                    { DBUG_SET("+d,simulate_no_free_space_error"); });
 
     if (binary_event_serialize(ev, &m_cache)) {
-      DBUG_EXECUTE_IF("simulate_disk_full_at_flush_pending", {
-        DBUG_SET("-d,simulate_file_write_error");
-        DBUG_SET("-d,simulate_disk_full_at_flush_pending");
-        /*
-           after +d,simulate_file_write_error the local cache
-           is in unsane state. Since -d,simulate_file_write_error
-           revokes the first simulation do_write_cache()
-           can't be run without facing an assert.
-           So it's blocked with the following 2nd simulation:
-        */
-        DBUG_SET("+d,simulate_do_write_cache_failure");
-      });
       DBUG_RETURN(1);
     }
+
+    DBUG_EXECUTE_IF("simulate_disk_full_at_binlog_cache_write",
+                    // this flag is cleared by my_write.cc but we clear it
+                    // explicitly in case if the even didn't hit my_write.cc
+                    // so the flag won't affect not targeted calls
+                    { DBUG_SET("-d,simulate_no_free_space_error"); });
+
     if (ev->get_type_code() == binary_log::XID_EVENT) flags.with_xid = true;
     if (ev->is_using_immediate_logging()) flags.immediate = true;
     /* DDL gets marked as xid-requiring at its caching. */
@@ -7013,10 +7008,6 @@ bool MYSQL_BIN_LOG::do_write_cache(Binlog_cache_storage *cache,
   DBUG_ENTER("MYSQL_BIN_LOG::do_write_cache");
 
   DBUG_EXECUTE_IF("simulate_do_write_cache_failure", {
-    /*
-       see binlog_cache_data::write_event() that reacts on
-       @c simulate_disk_full_at_flush_pending.
-    */
     DBUG_SET("-d,simulate_do_write_cache_failure");
     DBUG_RETURN(true);
   });

--- a/sql/binlog_ostream.cc
+++ b/sql/binlog_ostream.cc
@@ -27,7 +27,8 @@ IO_CACHE_binlog_cache_storage::~IO_CACHE_binlog_cache_storage() { close(); }
 bool IO_CACHE_binlog_cache_storage::open(const char *dir, const char *prefix,
                                          my_off_t cache_size,
                                          my_off_t max_cache_size) {
-  if (open_cached_file(&m_io_cache, dir, prefix, cache_size, MYF(MY_WME)))
+  if (open_cached_file(&m_io_cache, dir, prefix, cache_size,
+                       MYF(MY_WME | MY_WAIT_IF_FULL)))
     return true;
 
   m_max_cache_size = max_cache_size;


### PR DESCRIPTION
Jira issue: https://jira.percona.com/browse/FB8-136

Reference Patch: https://github.com/facebook/mysql-5.6/commit/6168b96

Summary: This branch unifies behavior when server faces disk full issue. Previously a server was waiting until disk is free for direct binlog writes but reported an error to a client if it hits the issue while writing to binlog cache which is written to a separate folder and might be mounted to a different partition.

Originally Reviewed By: abhinav04sharma

fbshipit-source-id: 3889417