### PR TITLE
FB8-187: New variable binlog_rows_event_max_rows to control the number of rows in a single rows event

### DIFF
--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -171,6 +171,8 @@ The following options may be given as the first argument:
  such updates, only the modified parts of the JSON
  document are included in the binary log, so small changes
  of big documents may need significantly less space.
+ --binlog-rows-event-max-rows[=#] 
+ Max number of rows in a single rows event
  --binlog-rows-query-log-events 
  Allow writing of Rows_query_log events into binary log.
  --binlog-stmt-cache-size=# 
@@ -1427,6 +1429,7 @@ binlog-row-event-max-size 8192
 binlog-row-image FULL
 binlog-row-metadata FACEBOOK
 binlog-row-value-options 
+binlog-rows-event-max-rows 18446744073709551615
 binlog-rows-query-log-events FALSE
 binlog-stmt-cache-size 32768
 binlog-transaction-dependency-history-size 25000

--- a/mysql-test/suite/binlog/r/binlog_rows_event_max_rows.result
+++ b/mysql-test/suite/binlog/r/binlog_rows_event_max_rows.result
@@ -1,0 +1,30 @@
+RESET MASTER;
+SET @old_binlog_rows_event_max_rows = @@global.binlog_rows_event_max_rows;
+SET @@global.binlog_rows_event_max_rows= 1;
+CREATE TABLE t1 (a INT);
+INSERT INTO t1 VALUES (1), (2), (3);
+UPDATE t1 SET a = 10;
+SET @@global.binlog_rows_event_max_rows= 2;
+DELETE FROM t1;
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+binlog.000001	#	Query	#	#	use `test`; CREATE TABLE t1 (a INT)
+binlog.000001	#	Query	#	#	BEGIN
+binlog.000001	#	Table_map	#	#	table_id: # (test.t1)
+binlog.000001	#	Write_rows	#	#	table_id: #
+binlog.000001	#	Write_rows	#	#	table_id: #
+binlog.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000001	#	Xid	#	#	COMMIT /* XID */
+binlog.000001	#	Query	#	#	BEGIN
+binlog.000001	#	Table_map	#	#	table_id: # (test.t1)
+binlog.000001	#	Update_rows	#	#	table_id: #
+binlog.000001	#	Update_rows	#	#	table_id: #
+binlog.000001	#	Update_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000001	#	Xid	#	#	COMMIT /* XID */
+binlog.000001	#	Query	#	#	BEGIN
+binlog.000001	#	Table_map	#	#	table_id: # (test.t1)
+binlog.000001	#	Delete_rows	#	#	table_id: #
+binlog.000001	#	Delete_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000001	#	Xid	#	#	COMMIT /* XID */
+DROP TABLE t1;
+SET @@global.binlog_rows_event_max_rows = @old_binlog_rows_event_max_rows;

--- a/mysql-test/suite/binlog/t/binlog_rows_event_max_rows.test
+++ b/mysql-test/suite/binlog/t/binlog_rows_event_max_rows.test
@@ -1,0 +1,30 @@
+source include/have_binlog_format_row.inc;
+
+# Deletes all the binary logs
+RESET MASTER;
+
+SET @old_binlog_rows_event_max_rows = @@global.binlog_rows_event_max_rows;
+
+# setup
+let $MYSQLD_DATADIR = `select @@datadir`;
+let $MYSQLD_SECURE_FILE_DIR = `select @@secure_file_priv`;
+SET @@global.binlog_rows_event_max_rows= 1;
+CREATE TABLE t1 (a INT);
+
+# each insert should be in a separate row event because binlog_rows_event_max_rows = 1
+INSERT INTO t1 VALUES (1), (2), (3);
+
+# each update should be in a separate row event because binlog_rows_event_max_rows = 1
+UPDATE t1 SET a = 10;
+
+# there should be two delete events, 1st one with 2 rows and 2nd one with one
+# row because binlog_rows_event_max_rows = 2
+SET @@global.binlog_rows_event_max_rows= 2;
+DELETE FROM t1;
+
+--source include/show_binlog_events.inc
+
+# cleanup
+DROP TABLE t1;
+
+SET @@global.binlog_rows_event_max_rows = @old_binlog_rows_event_max_rows;

--- a/mysql-test/suite/binlog_nogtid/r/binlog_persist_only_variables.result
+++ b/mysql-test/suite/binlog_nogtid/r/binlog_persist_only_variables.result
@@ -25,7 +25,7 @@ VARIABLE_NAME LIKE '%slave%') AND
 'reset_seconds_behind_master', 'skip_flush_master_info'))
 ORDER BY VARIABLE_NAME;
 
