### PR TITLE
FB8-72: Added session statistics on number of bytes written to temporary tables data files

### DIFF
--- a/mysql-test/suite/innodb/r/temp_table_size_counter.result
+++ b/mysql-test/suite/innodb/r/temp_table_size_counter.result
@@ -1,0 +1,60 @@
+create table t1 (i int, c char(255));
+create table t2 (i int, c varchar(255));
+insert into t1 values (0, lpad('a', 250, 'b'));
+insert into t1 select i+1,c from t1;
+insert into t1 select i+2,c from t1;
+insert into t1 select i+4,c from t1;
+insert into t1 select i+8,c from t1;
+insert into t1 select i+16,c from t1;
+insert into t1 select i+32,c from t1;
+insert into t1 select i+64,c from t1;
+insert into t1 select i+128,c from t1;
+insert into t1 select i+256,c from t1;
+insert into t1 select i+512,c from t1;
+insert into t1 select i+1024,c from t1;
+insert into t1 select i+2048,c from t1;
+insert into t1 select i+4096,c from t1;
+insert into t2 select * from t1;
+set session tmp_table_size=16384;
+set session max_heap_table_size=16384;
+create temporary table tm(i int, c char(255)) engine=innodb;
+include/assert.inc [The above statements should not have increased Tmp_table_bytes_written]
+insert into tm select * from t1;
+insert into tm select * from t1;
+insert into tm select * from t1;
+update tm set c = lpad('b', 250, 'a');
+include/assert.inc [The above statements should not have increased Tmp_table_bytes_written]
+drop temporary table tm;
+create temporary table tm(i int, c varchar(255)) engine=innodb;
+include/assert.inc [The above statements should not have increased Tmp_table_bytes_written]
+insert into tm select * from t2;
+include/assert.inc [The above statements should not have increased Tmp_table_bytes_written]
+update tm set c = lpad('b', 250, 'a');
+include/assert.inc [The above statements should not have increased Tmp_table_bytes_written]
+delete from tm where i < 100;
+include/assert.inc [The above statements should not have increased Tmp_table_bytes_written]
+select i, c, count(*) from t1 group by i, c having count(*) > 1;
+i	c	count(*)
+include/assert.inc [The above statements should not have increased Tmp_table_bytes_written]
+select i, c, count(*) from t2 group by i, c having count(*) > 1;
+i	c	count(*)
+include/assert.inc [The above statements should not have notincreased Tmp_table_bytes_written]
+drop temporary table tm;
+include/assert.inc [The above statements should not have increased Tmp_table_bytes_written]
+create temporary table tm(i int, c char(255)) engine=innodb;
+insert into tm select * from t1;
+insert into tm select * from t1;
+insert into tm select * from t1;
+insert into tm select * from t1;
+include/assert.inc [The above statements should not have increased session Tmp_table_bytes_written]
+drop temporary table tm;
+create temporary table tm(i int, c char(255)) engine=innodb;
+insert into tm select * from t1;
+insert into tm select * from t1;
+insert into tm select * from t1;
+insert into tm select * from t1;
+insert into tm select * from t1;
+insert into tm select * from t1;
+include/assert.inc [The above statements should not decrease global Tmp_table_bytes_written]
+drop table t1;
+drop table t2;

--- a/mysql-test/suite/innodb/t/temp_table_size_counter-master.opt
+++ b/mysql-test/suite/innodb/t/temp_table_size_counter-master.opt
@@ -1,0 +1,3 @@
+--innodb-max-dirty-pages-pct=0
+--innodb-max-dirty-pages-pct-lwm=0
+--innodb-adaptive-flushing=0

