### PR TITLE
FB8-105: Stop slave immediately in MTS if partial trx in the relay log can be rollbacked

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_multi_source_mts_reset_worker_info.result
+++ b/mysql-test/suite/rpl/r/rpl_multi_source_mts_reset_worker_info.result
@@ -7,6 +7,7 @@ Note	####	Storing MySQL user name or password information in the master info rep
 call mtr.add_suppression("Recovery from master pos .*");
 call mtr.add_suppression("Corrupted table mysql.slave_worker_info");
 call mtr.add_suppression("Could not delete from Slave Workers info repository");
+call mtr.add_suppression("The slave coordinator and worker threads are stopped, possibly leaving data in inconsistent state.");
 include/stop_slave.inc
 RESET SLAVE ALL;
 SET @save.slave_parallel_workers=@@global.slave_parallel_workers;

--- a/mysql-test/suite/rpl/t/rpl_multi_source_mts_reset_worker_info.test
+++ b/mysql-test/suite/rpl/t/rpl_multi_source_mts_reset_worker_info.test
@@ -13,6 +13,7 @@
 call mtr.add_suppression("Recovery from master pos .*");
 call mtr.add_suppression("Corrupted table mysql.slave_worker_info");
 call mtr.add_suppression("Could not delete from Slave Workers info repository");
+call mtr.add_suppression("The slave coordinator and worker threads are stopped, possibly leaving data in inconsistent state.");
 
 --source include/stop_slave.inc
 RESET SLAVE ALL;

--- a/mysql-test/suite/rpl_gtid/r/rpl_stop_slave_partial_trx.result
+++ b/mysql-test/suite/rpl_gtid/r/rpl_stop_slave_partial_trx.result
@@ -1,0 +1,85 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+call mtr.add_suppression("The slave coordinator and worker threads are stopped, possibly leaving data in inconsistent state");
+create database d1;
+create database d2;
+create database d3;
+create table d1.t1 (a int) engine=innodb;
+insert into d1.t1 values(1);
+create table d2.t2 (a int) engine=myisam;
+create table d3.t3 (a int) engine=innodb;
+include/sync_slave_sql_with_master.inc
+[connection slave]
+lock tables d1.t1 read;
+set global debug= '+d,after_executed_write_rows_event';
+[connection master]
+update d1.t1 set a= 5;
+update d1.t1 set a= 4;
+update d1.t1 set a= 3;
+update d1.t1 set a= 2;
+update d1.t1 set a= 1;
+set global debug= '+d,dump_thread_wait_after_send_write_rows';
+insert into d2.t2 values(1);
+[connection slave]
+unlock tables;
+set debug_sync= 'now WAIT_FOR executed';
+set global debug= '-d,after_executed_write_rows_event';
+set @start=now();
+include/stop_slave.inc
+select timestampdiff(SECOND, @start, now()) >= 20;
+timestampdiff(SECOND, @start, now()) >= 20
+1
+include/start_slave.inc
+[connection master]
+set debug_sync= 'now SIGNAL signal.continue';
+set debug_sync= 'RESET';
+[connection master]
+set @@global.debug= '-d,dump_thread_wait_after_send_write_rows';
+include/sync_slave_sql_with_master.inc
+include/rpl_diff.inc
+include/rpl_diff.inc
+include/rpl_diff.inc
+[connection master]
+delete from d1.t1;
+insert into d1.t1 values(1);
+delete from d2.t2;
+delete from d3.t3;
+include/sync_slave_sql_with_master.inc
+[connection slave]
+lock tables d1.t1 read;
+set global debug= '+d,after_executed_write_rows_event';
+[connection master]
+update d1.t1 set a= 5;
+update d1.t1 set a= 4;
+update d1.t1 set a= 3;
+update d1.t1 set a= 2;
+update d1.t1 set a= 1;
+set global debug= '+d,dump_thread_wait_after_send_write_rows';
+insert into d3.t3 values(1);
+[connection slave]
+unlock tables;
+set debug_sync= 'now WAIT_FOR executed';
+set global debug= '-d,after_executed_write_rows_event';
+set @start=now();
+include/stop_slave.inc
+select timestampdiff(SECOND, @start, now()) < 20;
+timestampdiff(SECOND, @start, now()) < 20
+1
+include/start_slave.inc
+[connection master]
+set debug_sync= 'now SIGNAL signal.continue';
+set debug_sync= 'RESET';
+[connection master]
+set global debug= '-d,dump_thread_wait_after_send_write_rows';
+include/sync_slave_sql_with_master.inc
+include/rpl_diff.inc
+include/rpl_diff.inc
+include/rpl_diff.inc
+[connection master]
+drop database d1;
+drop database d2;
+drop database d3;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl_gtid/t/rpl_stop_slave_partial_trx-master.opt
+++ b/mysql-test/suite/rpl_gtid/t/rpl_stop_slave_partial_trx-master.opt
@@ -1,0 +1,1 @@
+--slave_parallel_workers=8 --log-slave-updates --debug_sync_timeout=20