-include/assert.inc ['Expect 85 variables in the table.']
+include/assert.inc ['Expect 86 variables in the table.']
 
 # Test SET PERSIST_ONLY
 SET PERSIST_ONLY binlog_cache_size = @@GLOBAL.binlog_cache_size;
@@ -45,6 +45,7 @@ SET PERSIST_ONLY binlog_order_commits = @@GLOBAL.binlog_order_commits;
 SET PERSIST_ONLY binlog_row_image = @@GLOBAL.binlog_row_image;
 SET PERSIST_ONLY binlog_row_metadata = @@GLOBAL.binlog_row_metadata;
 SET PERSIST_ONLY binlog_row_value_options = @@GLOBAL.binlog_row_value_options;
+SET PERSIST_ONLY binlog_rows_event_max_rows = @@GLOBAL.binlog_rows_event_max_rows;
 SET PERSIST_ONLY binlog_rows_query_log_events = @@GLOBAL.binlog_rows_query_log_events;
 SET PERSIST_ONLY binlog_stmt_cache_size = @@GLOBAL.binlog_stmt_cache_size;
 SET PERSIST_ONLY binlog_transaction_dependency_history_size = @@GLOBAL.binlog_transaction_dependency_history_size;
@@ -127,16 +128,16 @@ SET PERSIST_ONLY sync_master_info = @@GLOBAL.sync_master_info;
 SET PERSIST_ONLY sync_relay_log = @@GLOBAL.sync_relay_log;
 SET PERSIST_ONLY sync_relay_log_info = @@GLOBAL.sync_relay_log_info;
 
-include/assert.inc ['Expect 75 persisted variables in persisted_variables table.']
+include/assert.inc ['Expect 76 persisted variables in persisted_variables table.']
 
 ############################################################
 # 2. Restart server, it must preserve the persisted variable
 #    settings. Verify persisted configuration.
 # restart
 
-include/assert.inc ['Expect 75 persisted variables in persisted_variables table.']
-include/assert.inc ['Expect 75 persisted variables shown as PERSISTED in variables_info table.']
-include/assert.inc ['Expect 75 persisted variables with matching peristed and global values.']
+include/assert.inc ['Expect 76 persisted variables in persisted_variables table.']
+include/assert.inc ['Expect 76 persisted variables shown as PERSISTED in variables_info table.']
+include/assert.inc ['Expect 76 persisted variables with matching peristed and global values.']
 
 ############################################################
 # 3. Test RESET PERSIST. Verify persisted variable settings
@@ -155,6 +156,7 @@ RESET PERSIST binlog_order_commits;
 RESET PERSIST binlog_row_image;
 RESET PERSIST binlog_row_metadata;
 RESET PERSIST binlog_row_value_options;
+RESET PERSIST binlog_rows_event_max_rows;
 RESET PERSIST binlog_rows_query_log_events;
 RESET PERSIST binlog_stmt_cache_size;
 RESET PERSIST binlog_transaction_dependency_history_size;

--- a/mysql-test/suite/binlog_nogtid/r/binlog_persist_variables.result
+++ b/mysql-test/suite/binlog_nogtid/r/binlog_persist_variables.result
@@ -25,7 +25,7 @@ VARIABLE_NAME LIKE '%slave%') AND
 'reset_seconds_behind_master', 'skip_flush_master_info'))
 ORDER BY VARIABLE_NAME;
 
-include/assert.inc ['Expect 85 variables in the table.']
+include/assert.inc ['Expect 86 variables in the table.']
 
 # Test SET PERSIST
 SET PERSIST binlog_cache_size = @@GLOBAL.binlog_cache_size;
