### PR TITLE
FB8-224: Fix handshake errors with debug builds

### DIFF
--- a/sql/auth/sql_authentication.cc
+++ b/sql/auth/sql_authentication.cc
@@ -1328,7 +1328,8 @@ static bool send_server_handshake_packet(MPVIO_EXT *mpvio, const char *data,
   DBUG_ASSERT(data_len <= 255);
   Protocol_classic *protocol = mpvio->protocol;
 
-  char *buff = (char *)my_alloca(1 + SERVER_VERSION_LENGTH + data_len + 64);
+  char *buff = (char *)my_alloca(1 + SERVER_VERSION_LENGTH + data_len + 64 +
+                                 strlen(MYSQL_COMPILATION_COMMENT) + 1);
   char scramble_buf[SCRAMBLE_LENGTH];
   char *end = buff;
 
@@ -1382,9 +1383,7 @@ static bool send_server_handshake_packet(MPVIO_EXT *mpvio, const char *data,
 
   end = my_stpnmov(end, server_version, SERVER_VERSION_LENGTH);
   end = my_stpcpy(end, " ");
-  end = my_stpnmov(end, MYSQL_COMPILATION_COMMENT,
-                   SERVER_VERSION_LENGTH - (end - buff - 1)) +
-        1;
+  end = my_stpcpy(end, MYSQL_COMPILATION_COMMENT) + 1;
 
   DBUG_ASSERT(sizeof(my_thread_id) == 4);
   int4store((uchar *)end, mpvio->thread_id);


### PR DESCRIPTION
Our Jenkins jobs showed up to 4K failures for a Debug build. Release builds were not affected.
The main issue were errors with a server handshake:
```
mysqltest: Could not open connection 'default': 2012 Error in server handshake
```

The reason was https://github.com/facebook/mysql-5.6/commit/c6bc747a764 incorrectly ported from 5.6.
This patch fixes the buffer overrun issue by allocating addidtional memory for a server handshake buffer: `strlen(MYSQL_COMPILATION_COMMENT) + strlen(" ")`

Squash with D8881186