--- a/mysql-test/suite/innodb/t/temp_table_size_counter.test
+++ b/mysql-test/suite/innodb/t/temp_table_size_counter.test
@@ -1,0 +1,183 @@
+--source include/count_sessions.inc
+
+--let $prevSize = query_get_value(SHOW STATUS LIKE 'Tmp_table_bytes_written', Value, 1)
+
+create table t1 (i int, c char(255));
+create table t2 (i int, c varchar(255));
+
+insert into t1 values (0, lpad('a', 250, 'b'));
+insert into t1 select i+1,c from t1;
+insert into t1 select i+2,c from t1;
+insert into t1 select i+4,c from t1;
+insert into t1 select i+8,c from t1;
+insert into t1 select i+16,c from t1;
+insert into t1 select i+32,c from t1;
+insert into t1 select i+64,c from t1;
+insert into t1 select i+128,c from t1;
+insert into t1 select i+256,c from t1;
+insert into t1 select i+512,c from t1;
+insert into t1 select i+1024,c from t1;
+insert into t1 select i+2048,c from t1;
+insert into t1 select i+4096,c from t1;
+
+insert into t2 select * from t1;
+
+set session tmp_table_size=16384;
+set session max_heap_table_size=16384;
+
+create temporary table tm(i int, c char(255)) engine=innodb;
+
+--let $nextSize = query_get_value(show status like 'Tmp_table_bytes_written', Value, 1)
+--let $assert_text= The above statements should not have increased Tmp_table_bytes_written
+--let $assert_cond= $nextSize = $prevSize
+--source include/assert.inc
+--let $prevSize = $nextSize
+
+insert into tm select * from t1;
+insert into tm select * from t1;
+insert into tm select * from t1;
+
+--let $wait_condition = select variable_value > $prevSize from performance_schema.session_status where variable_name = 'Tmp_table_bytes_written'
+--source include/wait_condition.inc
+--let $prevSize = query_get_value(show status like 'Tmp_table_bytes_written', Value, 1)
+
+update tm set c = lpad('b', 250, 'a');
+
+# The current approach measures file size, and as such, it doesn't result in any increase for this update
+--let $nextSize = query_get_value(show status like 'Tmp_table_bytes_written', Value, 1)
+--let $assert_text= The above statements should not have increased Tmp_table_bytes_written
+--let $assert_cond= $nextSize = $prevSize
+--source include/assert.inc
+--let $prevSize = $nextSize
+
+drop temporary table tm;
+
+# The location where the byte count is increment is different for static and dynamic
+# records. Test with varchar to see if the code path for dynamic records also works. The
+# char version above only tests static records.
+create temporary table tm(i int, c varchar(255)) engine=innodb;
+
+# The above statements should not have increased Tmp_table_bytes_written
+--let $nextSize = query_get_value(SHOW STATUS LIKE 'Tmp_table_bytes_written', Value, 1)
+--let $assert_text= The above statements should not have increased Tmp_table_bytes_written
+--let $assert_cond= $nextSize >= $prevSize
+--source include/assert.inc
+--let $prevSize = $nextSize
+
+insert into tm select * from t2;
+
+# The current approach measures file size, and as such, it doesn't result in any increase for this insert
+--let $nextSize = query_get_value(show status like 'Tmp_table_bytes_written', Value, 1)
+--let $assert_text= The above statements should not have increased Tmp_table_bytes_written
+--let $assert_cond= $nextSize = $prevSize
+--source include/assert.inc
+--let $prevSize = $nextSize
+
+update tm set c = lpad('b', 250, 'a');
+
+# The current approach measures file size, and as such, it doesn't result in any increase for this update
+--let $nextSize = query_get_value(show status like 'Tmp_table_bytes_written', Value, 1)
+--let $assert_text= The above statements should not have increased Tmp_table_bytes_written
+--let $assert_cond= $nextSize = $prevSize
+--source include/assert.inc
+--let $prevSize = $nextSize
+
+delete from tm where i < 100;
+
+# The current approach measures file size, and as such, it doesn't result in any increase for this delete
+--let $nextSize = query_get_value(show status like 'Tmp_table_bytes_written', Value, 1)
+--let $assert_text= The above statements should not have increased Tmp_table_bytes_written
+--let $assert_cond= $nextSize = $prevSize
+--source include/assert.inc
+--let $prevSize = $nextSize
+
+# Test implicit tables.
+select i, c, count(*) from t1 group by i, c having count(*) > 1;
+
+--let $nextSize = query_get_value(SHOW STATUS LIKE 'Tmp_table_bytes_written', Value, 1)
+--let $assert_text= The above statements should not have increased Tmp_table_bytes_written
+--let $assert_cond= $nextSize = $prevSize
+--source include/assert.inc
+--let $prevSize = $nextSize
+
+select i, c, count(*) from t2 group by i, c having count(*) > 1;
+
+--let $nextSize = query_get_value(SHOW STATUS LIKE 'Tmp_table_bytes_written', Value, 1)
+--let $assert_text= The above statements should not have notincreased Tmp_table_bytes_written
+--let $assert_cond= $nextSize = $prevSize
+--source include/assert.inc
+--let $prevSize = $nextSize
+
+drop temporary table tm;
+
+--let $nextSize = query_get_value(SHOW STATUS LIKE 'Tmp_table_bytes_written', Value, 1)
+--let $assert_text= The above statements should not have increased Tmp_table_bytes_written
+--let $assert_cond= $nextSize = $prevSize
+--source include/assert.inc
+--let $prevSize = $nextSize
+
+# Test whether variable is session level.
+#
+create temporary table tm(i int, c char(255)) engine=innodb;
+
+# First record session and global variable on con1
+connect(con1, localhost, root,,);
+connection con1;
+--let $con1PrevSize = query_get_value(SHOW STATUS LIKE 'Tmp_table_bytes_written', Value, 1)
+--let $globalPrevSize = query_get_value(SHOW GLOBAL STATUS LIKE 'Tmp_table_bytes_written', Value, 1)
+
+# Second, do some work on default connection.
+connection default;
+insert into tm select * from t1;
+insert into tm select * from t1;
+insert into tm select * from t1;
+insert into tm select * from t1;
+--let $globalNextSize = query_get_value(SHOW GLOBAL STATUS LIKE 'Tmp_table_bytes_written', Value, 1)
+# Third, check variables on con1
+connection con1;
+
+--let $wait_condition = select variable_value > $prevSize from performance_schema.global_status where variable_name = 'Tmp_table_bytes_written'
+--source include/wait_condition.inc
+
+--let $con1NextSize = query_get_value(SHOW STATUS LIKE 'Tmp_table_bytes_written', Value, 1)
+--let $assert_text= The above statements should not have increased session Tmp_table_bytes_written
+--let $assert_cond= $con1NextSize = $con1PrevSize
+--source include/assert.inc
+
+connection default;
+drop temporary table tm;
+
+
+# Test whether the global variable is monotonically increasing even when
+# session go away.
+
+# Record global status in default connection.
+--let $globalPrevSize = query_get_value(SHOW GLOBAL STATUS LIKE 'Tmp_table_bytes_written', Value, 1)
+
+# Do work in con1
+connection con1;
+create temporary table tm(i int, c char(255)) engine=innodb;
+insert into tm select * from t1;
+insert into tm select * from t1;
+insert into tm select * from t1;
+insert into tm select * from t1;
+insert into tm select * from t1;
+insert into tm select * from t1;
+
+--let $wait_condition = select variable_value > $prevSize from performance_schema.global_status where variable_name = 'Tmp_table_bytes_written'
+--source include/wait_condition.inc
+
+disconnect con1;
+--source include/wait_until_disconnected.inc
+
+connection default;
+--let $globalPrevSize = $globalNextSize
+--let $globalNextSize = query_get_value(SHOW GLOBAL STATUS LIKE 'Tmp_table_bytes_written', Value, 1)
+--let $assert_text= The above statements should not decrease global Tmp_table_bytes_written
+--let $assert_cond= $globalNextSize >= $globalPrevSize
+--source include/assert.inc
+
+drop table t1;
+drop table t2;
+
+--source include/wait_until_count_sessions.inc

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -746,8 +746,10 @@ bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
         " Sort_rows: %lu Sort_scan_count: %lu"
         " Created_tmp_disk_tables: %lu"
         " Created_tmp_tables: %lu"