@@ -46,6 +46,7 @@ SET PERSIST binlog_order_commits = @@GLOBAL.binlog_order_commits;
 SET PERSIST binlog_row_image = @@GLOBAL.binlog_row_image;
 SET PERSIST binlog_row_metadata = @@GLOBAL.binlog_row_metadata;
 SET PERSIST binlog_row_value_options = @@GLOBAL.binlog_row_value_options;
+SET PERSIST binlog_rows_event_max_rows = @@GLOBAL.binlog_rows_event_max_rows;
 SET PERSIST binlog_rows_query_log_events = @@GLOBAL.binlog_rows_query_log_events;
 SET PERSIST binlog_stmt_cache_size = @@GLOBAL.binlog_stmt_cache_size;
 SET PERSIST binlog_transaction_dependency_history_size = @@GLOBAL.binlog_transaction_dependency_history_size;
@@ -132,16 +133,16 @@ SET PERSIST sync_master_info = @@GLOBAL.sync_master_info;
 SET PERSIST sync_relay_log = @@GLOBAL.sync_relay_log;
 SET PERSIST sync_relay_log_info = @@GLOBAL.sync_relay_log_info;
 
-include/assert.inc ['Expect 70 persisted variables in persisted_variables table.']
+include/assert.inc ['Expect 71 persisted variables in persisted_variables table.']
 
 ############################################################
 # 2. Restart server, it must preserve the persisted variable
 #    settings. Verify persisted configuration.
 # restart
 
-include/assert.inc ['Expect 70 persisted variables in persisted_variables table.']
-include/assert.inc ['Expect 70 persisted variables shown as PERSISTED in variables_info table.']
-include/assert.inc ['Expect 70 persisted variables with matching peristed and global values.']
+include/assert.inc ['Expect 71 persisted variables in persisted_variables table.']
+include/assert.inc ['Expect 71 persisted variables shown as PERSISTED in variables_info table.']
+include/assert.inc ['Expect 71 persisted variables with matching peristed and global values.']
 
 ############################################################
 # 3. Test RESET PERSIST IF EXISTS. Verify persisted variable
@@ -162,6 +163,7 @@ RESET PERSIST IF EXISTS binlog_order_commits;
 RESET PERSIST IF EXISTS binlog_row_image;
 RESET PERSIST IF EXISTS binlog_row_metadata;
 RESET PERSIST IF EXISTS binlog_row_value_options;
+RESET PERSIST IF EXISTS binlog_rows_event_max_rows;
 RESET PERSIST IF EXISTS binlog_rows_query_log_events;
 RESET PERSIST IF EXISTS binlog_stmt_cache_size;
 RESET PERSIST IF EXISTS binlog_transaction_dependency_history_size;

--- a/mysql-test/suite/binlog_nogtid/t/binlog_persist_only_variables.test
+++ b/mysql-test/suite/binlog_nogtid/t/binlog_persist_only_variables.test
@@ -59,7 +59,7 @@ INSERT INTO rplvars (varname, varvalue)
 
 # If this count differs, it means a variable has been added or removed.
 # In that case, this testcase needs to be updated accordingly.
---let $var_count=85
+--let $var_count=86
 --echo
 --let $assert_text= 'Expect $var_count variables in the table.'
 --let $assert_cond= [SELECT COUNT(*) as count FROM rplvars, count, 1] = $var_count
@@ -91,7 +91,7 @@ while ( $varid <= $countvars )
   --inc $varid
 }
 
---let $var_count=75
+--let $var_count=76
 --echo
 --let $assert_text= 'Expect $var_count persisted variables in persisted_variables table.'
 --let $assert_cond= [SELECT COUNT(*) as count FROM performance_schema.persisted_variables, count, 1] = $var_count

--- a/mysql-test/suite/binlog_nogtid/t/binlog_persist_variables.test
+++ b/mysql-test/suite/binlog_nogtid/t/binlog_persist_variables.test
@@ -60,7 +60,7 @@ INSERT INTO rplvars (varname, varvalue)
 
 # If this count differs, it means a variable has been added or removed.
 # In that case, this testcase needs to be updated accordingly.
---let $var_count=85
+--let $var_count=86
 --echo
 --let $assert_text= 'Expect $var_count variables in the table.'
 --let $assert_cond= [SELECT COUNT(*) as count FROM rplvars, count, 1] = $var_count