--- a/mysql-test/suite/rpl_gtid/t/rpl_stop_slave_partial_trx-slave.opt
+++ b/mysql-test/suite/rpl_gtid/t/rpl_stop_slave_partial_trx-slave.opt
@@ -1,0 +1,1 @@
+--slave_parallel_workers=8 --log-slave-updates

--- a/mysql-test/suite/rpl_gtid/t/rpl_stop_slave_partial_trx.test
+++ b/mysql-test/suite/rpl_gtid/t/rpl_stop_slave_partial_trx.test
@@ -1,0 +1,154 @@
+source include/have_myisam.inc;
+source include/have_debug.inc;
+source include/have_debug_sync.inc;
+source include/have_binlog_format_row.inc;
+source include/master-slave.inc;
+
+call mtr.add_suppression("The slave coordinator and worker threads are stopped, possibly leaving data in inconsistent state");
+
+# Create schema
+create database d1;
+create database d2;
+create database d3;
+create table d1.t1 (a int) engine=innodb;
+insert into d1.t1 values(1); # add some data for update statements
+create table d2.t2 (a int) engine=myisam; # non-transactional engine
+create table d3.t3 (a int) engine=innodb; # transactional engine
+--source include/sync_slave_sql_with_master.inc
+
+
+
+## Test 1: STOP SLAVE when there are pending jobs in the worker queues and there
+## is a partial transaction on a non-transactional table. The slave should wait
+## for 1 minute to complete the partial transaction before giving up.
+
+# Block all d1.t1 transactions on the slave
+--source include/rpl_connection_slave.inc
+lock tables d1.t1 read;
+set global debug= '+d,after_executed_write_rows_event';
+
+# Generate some load, all of these will be blocked in the slave worker queue
+--source include/rpl_connection_master.inc
+let $num_updates=5;
+while ($num_updates)
+{
+  eval update d1.t1 set a= $num_updates;
+  dec $num_updates;
+}
+
+# This will stop the dump thread before sending the entire group
+set global debug= '+d,dump_thread_wait_after_send_write_rows';
+insert into d2.t2 values(1);
+
+# wait for the dump thread reach the sync point
+--let $wait_condition= select count(*)=1 from information_schema.processlist where state LIKE '%debug sync point%' and command like 'Binlog Dump%'
+--source include/wait_condition.inc
+
+--source include/rpl_connection_slave.inc
+# unblock d1.t1
+unlock tables;
+
+# This should take at least 20 seconds because the trx on t2 is not completely downloaded and cannot be rollbacked safely
+let $debug_sync_timeout= 20;  # should be equal to value of --debug_sync_timeout in rpl_stop_slave_partial_trx-master.opt file
+set debug_sync= 'now WAIT_FOR executed';
+set global debug= '-d,after_executed_write_rows_event';
+set @start=now();
+--source include/stop_slave.inc
+--eval select timestampdiff(SECOND, @start, now()) >= $debug_sync_timeout
+--source include/start_slave.inc
+
+--source include/rpl_connection_master.inc
+set debug_sync= 'now SIGNAL signal.continue';
+# wait for the dump thread to come out of the waiting phase before resetting the signals
+--let $wait_condition= select count(*)=0 from information_schema.processlist where state LIKE '%debug sync point%' and command='Binlog Dump'
+--source include/wait_condition.inc
+set debug_sync= 'RESET';
+
+--source include/rpl_connection_master.inc
+set @@global.debug= '-d,dump_thread_wait_after_send_write_rows';
+--source include/sync_slave_sql_with_master.inc
+
+# Verification
+--let $rpl_diff_statement= select * from d1.t1
+--source include/rpl_diff.inc
+--let $rpl_diff_statement= select * from d2.t2
+--source include/rpl_diff.inc
+--let $rpl_diff_statement= select * from d3.t3
+--source include/rpl_diff.inc
+
+# cleanup
+--source include/rpl_connection_master.inc
+delete from d1.t1;
+insert into d1.t1 values(1); # add some data for update statements
+delete from d2.t2;
+delete from d3.t3;
+--source include/sync_slave_sql_with_master.inc
+
+
+
+## Test 2: STOP SLAVE when there are pending jobs in the worker queues and there
+## is a partial transaction on a transactional table. The slave should stop
+## immidiately after completing all pending full transactions.
+
+# Block all d1.t1 transactions on the slave
+--source include/rpl_connection_slave.inc
+lock tables d1.t1 read;
+set global debug= '+d,after_executed_write_rows_event';
+
+# Generate some load, all of these will be blocked in the slave worker queue
+--source include/rpl_connection_master.inc
+let $num_updates=5;
+while ($num_updates)
+{
+  eval update d1.t1 set a= $num_updates;
+  dec $num_updates;
+}
+
+# This will stop the dump thread before sending the entire group
+set global debug= '+d,dump_thread_wait_after_send_write_rows';
+insert into d3.t3 values(1);
+
+# wait for the dump thread reach the sync point
+--let $wait_condition= select count(*)=1 from information_schema.processlist where state LIKE '%debug sync point%' and command like 'Binlog Dump%'
+--source include/wait_condition.inc
+
+--source include/rpl_connection_slave.inc
+# unblock d1.t1
+unlock tables;
+
+# Since the partial transaction is on a transactional table the slave should
+# stop as soon as is completes all pending full transactions
+set debug_sync= 'now WAIT_FOR executed';
+set global debug= '-d,after_executed_write_rows_event';
+set @start=now();
+--source include/stop_slave.inc
+--eval select timestampdiff(SECOND, @start, now()) < $debug_sync_timeout
+--source include/start_slave.inc
+
+--source include/rpl_connection_master.inc
+set debug_sync= 'now SIGNAL signal.continue';
+# wait for the dump thread to come out of the waiting phase before resetting the signals
+--let $wait_condition= select count(*)=0 from information_schema.processlist where state LIKE '%debug sync point%' and command='Binlog Dump'
+--source include/wait_condition.inc
+set debug_sync= 'RESET';
+
+--source include/rpl_connection_master.inc
+set global debug= '-d,dump_thread_wait_after_send_write_rows';
+--source include/sync_slave_sql_with_master.inc
+
+# Verification
+--let $rpl_diff_statement= select * from d1.t1
+--source include/rpl_diff.inc
+--let $rpl_diff_statement= select * from d2.t2
+--source include/rpl_diff.inc
+--let $rpl_diff_statement= select * from d3.t3
+--source include/rpl_diff.inc
+
+# final cleanup
+--source include/rpl_connection_master.inc
+drop database d1;
+drop database d2;
+drop database d3;
+
+
+source include/rpl_end.inc;

