### PR TITLE
FB8-222:  Add --gterm option to mtr

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -185,6 +185,8 @@ our $opt_client_ddd;
 our $opt_client_debugger;
 our $opt_client_gdb;
 our $opt_client_lldb;
+# option for gnome-terminal with gdb
+our $opt_gterm;
 our $opt_ctest_path;
 our $opt_ctest_report;
 our $opt_dbx;
@@ -1421,6 +1423,8 @@ sub command_line_setup {
     'debug-server'       => \$opt_debug_server,
     'debugger=s'         => \$opt_debugger,
     'gdb'                => \$opt_gdb,
+    # For using gnome-terminal with --gdb
+    'gterm'              => \$opt_gterm,
     'lldb'               => \$opt_lldb,
     'manual-boot-gdb'    => \$opt_manual_boot_gdb,
     'manual-dbx'         => \$opt_manual_dbx,
@@ -6398,9 +6402,18 @@ sub gdb_arguments {
   }
 
   $$args = [];
-  mtr_add_arg($$args, "-title");
-  mtr_add_arg($$args, "$type");
-  mtr_add_arg($$args, "-e");
+
+  if ($opt_gterm) {
+    mtr_add_arg($$args, "--title");
+    mtr_add_arg($$args, "$type");
+    mtr_add_arg($$args, "--wait");
+    mtr_add_arg($$args, "--");
+  } else {
+    mtr_add_arg($$args, "-title");
+    mtr_add_arg($$args, "$type");
+    mtr_add_arg($$args, "-e");
+  }
+
 
   if ($exe_libtool) {
     mtr_add_arg($$args, $exe_libtool);
@@ -6412,7 +6425,11 @@ sub gdb_arguments {
   mtr_add_arg($$args, "$gdb_init_file");
   mtr_add_arg($$args, "$$exe");
 
-  $$exe = "xterm";
+  if ($opt_gterm) {
+    $$exe= "gnome-terminal";
+  } else {
+    $$exe= "xterm";
+  }
 }
 
 # Modify the exe and args so that program is run in lldb


### PR DESCRIPTION
https://jira.percona.com/browse/FB8-222

Problem:
--------
When using --gdb option with mtr, it spawns xterm as terminal window
by default.

xterm is really outdated.
1. Can't easily copy text from it.
2. Text sometimes appear small by deafult
3. Window buffer isn't resized properly on maximize

Fix:
----
On linux systems, where gnome-termnial (/usr/bin/gnome-terminal) is
available, try to use it.

Introduce --gterm option. This is to be used along with --gdb option.

Ex: ./mtr --mem main.1st --gdb --gterm

Note: Not all gnome-terminal versions are supported. Only those
gnome-terminals which has "wait" option are supported.

gnome-terminal --help-all

should show:
--wait                          Wait until the child exits

Squash with /dev/null