@@ -83,7 +83,7 @@ while ( $varid <= $countvars )
   --inc $varid
 }
 
---let $var_count=70
+--let $var_count=71
 --echo
 --let $assert_text= 'Expect $var_count persisted variables in persisted_variables table.'
 --let $assert_cond= [SELECT COUNT(*) as count FROM performance_schema.persisted_variables, count, 1] = $var_count

--- a/mysql-test/suite/sys_vars/r/binlog_rows_event_max_rows_basic.result
+++ b/mysql-test/suite/sys_vars/r/binlog_rows_event_max_rows_basic.result
@@ -1,0 +1,45 @@
+SET @old_binlog_rows_event_max_rows = @@global.binlog_rows_event_max_rows;
+SELECT @old_binlog_rows_event_max_rows;
+@old_binlog_rows_event_max_rows
+18446744073709551615
+SET @@global.binlog_rows_event_max_rows = DEFAULT;
+SELECT @@global.binlog_rows_event_max_rows;
+@@global.binlog_rows_event_max_rows
+18446744073709551615
+# binlog_rows_event_max_rows is a global variable.
+SET @@session.binlog_rows_event_max_rows = 1;
+ERROR HY000: Variable 'binlog_rows_event_max_rows' is a GLOBAL variable and should be set with SET GLOBAL
+SELECT @@binlog_rows_event_max_rows;
+@@binlog_rows_event_max_rows
+18446744073709551615
+SET @@global.binlog_rows_event_max_rows = 512;
+SELECT @@global.binlog_rows_event_max_rows;
+@@global.binlog_rows_event_max_rows
+512
+SET @@global.binlog_rows_event_max_rows = 1000000;
+SELECT @@global.binlog_rows_event_max_rows;
+@@global.binlog_rows_event_max_rows
+1000000
+SET @@global.binlog_rows_event_max_rows = 1.01;
+ERROR 42000: Incorrect argument type to variable 'binlog_rows_event_max_rows'
+SET @@global.binlog_rows_event_max_rows = 'ten';
+ERROR 42000: Incorrect argument type to variable 'binlog_rows_event_max_rows'
+SELECT @@global.binlog_rows_event_max_rows;
+@@global.binlog_rows_event_max_rows
+1000000
+# set binlog_rows_event_max_rows to wrong value
+SET @@global.binlog_rows_event_max_rows = 1500000;
+SELECT @@global.binlog_rows_event_max_rows;
+@@global.binlog_rows_event_max_rows
+1500000
+# set binlog_rows_event_max_rows to wrong value
+SET @@global.binlog_rows_event_max_rows = 0;
+Warnings:
+Warning	1292	Truncated incorrect binlog_rows_event_max_rows value: '0'
+SELECT @@global.binlog_rows_event_max_rows;
+@@global.binlog_rows_event_max_rows
+1
+SET @@global.binlog_rows_event_max_rows = @old_binlog_rows_event_max_rows;
+SELECT @@global.binlog_rows_event_max_rows;
+@@global.binlog_rows_event_max_rows
+18446744073709551615