+        " Tmp_table_bytes_written: %lu"
         " Start: %s End: %s"
-        " Trace_Id: %s Instruction_Cost: %lu";
+        " Trace_Id: %s Instruction_Cost: %lu"
+        " Start: %s End: %s\n";
 
     // If the query start status is valid - i.e. the current thread's
     // status values should be no less than the query start status,
@@ -774,7 +776,9 @@ bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
             query_start->filesort_scan_count &&
         thd->status_var.created_tmp_disk_tables >=
             query_start->created_tmp_disk_tables &&
-        thd->status_var.created_tmp_tables >= query_start->created_tmp_tables) {
+        thd->status_var.created_tmp_tables >= query_start->created_tmp_tables &&
+        thd->status_var.tmp_table_bytes_written >=
+            query_start->tmp_table_bytes_written) {
       error = my_b_printf(
           &log_file, log_str, query_time_buff, lock_time_buff,
           (ulong)thd->get_sent_row_count(),
@@ -808,6 +812,8 @@ bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
                   query_start->created_tmp_disk_tables),
           (ulong)(thd->status_var.created_tmp_tables -
                   query_start->created_tmp_tables),
+          (ulong)(thd->status_var.tmp_table_bytes_written -
+                  query_start->tmp_table_bytes_written),
           start_time_buff, end_time_buff,
           (tid_present ? thd->trace_id.c_str() : "NA"),
           (tid_present ? thd->pc_val : 0));