--- a/sql/rpl_rli.cc
+++ b/sql/rpl_rli.cc
@@ -438,6 +438,37 @@ err:
   DBUG_RETURN(ret);
 }
 
+bool Relay_log_info::mts_workers_queue_empty() const {
+  ulong ret = 0;
+
+  for (const auto& worker: workers) {
+    mysql_mutex_lock(&worker->jobs_lock);
+    ret += worker->curr_jobs;
+    mysql_mutex_unlock(&worker->jobs_lock);
+  }
+
+  return ret == 0;
+}
+
+/* Checks if all in-flight stmts/trx can be safely rollbacked */
+bool Relay_log_info::cannot_safely_rollback() const {
+  if (!is_parallel_exec())
+    return info_thd->get_transaction()->cannot_safely_rollback(
+        Transaction_ctx::SESSION);
+
+  bool ret = false;
+
+  for (const auto& worker: workers) {
+    mysql_mutex_lock(&worker->jobs_lock);
+    ret = worker->info_thd->get_transaction()->cannot_safely_rollback(
+        Transaction_ctx::SESSION);
+    mysql_mutex_unlock(&worker->jobs_lock);
+    if (ret) break;
+  }
+
+  return ret;
+}
+
 static inline int add_relay_log(Relay_log_info *rli, LOG_INFO *linfo) {
   MY_STAT s;
   DBUG_ENTER("add_relay_log");

--- a/sql/rpl_rli.h
+++ b/sql/rpl_rli.h
@@ -1009,6 +1009,9 @@ class Relay_log_info : public Rpl_info {
     return is_parallel_exec() && mts_group_status == MTS_IN_GROUP;
   }
 
+  bool mts_workers_queue_empty() const;
+  bool cannot_safely_rollback() const;
+
   /**
      Check if it is time to compute MTS checkpoint.
 

--- a/sql/rpl_rli_pdb.cc
+++ b/sql/rpl_rli_pdb.cc
@@ -1731,6 +1731,15 @@ int Slave_worker::slave_worker_exec_event(Log_event *ev) {
   set_master_log_pos(static_cast<ulong>(ev->common_header->log_pos));
   set_gaq_index(ev->mts_group_idx);
   ret = ev->do_apply_event_worker(this);
+
+  DBUG_EXECUTE_IF("after_executed_write_rows_event", {
+    if (ev->get_type_code() == binary_log::WRITE_ROWS_EVENT) {
+      static constexpr char act[] = "now signal executed";
+      DBUG_ASSERT(opt_debug_sync_timeout > 0);
+      DBUG_ASSERT(!debug_sync_set_action(thd, STRING_WITH_LEN(act)));
+    }
+  };);
+
   DBUG_RETURN(ret);
 }
 

--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -2085,8 +2085,14 @@ bool sql_slave_killed(THD *thd, Relay_log_info *rli) {
                   DBUG_RETURN(false););
   if (connection_events_loop_aborted() || thd->killed || rli->abort_slave) {
     rli->sql_thread_kill_accepted = true;
+    /* NOTE: In MTS mode if all workers are done and if the partial trx
+       (if any) can be rollbacked safely we can accept the kill */
+    const bool can_rollback =
+        rli->abort_slave &&
+        (!rli->is_mts_in_group() ||
+         (rli->mts_workers_queue_empty() && !rli->cannot_safely_rollback()));
     is_parallel_warn =
-        (rli->is_parallel_exec() && (rli->is_mts_in_group() || thd->killed));
+        (rli->is_parallel_exec() && (!can_rollback || thd->killed));
     /*
       Slave can execute stop being in one of two MTS or Single-Threaded mode.
       The modes define different criteria to accept the stop.
@@ -2158,7 +2164,6 @@ bool sql_slave_killed(THD *thd, Relay_log_info *rli) {
         }
       }
       if (rli->sql_thread_kill_accepted) {
-        rli->last_event_start_time = 0;
         if (rli->mts_group_status == Relay_log_info::MTS_IN_GROUP) {
           rli->mts_group_status = Relay_log_info::MTS_KILLED_GROUP;
         }
@@ -2174,6 +2179,9 @@ bool sql_slave_killed(THD *thd, Relay_log_info *rli) {
       }
     }
   }
+
+  if (rli->sql_thread_kill_accepted) rli->last_event_start_time = 0;
+
   DBUG_RETURN(rli->sql_thread_kill_accepted);
 }
 


### PR DESCRIPTION
Summary:

Jira issue: https://jira.percona.com/browse/FB8-105

Reference Patch: https://github.com/facebook/mysql-5.6/commit/cd39ae1
Reference Patch: https://github.com/facebook/mysql-5.6/commit/0623a07

Stop slave immediately in MTS if partial trx in the relay log can be rollbacked

In MTS stop slave can take a minute to complete if the last transaction
is partially downloaded from the master. The slave waits for a minute for the
master to send the rest of the trx and then finally gives up. Strictly, this
wait is only required if the partial trx cannot be rollbacked safely (e.g. trx
on non-transactional engine, DDLs etc.). This change checks if there are no jobs
queued in the worker threads and if the partial trx can be rollbacked, if yes,
it immediately stops the slave.

Originally Reviewed By: tianx