--- a/mysql-test/suite/sys_vars/t/binlog_rows_event_max_rows_basic.test
+++ b/mysql-test/suite/sys_vars/t/binlog_rows_event_max_rows_basic.test
@@ -1,0 +1,33 @@
+--source include/load_sysvars.inc
+
+SET @old_binlog_rows_event_max_rows = @@global.binlog_rows_event_max_rows;
+SELECT @old_binlog_rows_event_max_rows;
+
+SET @@global.binlog_rows_event_max_rows = DEFAULT;
+SELECT @@global.binlog_rows_event_max_rows;
+
+-- echo # binlog_rows_event_max_rows is a global variable.
+--error ER_GLOBAL_VARIABLE
+SET @@session.binlog_rows_event_max_rows = 1;
+SELECT @@binlog_rows_event_max_rows;
+
+SET @@global.binlog_rows_event_max_rows = 512;
+SELECT @@global.binlog_rows_event_max_rows;
+SET @@global.binlog_rows_event_max_rows = 1000000;
+SELECT @@global.binlog_rows_event_max_rows;
+
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@global.binlog_rows_event_max_rows = 1.01;
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@global.binlog_rows_event_max_rows = 'ten';
+SELECT @@global.binlog_rows_event_max_rows;
+-- echo # set binlog_rows_event_max_rows to wrong value
+SET @@global.binlog_rows_event_max_rows = 1500000;
+SELECT @@global.binlog_rows_event_max_rows;
+-- echo # set binlog_rows_event_max_rows to wrong value
+SET @@global.binlog_rows_event_max_rows = 0;
+SELECT @@global.binlog_rows_event_max_rows;
+
+
+SET @@global.binlog_rows_event_max_rows = @old_binlog_rows_event_max_rows;
+SELECT @@global.binlog_rows_event_max_rows;

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -10362,6 +10362,7 @@ Rows_log_event *THD::binlog_prepare_pending_rows_event(
       pending->get_table_id() != table->s->table_map_id ||
       pending->get_general_type_code() != general_type_code ||
       pending->get_data_size() + needed > opt_binlog_rows_event_max_size ||
+      pending->m_row_count >= opt_binlog_rows_event_max_rows ||
       pending->read_write_bitmaps_cmp(table) == false ||
       !binlog_row_event_extra_data_eq(pending->get_extra_row_data(),
                                       extra_row_info)) {

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -2631,7 +2631,7 @@ class Rows_log_event : public virtual binary_log::Rows_event, public Log_event {
                         bool old_row_is_record1);
 #endif
 
-  uint m_row_count; /* The number of rows added to the event */
+  ulonglong m_row_count; /* The number of rows added to the event */
 
   const uchar *get_extra_row_data() const { return m_extra_row_data; }
 

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1053,6 +1053,7 @@ int32_t opt_regexp_time_limit;
 int32_t opt_regexp_stack_limit;
 
 ulong opt_binlog_rows_event_max_size;
+ulonglong opt_binlog_rows_event_max_rows = 0;
 bool opt_log_only_query_comments = false;
 bool opt_log_column_names = false;
 ulong binlog_checksum_options;

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -306,6 +306,7 @@ extern long opt_binlog_group_commit_sync_delay;
 extern ulong opt_binlog_group_commit_sync_no_delay_count;
 extern ulong max_binlog_size, max_relay_log_size;
 extern ulong slave_max_allowed_packet;
+extern ulonglong opt_binlog_rows_event_max_rows;
 extern ulong opt_binlog_rows_event_max_size;
 extern ulong binlog_checksum_options;
 extern ulong binlog_row_metadata;

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -858,6 +858,12 @@ static Sys_var_ulong Sys_binlog_group_commit_sync_no_delay_count(
     CMD_LINE(REQUIRED_ARG), VALID_RANGE(0, 100000 /* max connections */),
     DEFAULT(0), BLOCK_SIZE(1), NO_MUTEX_GUARD, NOT_IN_BINLOG);
 
+static Sys_var_ulonglong Sys_binlog_rows_event_max_rows(
+    "binlog_rows_event_max_rows", "Max number of rows in a single rows event",
+    GLOBAL_VAR(opt_binlog_rows_event_max_rows), CMD_LINE(OPT_ARG),
+    VALID_RANGE(1, ULLONG_MAX), DEFAULT(ULLONG_MAX), BLOCK_SIZE(1),
+    NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(nullptr), ON_UPDATE(nullptr));
+
 static bool check_has_super(sys_var *self MY_ATTRIBUTE((unused)), THD *thd,
                             set_var *) {
   DBUG_ASSERT(self->scope() !=


### PR DESCRIPTION
Summary:
Jira issue: https://jira.percona.com/browse/FB8-187

Reference Patch: https://github.com/facebook/mysql-5.6/commit/dfe6746cdfd

Number of rows in a single event can be indirectly controlled with
binlog_rows_event_max_size. This new variable will give more direct control to
the user.

Originally Reviewed By: anirbanr-fb

Todo: Because of conflicts I removed changes in `mysql-test/t/all_persisted_variables.test`. This test has to be modified at `let $total_persistent_vars=XXX;` (+1 increase) and it should be re-recorded.