@@ -831,7 +837,8 @@ bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
           (ulong)thd->status_var.filesort_rows,
           (ulong)thd->status_var.filesort_scan_count,
           (ulong)thd->status_var.created_tmp_disk_tables,
-          (ulong)thd->status_var.created_tmp_tables, start_time_buff,
+          (ulong)thd->status_var.created_tmp_tables,
+          (ulong)thd->status_var.tmp_table_bytes_written, start_time_buff,
           end_time_buff, (tid_present ? thd->trace_id.c_str() : "NA"),
           (tid_present ? thd->pc_val : 0));
     }

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -8996,6 +8996,9 @@ SHOW_VAR status_vars[] = {
     {"Threads_running", (char *)&show_num_thread_running, SHOW_FUNC,
      SHOW_SCOPE_GLOBAL},
     {"Timer_in_use", (char *)&timer_in_use, SHOW_CHAR_PTR, SHOW_SCOPE_GLOBAL},
+    {"Tmp_table_bytes_written",
+     (char *)offsetof(System_status_var, tmp_table_bytes_written),
+     SHOW_LONGLONG_STATUS, SHOW_SCOPE_ALL},
     {"Uptime", (char *)&show_starttime, SHOW_FUNC, SHOW_SCOPE_GLOBAL},
 #ifdef ENABLED_PROFILING
     {"Uptime_since_flush_status", (char *)&show_flushstatustime, SHOW_FUNC,

--- a/sql/system_variables.h
+++ b/sql/system_variables.h
@@ -452,6 +452,8 @@ struct System_status_var {
   ulonglong max_execution_time_set;
   ulonglong max_execution_time_set_failed;
 
+  ulonglong tmp_table_bytes_written;
+
   /* Number of statements sent from the client. */
   ulonglong questions;
 

--- a/storage/innobase/handler/ha_innodb.h
+++ b/storage/innobase/handler/ha_innodb.h
@@ -132,6 +132,8 @@ class ha_innobase : public handler {
 
   longlong get_memory_buffer_size() const;
 
+  void inc_tmp_table_bytes_written(ulint by_value) noexcept;
+
   int write_row(uchar *buf);
 
   int update_row(const uchar *old_data, uchar *new_data);

--- a/storage/innobase/include/sess0sess.h
+++ b/storage/innobase/include/sess0sess.h
@@ -135,6 +135,10 @@ class innodb_session_t {
     return (m_usr_temp_tblsp);
   }
 
+  ibt::Tablespace *get_usr_temp_tblsp_if_exists() const noexcept {
+    return m_usr_temp_tblsp;
+  }
+
   ibt::Tablespace *get_instrinsic_temp_tblsp() {
     if (m_intrinsic_temp_tblsp == nullptr) {
       my_thread_id id = thd_thread_id(m_trx->mysql_thd);


### PR DESCRIPTION
Summary:

JIRA ticket: https://jira.percona.com/browse/FB8-72

Reference commit: https://github.com/facebook/mysql-5.6/commit/c03842f888b0ddd509c2d112f1b599b7ceaa2f5b
Reference commit: https://github.com/facebook/mysql-5.6/commit/672cf0e

-------- c03842f --------

This change adds a global statistic called 'Tmp_table_bytes_written' on the number of bytes written to temporary tables data files. This was done mostly by checking in the debugger what called my_pwrite/my_write during writes/updates/deletes.

The key files were trickier to handle, because they are only written to on eviction from the key cache, so this wasn't done. I could either make some data structure that mapped file descriptors to whether they belong to temporary tables or not, or I could tag every page in the key cache with a flag, so that I would know what to do on eviction.

-------- 672cf0e --------

The global status variable 'Tmp_table_bytes_written' is changed so
that it is now a session variable.

Also, its value is logged to the slow query log.

Test Plan: mysqltest.sh temp_table_size_counter.test