### PR TITLE
FB8-104: enabling subsecond lock_wait_timeout

### DIFF
--- a/components/example/test_backup_lock_service.cc
+++ b/components/example/test_backup_lock_service.cc
@@ -38,8 +38,8 @@ extern REQUIRES_SERVICE_PLACEHOLDER(mysql_backup_lock);
 */
 
 mysql_service_status_t test_backup_lock_service_init() {
-  return mysql_service_mysql_backup_lock->acquire(
-      nullptr, BACKUP_LOCK_SERVICE_DEFAULT, 100);
+  return mysql_service_mysql_backup_lock->acquire_nsec(
+      nullptr, BACKUP_LOCK_SERVICE_DEFAULT, 100 * 1000000000ULL);
 }
 
 /**

--- a/components/mysql_server/mysql_backup_lock.h
+++ b/components/mysql_server/mysql_backup_lock.h
@@ -1,24 +1,24 @@
 /* Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
 
-   This program is free software; you can redistribute it and/or modify
-   it under the terms of the GNU General Public License, version 2.0,
-   as published by the Free Software Foundation.
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License, version 2.0,
+  as published by the Free Software Foundation.
 
-   This program is also distributed with certain software (including
-   but not limited to OpenSSL) that is licensed under separate terms,
-   as designated in a particular file or component or in included license
-   documentation.  The authors of MySQL hereby grant you an additional
-   permission to link the program and your derivative works with the
-   separately licensed software that they have included with MySQL.
+  This program is also distributed with certain software (including
+  but not limited to OpenSSL) that is licensed under separate terms,
+  as designated in a particular file or component or in included license
+  documentation.  The authors of MySQL hereby grant you an additional
+  permission to link the program and your derivative works with the
+  separately licensed software that they have included with MySQL.
 
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License, version 2.0, for more details.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License, version 2.0, for more details.
 
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
 #ifndef MYSQL_BACKUP_LOCK_INCLUDED
 #define MYSQL_BACKUP_LOCK_INCLUDED
@@ -39,10 +39,10 @@
     @retval true  Failure
 */
 
-DEFINE_BOOL_METHOD(mysql_acquire_backup_lock,
+DEFINE_BOOL_METHOD(mysql_acquire_backup_lock_nsec,
                    (MYSQL_THD opaque_thd,
                     enum enum_backup_lock_service_lock_kind lock_kind,
-                    unsigned long lock_timeout));
+                    ulonglong lock_timeout));
 
 /**
   Service API to release Backup Lock.

--- a/components/mysql_server/server_component.cc
+++ b/components/mysql_server/server_component.cc
@@ -254,7 +254,7 @@ BEGIN_SERVICE_IMPLEMENTATION(mysql_server, system_variable_source)
 mysql_system_variable_source_imp::get END_SERVICE_IMPLEMENTATION();
 
 BEGIN_SERVICE_IMPLEMENTATION(mysql_server, mysql_backup_lock)
-mysql_acquire_backup_lock,
+mysql_acquire_backup_lock_nsec,
     mysql_release_backup_lock END_SERVICE_IMPLEMENTATION();
 
 BEGIN_SERVICE_IMPLEMENTATION(mysql_server, mysql_thd_security_context)

--- a/include/mysql/components/services/backup_lock_service.h
+++ b/include/mysql/components/services/backup_lock_service.h
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 #define BACKUP_LOCK_SERVICE_H
 #include <mysql/components/service.h>
 #include <stddef.h>
+#include "my_inttypes.h"
 
 /**
   Kind of Backup Lock to be acquired. In future we might
@@ -59,9 +60,9 @@ BEGIN_SERVICE_DEFINITION(mysql_backup_lock)
     @retval true  Failure
 */
 
-DECLARE_BOOL_METHOD(acquire,
+DECLARE_BOOL_METHOD(acquire_nsec,
                     (MYSQL_THD, enum enum_backup_lock_service_lock_kind,
-                     unsigned long /* lock_timeout*/));
+                     ulonglong /* lock_timeout*/));
 
 /**
   Service API to release Backup Lock.

--- a/include/mysql/service_locking.h
+++ b/include/mysql/service_locking.h
@@ -38,6 +38,8 @@ class THD;
 #define MYSQL_THD void *
 #endif
 
+#include "my_inttypes.h"
+
 /**
   Types of locking service locks.
   LOCKING_SERVICE_READ is compatible with LOCKING_SERVICE_READ.
@@ -51,7 +53,7 @@ enum enum_locking_service_lock_type {
 typedef int (*mysql_acquire_locks_t)(
     MYSQL_THD opaque_thd, const char *lock_namespace, const char **lock_names,
     size_t lock_num, enum enum_locking_service_lock_type lock_type,
-    unsigned long lock_timeout);
+    ulonglong lock_timeout_nsec);
 
 typedef int (*mysql_release_locks_t)(MYSQL_THD opaque_thd,
                                      const char *lock_namespace);
@@ -88,7 +90,7 @@ extern "C" struct mysql_locking_service_st {
 
     @sa acquire_locking_service_locks, MDL_context::acquire_locks
   */
-  mysql_acquire_locks_t mysql_acquire_locks;
+  mysql_acquire_locks_t mysql_acquire_locks_nsec;
   /**
     Release all lock service locks taken by the given connection
     in the given namespace.
@@ -106,19 +108,19 @@ extern "C" struct mysql_locking_service_st {
 
 #ifdef MYSQL_DYNAMIC_PLUGIN
 
-#define mysql_acquire_locking_service_locks(_THD, _NAMESPACE, _NAMES, _NUM,  \
-                                            _TYPE, _TIMEOUT)                 \
-  mysql_locking_service->mysql_acquire_locks(_THD, _NAMESPACE, _NAMES, _NUM, \
-                                             _TYPE, _TIMEOUT)
+#define mysql_acquire_locking_service_locks_nsec(_THD, _NAMESPACE, _NAMES,  \
+                                                 _NUM, _TYPE, _TIMEOUT)     \
+  mysql_locking_service->mysql_acquire_locks_nsec(_THD, _NAMESPACE, _NAMES, \
+                                                  _NUM, _TYPE, _TIMEOUT)
 #define mysql_release_locking_service_locks(_THD, _NAMESPACE) \
   mysql_locking_service->mysql_release_locks(_THD, _NAMESPACE)
 
 #else
 
-int mysql_acquire_locking_service_locks(
+int mysql_acquire_locking_service_locks_nsec(
     MYSQL_THD opaque_thd, const char *lock_namespace, const char **lock_names,
     size_t lock_num, enum enum_locking_service_lock_type lock_type,
-    unsigned long lock_timeout);
+    ulonglong lock_timeout);
 
 int mysql_release_locking_service_locks(MYSQL_THD opaque_thd,
                                         const char *lock_namespace);

--- a/include/mysql/services.h.pp
+++ b/include/mysql/services.h.pp
@@ -222,6 +222,7 @@ int command_service_run_command(MYSQL_SESSION session,
                                 enum cs_text_or_binary text_or_binary,
                                 void *service_callbacks_ctx);
 #include <mysql/service_locking.h>
+#include "my_inttypes.h"
 enum enum_locking_service_lock_type {
   LOCKING_SERVICE_READ,
   LOCKING_SERVICE_WRITE
@@ -229,17 +230,17 @@ enum enum_locking_service_lock_type {
 typedef int (*mysql_acquire_locks_t)(
     void * opaque_thd, const char *lock_namespace, const char **lock_names,
     size_t lock_num, enum enum_locking_service_lock_type lock_type,
-    unsigned long lock_timeout);
+    ulonglong lock_timeout_nsec);
 typedef int (*mysql_release_locks_t)(void * opaque_thd,
                                      const char *lock_namespace);
 extern "C" struct mysql_locking_service_st {
-  mysql_acquire_locks_t mysql_acquire_locks;
+  mysql_acquire_locks_t mysql_acquire_locks_nsec;
   mysql_release_locks_t mysql_release_locks;
 } * mysql_locking_service;
-int mysql_acquire_locking_service_locks(
+int mysql_acquire_locking_service_locks_nsec(
     void * opaque_thd, const char *lock_namespace, const char **lock_names,
     size_t lock_num, enum enum_locking_service_lock_type lock_type,
-    unsigned long lock_timeout);
+    ulonglong lock_timeout);
 int mysql_release_locking_service_locks(void * opaque_thd,
                                         const char *lock_namespace);
 #include <mysql/service_my_plugin_log.h>

--- a/include/thr_lock.h
+++ b/include/thr_lock.h
@@ -173,13 +173,14 @@ void thr_lock_init(THR_LOCK *lock);
 void thr_lock_delete(THR_LOCK *lock);
 void thr_lock_data_init(THR_LOCK *lock, THR_LOCK_DATA *data,
                         void *status_param);
-enum enum_thr_lock_result thr_lock(THR_LOCK_DATA *data, THR_LOCK_INFO *owner,
-                                   enum thr_lock_type lock_type,
-                                   ulong lock_wait_timeout);
+enum enum_thr_lock_result thr_lock_nsec(THR_LOCK_DATA *data,
+                                        THR_LOCK_INFO *owner,
+                                        enum thr_lock_type lock_type,
+                                        ulonglong lock_wait_timeout_nsec);
 void thr_unlock(THR_LOCK_DATA *data);
-enum enum_thr_lock_result thr_multi_lock(THR_LOCK_DATA **data, uint count,
-                                         THR_LOCK_INFO *owner,
-                                         ulong lock_wait_timeout,
+enum enum_thr_lock_result thr_multi_lock_nsec(THR_LOCK_DATA **data, uint count,
+                                              THR_LOCK_INFO *owner,
+                                              ulonglong lock_wait_timeout_nsec,
                                          THR_LOCK_DATA **error_pos);
 void thr_multi_unlock(THR_LOCK_DATA **data, uint count);
 void thr_lock_merge_status(THR_LOCK_DATA **data, uint count);

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -447,7 +447,8 @@ The following options may be given as the first argument:
  --local-infile      Enable LOAD DATA LOCAL INFILE
  --lock-wait-timeout=# 
  Timeout in seconds to wait for a lock before returning an
- error.
+ error. The argument will be treated as a decimal value
+ with nanosecond precision.
  --log-bin[=name]    Configures the name prefix to use for binary log files.
  If the --log-bin option is not supplied, the name prefix
  defaults to "binlog". If the --log-bin option is supplied
@@ -1515,7 +1516,7 @@ large-pages FALSE
 lc-messages en_US
 lc-time-names en_US
 local-infile FALSE
-lock-wait-timeout 31536000
+lock-wait-timeout 3.1536e+07
 log-bin (No default value)
 log-bin-index (No default value)
 log-bin-trust-function-creators FALSE

--- a/mysql-test/r/opt_hints_set_var.result
+++ b/mysql-test/r/opt_hints_set_var.result
@@ -309,11 +309,11 @@ UNLOCK TABLES;
 DROP TABLE t1;
 CALL test_hint("SET_VAR(lock_wait_timeout=1)", "lock_wait_timeout");
 VARIABLE_VALUE
-31536000
+31536000.000000
 VARIABLE_VALUE
-1
+1.000000
 VARIABLE_VALUE
-31536000
+31536000.000000
 CREATE TABLE t1(f1 INT);
 EXPLAIN SELECT /*+ SET_VAR(max_error_count=0) SET_VAR(optimizer_switch = 'batched_key_acces=off') SET_VAR(range_alloc_block_size=amba)*/ * FROM t1;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra

--- a/mysql-test/suite/parts/r/partition-dml-1-10-innodb.result
+++ b/mysql-test/suite/parts/r/partition-dml-1-10-innodb.result
@@ -8,7 +8,7 @@ SET @lock_timeout= @@global.lock_wait_timeout;
 SET @@global.lock_wait_timeout= 1;
 SELECT @@global.lock_wait_timeout;
 @@global.lock_wait_timeout
-1
+1.000000
 SET @innodb_lock_timeout= @@global.innodb_lock_wait_timeout;
 SET @@global.innodb_lock_wait_timeout= 1;
 # Additional tests for WL#5217 by QA, testplan 1.1

--- a/mysql-test/suite/parts/r/partition-dml-1-4-innodb.result
+++ b/mysql-test/suite/parts/r/partition-dml-1-4-innodb.result
@@ -8,7 +8,7 @@ SET @lock_timeout= @@global.lock_wait_timeout;
 SET @@global.lock_wait_timeout= 1;
 SELECT @@global.lock_wait_timeout;
 @@global.lock_wait_timeout
-1
+1.000000
 SET @innodb_lock_timeout= @@global.innodb_lock_wait_timeout;
 SET @@global.innodb_lock_wait_timeout= 1;
 SELECT @@global.innodb_lock_wait_timeout;

--- a/mysql-test/suite/parts/r/partition-dml-1-5-innodb.result
+++ b/mysql-test/suite/parts/r/partition-dml-1-5-innodb.result
@@ -8,7 +8,7 @@ SET @lock_timeout= @@global.lock_wait_timeout;
 SET @@global.lock_wait_timeout= 1;
 SELECT @@global.lock_wait_timeout;
 @@global.lock_wait_timeout
-1
+1.000000
 SET @innodb_lock_timeout= @@global.innodb_lock_wait_timeout;
 SET @@global.innodb_lock_wait_timeout= 1;
 SELECT @@global.innodb_lock_wait_timeout;

--- a/mysql-test/suite/parts/r/partition-dml-1-6-innodb.result
+++ b/mysql-test/suite/parts/r/partition-dml-1-6-innodb.result
@@ -8,7 +8,7 @@ SET @lock_timeout= @@global.lock_wait_timeout;
 SET @@global.lock_wait_timeout= 1;
 SELECT @@global.lock_wait_timeout;
 @@global.lock_wait_timeout
-1
+1.000000
 SET @innodb_lock_timeout= @@global.innodb_lock_wait_timeout;
 SET @@global.innodb_lock_wait_timeout= 1;
 SELECT @@global.innodb_lock_wait_timeout;

--- a/mysql-test/suite/parts/r/partition-dml-1-7-innodb.result
+++ b/mysql-test/suite/parts/r/partition-dml-1-7-innodb.result
@@ -8,7 +8,7 @@ SET @lock_timeout= @@global.lock_wait_timeout;
 SET @@global.lock_wait_timeout= 1;
 SELECT @@global.lock_wait_timeout;
 @@global.lock_wait_timeout
-1
+1.000000
 SET @innodb_lock_timeout= @@global.innodb_lock_wait_timeout;
 SET @@global.innodb_lock_wait_timeout= 1;
 # Additional tests for WL#5217 by QA, testplan 1.1

--- a/mysql-test/suite/parts/r/partition-dml-1-8-innodb.result
+++ b/mysql-test/suite/parts/r/partition-dml-1-8-innodb.result
@@ -8,7 +8,7 @@ SET @lock_timeout= @@global.lock_wait_timeout;
 SET @@global.lock_wait_timeout= 1;
 SELECT @@global.lock_wait_timeout;
 @@global.lock_wait_timeout
-1
+1.000000
 SET @innodb_lock_timeout= @@global.innodb_lock_wait_timeout;
 SET @@global.innodb_lock_wait_timeout= 1;
 # Additional tests for WL#5217 by QA, testplan 1.1

--- a/mysql-test/suite/sys_vars/r/lock_wait_timeout_basic.result
+++ b/mysql-test/suite/sys_vars/r/lock_wait_timeout_basic.result
@@ -11,12 +11,12 @@ SET @@global.lock_wait_timeout = 100;
 SET @@global.lock_wait_timeout = DEFAULT;
 SELECT @@global.lock_wait_timeout;
 @@global.lock_wait_timeout
-31536000
+31536000.000000
 SET @@session.lock_wait_timeout = 200;
 SET @@session.lock_wait_timeout = DEFAULT;
 SELECT @@session.lock_wait_timeout;
 @@session.lock_wait_timeout
-31536000
+31536000.000000
 '#--------------------FN_DYNVARS_002_02-------------------------#'
 SET @@global.lock_wait_timeout = @start_global_value;
 SELECT @@global.lock_wait_timeout = 31536000;
@@ -27,149 +27,157 @@ SELECT @@session.lock_wait_timeout = 31536000;
 @@session.lock_wait_timeout = 31536000
 1
 '#--------------------FN_DYNVARS_002_03-------------------------#'
+SET @@global.lock_wait_timeout = 0;
+SELECT @@global.lock_wait_timeout;
+@@global.lock_wait_timeout
+0.000000
+SET @@global.lock_wait_timeout = 0.005;
+SELECT @@global.lock_wait_timeout;
+@@global.lock_wait_timeout
+0.005000
 SET @@global.lock_wait_timeout = 1;
 SELECT @@global.lock_wait_timeout;
 @@global.lock_wait_timeout
-1
+1.000000
+SET @@global.lock_wait_timeout = 1.23;
+SELECT @@global.lock_wait_timeout;
+@@global.lock_wait_timeout
+1.230000
 SET @@global.lock_wait_timeout = 60020;
 SELECT @@global.lock_wait_timeout;
 @@global.lock_wait_timeout
-60020
+60020.000000
 SET @@global.lock_wait_timeout = 65535;
 SELECT @@global.lock_wait_timeout;
 @@global.lock_wait_timeout
-65535
+65535.000000
 SET @@global.lock_wait_timeout = 31536000;
 SELECT @@global.lock_wait_timeout;
 @@global.lock_wait_timeout
-31536000
+31536000.000000
 '#--------------------FN_DYNVARS_002_04-------------------------#'
+SET @@global.lock_wait_timeout = 0;
+SELECT @@global.lock_wait_timeout;
+@@global.lock_wait_timeout
+0.000000
+SET @@global.lock_wait_timeout = 0.005;
+SELECT @@global.lock_wait_timeout;
+@@global.lock_wait_timeout
+0.005000
 SET @@session.lock_wait_timeout = 1;
 SELECT @@session.lock_wait_timeout;
 @@session.lock_wait_timeout
-1
+1.000000
+SET @@global.lock_wait_timeout = 1.23;
+SELECT @@global.lock_wait_timeout;
+@@global.lock_wait_timeout
+1.230000
 SET @@session.lock_wait_timeout = 50050;
 SELECT @@session.lock_wait_timeout;
 @@session.lock_wait_timeout
-50050
+50050.000000
 SET @@session.lock_wait_timeout = 65535;
 SELECT @@session.lock_wait_timeout;
 @@session.lock_wait_timeout
-65535
+65535.000000
 SET @@session.lock_wait_timeout = 31536000;
 SELECT @@session.lock_wait_timeout;
 @@session.lock_wait_timeout
-31536000
+31536000.000000
 '#------------------FN_DYNVARS_002_05-----------------------#'
-SET @@global.lock_wait_timeout = 0;
-Warnings:
-Warning	1292	Truncated incorrect lock_wait_timeout value: '0'
-SELECT @@global.lock_wait_timeout;
-@@global.lock_wait_timeout
-1
 SET @@global.lock_wait_timeout = -1024;
 Warnings:
 Warning	1292	Truncated incorrect lock_wait_timeout value: '-1024'
 SELECT @@global.lock_wait_timeout;
 @@global.lock_wait_timeout
-1
+0.000000
 SET @@global.lock_wait_timeout = 31536001;
 Warnings:
 Warning	1292	Truncated incorrect lock_wait_timeout value: '31536001'
 SELECT @@global.lock_wait_timeout;
 @@global.lock_wait_timeout
-31536000
+31536000.000000
 SET @@global.lock_wait_timeout = 3153600112;
 Warnings:
 Warning	1292	Truncated incorrect lock_wait_timeout value: '3153600112'
 SELECT @@global.lock_wait_timeout;
 @@global.lock_wait_timeout
-31536000
-SET @@global.lock_wait_timeout = 65532.01;
-ERROR 42000: Incorrect argument type to variable 'lock_wait_timeout'
+31536000.000000
 SELECT @@global.lock_wait_timeout;
 @@global.lock_wait_timeout
-31536000
+31536000.000000
 SET @@global.lock_wait_timeout = ON;
 ERROR 42000: Incorrect argument type to variable 'lock_wait_timeout'
 SELECT @@global.lock_wait_timeout;
 @@global.lock_wait_timeout
-31536000
+31536000.000000
 SET @@global.lock_wait_timeout = OFF;
 ERROR 42000: Incorrect argument type to variable 'lock_wait_timeout'
 SELECT @@global.lock_wait_timeout;
 @@global.lock_wait_timeout
-31536000
+31536000.000000
 SET @@global.lock_wait_timeout = test;
 ERROR 42000: Incorrect argument type to variable 'lock_wait_timeout'
 SELECT @@global.lock_wait_timeout;
 @@global.lock_wait_timeout
-31536000
+31536000.000000
 SET @@global.lock_wait_timeout = " ";
 ERROR 42000: Incorrect argument type to variable 'lock_wait_timeout'
 SELECT @@global.lock_wait_timeout;
 @@global.lock_wait_timeout
-31536000
+31536000.000000
 SET @@global.lock_wait_timeout = ' ';
 ERROR 42000: Incorrect argument type to variable 'lock_wait_timeout'
 SELECT @@global.lock_wait_timeout;
 @@global.lock_wait_timeout
-31536000
-SET @@session.lock_wait_timeout = 0;
-Warnings:
-Warning	1292	Truncated incorrect lock_wait_timeout value: '0'
-SELECT @@session.lock_wait_timeout;
-@@session.lock_wait_timeout
-1
+31536000.000000
 SET @@session.lock_wait_timeout = -2;
 Warnings:
 Warning	1292	Truncated incorrect lock_wait_timeout value: '-2'
 SELECT @@session.lock_wait_timeout;
 @@session.lock_wait_timeout
-1
+0.000000
 SET @@session.lock_wait_timeout = 3176990909;
 Warnings:
 Warning	1292	Truncated incorrect lock_wait_timeout value: '3176990909'
 SELECT @@session.lock_wait_timeout;
 @@session.lock_wait_timeout
-31536000
+31536000.000000
 SET @@session.lock_wait_timeout = 31536001;
 Warnings:
 Warning	1292	Truncated incorrect lock_wait_timeout value: '31536001'
 SELECT @@session.lock_wait_timeout;
 @@session.lock_wait_timeout
-31536000
+31536000.000000
 SET @@session.lock_wait_timeout = -1024;
 Warnings:
 Warning	1292	Truncated incorrect lock_wait_timeout value: '-1024'
 SELECT @@session.lock_wait_timeout;
 @@session.lock_wait_timeout
-1
-SET @@session.lock_wait_timeout = 65532.01;
-ERROR 42000: Incorrect argument type to variable 'lock_wait_timeout'
+0.000000
 SELECT @@session.lock_wait_timeout;
 @@session.lock_wait_timeout
-1
+0.000000
 SET @@session.lock_wait_timeout = ON;
 ERROR 42000: Incorrect argument type to variable 'lock_wait_timeout'
 SELECT @@session.lock_wait_timeout;
 @@session.lock_wait_timeout
-1
+0.000000
 SET @@session.lock_wait_timeout = OFF;
 ERROR 42000: Incorrect argument type to variable 'lock_wait_timeout'
 SELECT @@session.lock_wait_timeout;
 @@session.lock_wait_timeout
-1
+0.000000
 SET @@session.lock_wait_timeout = test;
 ERROR 42000: Incorrect argument type to variable 'lock_wait_timeout'
 SELECT @@session.lock_wait_timeout;
 @@session.lock_wait_timeout
-1
+0.000000
 SET @@session.lock_wait_timeout = ' ';
 ERROR 42000: Incorrect argument type to variable 'lock_wait_timeout'
 SELECT @@session.lock_wait_timeout;
 @@session.lock_wait_timeout
-1
+0.000000
 '#------------------FN_DYNVARS_002_06-----------------------#'
 SELECT @@global.lock_wait_timeout = VARIABLE_VALUE 
 FROM performance_schema.global_variables 
@@ -186,13 +194,11 @@ WHERE VARIABLE_NAME='lock_wait_timeout';
 SET @@global.lock_wait_timeout = TRUE;
 SELECT @@global.lock_wait_timeout;
 @@global.lock_wait_timeout
-1
+1.000000
 SET @@global.lock_wait_timeout = FALSE;
-Warnings:
-Warning	1292	Truncated incorrect lock_wait_timeout value: '0'
 SELECT @@global.lock_wait_timeout;
 @@global.lock_wait_timeout
-1
+0.000000
 '#---------------------FN_DYNVARS_001_09----------------------#'
 SET @@global.lock_wait_timeout = 10;
 SET @@session.lock_wait_timeout = 11;
@@ -211,7 +217,7 @@ SELECT @@local.lock_wait_timeout = @@session.lock_wait_timeout;
 SET lock_wait_timeout = 1;
 SELECT @@lock_wait_timeout;
 @@lock_wait_timeout
-1
+1.000000
 SELECT local.lock_wait_timeout;
 ERROR 42S02: Unknown table 'local' in field list
 SELECT session.lock_wait_timeout;
@@ -221,8 +227,8 @@ ERROR 42S22: Unknown column 'lock_wait_timeout' in 'field list'
 SET @@global.lock_wait_timeout = @start_global_value;
 SELECT @@global.lock_wait_timeout;
 @@global.lock_wait_timeout
-31536000
+31536000.000000
 SET @@session.lock_wait_timeout = @start_session_value;
 SELECT @@session.lock_wait_timeout;
 @@session.lock_wait_timeout
-31536000
+31536000.000000

--- a/mysql-test/suite/sys_vars/t/lock_wait_timeout_basic.test
+++ b/mysql-test/suite/sys_vars/t/lock_wait_timeout_basic.test
@@ -69,7 +69,13 @@ SELECT @@session.lock_wait_timeout = 31536000;
 # Change the value of lock_wait_timeout to a valid value for GLOBAL Scope     #
 ###############################################################################
 
+SET @@global.lock_wait_timeout = 0;
+SELECT @@global.lock_wait_timeout;
+SET @@global.lock_wait_timeout = 0.005;
+SELECT @@global.lock_wait_timeout;
 SET @@global.lock_wait_timeout = 1;
+SELECT @@global.lock_wait_timeout;
+SET @@global.lock_wait_timeout = 1.23;
 SELECT @@global.lock_wait_timeout;
 SET @@global.lock_wait_timeout = 60020;
 SELECT @@global.lock_wait_timeout;
@@ -83,8 +89,14 @@ SELECT @@global.lock_wait_timeout;
 # Change the value of lock_wait_timeout to a valid value for SESSION Scope    #
 ###############################################################################
 
+SET @@global.lock_wait_timeout = 0;
+SELECT @@global.lock_wait_timeout;
+SET @@global.lock_wait_timeout = 0.005;
+SELECT @@global.lock_wait_timeout;
 SET @@session.lock_wait_timeout = 1;
 SELECT @@session.lock_wait_timeout;
+SET @@global.lock_wait_timeout = 1.23;
+SELECT @@global.lock_wait_timeout;
 SET @@session.lock_wait_timeout = 50050;
 SELECT @@session.lock_wait_timeout;
 SET @@session.lock_wait_timeout = 65535;
@@ -98,8 +110,6 @@ SELECT @@session.lock_wait_timeout;
 # Change the value of lock_wait_timeout to an invalid value     #
 #################################################################
 # for global scope
-SET @@global.lock_wait_timeout = 0;
-SELECT @@global.lock_wait_timeout;
 SET @@global.lock_wait_timeout = -1024;
 SELECT @@global.lock_wait_timeout;
 SET @@global.lock_wait_timeout = 31536001;
@@ -107,8 +117,6 @@ SELECT @@global.lock_wait_timeout;
 SET @@global.lock_wait_timeout = 3153600112;
 SELECT @@global.lock_wait_timeout;
 
---Error ER_WRONG_TYPE_FOR_VAR
-SET @@global.lock_wait_timeout = 65532.01;
 SELECT @@global.lock_wait_timeout;
 --Error ER_WRONG_TYPE_FOR_VAR
 SET @@global.lock_wait_timeout = ON;
@@ -127,8 +135,6 @@ SET @@global.lock_wait_timeout = ' ';
 SELECT @@global.lock_wait_timeout;
 
 # for session scope
-SET @@session.lock_wait_timeout = 0;
-SELECT @@session.lock_wait_timeout;
 SET @@session.lock_wait_timeout = -2;
 SELECT @@session.lock_wait_timeout;
 SET @@session.lock_wait_timeout = 3176990909;
@@ -138,8 +144,6 @@ SELECT @@session.lock_wait_timeout;
 SET @@session.lock_wait_timeout = -1024;
 SELECT @@session.lock_wait_timeout;
 
---Error ER_WRONG_TYPE_FOR_VAR
-SET @@session.lock_wait_timeout = 65532.01;
 SELECT @@session.lock_wait_timeout;
 --Error ER_WRONG_TYPE_FOR_VAR
 SET @@session.lock_wait_timeout = ON;

--- a/plugin/version_token/version_token.cc
+++ b/plugin/version_token/version_token.cc
@@ -372,9 +372,9 @@ static int parse_vtokens(char *input, enum command type) {
 
       case CHECK_VTOKEN: {
         char error_str[MYSQL_ERRMSG_SIZE];
-        if (!mysql_acquire_locking_service_locks(
+        if (!mysql_acquire_locking_service_locks_nsec(
                 thd, VTOKEN_LOCKS_NAMESPACE, (const char **)&(token_name.str),
-                1, LOCKING_SERVICE_READ, LONG_TIMEOUT) &&
+                1, LOCKING_SERVICE_READ, LONG_TIMEOUT_NSEC) &&
             !vtokens_unchanged) {
           auto it = version_tokens_hash->find(to_string(token_name));
           if (it != version_tokens_hash->end()) {
@@ -1020,9 +1020,10 @@ PLUGIN_EXPORT long long version_tokens_lock_shared(UDF_INIT *, UDF_ARGS *args,
   }
 
   // For the UDF 1 == success, 0 == failure.
-  return !acquire_locking_service_locks(
+  return !acquire_locking_service_locks_nsec(
       NULL, VTOKEN_LOCKS_NAMESPACE, const_cast<const char **>(&args->args[0]),
-      args->arg_count - 1, LOCKING_SERVICE_READ, (unsigned long)timeout);
+      args->arg_count - 1, LOCKING_SERVICE_READ,
+      (ulonglong)timeout * 1000000000ULL);
 }
 
 PLUGIN_EXPORT bool version_tokens_lock_exclusive_init(UDF_INIT *initid,
@@ -1046,9 +1047,10 @@ PLUGIN_EXPORT long long version_tokens_lock_exclusive(UDF_INIT *,
   }
 
   // For the UDF 1 == success, 0 == failure.
-  return !acquire_locking_service_locks(
+  return !acquire_locking_service_locks_nsec(
       NULL, VTOKEN_LOCKS_NAMESPACE, const_cast<const char **>(&args->args[0]),
-      args->arg_count - 1, LOCKING_SERVICE_WRITE, (unsigned long)timeout);
+      args->arg_count - 1, LOCKING_SERVICE_WRITE,
+      (ulonglong)timeout * 1000000000ULL);
 }
 
 PLUGIN_EXPORT bool version_tokens_unlock_init(UDF_INIT *, UDF_ARGS *args,

--- a/sql/auth/sql_auth_cache.cc
+++ b/sql/auth/sql_auth_cache.cc
@@ -3475,6 +3475,8 @@ void shutdown_acl_cache() {
 
 /* Constants used by Acl_cache_lock_guard */
 static const ulong ACL_CACHE_LOCK_TIMEOUT = 3600UL;
+static const ulonglong ACL_CACHE_LOCK_TIMEOUT_NSEC =
+    ACL_CACHE_LOCK_TIMEOUT * 1000000000ULL;
 static const MDL_key ACL_CACHE_KEY(MDL_key::ACL_CACHE, "", "");
 
 /**
@@ -3568,8 +3570,8 @@ bool Acl_cache_lock_guard::lock(bool raise_error) /* = true */
       MDL_EXPLICIT);
   Acl_cache_error_handler handler;
   m_thd->push_internal_handler(&handler);
-  m_locked =
-      !m_thd->mdl_context.acquire_lock(&lock_request, ACL_CACHE_LOCK_TIMEOUT);
+  m_locked = !m_thd->mdl_context.acquire_lock_nsec(&lock_request,
+                                                   ACL_CACHE_LOCK_TIMEOUT_NSEC);
   m_thd->pop_internal_handler();
 
   if (!m_locked && raise_error)

--- a/sql/auth/sql_authorization.cc
+++ b/sql/auth/sql_authorization.cc
@@ -2346,8 +2346,8 @@ int mysql_table_grant(THD *thd, TABLE_LIST *table_list,
         MDL_request mdl_request;
         MDL_REQUEST_INIT(&mdl_request, MDL_key::TABLE, table_list->db,
                          table_list->table_name, MDL_SHARED, MDL_TRANSACTION);
-        if (thd->mdl_context.acquire_lock(&mdl_request,
-                                          thd->variables.lock_wait_timeout))
+        if (thd->mdl_context.acquire_lock_nsec(
+                &mdl_request, thd->variables.lock_wait_timeout_nsec))
           DBUG_RETURN(true);
 
         bool exists;

--- a/sql/dd/dd_schema.cc
+++ b/sql/dd/dd_schema.cc
@@ -111,8 +111,8 @@ bool mdl_lock_schema(THD *thd, const char *schema_name,
     Acquire the lock request created above, and check if
     acquisition fails (e.g. timeout or deadlock).
   */
-  if (thd->mdl_context.acquire_lock(&mdl_request,
-                                    thd->variables.lock_wait_timeout)) {
+  if (thd->mdl_context.acquire_lock_nsec(
+          &mdl_request, thd->variables.lock_wait_timeout_nsec)) {
     DBUG_ASSERT(thd->is_system_thread() || thd->killed || thd->is_error());
     return true;
   }

--- a/sql/dd/impl/bootstrapper.cc
+++ b/sql/dd/impl/bootstrapper.cc
@@ -597,8 +597,8 @@ bool acquire_exclusive_mdl(THD *thd) {
   }
 
   // Finally, acquire all the MDL locks.
-  return (thd->mdl_context.acquire_locks(&mdl_requests,
-                                         thd->variables.lock_wait_timeout));
+  return (thd->mdl_context.acquire_locks_nsec(
+      &mdl_requests, thd->variables.lock_wait_timeout_nsec));
 }
 
 /*

--- a/sql/dd/impl/cache/shared_multi_map.cc
+++ b/sql/dd/impl/cache/shared_multi_map.cc
@@ -226,8 +226,8 @@ bool Shared_multi_map<T>::reset(THD *thd) {
     mdl_requests.push_front(
         lock_request(thd, schema_map, it->second->object()));
 
-  if (thd->mdl_context.acquire_locks(&mdl_requests,
-                                     thd->variables.lock_wait_timeout))
+  if (thd->mdl_context.acquire_locks_nsec(
+          &mdl_requests, thd->variables.lock_wait_timeout_nsec))
     return true;
 
   /*

--- a/sql/dd/impl/sdi_utils.h
+++ b/sql/dd/impl/sdi_utils.h
@@ -83,8 +83,8 @@ inline bool mdl_lock(THD *thd, MDL_key::enum_mdl_namespace ns,
   MDL_request mdl_request;
   MDL_REQUEST_INIT(&mdl_request, ns, schema_name.c_str(), object_name.c_str(),
                    mt, md);
-  return checked_return(thd->mdl_context.acquire_lock(
-      &mdl_request, thd->variables.lock_wait_timeout));
+  return checked_return(thd->mdl_context.acquire_lock_nsec(
+      &mdl_request, thd->variables.lock_wait_timeout_nsec));
 }
 
 template <typename T>

--- a/sql/dd/info_schema/metadata.cc
+++ b/sql/dd/info_schema/metadata.cc
@@ -282,8 +282,8 @@ bool store_in_dd(THD *thd, Update_context *ctx, ST_SCHEMA_TABLE *schema_table,
     MDL_REQUEST_INIT(&mdl_request, MDL_key::TABLE,
                      ctx->info_schema()->name().c_str(),
                      view_obj->name().c_str(), MDL_EXCLUSIVE, MDL_TRANSACTION);
-    if (thd->mdl_context.acquire_lock(&mdl_request,
-                                      thd->variables.lock_wait_timeout))
+    if (thd->mdl_context.acquire_lock_nsec(
+            &mdl_request, thd->variables.lock_wait_timeout_nsec))
       return true;
   }
 
@@ -639,8 +639,8 @@ bool remove_I_S_view_metadata(THD *thd, const dd::String_type &view_name) {
   MDL_request mdl_request;
   MDL_REQUEST_INIT(&mdl_request, MDL_key::TABLE, INFORMATION_SCHEMA_NAME.str,
                    view_name.c_str(), MDL_EXCLUSIVE, MDL_TRANSACTION);
-  if (thd->mdl_context.acquire_lock(&mdl_request,
-                                    thd->variables.lock_wait_timeout))
+  if (thd->mdl_context.acquire_lock_nsec(&mdl_request,
+                                         thd->variables.lock_wait_timeout_nsec))
     return (true);
 
   // Acquire the object.

--- a/sql/dd/info_schema/table_stats.cc
+++ b/sql/dd/info_schema/table_stats.cc
@@ -523,8 +523,8 @@ ulonglong Table_statistics::read_stat_from_SE(
   Info_schema_error_handler info_schema_error_handler(thd, &schema_name_ptr,
                                                       &table_name_ptr);
   thd->push_internal_handler(&info_schema_error_handler);
-  if (thd->mdl_context.acquire_lock(&mdl_request,
-                                    thd->variables.lock_wait_timeout)) {
+  if (thd->mdl_context.acquire_lock_nsec(
+          &mdl_request, thd->variables.lock_wait_timeout_nsec)) {
     error = -1;
   }
   thd->pop_internal_handler();

--- a/sql/dd/info_schema/tablespace_stats.cc
+++ b/sql/dd/info_schema/tablespace_stats.cc
@@ -223,8 +223,8 @@ bool Tablespace_statistics::read_stat_from_SE(THD *thd,
     error = true;
   }
 
-  error = error || thd->mdl_context.acquire_lock(
-                       &mdl_request, thd->variables.lock_wait_timeout);
+  error = error || thd->mdl_context.acquire_lock_nsec(
+                       &mdl_request, thd->variables.lock_wait_timeout_nsec);
   thd->pop_internal_handler();
 
   if (!error) {

--- a/sql/dd/upgrade/table.cc
+++ b/sql/dd/upgrade/table.cc
@@ -553,8 +553,8 @@ class Upgrade_MDL_guard {
   }
   bool acquire_lock_tablespace(Tablespace_hash_set *tablespace_names) {
     m_tablespace_lock = true;
-    return lock_tablespace_names(m_thd, tablespace_names,
-                                 m_thd->variables.lock_wait_timeout);
+    return lock_tablespace_names_nsec(m_thd, tablespace_names,
+                                      m_thd->variables.lock_wait_timeout_nsec);
   }
 
   Upgrade_MDL_guard(THD *thd)

--- a/sql/dd_sql_view.cc
+++ b/sql/dd_sql_view.cc
@@ -299,8 +299,8 @@ static bool mark_all_views_invalid(THD *thd, const char *db,
     mdl_requests.push_front(schema_request);
     mdl_requests.push_front(&view->mdl_request);
   }
-  if (thd->mdl_context.acquire_locks(&mdl_requests,
-                                     thd->variables.lock_wait_timeout))
+  if (thd->mdl_context.acquire_locks_nsec(
+          &mdl_requests, thd->variables.lock_wait_timeout_nsec))
     DBUG_RETURN(true);
 
   /*
@@ -374,14 +374,14 @@ static bool open_views_and_update_metadata(
 
       MDL_REQUEST_INIT(&schema_request, MDL_key::SCHEMA, view->db, "",
                        MDL_INTENTION_EXCLUSIVE, MDL_STATEMENT);
-      if (thd->mdl_context.acquire_lock(&schema_request,
-                                        thd->variables.lock_wait_timeout))
+      if (thd->mdl_context.acquire_lock_nsec(
+              &schema_request, thd->variables.lock_wait_timeout_nsec))
         DBUG_RETURN(true);
 
       MDL_REQUEST_INIT_BY_KEY(&view_request, &view->mdl_request.key,
                               MDL_EXCLUSIVE, MDL_STATEMENT);
-      if (thd->mdl_context.acquire_lock(&view_request,
-                                        thd->variables.lock_wait_timeout))
+      if (thd->mdl_context.acquire_lock_nsec(
+              &view_request, thd->variables.lock_wait_timeout_nsec))
         DBUG_RETURN(true);
     }
   }

--- a/sql/event_scheduler.cc
+++ b/sql/event_scheduler.cc
@@ -231,7 +231,7 @@ void pre_init_event_thread(THD *thd) {
   thd->set_time();
 
   /* Do not use user-supplied timeout value for system threads. */
-  thd->variables.lock_wait_timeout = LONG_TIMEOUT;
+  thd->variables.lock_wait_timeout_nsec = LONG_TIMEOUT_NSEC;
 
   DBUG_VOID_RETURN;
 }
@@ -365,8 +365,8 @@ void Event_worker_thread::run(THD *thd, Event_queue_element_for_exec *event) {
 
     MDL_REQUEST_INIT(&event_mdl_request, MDL_key::EVENT, event->dbname.str,
                      event_name_buf, MDL_SHARED, MDL_EXPLICIT);
-    if (thd->mdl_context.acquire_lock(&event_mdl_request,
-                                      thd->variables.lock_wait_timeout)) {
+    if (thd->mdl_context.acquire_lock_nsec(
+            &event_mdl_request, thd->variables.lock_wait_timeout_nsec)) {
       DBUG_PRINT("error", ("Got error in getting MDL locks"));
       goto end;
     }

--- a/sql/events.cc
+++ b/sql/events.cc
@@ -716,8 +716,8 @@ bool Events::lock_schema_events(THD *thd, const dd::Schema &schema) {
     mdl_requests.push_front(mdl_request);
   }
 
-  DBUG_RETURN(thd->mdl_context.acquire_locks(&mdl_requests,
-                                             thd->variables.lock_wait_timeout));
+  DBUG_RETURN(thd->mdl_context.acquire_locks_nsec(
+      &mdl_requests, thd->variables.lock_wait_timeout_nsec));
 }
 
 /**
@@ -849,8 +849,8 @@ bool Events::show_create_event(THD *thd, LEX_STRING dbname, LEX_STRING name) {
   MDL_request event_mdl_request;
   MDL_REQUEST_INIT(&event_mdl_request, MDL_key::EVENT, dbname.str,
                    event_name_buf, MDL_SHARED_HIGH_PRIO, MDL_TRANSACTION);
-  if (thd->mdl_context.acquire_lock(&event_mdl_request,
-                                    thd->variables.lock_wait_timeout))
+  if (thd->mdl_context.acquire_lock_nsec(&event_mdl_request,
+                                         thd->variables.lock_wait_timeout_nsec))
     DBUG_RETURN(true);
 
   /*

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -1678,8 +1678,8 @@ int ha_commit_trans(THD *thd, bool all, bool ignore_global_read_lock) {
                        MDL_INTENTION_EXCLUSIVE, MDL_EXPLICIT);
 
       DBUG_PRINT("debug", ("Acquire MDL commit lock"));
-      if (thd->mdl_context.acquire_lock(&mdl_request,
-                                        thd->variables.lock_wait_timeout)) {
+      if (thd->mdl_context.acquire_lock_nsec(
+              &mdl_request, thd->variables.lock_wait_timeout_nsec)) {
         ha_rollback_trans(thd, all);
         thd->enter_stage(&old_stage, NULL, __func__, __FILE__, __LINE__);
         DBUG_RETURN(1);

--- a/sql/histograms/histogram.cc
+++ b/sql/histograms/histogram.cc
@@ -207,8 +207,8 @@ static bool lock_for_write(THD *thd, const MDL_key &mdl_key) {
                           MDL_TRANSACTION);
 
   // If locking fails, an error has already been flagged.
-  return thd->mdl_context.acquire_lock(&mdl_request,
-                                       thd->variables.lock_wait_timeout);
+  return thd->mdl_context.acquire_lock_nsec(
+      &mdl_request, thd->variables.lock_wait_timeout_nsec);
 }
 
 Histogram::Histogram(MEM_ROOT *mem_root, const std::string &db_name,
@@ -1243,8 +1243,8 @@ bool rename_histograms(THD *thd, const char *old_schema_name,
   MDL_REQUEST_INIT(&mdl_request, MDL_key::TABLE, old_schema_name,
                    old_table_name, MDL_SHARED_READ_ONLY, MDL_TRANSACTION);
 
-  if (thd->mdl_context.acquire_lock(&mdl_request,
-                                    thd->variables.lock_wait_timeout)) {
+  if (thd->mdl_context.acquire_lock_nsec(
+          &mdl_request, thd->variables.lock_wait_timeout_nsec)) {
     // error has already been reported
     return true; /* purecov: deadcode */
   }

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -4567,8 +4567,8 @@ longlong Item_func_get_lock::val_int() {
   User_level_lock_wait_error_handler error_handler;
 
   thd->push_internal_handler(&error_handler);
-  bool error =
-      thd->mdl_context.acquire_lock(&ull_request, static_cast<ulong>(timeout));
+  bool error = thd->mdl_context.acquire_lock_nsec(
+      &ull_request, static_cast<ulonglong>(timeout) * 1000000000ULL);
   (void)thd->pop_internal_handler();
 
   if (error) {

--- a/sql/item_geofunc_internal.cc
+++ b/sql/item_geofunc_internal.cc
@@ -66,8 +66,8 @@ bool Srs_fetcher::lock(gis::srid_t srid, enum_mdl_type lock_type) {
   MDL_request mdl_request;
   mdl_request.init_with_source(MDL_key::SRID, "", id_str, lock_type,
                                MDL_TRANSACTION, __FILE__, __LINE__);
-  if (m_thd->mdl_context.acquire_lock(&mdl_request,
-                                      m_thd->variables.lock_wait_timeout)) {
+  if (m_thd->mdl_context.acquire_lock_nsec(
+          &mdl_request, m_thd->variables.lock_wait_timeout_nsec)) {
     /* purecov: begin inspected */
     // If locking fails, an error has already been flagged.
     DBUG_RETURN(true);

--- a/sql/lock.cc
+++ b/sql/lock.cc
@@ -318,9 +318,9 @@ MYSQL_LOCK *mysql_lock_tables(THD *thd, TABLE **tables, size_t count,
   int rc;
   MYSQL_LOCK *sql_lock;
   THR_LOCK_DATA *error_pos = nullptr;
-  ulong timeout = (flags & MYSQL_LOCK_IGNORE_TIMEOUT)
-                      ? LONG_TIMEOUT
-                      : thd->variables.lock_wait_timeout;
+  ulong timeout_nsec = (flags & MYSQL_LOCK_IGNORE_TIMEOUT)
+                           ? LONG_TIMEOUT_NSEC
+                           : thd->variables.lock_wait_timeout_nsec;
 
   DBUG_ENTER("mysql_lock_tables");
 
@@ -344,9 +344,9 @@ MYSQL_LOCK *mysql_lock_tables(THD *thd, TABLE **tables, size_t count,
   memcpy(sql_lock->locks + sql_lock->lock_count, sql_lock->locks,
          sql_lock->lock_count * sizeof(*sql_lock->locks));
   /* Lock on the copied half of the lock data array. */
-  rc = thr_lock_errno_to_mysql[(int)thr_multi_lock(
+  rc = thr_lock_errno_to_mysql[(int)thr_multi_lock_nsec(
       sql_lock->locks + sql_lock->lock_count, sql_lock->lock_count,
-      &thd->lock_info, timeout, &error_pos)];
+      &thd->lock_info, timeout_nsec, &error_pos)];
 
   DBUG_EXECUTE_IF("mysql_lock_tables_kill_query",
                   thd->killed = THD::KILL_QUERY;);
@@ -771,8 +771,8 @@ bool lock_schema_name(THD *thd, const char *db) {
   mdl_requests.push_front(&global_request);
   mdl_requests.push_front(&backup_lock_request);
 
-  if (thd->mdl_context.acquire_locks(&mdl_requests,
-                                     thd->variables.lock_wait_timeout))
+  if (thd->mdl_context.acquire_locks_nsec(
+          &mdl_requests, thd->variables.lock_wait_timeout_nsec))
     return true;
 
   DEBUG_SYNC(thd, "after_wait_locked_schema_name");
@@ -789,8 +789,8 @@ bool lock_schema_name(THD *thd, const char *db) {
   @return true - On failure
   @return false - On Success.
 */
-bool lock_tablespace_names(THD *thd, Tablespace_hash_set *tablespace_set,
-                           ulong lock_wait_timeout) {
+bool lock_tablespace_names_nsec(THD *thd, Tablespace_hash_set *tablespace_set,
+                                ulonglong lock_wait_timeout_nsec) {
   // Stop if we have nothing to lock
   if (tablespace_set->empty()) return false;
 
@@ -808,8 +808,8 @@ bool lock_tablespace_names(THD *thd, Tablespace_hash_set *tablespace_set,
   }
 
   // Finally, acquire IX MDL locks.
-  if (thd->mdl_context.acquire_locks(&mdl_tablespace_requests,
-                                     lock_wait_timeout))
+  if (thd->mdl_context.acquire_locks_nsec(&mdl_tablespace_requests,
+                                          lock_wait_timeout_nsec))
     return true;
 
   DEBUG_SYNC(thd, "after_wait_locked_tablespace_name_for_table");
@@ -827,7 +827,7 @@ bool lock_tablespace_names(THD *thd, Tablespace_hash_set *tablespace_set,
   @param name        Object name in the schema.
 
   This function cannot be called while holding LOCK_open_mutex.
-  This invariant is enforced by asserts in MDL_context::acquire_locks.
+  This invariant is enforced by asserts in MDL_context::acquire_locks_nsec.
   To avoid deadlocks, we do not try to obtain exclusive metadata
   locks in LOCK TABLES mode, since in this mode there may be
   other metadata locks already taken by the current connection,
@@ -885,8 +885,8 @@ bool lock_object_name(THD *thd, MDL_key::enum_mdl_namespace mdl_type,
   mdl_requests.push_front(&global_request);
   mdl_requests.push_front(&backup_lock_request);
 
-  if (thd->mdl_context.acquire_locks(&mdl_requests,
-                                     thd->variables.lock_wait_timeout))
+  if (thd->mdl_context.acquire_locks_nsec(
+          &mdl_requests, thd->variables.lock_wait_timeout_nsec))
     return true;
 
   DEBUG_SYNC(thd, "after_wait_locked_pname");
@@ -989,8 +989,8 @@ std::atomic<int32> Global_read_lock::m_atomic_active_requests;
   @retval true    Error, meta data lock not acquired.
 */
 
-bool acquire_shared_global_read_lock(THD *thd,
-                                     unsigned long lock_wait_timeout) {
+bool acquire_shared_global_read_lock_nsec(THD *thd,
+                                          ulonglong lock_wait_timeout_nsec) {
   // If we cannot acuqire protection against GRL, err out.
   if (thd->global_read_lock.can_acquire_protection()) return true;
 
@@ -998,7 +998,8 @@ bool acquire_shared_global_read_lock(THD *thd,
   MDL_REQUEST_INIT(&grl_request, MDL_key::GLOBAL, "", "",
                    MDL_INTENTION_EXCLUSIVE, MDL_TRANSACTION);
 
-  return thd->mdl_context.acquire_lock(&grl_request, lock_wait_timeout);
+  return thd->mdl_context.acquire_lock_nsec(&grl_request,
+                                            lock_wait_timeout_nsec);
 }
 
 /**
@@ -1028,8 +1029,8 @@ bool Global_read_lock::lock_global_read_lock(THD *thd) {
     /* Increment static variable first to signal innodb memcached server
        to release mdl locks held by it */
     Global_read_lock::m_atomic_active_requests++;
-    if (thd->mdl_context.acquire_lock(&mdl_request,
-                                      thd->variables.lock_wait_timeout)) {
+    if (thd->mdl_context.acquire_lock_nsec(
+            &mdl_request, thd->variables.lock_wait_timeout_nsec)) {
       Global_read_lock::m_atomic_active_requests--;
       DBUG_RETURN(1);
     }
@@ -1102,8 +1103,8 @@ bool Global_read_lock::make_global_read_lock_block_commit(THD *thd) {
   MDL_REQUEST_INIT(&mdl_request, MDL_key::COMMIT, "", "", MDL_SHARED,
                    MDL_EXPLICIT);
 
-  if (thd->mdl_context.acquire_lock(&mdl_request,
-                                    thd->variables.lock_wait_timeout))
+  if (thd->mdl_context.acquire_lock_nsec(&mdl_request,
+                                         thd->variables.lock_wait_timeout_nsec))
     DBUG_RETURN(true);
 
   m_mdl_blocks_commits_lock = mdl_request.ticket;

--- a/sql/lock.h
+++ b/sql/lock.h
@@ -56,14 +56,15 @@ bool lock_schema_name(THD *thd, const char *db);
 typedef malloc_unordered_set<std::string> Tablespace_hash_set;
 
 // Lock tablespace names.
-bool lock_tablespace_names(THD *thd, Tablespace_hash_set *tablespace_set,
-                           ulong lock_wait_timeout);
+bool lock_tablespace_names_nsec(THD *thd, Tablespace_hash_set *tablespace_set,
+                                ulonglong lock_wait_timeout_nsec);
 
 /* Lock based on stored routine name */
 bool lock_object_name(THD *thd, MDL_key::enum_mdl_namespace mdl_type,
                       const char *db, const char *name);
 
 /* Acquire protection against the global read lock. */
-bool acquire_shared_global_read_lock(THD *thd, unsigned long lock_wait_timeout);
+bool acquire_shared_global_read_lock_nsec(THD *thd,
+                                          ulonglong lock_wait_timeout_nsec);
 
 #endif /* LOCK_INCLUDED */

--- a/sql/locking_service.cc
+++ b/sql/locking_service.cc
@@ -106,11 +106,11 @@ class Release_locking_service_locks : public MDL_release_locks_visitor {
   }
 };
 
-int acquire_locking_service_locks(MYSQL_THD opaque_thd,
-                                  const char *lock_namespace,
-                                  const char **lock_names, size_t lock_num,
-                                  enum_locking_service_lock_type lock_type,
-                                  ulong lock_timeout) {
+int acquire_locking_service_locks_nsec(MYSQL_THD opaque_thd,
+                                       const char *lock_namespace,
+                                       const char **lock_names, size_t lock_num,
+                                       enum_locking_service_lock_type lock_type,
+                                       ulonglong lock_timeout_nsec) {
   if (lock_num == 0) return 0;
 
   // Check that namespace length is acceptable
@@ -139,7 +139,8 @@ int acquire_locking_service_locks(MYSQL_THD opaque_thd,
   // Acquire locks
   Locking_service_deadlock_error_handler handler;
   thd->push_internal_handler(&handler);
-  bool res = thd->mdl_context.acquire_locks(&mdl_requests, lock_timeout);
+  bool res =
+      thd->mdl_context.acquire_locks_nsec(&mdl_requests, lock_timeout_nsec);
   thd->pop_internal_handler();
   if (res) return 1;
 
@@ -174,12 +175,13 @@ void release_all_locking_service_locks(THD *thd) {
   in service_locking.h as UDFs are built with MYSQL_DYNAMIC_PLUGIN
   yet are not able to call service API functions.
 */
-int mysql_acquire_locking_service_locks(
+int mysql_acquire_locking_service_locks_nsec(
     MYSQL_THD opaque_thd, const char *lock_namespace, const char **lock_names,
     size_t lock_num, enum_locking_service_lock_type lock_type,
-    ulong lock_timeout) {
-  return acquire_locking_service_locks(opaque_thd, lock_namespace, lock_names,
-                                       lock_num, lock_type, lock_timeout);
+    ulonglong lock_timeout_nsec) {
+  return acquire_locking_service_locks_nsec(opaque_thd, lock_namespace,
+                                            lock_names, lock_num, lock_type,
+                                            lock_timeout_nsec);
 }
 
 int mysql_release_locking_service_locks(MYSQL_THD opaque_thd,

--- a/sql/locking_service.h
+++ b/sql/locking_service.h
@@ -45,11 +45,10 @@ class THD;
   @note both lock_namespace and lock_names are limited to 64 characters max.
   Names are compared using binary comparison.
 */
-int acquire_locking_service_locks(MYSQL_THD opaque_thd,
-                                  const char *lock_namespace,
-                                  const char **lock_names, size_t lock_num,
-                                  enum enum_locking_service_lock_type lock_type,
-                                  unsigned long lock_timeout);
+int acquire_locking_service_locks_nsec(
+    MYSQL_THD opaque_thd, const char *lock_namespace, const char **lock_names,
+    size_t lock_num, enum enum_locking_service_lock_type lock_type,
+    ulonglong lock_timeout_nsec);
 
 /**
   Release all lock service locks taken by the given connection

--- a/sql/locking_service_udf.cc
+++ b/sql/locking_service_udf.cc
@@ -85,9 +85,10 @@ long long service_get_read_locks(UDF_INIT *, UDF_ARGS *args, unsigned char *,
   const char *lock_namespace = args->args[0];
   long long timeout = *((long long *)args->args[args->arg_count - 1]);
   // For the UDF 1 == success, 0 == failure.
-  return !acquire_locking_service_locks(
+  return !acquire_locking_service_locks_nsec(
       NULL, lock_namespace, const_cast<const char **>(&args->args[1]),
-      args->arg_count - 2, LOCKING_SERVICE_READ, static_cast<ulong>(timeout));
+      args->arg_count - 2, LOCKING_SERVICE_READ,
+      static_cast<ulonglong>(timeout) * 1000000000ULL);
 }
 
 bool service_get_write_locks_init(UDF_INIT *initid, UDF_ARGS *args,
@@ -100,9 +101,10 @@ long long service_get_write_locks(UDF_INIT *, UDF_ARGS *args, unsigned char *,
   const char *lock_namespace = args->args[0];
   long long timeout = *((long long *)args->args[args->arg_count - 1]);
   // For the UDF 1 == success, 0 == failure.
-  return !acquire_locking_service_locks(
+  return !acquire_locking_service_locks_nsec(
       NULL, lock_namespace, const_cast<const char **>(&args->args[1]),
-      args->arg_count - 2, LOCKING_SERVICE_WRITE, static_cast<ulong>(timeout));
+      args->arg_count - 2, LOCKING_SERVICE_WRITE,
+      static_cast<ulonglong>(timeout) * 1000000000ULL);
 }
 
 bool service_release_locks_init(UDF_INIT *initid, UDF_ARGS *args,

--- a/sql/mdl.h
+++ b/sql/mdl.h
@@ -1298,10 +1298,12 @@ class MDL_context {
   void destroy();
 
   bool try_acquire_lock(MDL_request *mdl_request);
-  bool acquire_lock(MDL_request *mdl_request, ulong lock_wait_timeout);
-  bool acquire_locks(MDL_request_list *requests, ulong lock_wait_timeout);
-  bool upgrade_shared_lock(MDL_ticket *mdl_ticket, enum_mdl_type new_type,
-                           ulong lock_wait_timeout);
+  bool acquire_lock_nsec(MDL_request *mdl_request,
+                         ulonglong lock_wait_timeout_nsec);
+  bool acquire_locks_nsec(MDL_request_list *requests,
+                          ulonglong lock_wait_timeout_nsec);
+  bool upgrade_shared_lock_nsec(MDL_ticket *mdl_ticket, enum_mdl_type new_type,
+                                ulonglong lock_wait_timeout_nsec);
 
   bool clone_ticket(MDL_request *mdl_request);
 

--- a/sql/mdl_context_backup.cc
+++ b/sql/mdl_context_backup.cc
@@ -213,7 +213,8 @@ bool MDL_context_backup_manager::create_backup(MDL_request_list *mdl_requests,
       DBUG_RETURN(true);
     }
 
-    if (element->get_context()->acquire_locks(mdl_requests, LONG_TIMEOUT))
+    if (element->get_context()->acquire_locks_nsec(mdl_requests,
+                                                   LONG_TIMEOUT_NSEC))
       DBUG_RETURN(true);
 
     MUTEX_LOCK(guard, &m_LOCK_mdl_context_backup);

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -9984,6 +9984,9 @@ static int get_options(int *argc_ptr, char ***argv_ptr) {
   global_system_variables.long_query_time =
       (ulonglong)(global_system_variables.long_query_time_double * 1e6);
 
+  global_system_variables.lock_wait_timeout_nsec =
+      (ulonglong)(global_system_variables.lock_wait_timeout_double * 1e9);
+
   if (opt_short_log_format) opt_specialflag |= SPECIAL_SHORT_LOG_FORMAT;
 
   if (Connection_handler_manager::init()) {
@@ -11199,8 +11202,8 @@ bool do_create_native_table_for_pfs(THD *thd, const Plugin_table *t) {
   MDL_REQUEST_INIT(&table_request, MDL_key::TABLE, schema_name, table_name,
                    MDL_EXCLUSIVE, MDL_TRANSACTION);
 
-  if (thd->mdl_context.acquire_lock(&table_request,
-                                    thd->variables.lock_wait_timeout)) {
+  if (thd->mdl_context.acquire_lock_nsec(
+          &table_request, thd->variables.lock_wait_timeout_nsec)) {
     /* Error, failed to get MDL lock. */
     return true;
   }
@@ -11230,8 +11233,8 @@ static bool do_drop_native_table_for_pfs(THD *thd, const char *schema_name,
   MDL_REQUEST_INIT(&table_request, MDL_key::TABLE, schema_name, table_name,
                    MDL_EXCLUSIVE, MDL_TRANSACTION);
 
-  if (thd->mdl_context.acquire_lock(&table_request,
-                                    thd->variables.lock_wait_timeout)) {
+  if (thd->mdl_context.acquire_lock_nsec(
+          &table_request, thd->variables.lock_wait_timeout_nsec)) {
     /* Error, failed to get MDL lock. */
     return true;
   }

--- a/sql/resourcegroups/resource_group_mgr.cc
+++ b/sql/resourcegroups/resource_group_mgr.cc
@@ -258,9 +258,10 @@ bool Resource_group_mgr::acquire_shared_mdl_for_resource_group(
   MDL_REQUEST_INIT(&mdl_request, MDL_key::RESOURCE_GROUPS, "", lc_name,
                    MDL_INTENTION_EXCLUSIVE, lock_duration);
 
-  bool res = try_acquire ? thd->mdl_context.acquire_lock(&mdl_request, 0)
-                         : thd->mdl_context.acquire_lock(
-                               &mdl_request, thd->variables.lock_wait_timeout);
+  bool res = try_acquire
+                 ? thd->mdl_context.acquire_lock_nsec(&mdl_request, 0)
+                 : thd->mdl_context.acquire_lock_nsec(
+                       &mdl_request, thd->variables.lock_wait_timeout_nsec);
   if (!res && ticket != nullptr) *ticket = mdl_request.ticket;
 
   DBUG_RETURN(res);

--- a/sql/resourcegroups/resource_group_sql_cmd.cc
+++ b/sql/resourcegroups/resource_group_sql_cmd.cc
@@ -89,8 +89,8 @@ static bool acquire_exclusive_mdl_for_resource_group(THD *thd,
   MDL_request mdl_request;
   MDL_REQUEST_INIT(&mdl_request, MDL_key::RESOURCE_GROUPS, "", lc_name,
                    MDL_EXCLUSIVE, MDL_TRANSACTION);
-  if (thd->mdl_context.acquire_lock(&mdl_request,
-                                    thd->variables.lock_wait_timeout))
+  if (thd->mdl_context.acquire_lock_nsec(&mdl_request,
+                                         thd->variables.lock_wait_timeout_nsec))
     DBUG_RETURN(true);
 
   DBUG_RETURN(false);
@@ -217,8 +217,10 @@ bool resourcegroups::Sql_cmd_create_resource_group::execute(THD *thd) {
                                  num_vcpus))
     DBUG_RETURN(true);
 
-  if (acquire_shared_global_read_lock(thd, thd->variables.lock_wait_timeout) ||
-      acquire_shared_backup_lock(thd, thd->variables.lock_wait_timeout))
+  if (acquire_shared_global_read_lock_nsec(
+          thd, thd->variables.lock_wait_timeout_nsec) ||
+      acquire_shared_backup_lock_nsec(thd,
+                                      thd->variables.lock_wait_timeout_nsec))
     DBUG_RETURN(true);
 
   // Acquire exclusive lock on the resource group name.
@@ -331,8 +333,10 @@ bool resourcegroups::Sql_cmd_alter_resource_group::execute(THD *thd) {
     DBUG_RETURN(true);
   }
 
-  if (acquire_shared_global_read_lock(thd, thd->variables.lock_wait_timeout) ||
-      acquire_shared_backup_lock(thd, thd->variables.lock_wait_timeout))
+  if (acquire_shared_global_read_lock_nsec(
+          thd, thd->variables.lock_wait_timeout_nsec) ||
+      acquire_shared_backup_lock_nsec(thd,
+                                      thd->variables.lock_wait_timeout_nsec))
     DBUG_RETURN(true);
 
   // Acquire exclusive lock on the resource group name.
@@ -448,8 +452,10 @@ bool resourcegroups::Sql_cmd_drop_resource_group::execute(THD *thd) {
     DBUG_RETURN(true);
   }
 
-  if (acquire_shared_global_read_lock(thd, thd->variables.lock_wait_timeout) ||
-      acquire_shared_backup_lock(thd, thd->variables.lock_wait_timeout))
+  if (acquire_shared_global_read_lock_nsec(
+          thd, thd->variables.lock_wait_timeout_nsec) ||
+      acquire_shared_backup_lock_nsec(thd,
+                                      thd->variables.lock_wait_timeout_nsec))
     DBUG_RETURN(true);
 
   // Acquire exclusive lock on the resource group name.

--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -3884,7 +3884,7 @@ static int init_slave_thread(THD *thd, SLAVE_THD_TYPE thd_type) {
   }
   thd->set_time();
   /* Do not use user-supplied timeout value for system threads. */
-  thd->variables.lock_wait_timeout = LONG_TIMEOUT;
+  thd->variables.lock_wait_timeout_nsec = LONG_TIMEOUT_NSEC;
   DBUG_RETURN(0);
 }
 

--- a/sql/server_component/backup_lock_service.cc
+++ b/sql/server_component/backup_lock_service.cc
@@ -30,10 +30,10 @@ class THD;
 
 void mysql_backup_lock_service_init() { return; }
 
-DEFINE_BOOL_METHOD(mysql_acquire_backup_lock,
+DEFINE_BOOL_METHOD(mysql_acquire_backup_lock_nsec,
                    (MYSQL_THD opaque_thd,
                     enum enum_backup_lock_service_lock_kind lock_kind,
-                    unsigned long lock_timeout)) {
+                    ulonglong lock_timeout_nsec)) {
   THD *thd;
   if (opaque_thd)
     thd = static_cast<THD *>(opaque_thd);
@@ -41,7 +41,7 @@ DEFINE_BOOL_METHOD(mysql_acquire_backup_lock,
     thd = current_thd;
 
   if (lock_kind == BACKUP_LOCK_SERVICE_DEFAULT)
-    return acquire_exclusive_backup_lock(thd, lock_timeout);
+    return acquire_exclusive_backup_lock_nsec(thd, lock_timeout_nsec);
 
   /*
     Return error in case lock_kind has an unexpected value.

--- a/sql/sp.cc
+++ b/sql/sp.cc
@@ -274,8 +274,8 @@ static bool lock_routine_name(THD *thd, enum_sp_type type, sp_name *name,
   MDL_REQUEST_INIT(&routine_request, mdl_type, name->m_db.str, lc_routine_name,
                    mdl_lock_type, MDL_TRANSACTION);
   // Acquire MDL locks
-  if (thd->mdl_context.acquire_lock(&routine_request,
-                                    thd->variables.lock_wait_timeout))
+  if (thd->mdl_context.acquire_lock_nsec(&routine_request,
+                                         thd->variables.lock_wait_timeout_nsec))
     DBUG_RETURN(true);
 
   DBUG_RETURN(false);
@@ -1108,8 +1108,8 @@ bool lock_db_routines(THD *thd, const dd::Schema &schema) {
     mdl_requests.push_front(mdl_request);
   }
 
-  DBUG_RETURN(thd->mdl_context.acquire_locks(&mdl_requests,
-                                             thd->variables.lock_wait_timeout));
+  DBUG_RETURN(thd->mdl_context.acquire_locks_nsec(
+      &mdl_requests, thd->variables.lock_wait_timeout_nsec));
 }
 
 /**

--- a/sql/sql_admin.cc
+++ b/sql/sql_admin.cc
@@ -147,8 +147,8 @@ static int prepare_for_repair(THD *thd, TABLE_LIST *table_list,
     MDL_REQUEST_INIT(&table_list->mdl_request, MDL_key::TABLE, table_list->db,
                      table_list->table_name, MDL_EXCLUSIVE, MDL_TRANSACTION);
 
-    if (lock_table_names(thd, table_list, table_list->next_global,
-                         thd->variables.lock_wait_timeout, 0))
+    if (lock_table_names_nsec(thd, table_list, table_list->next_global,
+                              thd->variables.lock_wait_timeout_nsec, 0))
       DBUG_RETURN(0);
     has_mdl_lock = true;
 
@@ -490,7 +490,8 @@ static Check_result check_for_upgrade(THD *thd, dd::String_type &sname,
   // Ok we have successfully checked table for upgrade. Record
   // this fact in the DD.
 
-  if (acquire_shared_global_read_lock(thd, thd->variables.lock_wait_timeout)) {
+  if (acquire_shared_global_read_lock_nsec(
+          thd, thd->variables.lock_wait_timeout_nsec)) {
     return error;
   }
 
@@ -656,8 +657,8 @@ static bool mysql_admin_table(
                 admin statements won't cause its automatic acquisition
                 in open_and_lock_tables().
               */
-              acquire_shared_backup_lock(thd,
-                                         thd->variables.lock_wait_timeout)) {
+              acquire_shared_backup_lock_nsec(
+                  thd, thd->variables.lock_wait_timeout_nsec)) {
             result_code = HA_ADMIN_FAILED;
             goto send_result;
           }
@@ -690,8 +691,8 @@ static bool mysql_admin_table(
                 admin statements won't cause its automatic acquisition
                 in open_and_lock_tables().
               */
-              acquire_shared_backup_lock(thd,
-                                         thd->variables.lock_wait_timeout)) {
+              acquire_shared_backup_lock_nsec(
+                  thd, thd->variables.lock_wait_timeout_nsec)) {
             result_code = HA_ADMIN_FAILED;
             goto send_result;
           }
@@ -1115,8 +1116,8 @@ static bool mysql_admin_table(
         if (!result_code)  // recreation went ok
         {
           DEBUG_SYNC(thd, "ha_admin_open_ltable");
-          if (acquire_shared_backup_lock(thd,
-                                         thd->variables.lock_wait_timeout)) {
+          if (acquire_shared_backup_lock_nsec(
+                  thd, thd->variables.lock_wait_timeout_nsec)) {
             result_code = HA_ADMIN_FAILED;
           } else {
             table->mdl_request.set_type(MDL_SHARED_READ);
@@ -1414,13 +1415,13 @@ bool Sql_cmd_analyze_table::handle_histogram_command(THD *thd,
       dd::cache::Dictionary_client::Auto_releaser releaser(thd->dd_client());
       switch (get_histogram_command()) {
         case Histogram_command::UPDATE_HISTOGRAM:
-          res = acquire_shared_backup_lock(thd,
-                                           thd->variables.lock_wait_timeout) ||
+          res = acquire_shared_backup_lock_nsec(
+                    thd, thd->variables.lock_wait_timeout_nsec) ||
                 update_histogram(thd, table, results);
           break;
         case Histogram_command::DROP_HISTOGRAM:
-          res = acquire_shared_backup_lock(thd,
-                                           thd->variables.lock_wait_timeout) ||
+          res = acquire_shared_backup_lock_nsec(
+                    thd, thd->variables.lock_wait_timeout_nsec) ||
                 drop_histogram(thd, table, results);
 
           if (res) {

--- a/sql/sql_alter_instance.cc
+++ b/sql/sql_alter_instance.cc
@@ -96,7 +96,8 @@ bool Rotate_innodb_master_key::execute() {
     return true;
   }
 
-  if (acquire_shared_backup_lock(m_thd, m_thd->variables.lock_wait_timeout)) {
+  if (acquire_shared_backup_lock_nsec(
+          m_thd, m_thd->variables.lock_wait_timeout_nsec)) {
     // MDL subsystem has to set an error in Diagnostics Area
     DBUG_ASSERT(m_thd->get_stmt_da()->is_error());
     return true;

--- a/sql/sql_backup_lock.h
+++ b/sql/sql_backup_lock.h
@@ -25,6 +25,7 @@
 
 #include <sys/types.h>
 
+#include "my_inttypes.h"
 #include "my_sqlcommand.h"  // SQLCOM_LOCK_INSTANCE, SQLCOM_UNLOCK_INSTANCE
 #include "sql_cmd.h"        // Sql_cmd
 
@@ -76,14 +77,15 @@ class Sql_cmd_unlock_instance : public Sql_cmd {
   Acquire exclusive Backup Lock.
 
   @param[in] thd                Current thread context
-  @param[in] lock_wait_timeout  How many seconds to wait before timeout.
+  @param[in] lock_wait_timeout  How many nanoseconds to wait before timeout.
 
   @return Operation status.
     @retval false Success
     @retval true  Failure
 */
 
-bool acquire_exclusive_backup_lock(THD *thd, unsigned long lock_wait_timeout);
+bool acquire_exclusive_backup_lock_nsec(THD *thd,
+                                        ulonglong lock_wait_timeout_nsec);
 
 /**
   Acquire shared Backup Lock.
@@ -96,7 +98,8 @@ bool acquire_exclusive_backup_lock(THD *thd, unsigned long lock_wait_timeout);
     @retval true  Failure
 */
 
-bool acquire_shared_backup_lock(THD *thd, unsigned long lock_wait_timeout);
+bool acquire_shared_backup_lock_nsec(THD *thd,
+                                     ulonglong lock_wait_timeout_nsec);
 
 /**
   Release Backup Lock if it was acquired.

--- a/sql/sql_base.h
+++ b/sql/sql_base.h
@@ -266,12 +266,13 @@ void update_non_unique_table_error(TABLE_LIST *update, const char *operation,
 int setup_ftfuncs(const THD *thd, SELECT_LEX *select);
 bool init_ftfuncs(THD *thd, SELECT_LEX *select);
 int run_before_dml_hook(THD *thd);
-bool get_and_lock_tablespace_names(THD *thd, TABLE_LIST *tables_start,
-                                   TABLE_LIST *tables_end,
-                                   ulong lock_wait_timeout, uint flags);
-bool lock_table_names(
+bool get_and_lock_tablespace_names_nsec(THD *thd, TABLE_LIST *tables_start,
+                                        TABLE_LIST *tables_end,
+                                        ulonglong lock_wait_timeout_nsec,
+                                        uint flags);
+bool lock_table_names_nsec(
     THD *thd, TABLE_LIST *table_list, TABLE_LIST *table_list_end,
-    ulong lock_wait_timeout, uint flags,
+    ulonglong lock_wait_timeout_nsec, uint flags,
     Prealloced_array<MDL_request *, 1> *schema_reqs = nullptr);
 bool open_tables(THD *thd, TABLE_LIST **tables, uint *counter, uint flags,
                  Prelocking_strategy *prelocking_strategy);
@@ -309,8 +310,8 @@ TABLE *open_log_table(THD *thd, TABLE_LIST *one_table,
                       Open_tables_backup *backup);
 void close_log_table(THD *thd, Open_tables_backup *backup);
 
-bool close_cached_tables(THD *thd, TABLE_LIST *tables, bool wait_for_refresh,
-                         ulong timeout);
+bool close_cached_tables_nsec(THD *thd, TABLE_LIST *tables,
+                              bool wait_for_refresh, ulonglong timeout_nsec);
 
 /**
   Close all open instances of the table but keep the MDL lock.
@@ -496,7 +497,7 @@ class Open_table_context {
     return m_start_of_statement_svp;
   }
 
-  inline ulong get_timeout() const { return m_timeout; }
+  inline ulong get_timeout_nsec() const { return m_timeout_nsec; }
 
   uint get_flags() const { return m_flags; }
 
@@ -526,7 +527,7 @@ class Open_table_context {
     Lock timeout in seconds. Initialized to LONG_TIMEOUT when opening system
     tables or to the "lock_wait_timeout" system variable for regular tables.
   */
-  ulong m_timeout;
+  ulonglong m_timeout_nsec;
   /* open_table() flags. */
   uint m_flags;
   /** Back off action. */

--- a/sql/sql_cmd_srs.cc
+++ b/sql/sql_cmd_srs.cc
@@ -167,8 +167,10 @@ bool Sql_cmd_create_srs::execute(THD *thd) {
     return true;
   }
 
-  if (acquire_shared_global_read_lock(thd, thd->variables.lock_wait_timeout) ||
-      acquire_shared_backup_lock(thd, thd->variables.lock_wait_timeout))
+  if (acquire_shared_global_read_lock_nsec(
+          thd, thd->variables.lock_wait_timeout_nsec) ||
+      acquire_shared_backup_lock_nsec(thd,
+                                      thd->variables.lock_wait_timeout_nsec))
     return true;
 
   Disable_autocommit_guard dag(thd);
@@ -237,8 +239,10 @@ bool Sql_cmd_drop_srs::execute(THD *thd) {
     return true;
   }
 
-  if (acquire_shared_global_read_lock(thd, thd->variables.lock_wait_timeout) ||
-      acquire_shared_backup_lock(thd, thd->variables.lock_wait_timeout))
+  if (acquire_shared_global_read_lock_nsec(
+          thd, thd->variables.lock_wait_timeout_nsec) ||
+      acquire_shared_backup_lock_nsec(thd,
+                                      thd->variables.lock_wait_timeout_nsec))
     return true;
 
   Disable_autocommit_guard dag(thd);

--- a/sql/sql_component.cc
+++ b/sql/sql_component.cc
@@ -52,7 +52,8 @@ bool Sql_cmd_install_component::execute(THD *thd) {
     return true;
   }
 
-  if (acquire_shared_backup_lock(thd, thd->variables.lock_wait_timeout))
+  if (acquire_shared_backup_lock_nsec(thd,
+                                      thd->variables.lock_wait_timeout_nsec))
     return true;
 
   Disable_autocommit_guard autocommit_guard(thd);
@@ -86,7 +87,8 @@ bool Sql_cmd_uninstall_component::execute(THD *thd) {
     return true;
   }
 
-  if (acquire_shared_backup_lock(thd, thd->variables.lock_wait_timeout))
+  if (acquire_shared_backup_lock_nsec(thd,
+                                      thd->variables.lock_wait_timeout_nsec))
     return true;
 
   Disable_autocommit_guard autocommit_guard(thd);

--- a/sql/sql_const.h
+++ b/sql/sql_const.h
@@ -279,6 +279,7 @@ static const ulong EVENT_DEF_CACHE_MIN = 256;
 #define DELAYED_WAIT_TIMEOUT 5 * 60 /**< Wait for delayed insert */
 
 #define LONG_TIMEOUT ((ulong)3600L * 24L * 365L)
+#define LONG_TIMEOUT_NSEC ((ulonglong)LONG_TIMEOUT * 1000000000ULL)
 
 /**
   Maximum length of time zone name that we support (Time zone name is

--- a/sql/sql_db.cc
+++ b/sql/sql_db.cc
@@ -557,8 +557,8 @@ bool mysql_alter_db(THD *thd, const char *db, HA_CREATE_INFO *create_info) {
     DBUG_RETURN(true);
   }
 
-  if (lock_table_names(thd, tables, NULL, thd->variables.lock_wait_timeout,
-                       0)) {
+  if (lock_table_names_nsec(thd, tables, NULL,
+                            thd->variables.lock_wait_timeout_nsec, 0)) {
     DBUG_RETURN(true);
   }
 
@@ -760,8 +760,8 @@ bool mysql_rm_db(THD *thd, const LEX_CSTRING &db, bool if_exists) {
     }
 
     /* Lock all tables and stored routines about to be dropped. */
-    if (lock_table_names(thd, tables, NULL, thd->variables.lock_wait_timeout,
-                         0) ||
+    if (lock_table_names_nsec(thd, tables, NULL,
+                              thd->variables.lock_wait_timeout_nsec, 0) ||
         rm_table_do_discovery_and_lock_fk_tables(thd, tables) ||
         Events::lock_schema_events(thd, *schema) ||
         lock_db_routines(thd, *schema) || lock_trigger_names(thd, tables))

--- a/sql/sql_handler.cc
+++ b/sql/sql_handler.cc
@@ -493,8 +493,8 @@ retry:
 
     thd->push_internal_handler(&sql_handler_lock_error);
 
-    error = thd->mdl_context.acquire_lock(&read_request,
-                                          thd->variables.lock_wait_timeout);
+    error = thd->mdl_context.acquire_lock_nsec(
+        &read_request, thd->variables.lock_wait_timeout_nsec);
     thd->pop_internal_handler();
 
     if (sql_handler_lock_error.need_reopen()) {

--- a/sql/sql_import.cc
+++ b/sql/sql_import.cc
@@ -158,8 +158,8 @@ bool Sql_cmd_import_table::execute(THD *thd) {
                    MDL_INTENTION_EXCLUSIVE, MDL_TRANSACTION);
   mdl_requests.push_front(mdl_request_for_grl);
 
-  if (thd->mdl_context.acquire_locks(&mdl_requests,
-                                     thd->variables.lock_wait_timeout)) {
+  if (thd->mdl_context.acquire_locks_nsec(
+          &mdl_requests, thd->variables.lock_wait_timeout_nsec)) {
     return true;
   }
   // Now we have MDL on all schemas and tables involved

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -2383,8 +2383,8 @@ static TABLE *create_table_from_items(THD *thd, HA_CREATE_INFO *create_info,
       DBUG_RETURN(NULL);
 
     if (!mdl_requests.is_empty() &&
-        thd->mdl_context.acquire_locks(&mdl_requests,
-                                       thd->variables.lock_wait_timeout))
+        thd->mdl_context.acquire_locks_nsec(
+            &mdl_requests, thd->variables.lock_wait_timeout_nsec))
       DBUG_RETURN(NULL);
   }
 
@@ -2756,8 +2756,8 @@ bool Query_result_create::send_eof() {
                                        MDL_EXCLUSIVE, create_info->db_type,
                                        &mdl_requests, &fk_invalidator) ||
         (!mdl_requests.is_empty() &&
-         thd->mdl_context.acquire_locks(&mdl_requests,
-                                        thd->variables.lock_wait_timeout)))
+         thd->mdl_context.acquire_locks_nsec(
+             &mdl_requests, thd->variables.lock_wait_timeout_nsec)))
       error = true;
     else {
       dd::cache::Dictionary_client::Auto_releaser releaser(thd->dd_client());

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -2502,9 +2502,9 @@ retry:
           triggers as we always acquire SRO (or even stronger SNRW) metadata
           lock for them.
         */
-        bool result = thd->mdl_context.upgrade_shared_lock(
+        bool result = thd->mdl_context.upgrade_shared_lock_nsec(
             table->table->mdl_ticket, MDL_SHARED_READ_ONLY,
-            thd->variables.lock_wait_timeout);
+            thd->variables.lock_wait_timeout_nsec);
 
         if (deadlock_handler.need_reopen()) {
           /*
@@ -4910,8 +4910,8 @@ bool show_precheck(THD *thd, LEX *lex, bool lock) {
       MDL_request mdl_request;
       MDL_REQUEST_INIT(&mdl_request, MDL_key::SCHEMA, lex_str_db.str, "",
                        MDL_INTENTION_EXCLUSIVE, MDL_TRANSACTION);
-      if (thd->mdl_context.acquire_lock(&mdl_request,
-                                        thd->variables.lock_wait_timeout))
+      if (thd->mdl_context.acquire_lock_nsec(
+              &mdl_request, thd->variables.lock_wait_timeout_nsec))
         return true;
 
       // Stop if given database does not exist.

--- a/sql/sql_partition_admin.cc
+++ b/sql/sql_partition_admin.cc
@@ -581,7 +581,7 @@ bool Sql_cmd_alter_table_repair_partition::execute(THD *thd) {
 
 bool Sql_cmd_alter_table_truncate_partition::execute(THD *thd) {
   int error;
-  ulong timeout = thd->variables.lock_wait_timeout;
+  ulonglong timeout_nsec = thd->variables.lock_wait_timeout_nsec;
   TABLE_LIST *first_table = thd->lex->select_lex->table_list.first;
   uint table_counter;
   Partition_handler *part_handler = nullptr;
@@ -639,7 +639,8 @@ bool Sql_cmd_alter_table_truncate_partition::execute(THD *thd) {
 
   if (thd->locked_tables_mode) {
     MDL_ticket *ticket = first_table->table->mdl_ticket;
-    if (thd->mdl_context.upgrade_shared_lock(ticket, MDL_EXCLUSIVE, timeout))
+    if (thd->mdl_context.upgrade_shared_lock_nsec(ticket, MDL_EXCLUSIVE,
+                                                  timeout_nsec))
       DBUG_RETURN(true);
     downgrade_mdl_guard.reset(ticket);
   }

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -2067,7 +2067,8 @@ static bool mysql_install_plugin(THD *thd, const LEX_STRING *name,
       check_table_access(thd, INSERT_ACL, &tables, false, 1, false))
     DBUG_RETURN(true);
 
-  if (acquire_shared_backup_lock(thd, thd->variables.lock_wait_timeout))
+  if (acquire_shared_backup_lock_nsec(thd,
+                                      thd->variables.lock_wait_timeout_nsec))
     DBUG_RETURN(true);
 
   /* need to open before acquiring LOCK_plugin or it will deadlock */
@@ -2155,8 +2156,8 @@ static bool mysql_install_plugin(THD *thd, const LEX_STRING *name,
       MDL_REQUEST_INIT(&mdl_request, MDL_key::TABLE,
                        INFORMATION_SCHEMA_NAME.str, tmp->name.str,
                        MDL_EXCLUSIVE, MDL_TRANSACTION);
-      if (thd->mdl_context.acquire_lock(&mdl_request,
-                                        thd->variables.lock_wait_timeout))
+      if (thd->mdl_context.acquire_lock_nsec(
+              &mdl_request, thd->variables.lock_wait_timeout_nsec))
         error = true;
     } else
       error = true;
@@ -2256,7 +2257,8 @@ static bool mysql_uninstall_plugin(THD *thd, const LEX_STRING *name) {
     DBUG_RETURN(true);
   }
 
-  if (acquire_shared_backup_lock(thd, thd->variables.lock_wait_timeout))
+  if (acquire_shared_backup_lock_nsec(thd,
+                                      thd->variables.lock_wait_timeout_nsec))
     DBUG_RETURN(true);
 
   Disable_autocommit_guard autocommit_guard(thd);

--- a/sql/sql_plugin_services.h
+++ b/sql/sql_plugin_services.h
@@ -289,7 +289,8 @@ static struct transaction_write_set_service_st transaction_write_set_handler = {
 };
 
 static struct mysql_locking_service_st locking_service_handler = {
-    mysql_acquire_locking_service_locks, mysql_release_locking_service_locks};
+    mysql_acquire_locking_service_locks_nsec,
+    mysql_release_locking_service_locks};
 
 static struct security_context_service_st security_context_handler = {
     thd_get_security_context,    thd_set_security_context,

--- a/sql/sql_reload.cc
+++ b/sql/sql_reload.cc
@@ -211,9 +211,9 @@ bool handle_reload_request(THD *thd, unsigned long options, TABLE_LIST *tables,
       */
       tmp_write_to_binlog = 0;
       if (thd->global_read_lock.lock_global_read_lock(thd)) return 1;  // Killed
-      if (close_cached_tables(thd, tables,
-                              ((options & REFRESH_FAST) ? false : true),
-                              thd->variables.lock_wait_timeout)) {
+      if (close_cached_tables_nsec(thd, tables,
+                                   ((options & REFRESH_FAST) ? false : true),
+                                   thd->variables.lock_wait_timeout_nsec)) {
         /*
           NOTE: my_error() has been already called by reopen_tables() within
           close_cached_tables().
@@ -263,9 +263,10 @@ bool handle_reload_request(THD *thd, unsigned long options, TABLE_LIST *tables,
         }
       }
 
-      if (close_cached_tables(
-              thd, tables, ((options & REFRESH_FAST) ? false : true),
-              (thd ? thd->variables.lock_wait_timeout : LONG_TIMEOUT))) {
+      if (close_cached_tables_nsec(thd, tables,
+                                   ((options & REFRESH_FAST) ? false : true),
+                                   (thd ? thd->variables.lock_wait_timeout_nsec
+                                        : LONG_TIMEOUT_NSEC))) {
         /*
           NOTE: my_error() has been already called by reopen_tables() within
           close_cached_tables().
@@ -404,8 +405,9 @@ bool flush_tables_with_read_lock(THD *thd, TABLE_LIST *all_tables) {
     IX and database-scope IX locks on the tables as this will make
     this statement incompatible with FLUSH TABLES WITH READ LOCK.
   */
-  if (lock_table_names(thd, all_tables, NULL, thd->variables.lock_wait_timeout,
-                       MYSQL_OPEN_SKIP_SCOPED_MDL_LOCK))
+  if (lock_table_names_nsec(thd, all_tables, NULL,
+                            thd->variables.lock_wait_timeout_nsec,
+                            MYSQL_OPEN_SKIP_SCOPED_MDL_LOCK))
     goto error;
 
   DEBUG_SYNC(thd, "flush_tables_with_read_lock_after_acquire_locks");

--- a/sql/sql_rename.cc
+++ b/sql/sql_rename.cc
@@ -284,8 +284,9 @@ bool mysql_rename_tables(THD *thd, TABLE_LIST *table_list) {
     */
   }
 
-  if (lock_table_names(thd, table_list, 0, thd->variables.lock_wait_timeout, 0,
-                       &schema_reqs) ||
+  if (lock_table_names_nsec(thd, table_list, 0,
+                            thd->variables.lock_wait_timeout_nsec, 0,
+                            &schema_reqs) ||
       lock_trigger_names(thd, table_list))
     DBUG_RETURN(true);
 

--- a/sql/sql_servers.cc
+++ b/sql/sql_servers.cc
@@ -426,7 +426,8 @@ static bool close_cached_connection_tables(THD *thd,
   }
   mysql_mutex_unlock(&LOCK_open);
 
-  if (tables) result = close_cached_tables(thd, tables, false, LONG_TIMEOUT);
+  if (tables)
+    result = close_cached_tables_nsec(thd, tables, false, LONG_TIMEOUT_NSEC);
 
   DBUG_RETURN(result);
 }
@@ -614,7 +615,8 @@ void Server_options::store_altered_server(TABLE *table,
 
 bool Sql_cmd_common_server::check_and_open_table(THD *thd) {
   if (check_global_access(thd, SUPER_ACL) ||
-      acquire_shared_backup_lock(thd, thd->variables.lock_wait_timeout))
+      acquire_shared_backup_lock_nsec(thd,
+                                      thd->variables.lock_wait_timeout_nsec))
     return true;
 
   TABLE_LIST tables;

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -3727,8 +3727,8 @@ bool try_acquire_high_prio_shared_mdl_lock(THD *thd, TABLE_LIST *table,
     */
     error = thd->mdl_context.try_acquire_lock(&table->mdl_request);
   } else
-    error = thd->mdl_context.acquire_lock(&table->mdl_request,
-                                          thd->variables.lock_wait_timeout);
+    error = thd->mdl_context.acquire_lock_nsec(
+        &table->mdl_request, thd->variables.lock_wait_timeout_nsec);
 
   return error;
 }
@@ -5451,8 +5451,8 @@ static bool acquire_mdl_for_table(THD *thd, const char *db_name,
   MDL_REQUEST_INIT(&table_request, MDL_key::TABLE, db_name, table_name,
                    MDL_SHARED, MDL_TRANSACTION);
 
-  if (thd->mdl_context.acquire_lock(&table_request,
-                                    thd->variables.lock_wait_timeout))
+  if (thd->mdl_context.acquire_lock_nsec(&table_request,
+                                         thd->variables.lock_wait_timeout_nsec))
     return true;
 
   return false;

--- a/sql/sql_tablespace.cc
+++ b/sql/sql_tablespace.cc
@@ -202,7 +202,8 @@ bool lock_rec(THD *thd, MDL_request_list *rlst, const LEX_STRING &tsp) {
                    MDL_INTENTION_EXCLUSIVE, MDL_TRANSACTION);
   rlst->push_front(&backup_lock_request);
 
-  return thd->mdl_context.acquire_locks(rlst, thd->variables.lock_wait_timeout);
+  return thd->mdl_context.acquire_locks_nsec(
+      rlst, thd->variables.lock_wait_timeout_nsec);
 }
 
 template <typename... Names>
@@ -979,8 +980,8 @@ bool Sql_cmd_alter_tablespace_rename::execute(THD *thd) {
     table_reqs.push_front(dd::mdl_req(thd, tref));
   }
 
-  if (thd->mdl_context.acquire_locks(&table_reqs,
-                                     thd->variables.lock_wait_timeout)) {
+  if (thd->mdl_context.acquire_locks_nsec(
+          &table_reqs, thd->variables.lock_wait_timeout_nsec)) {
     return true;
   }
 

--- a/sql/sql_trigger.cc
+++ b/sql/sql_trigger.cc
@@ -270,8 +270,8 @@ bool acquire_mdl_for_trigger(THD *thd, const char *db, const char *trg_name,
 
   mdl_requests.push_front(&mdl_request);
 
-  if (thd->mdl_context.acquire_locks(&mdl_requests,
-                                     thd->variables.lock_wait_timeout))
+  if (thd->mdl_context.acquire_locks_nsec(
+          &mdl_requests, thd->variables.lock_wait_timeout_nsec))
     return true;
 
   return false;
@@ -333,7 +333,8 @@ TABLE *Sql_cmd_ddl_trigger_common::open_and_lock_subj_table(
         find_table_for_mdl_upgrade(thd, tables->db, tables->table_name, false);
     if (tables->table == nullptr) return nullptr;
 
-    if (acquire_shared_backup_lock(thd, thd->variables.lock_wait_timeout))
+    if (acquire_shared_backup_lock_nsec(thd,
+                                        thd->variables.lock_wait_timeout_nsec))
       return nullptr;
   } else {
     tables->table = open_n_lock_single_table(thd, tables, TL_READ_NO_INSERT, 0);

--- a/sql/sql_truncate.cc
+++ b/sql/sql_truncate.cc
@@ -327,7 +327,8 @@ bool Sql_cmd_truncate_table::lock_table(THD *thd, TABLE_LIST *table_ref,
                                              table_ref->table_name, false)))
       DBUG_RETURN(true);
 
-    if (acquire_shared_backup_lock(thd, thd->variables.lock_wait_timeout))
+    if (acquire_shared_backup_lock_nsec(thd,
+                                        thd->variables.lock_wait_timeout_nsec))
       DBUG_RETURN(true);
 
     *hton = table->s->db_type();
@@ -336,8 +337,8 @@ bool Sql_cmd_truncate_table::lock_table(THD *thd, TABLE_LIST *table_ref,
   } else {
     /* Acquire an exclusive lock. */
     DBUG_ASSERT(table_ref->next_global == NULL);
-    if (lock_table_names(thd, table_ref, NULL, thd->variables.lock_wait_timeout,
-                         0))
+    if (lock_table_names_nsec(thd, table_ref, NULL,
+                              thd->variables.lock_wait_timeout_nsec, 0))
       DBUG_RETURN(true);
 
     const char *schema_name = table_ref->db;

--- a/sql/sql_view.cc
+++ b/sql/sql_view.cc
@@ -1645,7 +1645,8 @@ bool mysql_drop_view(THD *thd, TABLE_LIST *views) {
     DBUG_RETURN(true);
   }
 
-  if (lock_table_names(thd, views, 0, thd->variables.lock_wait_timeout, 0))
+  if (lock_table_names_nsec(thd, views, 0,
+                            thd->variables.lock_wait_timeout_nsec, 0))
     DBUG_RETURN(true);
 
   dd::cache::Dictionary_client::Auto_releaser releaser(thd->dd_client());

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -1992,11 +1992,27 @@ static Sys_var_bool Sys_local_infile("local_infile",
                                      GLOBAL_VAR(opt_local_infile),
                                      CMD_LINE(OPT_ARG), DEFAULT(false));
 
-static Sys_var_ulong Sys_lock_wait_timeout(
+static bool update_cached_lock_wait_timeout(sys_var * /* unused */, THD *thd,
+                                            enum_var_type type) {
+  if (type == OPT_SESSION)
+    thd->variables.lock_wait_timeout_nsec =
+        double2ulonglong(thd->variables.lock_wait_timeout_double * 1e9);
+  else
+    global_system_variables.lock_wait_timeout_nsec = double2ulonglong(
+        global_system_variables.lock_wait_timeout_double * 1e9);
+  return false;
+}
+
+static Sys_var_double Sys_lock_wait_timeout(
     "lock_wait_timeout",
-    "Timeout in seconds to wait for a lock before returning an error.",
-    HINT_UPDATEABLE SESSION_VAR(lock_wait_timeout), CMD_LINE(REQUIRED_ARG),
-    VALID_RANGE(1, LONG_TIMEOUT), DEFAULT(LONG_TIMEOUT), BLOCK_SIZE(1));
+    "Timeout in seconds to wait for a lock before returning an error. "
+    "The argument will be treated as a decimal value with nanosecond "
+    "precision.",
+    // very small nanosecond values will effectively be no waiting
+    HINT_UPDATEABLE SESSION_VAR(lock_wait_timeout_double),
+    CMD_LINE(REQUIRED_ARG), VALID_RANGE(0, LONG_TIMEOUT), DEFAULT(LONG_TIMEOUT),
+    NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(0),
+    ON_UPDATE(update_cached_lock_wait_timeout));
 
 #ifdef HAVE_MLOCKALL
 static Sys_var_bool Sys_locked_in_memory(

--- a/sql/system_variables.h
+++ b/sql/system_variables.h
@@ -218,7 +218,7 @@ struct System_variables {
   uint cte_max_recursion_depth;
   ulonglong histogram_generation_max_mem_size;
   ulong join_buff_size;
-  ulong lock_wait_timeout;
+  ulonglong lock_wait_timeout_nsec;
   ulong max_allowed_packet;
   ulong max_error_count;
   ulong max_length_for_sort_data;
@@ -319,6 +319,7 @@ struct System_variables {
   bool binlog_rows_query_log_events;
 
   double long_query_time_double;
+  double lock_wait_timeout_double;
 
   bool pseudo_slave_mode;
 

--- a/sql/xa.cc
+++ b/sql/xa.cc
@@ -532,8 +532,8 @@ static bool acquire_mandatory_metadata_locks(THD *thd, xid_t *external_xid) {
   MDL_request mdl_request;
   MDL_REQUEST_INIT(&mdl_request, MDL_key::COMMIT, "", "",
                    MDL_INTENTION_EXCLUSIVE, MDL_STATEMENT);
-  if (thd->mdl_context.acquire_lock(&mdl_request,
-                                    thd->variables.lock_wait_timeout)) {
+  if (thd->mdl_context.acquire_lock_nsec(
+          &mdl_request, thd->variables.lock_wait_timeout_nsec)) {
     return true;
   }
 
@@ -665,8 +665,8 @@ bool Sql_cmd_xa_commit::process_internal_xa_commit(THD *thd,
     */
     MDL_REQUEST_INIT(&mdl_request, MDL_key::COMMIT, "", "",
                      MDL_INTENTION_EXCLUSIVE, MDL_STATEMENT);
-    if (thd->mdl_context.acquire_lock(&mdl_request,
-                                      thd->variables.lock_wait_timeout)) {
+    if (thd->mdl_context.acquire_lock_nsec(
+            &mdl_request, thd->variables.lock_wait_timeout_nsec)) {
       /*
         We can't rollback an XA transaction on lock failure due to
         Innodb redo log and bin log update are involved in rollback.
@@ -864,8 +864,8 @@ bool Sql_cmd_xa_rollback::process_internal_xa_rollback(THD *thd,
   MDL_request mdl_request;
   MDL_REQUEST_INIT(&mdl_request, MDL_key::COMMIT, "", "",
                    MDL_INTENTION_EXCLUSIVE, MDL_STATEMENT);
-  if (thd->mdl_context.acquire_lock(&mdl_request,
-                                    thd->variables.lock_wait_timeout)) {
+  if (thd->mdl_context.acquire_lock_nsec(
+          &mdl_request, thd->variables.lock_wait_timeout_nsec)) {
     /*
       We can't rollback an XA transaction on lock failure due to
       Innodb redo log and bin log update is involved in rollback.
@@ -1039,8 +1039,8 @@ bool Sql_cmd_xa_prepare::trans_xa_prepare(THD *thd) {
     MDL_request mdl_request;
     MDL_REQUEST_INIT(&mdl_request, MDL_key::COMMIT, "", "",
                      MDL_INTENTION_EXCLUSIVE, MDL_STATEMENT);
-    if (thd->mdl_context.acquire_lock(&mdl_request,
-                                      thd->variables.lock_wait_timeout) ||
+    if (thd->mdl_context.acquire_lock_nsec(
+            &mdl_request, thd->variables.lock_wait_timeout_nsec) ||
         ha_prepare(thd)) {
       /*
         Rollback the transaction if lock failed. For ha_prepare() failure

--- a/unittest/gunit/components/mysql_server/dynamic_loader-t.cc
+++ b/unittest/gunit/components/mysql_server/dynamic_loader-t.cc
@@ -132,9 +132,9 @@ DEFINE_BOOL_METHOD(mysql_system_variable_source_imp::get,
   return true;
 }
 
-DEFINE_BOOL_METHOD(mysql_acquire_backup_lock,
+DEFINE_BOOL_METHOD(mysql_acquire_backup_lock_nsec,
                    (MYSQL_THD, enum enum_backup_lock_service_lock_kind,
-                    unsigned long)) {
+                    ulonglong)) {
   return true;
 }
 

--- a/unittest/gunit/components/mysql_server/registry-t.cc
+++ b/unittest/gunit/components/mysql_server/registry-t.cc
@@ -137,9 +137,9 @@ DEFINE_BOOL_METHOD(mysql_system_variable_source_imp::get,
   return true;
 }
 
-DEFINE_BOOL_METHOD(mysql_acquire_backup_lock,
+DEFINE_BOOL_METHOD(mysql_acquire_backup_lock_nsec,
                    (MYSQL_THD, enum enum_backup_lock_service_lock_kind,
-                    unsigned long)) {
+                    ulonglong)) {
   return true;
 }
 

--- a/unittest/gunit/dd_cache-t.cc
+++ b/unittest/gunit/dd_cache-t.cc
@@ -104,8 +104,8 @@ class CacheStorageTest : public ::testing::Test, public Test_MDL_context_owner {
     MDL_request mdl_request;
     MDL_REQUEST_INIT(&mdl_request, MDL_key::TABLE, MYSQL_SCHEMA_NAME.str,
                      name.c_str(), MDL_EXCLUSIVE, MDL_TRANSACTION);
-    EXPECT_FALSE(m_mdl_context.acquire_lock(
-        &mdl_request, thd()->variables.lock_wait_timeout));
+    EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(
+        &mdl_request, thd()->variables.lock_wait_timeout_nsec));
   }
 
  protected:
@@ -1135,8 +1135,8 @@ TEST_F(CacheStorageTest, TestSchema) {
       MDL_REQUEST_INIT(&m_request, MDL_key::TABLE, "schema1", "table1",
                        MDL_EXCLUSIVE, MDL_TRANSACTION);
 
-      m_mdl_context.acquire_lock(&m_request,
-                                 thd()->variables.lock_wait_timeout);
+      m_mdl_context.acquire_lock_nsec(&m_request,
+                                      thd()->variables.lock_wait_timeout_nsec);
 
       // Get "schema1.table1" table from cache.
       const dd::Table *s1_t1 = NULL;

--- a/unittest/gunit/locking_service-t.cc
+++ b/unittest/gunit/locking_service-t.cc
@@ -33,6 +33,8 @@
 #include "unittest/gunit/test_utils.h"
 #include "unittest/gunit/thread_utils.h"
 
+static constexpr const ulonglong sec3600 = 3600000000000ULL;
+
 /*
   Putting everything in a namespace prevents any (unintentional)
   name clashes with the code under test.
@@ -97,8 +99,8 @@ void (*LockingServiceTest::m_old_error_handler_hook)(uint, const char *, myf);
 TEST_F(LockingServiceTest, AcquireAndRelease) {
   // Take two read locks
   const char *names1[] = {lock_name1, lock_name2};
-  EXPECT_FALSE(acquire_locking_service_locks(m_thd, namespace1, names1, 2,
-                                             LOCKING_SERVICE_READ, 3600));
+  EXPECT_FALSE(acquire_locking_service_locks_nsec(
+      m_thd, namespace1, names1, 2, LOCKING_SERVICE_READ, sec3600));
   EXPECT_TRUE(m_thd->mdl_context.owns_equal_or_stronger_lock(
       MDL_key::LOCKING_SERVICE, namespace1, lock_name1, MDL_SHARED));
   EXPECT_TRUE(m_thd->mdl_context.owns_equal_or_stronger_lock(
@@ -113,23 +115,23 @@ TEST_F(LockingServiceTest, AcquireAndRelease) {
 
   // Take one write lock
   const char *names2[] = {lock_name3};
-  EXPECT_FALSE(acquire_locking_service_locks(m_thd, namespace1, names2, 1,
-                                             LOCKING_SERVICE_WRITE, 3600));
+  EXPECT_FALSE(acquire_locking_service_locks_nsec(m_thd, namespace1, names2, 1,
+                                                  LOCKING_SERVICE_WRITE, 3600));
   EXPECT_TRUE(m_thd->mdl_context.owns_equal_or_stronger_lock(
       MDL_key::LOCKING_SERVICE, namespace1, lock_name3, MDL_EXCLUSIVE));
 
   // Take another write lock
   const char *names3[] = {lock_name4};
-  EXPECT_FALSE(acquire_locking_service_locks(m_thd, namespace1, names3, 1,
-                                             LOCKING_SERVICE_WRITE, 3600));
+  EXPECT_FALSE(acquire_locking_service_locks_nsec(
+      m_thd, namespace1, names3, 1, LOCKING_SERVICE_WRITE, sec3600));
   EXPECT_TRUE(m_thd->mdl_context.owns_equal_or_stronger_lock(
       MDL_key::LOCKING_SERVICE, namespace1, lock_name3, MDL_EXCLUSIVE));
   EXPECT_TRUE(m_thd->mdl_context.owns_equal_or_stronger_lock(
       MDL_key::LOCKING_SERVICE, namespace1, lock_name4, MDL_EXCLUSIVE));
 
   // Take the read locks again
-  EXPECT_FALSE(acquire_locking_service_locks(m_thd, namespace1, names1, 2,
-                                             LOCKING_SERVICE_READ, 3600));
+  EXPECT_FALSE(acquire_locking_service_locks_nsec(
+      m_thd, namespace1, names1, 2, LOCKING_SERVICE_READ, sec3600));
   EXPECT_TRUE(m_thd->mdl_context.owns_equal_or_stronger_lock(
       MDL_key::LOCKING_SERVICE, namespace1, lock_name1, MDL_SHARED));
   EXPECT_TRUE(m_thd->mdl_context.owns_equal_or_stronger_lock(
@@ -158,16 +160,16 @@ TEST_F(LockingServiceTest, CaseSensitive) {
   const char *lower[] = {"test"};
   const char *upper[] = {"TEST"};
 
-  EXPECT_FALSE(acquire_locking_service_locks(m_thd, namespace1, lower, 1,
-                                             LOCKING_SERVICE_WRITE, 3600));
+  EXPECT_FALSE(acquire_locking_service_locks_nsec(
+      m_thd, namespace1, lower, 1, LOCKING_SERVICE_WRITE, sec3600));
   EXPECT_TRUE(m_thd->mdl_context.owns_equal_or_stronger_lock(
       MDL_key::LOCKING_SERVICE, namespace1, "test", MDL_EXCLUSIVE));
   EXPECT_FALSE(m_thd->mdl_context.owns_equal_or_stronger_lock(
       MDL_key::LOCKING_SERVICE, namespace1, "TEST", MDL_EXCLUSIVE));
   EXPECT_FALSE(release_locking_service_locks(m_thd, namespace1));
 
-  EXPECT_FALSE(acquire_locking_service_locks(m_thd, "test", upper, 1,
-                                             LOCKING_SERVICE_WRITE, 3600));
+  EXPECT_FALSE(acquire_locking_service_locks_nsec(
+      m_thd, "test", upper, 1, LOCKING_SERVICE_WRITE, sec3600));
   EXPECT_TRUE(m_thd->mdl_context.owns_equal_or_stronger_lock(
       MDL_key::LOCKING_SERVICE, "test", "TEST", MDL_EXCLUSIVE));
   EXPECT_FALSE(m_thd->mdl_context.owns_equal_or_stronger_lock(
@@ -184,10 +186,10 @@ TEST_F(LockingServiceTest, ValidNames) {
     const char *null = NULL;
     const char *names1[] = {null};
     Mock_error_handler error_handler(m_thd, ER_LOCKING_SERVICE_WRONG_NAME);
-    EXPECT_TRUE(acquire_locking_service_locks(m_thd, namespace1, names1, 1,
-                                              LOCKING_SERVICE_READ, 3600));
-    EXPECT_TRUE(acquire_locking_service_locks(m_thd, null, ok_name, 1,
-                                              LOCKING_SERVICE_READ, 3600));
+    EXPECT_TRUE(acquire_locking_service_locks_nsec(
+        m_thd, namespace1, names1, 1, LOCKING_SERVICE_READ, sec3600));
+    EXPECT_TRUE(acquire_locking_service_locks_nsec(
+        m_thd, null, ok_name, 1, LOCKING_SERVICE_READ, sec3600));
     EXPECT_TRUE(release_locking_service_locks(m_thd, null));
     EXPECT_EQ(3, error_handler.handle_called());
   }
@@ -196,10 +198,10 @@ TEST_F(LockingServiceTest, ValidNames) {
     const char *empty = "";
     const char *names2[] = {empty};
     Mock_error_handler error_handler(m_thd, ER_LOCKING_SERVICE_WRONG_NAME);
-    EXPECT_TRUE(acquire_locking_service_locks(m_thd, namespace1, names2, 1,
-                                              LOCKING_SERVICE_READ, 3600));
-    EXPECT_TRUE(acquire_locking_service_locks(m_thd, empty, ok_name, 1,
-                                              LOCKING_SERVICE_READ, 3600));
+    EXPECT_TRUE(acquire_locking_service_locks_nsec(
+        m_thd, namespace1, names2, 1, LOCKING_SERVICE_READ, sec3600));
+    EXPECT_TRUE(acquire_locking_service_locks_nsec(
+        m_thd, empty, ok_name, 1, LOCKING_SERVICE_READ, sec3600));
     EXPECT_TRUE(release_locking_service_locks(m_thd, empty));
     EXPECT_EQ(3, error_handler.handle_called());
   }
@@ -209,10 +211,10 @@ TEST_F(LockingServiceTest, ValidNames) {
         "12345678901234567890123456789012345678901234567890123456789012345";
     const char *names3[] = {long65};
     Mock_error_handler error_handler(m_thd, ER_LOCKING_SERVICE_WRONG_NAME);
-    EXPECT_TRUE(acquire_locking_service_locks(m_thd, namespace1, names3, 1,
-                                              LOCKING_SERVICE_READ, 3600));
-    EXPECT_TRUE(acquire_locking_service_locks(m_thd, long65, ok_name, 1,
-                                              LOCKING_SERVICE_READ, 3600));
+    EXPECT_TRUE(acquire_locking_service_locks_nsec(
+        m_thd, namespace1, names3, 1, LOCKING_SERVICE_READ, sec3600));
+    EXPECT_TRUE(acquire_locking_service_locks_nsec(
+        m_thd, long65, ok_name, 1, LOCKING_SERVICE_READ, sec3600));
     EXPECT_TRUE(release_locking_service_locks(m_thd, long65));
     EXPECT_EQ(3, error_handler.handle_called());
   }
@@ -224,15 +226,15 @@ TEST_F(LockingServiceTest, ValidNames) {
 TEST_F(LockingServiceTest, TransactionInteraction) {
   // Releasing transactional locks should not affect lock service locks.
   const char *names1[] = {lock_name1};
-  EXPECT_FALSE(acquire_locking_service_locks(m_thd, namespace1, names1, 1,
-                                             LOCKING_SERVICE_READ, 3600));
+  EXPECT_FALSE(acquire_locking_service_locks_nsec(
+      m_thd, namespace1, names1, 1, LOCKING_SERVICE_READ, sec3600));
 
   m_thd->mdl_context.release_transactional_locks();
   EXPECT_TRUE(m_thd->mdl_context.owns_equal_or_stronger_lock(
       MDL_key::LOCKING_SERVICE, namespace1, lock_name1, MDL_SHARED));
 
-  EXPECT_FALSE(acquire_locking_service_locks(m_thd, namespace1, names1, 1,
-                                             LOCKING_SERVICE_WRITE, 3600));
+  EXPECT_FALSE(acquire_locking_service_locks_nsec(
+      m_thd, namespace1, names1, 1, LOCKING_SERVICE_WRITE, sec3600));
   EXPECT_TRUE(m_thd->mdl_context.owns_equal_or_stronger_lock(
       MDL_key::LOCKING_SERVICE, namespace1, lock_name1, MDL_EXCLUSIVE));
   m_thd->mdl_context.release_transactional_locks();
@@ -245,10 +247,11 @@ TEST_F(LockingServiceTest, TransactionInteraction) {
   MDL_request fake_request;
   MDL_REQUEST_INIT(&fake_request, MDL_key::SCHEMA, "db", "table", MDL_EXCLUSIVE,
                    MDL_TRANSACTION);
-  EXPECT_FALSE(m_thd->mdl_context.acquire_lock(&fake_request, 3600));
+  EXPECT_FALSE(
+      m_thd->mdl_context.acquire_lock_nsec(&fake_request, 3600000000000ULL));
 
-  EXPECT_FALSE(acquire_locking_service_locks(m_thd, namespace1, names1, 1,
-                                             LOCKING_SERVICE_READ, 3600));
+  EXPECT_FALSE(acquire_locking_service_locks_nsec(
+      m_thd, namespace1, names1, 1, LOCKING_SERVICE_READ, sec3600));
 
   m_thd->mdl_context.release_transactional_locks();
   EXPECT_TRUE(m_thd->mdl_context.owns_equal_or_stronger_lock(
@@ -277,8 +280,8 @@ class LockServiceThread : public Thread {
     m_initializer.SetUp();
     THD *m_thd = m_initializer.thd();
 
-    EXPECT_FALSE(acquire_locking_service_locks(m_thd, namespace1, m_names,
-                                               m_num, m_lock_type, 3600));
+    EXPECT_FALSE(acquire_locking_service_locks_nsec(
+        m_thd, namespace1, m_names, m_num, m_lock_type, sec3600));
     if (m_lock_grabbed) m_lock_grabbed->notify();
     if (m_lock_release) m_lock_release->wait_for_notification();
 
@@ -307,16 +310,16 @@ TEST_F(LockingServiceTest, ReadCompatibility) {
   thread.start();
   lock_grabbed.wait_for_notification();
 
-  EXPECT_FALSE(acquire_locking_service_locks(m_thd, namespace1, names1, 1,
-                                             LOCKING_SERVICE_READ, 3600));
+  EXPECT_FALSE(acquire_locking_service_locks_nsec(
+      m_thd, namespace1, names1, 1, LOCKING_SERVICE_READ, sec3600));
   EXPECT_TRUE(m_thd->mdl_context.owns_equal_or_stronger_lock(
       MDL_key::LOCKING_SERVICE, namespace1, lock_name1, MDL_SHARED));
   EXPECT_FALSE(release_locking_service_locks(m_thd, namespace1));
 
   {
     Mock_error_handler error_handler(m_thd, ER_LOCKING_SERVICE_TIMEOUT);
-    EXPECT_TRUE(acquire_locking_service_locks(m_thd, namespace1, names1, 1,
-                                              LOCKING_SERVICE_WRITE, 2));
+    EXPECT_TRUE(acquire_locking_service_locks_nsec(
+        m_thd, namespace1, names1, 1, LOCKING_SERVICE_WRITE, 2000000000ULL));
     // Wait 2 seconds here so that we hit the "abs_timeout is far away"
     // code path in MDL_context::acquire_lock() on all platforms.
     EXPECT_FALSE(m_thd->mdl_context.owns_equal_or_stronger_lock(
@@ -341,8 +344,8 @@ TEST_F(LockingServiceTest, WriteCompatibility) {
 
   {
     Mock_error_handler error_handler(m_thd, ER_LOCKING_SERVICE_TIMEOUT);
-    EXPECT_TRUE(acquire_locking_service_locks(m_thd, namespace1, names1, 1,
-                                              LOCKING_SERVICE_WRITE, 1));
+    EXPECT_TRUE(acquire_locking_service_locks_nsec(
+        m_thd, namespace1, names1, 1, LOCKING_SERVICE_WRITE, 1000000000ULL));
     EXPECT_FALSE(m_thd->mdl_context.owns_equal_or_stronger_lock(
         MDL_key::LOCKING_SERVICE, namespace1, lock_name1, MDL_SHARED));
     EXPECT_EQ(1, error_handler.handle_called());
@@ -368,8 +371,8 @@ TEST_F(LockingServiceTest, AtomicAcquire) {
     // Conflict on lock_name1, lock_name2 should not be acquired.
     const char *names2[] = {lock_name1, lock_name2};
     Mock_error_handler error_handler(m_thd, ER_LOCKING_SERVICE_TIMEOUT);
-    EXPECT_TRUE(acquire_locking_service_locks(m_thd, namespace1, names2, 2,
-                                              LOCKING_SERVICE_WRITE, 1));
+    EXPECT_TRUE(acquire_locking_service_locks_nsec(
+        m_thd, namespace1, names2, 2, LOCKING_SERVICE_WRITE, 1000000000ULL));
     EXPECT_FALSE(m_thd->mdl_context.owns_equal_or_stronger_lock(
         MDL_key::LOCKING_SERVICE, namespace1, lock_name1, MDL_SHARED));
     EXPECT_FALSE(m_thd->mdl_context.owns_equal_or_stronger_lock(
@@ -381,8 +384,8 @@ TEST_F(LockingServiceTest, AtomicAcquire) {
     // Reverse order of lock names - should give same result.
     const char *names2[] = {lock_name2, lock_name1};
     Mock_error_handler error_handler(m_thd, ER_LOCKING_SERVICE_TIMEOUT);
-    EXPECT_TRUE(acquire_locking_service_locks(m_thd, namespace1, names2, 2,
-                                              LOCKING_SERVICE_WRITE, 1));
+    EXPECT_TRUE(acquire_locking_service_locks_nsec(
+        m_thd, namespace1, names2, 2, LOCKING_SERVICE_WRITE, 1000000000ULL));
     EXPECT_FALSE(m_thd->mdl_context.owns_equal_or_stronger_lock(
         MDL_key::LOCKING_SERVICE, namespace1, lock_name1, MDL_SHARED));
     EXPECT_FALSE(m_thd->mdl_context.owns_equal_or_stronger_lock(
@@ -399,8 +402,8 @@ TEST_F(LockingServiceTest, AtomicAcquire) {
 */
 TEST_F(LockingServiceTest, Namespaces) {
   const char *names1[] = {lock_name1};
-  EXPECT_FALSE(acquire_locking_service_locks(m_thd, namespace1, names1, 1,
-                                             LOCKING_SERVICE_READ, 3600));
+  EXPECT_FALSE(acquire_locking_service_locks_nsec(
+      m_thd, namespace1, names1, 1, LOCKING_SERVICE_READ, sec3600));
   EXPECT_TRUE(m_thd->mdl_context.owns_equal_or_stronger_lock(
       MDL_key::LOCKING_SERVICE, namespace1, lock_name1, MDL_SHARED));
   EXPECT_FALSE(m_thd->mdl_context.owns_equal_or_stronger_lock(
@@ -419,8 +422,8 @@ TEST_F(LockingServiceTest, Namespaces) {
   lock_grabbed.wait_for_notification();
 
   // We should be able to take a write lock in namespace2.
-  EXPECT_FALSE(acquire_locking_service_locks(m_thd, namespace2, names1, 1,
-                                             LOCKING_SERVICE_WRITE, 3600));
+  EXPECT_FALSE(acquire_locking_service_locks_nsec(
+      m_thd, namespace2, names1, 1, LOCKING_SERVICE_WRITE, sec3600));
   EXPECT_TRUE(m_thd->mdl_context.owns_equal_or_stronger_lock(
       MDL_key::LOCKING_SERVICE, namespace2, lock_name1, MDL_EXCLUSIVE));
   EXPECT_FALSE(m_thd->mdl_context.owns_equal_or_stronger_lock(
@@ -444,8 +447,8 @@ class LockServiceDisconnectThread : public Thread {
     THD *m_thd = m_initializer.thd();
 
     const char *names1[] = {lock_name1};
-    EXPECT_FALSE(acquire_locking_service_locks(m_thd, namespace1, names1, 1,
-                                               LOCKING_SERVICE_WRITE, 3600));
+    EXPECT_FALSE(acquire_locking_service_locks_nsec(
+        m_thd, namespace1, names1, 1, LOCKING_SERVICE_WRITE, sec3600));
     m_initializer.TearDown();
   }
 };
@@ -460,8 +463,8 @@ TEST_F(LockingServiceTest, Disconnect) {
 
   // Check that we now can acquire a write lock on name1.
   const char *names1[] = {lock_name1};
-  EXPECT_FALSE(acquire_locking_service_locks(m_thd, namespace1, names1, 1,
-                                             LOCKING_SERVICE_WRITE, 3600));
+  EXPECT_FALSE(acquire_locking_service_locks_nsec(
+      m_thd, namespace1, names1, 1, LOCKING_SERVICE_WRITE, sec3600));
   EXPECT_FALSE(release_locking_service_locks(m_thd, namespace1));
 }
 
@@ -479,8 +482,8 @@ class LockServiceDeadlockThread : public Thread {
     THD *m_thd = m_initializer.thd();
 
     const char *names1[] = {lock_name1};
-    EXPECT_FALSE(acquire_locking_service_locks(m_thd, namespace1, names1, 1,
-                                               LOCKING_SERVICE_WRITE, 3600));
+    EXPECT_FALSE(acquire_locking_service_locks_nsec(
+        m_thd, namespace1, names1, 1, LOCKING_SERVICE_WRITE, sec3600));
     m_lock_grabbed1->notify();
 
     m_wait->wait_for_notification();
@@ -490,8 +493,8 @@ class LockServiceDeadlockThread : public Thread {
       // We should therefore fail.
       const char *names2[] = {lock_name2};
       Mock_error_handler error_handler(m_thd, ER_LOCKING_SERVICE_DEADLOCK);
-      EXPECT_TRUE(acquire_locking_service_locks(m_thd, namespace1, names2, 1,
-                                                LOCKING_SERVICE_READ, 3600));
+      EXPECT_TRUE(acquire_locking_service_locks_nsec(
+          m_thd, namespace1, names2, 1, LOCKING_SERVICE_READ, sec3600));
       EXPECT_EQ(1, error_handler.handle_called());
     }
 
@@ -524,16 +527,16 @@ TEST_F(LockingServiceTest, DeadlockRead) {
 
   // Acquire write lock on name 2
   const char *names2[] = {lock_name2};
-  EXPECT_FALSE(acquire_locking_service_locks(m_thd, namespace1, names2, 1,
-                                             LOCKING_SERVICE_WRITE, 3600));
+  EXPECT_FALSE(acquire_locking_service_locks_nsec(
+      m_thd, namespace1, names2, 1, LOCKING_SERVICE_WRITE, sec3600));
 
   // Signal the other thread to continue, taking write lock on name1
   wait.notify();
 
   // The other thread will be aborted so that we will acquire the lock.
   const char *names1[] = {lock_name1};
-  EXPECT_FALSE(acquire_locking_service_locks(m_thd, namespace1, names1, 1,
-                                             LOCKING_SERVICE_WRITE, 3600));
+  EXPECT_FALSE(acquire_locking_service_locks_nsec(
+      m_thd, namespace1, names1, 1, LOCKING_SERVICE_WRITE, sec3600));
 
   // Both locks should now be held
   EXPECT_TRUE(m_thd->mdl_context.owns_equal_or_stronger_lock(

--- a/unittest/gunit/mdl-t.cc
+++ b/unittest/gunit/mdl-t.cc
@@ -89,6 +89,8 @@ const char table_name3[] = "some_table3";
 const char table_name4[] = "some_table4";
 const ulong zero_timeout = 0;
 const ulong long_timeout = (ulong)3600L * 24L * 365L;
+const ulonglong long_timeout_nsec =
+    static_cast<ulonglong>(long_timeout) * 1000000000ULL;
 
 class MDLTest : public ::testing::Test, public Test_MDL_context_owner {
  protected:
@@ -216,7 +218,7 @@ void MDL_thread::run() {
   MDL_REQUEST_INIT(&request, MDL_key::TABLE, db_name, m_table_name, m_mdl_type,
                    MDL_TRANSACTION);
 
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&request, long_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&request, long_timeout_nsec));
   EXPECT_TRUE(m_mdl_context.owns_equal_or_stronger_lock(
       MDL_key::TABLE, db_name, m_table_name, m_mdl_type));
 
@@ -315,7 +317,8 @@ TEST_F(MDLTest, OneExclusive) {
   m_request_list.push_front(&m_request);
   m_request_list.push_front(&m_global_request);
 
-  EXPECT_FALSE(m_mdl_context.acquire_locks(&m_request_list, long_timeout));
+  EXPECT_FALSE(
+      m_mdl_context.acquire_locks_nsec(&m_request_list, long_timeout_nsec));
 
   EXPECT_NE(m_null_ticket, m_request.ticket);
   EXPECT_NE(m_null_ticket, m_global_request.ticket);
@@ -400,14 +403,15 @@ TEST_F(MDLTest, UpgradeSharedUpgradable) {
   m_request_list.push_front(&m_request);
   m_request_list.push_front(&m_global_request);
 
-  EXPECT_FALSE(m_mdl_context.acquire_locks(&m_request_list, long_timeout));
-  EXPECT_FALSE(m_mdl_context.upgrade_shared_lock(m_request.ticket,
-                                                 MDL_EXCLUSIVE, long_timeout));
+  EXPECT_FALSE(
+      m_mdl_context.acquire_locks_nsec(&m_request_list, long_timeout_nsec));
+  EXPECT_FALSE(m_mdl_context.upgrade_shared_lock_nsec(
+      m_request.ticket, MDL_EXCLUSIVE, long_timeout_nsec));
   EXPECT_EQ(MDL_EXCLUSIVE, m_request.ticket->get_type());
 
   // Another upgrade should be a no-op.
-  EXPECT_FALSE(m_mdl_context.upgrade_shared_lock(m_request.ticket,
-                                                 MDL_EXCLUSIVE, long_timeout));
+  EXPECT_FALSE(m_mdl_context.upgrade_shared_lock_nsec(
+      m_request.ticket, MDL_EXCLUSIVE, long_timeout_nsec));
   EXPECT_EQ(MDL_EXCLUSIVE, m_request.ticket->get_type());
 
   m_mdl_context.release_transactional_locks();
@@ -475,7 +479,7 @@ TEST_F(MDLTest, ConcurrentShared) {
   MDL_REQUEST_INIT(&m_request, MDL_key::TABLE, db_name, table_name1, MDL_SHARED,
                    MDL_TRANSACTION);
 
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&m_request, long_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&m_request, long_timeout_nsec));
   EXPECT_TRUE(m_mdl_context.owns_equal_or_stronger_lock(
       MDL_key::TABLE, db_name, table_name1, MDL_SHARED));
 
@@ -506,7 +510,7 @@ TEST_F(MDLTest, ConcurrentSharedExclusive) {
   m_request_list.push_front(&m_global_request);
 
   // We should *not* be able to grab the lock here.
-  EXPECT_TRUE(m_mdl_context.acquire_locks(&m_request_list, zero_timeout));
+  EXPECT_TRUE(m_mdl_context.acquire_locks_nsec(&m_request_list, zero_timeout));
   EXPECT_FALSE(m_mdl_context.owns_equal_or_stronger_lock(
       MDL_key::TABLE, db_name, table_name1, MDL_EXCLUSIVE));
 
@@ -514,7 +518,7 @@ TEST_F(MDLTest, ConcurrentSharedExclusive) {
   mdl_thread.join();
 
   // Now we should be able to grab the lock.
-  EXPECT_FALSE(m_mdl_context.acquire_locks(&m_request_list, zero_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_locks_nsec(&m_request_list, zero_timeout));
   EXPECT_NE(m_null_ticket, m_request.ticket);
 
   m_mdl_context.release_transactional_locks();
@@ -542,7 +546,7 @@ TEST_F(MDLTest, ConcurrentExclusiveShared) {
   release_locks.notify();
 
   // The other thread should eventually release its locks.
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&m_request, long_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&m_request, long_timeout_nsec));
   EXPECT_NE(m_null_ticket, m_request.ticket);
 
   mdl_thread.join();
@@ -563,7 +567,8 @@ TEST_F(MDLTest, ConcurrentUpgrade) {
   m_request_list.push_front(&m_request);
   m_request_list.push_front(&m_global_request);
 
-  EXPECT_FALSE(m_mdl_context.acquire_locks(&m_request_list, long_timeout));
+  EXPECT_FALSE(
+      m_mdl_context.acquire_locks_nsec(&m_request_list, long_timeout_nsec));
   EXPECT_TRUE(m_mdl_context.owns_equal_or_stronger_lock(
       MDL_key::TABLE, db_name, table_name1, MDL_SHARED_UPGRADABLE));
   EXPECT_FALSE(m_mdl_context.owns_equal_or_stronger_lock(
@@ -577,8 +582,8 @@ TEST_F(MDLTest, ConcurrentUpgrade) {
   mdl_thread.start();
   lock_grabbed.wait_for_notification();
 
-  EXPECT_FALSE(m_mdl_context.upgrade_shared_lock(m_request.ticket,
-                                                 MDL_EXCLUSIVE, long_timeout));
+  EXPECT_FALSE(m_mdl_context.upgrade_shared_lock_nsec(
+      m_request.ticket, MDL_EXCLUSIVE, long_timeout_nsec));
   EXPECT_TRUE(m_mdl_context.owns_equal_or_stronger_lock(
       MDL_key::TABLE, db_name, table_name1, MDL_EXCLUSIVE));
 
@@ -608,7 +613,7 @@ TEST_F(MDLTest, UpgradableConcurrency) {
                    MDL_SHARED_UPGRADABLE, MDL_TRANSACTION);
   request_list.push_front(&m_global_request);
   request_list.push_front(&request_2);
-  EXPECT_TRUE(m_mdl_context.acquire_locks(&request_list, zero_timeout));
+  EXPECT_TRUE(m_mdl_context.acquire_locks_nsec(&request_list, zero_timeout));
   EXPECT_EQ(m_null_ticket, request_2.ticket);
 
   release_locks.notify();
@@ -2033,10 +2038,11 @@ TEST_F(MDLTest, SelfConflict) {
   /* Acquire S lock, it will be acquired using "fast path" algorithm. */
   MDL_REQUEST_INIT(&m_request, MDL_key::TABLE, db_name, table_name1, MDL_SHARED,
                    MDL_TRANSACTION);
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&m_request, long_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&m_request, long_timeout_nsec));
 
   /* Acquire global IX lock to be able acquire X lock later. */
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&m_global_request, long_timeout));
+  EXPECT_FALSE(
+      m_mdl_context.acquire_lock_nsec(&m_global_request, long_timeout_nsec));
 
   /*
     Acquire X lock on the same table. MDL subsystem should be able to detect
@@ -2045,7 +2051,7 @@ TEST_F(MDLTest, SelfConflict) {
   */
   MDL_REQUEST_INIT(&m_request, MDL_key::TABLE, db_name, table_name1,
                    MDL_EXCLUSIVE, MDL_TRANSACTION);
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&m_request, long_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&m_request, long_timeout_nsec));
 
   m_mdl_context.release_transactional_locks();
 
@@ -2056,7 +2062,8 @@ TEST_F(MDLTest, SelfConflict) {
   */
   MDL_REQUEST_INIT(&m_global_request, MDL_key::GLOBAL, "", "", MDL_SHARED,
                    MDL_TRANSACTION);
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&m_global_request, long_timeout));
+  EXPECT_FALSE(
+      m_mdl_context.acquire_lock_nsec(&m_global_request, long_timeout_nsec));
 
   /*
     Now let us acquire IX lock. Note that S lock is not exactly stronger
@@ -2065,7 +2072,8 @@ TEST_F(MDLTest, SelfConflict) {
   */
   MDL_REQUEST_INIT(&m_global_request, MDL_key::GLOBAL, "", "",
                    MDL_INTENTION_EXCLUSIVE, MDL_TRANSACTION);
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&m_global_request, long_timeout));
+  EXPECT_FALSE(
+      m_mdl_context.acquire_lock_nsec(&m_global_request, long_timeout_nsec));
 
   m_mdl_context.release_transactional_locks();
 }
@@ -2084,7 +2092,7 @@ TEST_F(MDLTest, CloneSharedExclusive) {
   /* Acquire SHARED lock, it will be acquired using "fast path" algorithm. */
   MDL_REQUEST_INIT(&m_request, MDL_key::TABLE, db_name, table_name1, MDL_SHARED,
                    MDL_EXPLICIT);
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&m_request, long_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&m_request, long_timeout_nsec));
 
   /*
     Save initial ticket and create its clone.
@@ -2125,7 +2133,7 @@ TEST_F(MDLTest, CloneExclusiveShared) {
   MDL_REQUEST_INIT(&m_request, MDL_key::TABLE, db_name, table_name1,
                    MDL_EXCLUSIVE, MDL_EXPLICIT);
 
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&m_request, long_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&m_request, long_timeout_nsec));
 
   /*
     Save initial ticket and create its clone.
@@ -2244,14 +2252,15 @@ TEST_F(MDLTest, UpgradeScenarios) {
   /* Acquire S lock to be upgraded. */
   MDL_REQUEST_INIT(&m_request, MDL_key::TABLE, db_name, table_name1, MDL_SHARED,
                    MDL_TRANSACTION);
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&m_request, long_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&m_request, long_timeout_nsec));
 
   /* Acquire IX lock to be able to upgrade. */
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&m_global_request, long_timeout));
+  EXPECT_FALSE(
+      m_mdl_context.acquire_lock_nsec(&m_global_request, long_timeout_nsec));
 
   /* Upgrade S lock to X lock. */
-  EXPECT_FALSE(m_mdl_context.upgrade_shared_lock(m_request.ticket,
-                                                 MDL_EXCLUSIVE, long_timeout));
+  EXPECT_FALSE(m_mdl_context.upgrade_shared_lock_nsec(
+      m_request.ticket, MDL_EXCLUSIVE, long_timeout_nsec));
 
   /*
     Ensure that there is pending S lock, so release of X lock won't destroy
@@ -2291,11 +2300,11 @@ TEST_F(MDLTest, UpgradeScenarios) {
   /* Acquire S lock to be upgraded. */
   MDL_REQUEST_INIT(&m_request, MDL_key::TABLE, db_name, table_name1, MDL_SHARED,
                    MDL_TRANSACTION);
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&m_request, long_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&m_request, long_timeout_nsec));
 
   /* Upgrade S lock to X lock. */
-  EXPECT_FALSE(m_mdl_context.upgrade_shared_lock(m_request.ticket,
-                                                 MDL_EXCLUSIVE, long_timeout));
+  EXPECT_FALSE(m_mdl_context.upgrade_shared_lock_nsec(
+      m_request.ticket, MDL_EXCLUSIVE, long_timeout_nsec));
 
   /*
     Try to acquire X lock, it will block.
@@ -2328,11 +2337,11 @@ TEST_F(MDLTest, UpgradeScenarios) {
   /* Acquire SU lock to be upgraded. */
   MDL_REQUEST_INIT(&m_request, MDL_key::TABLE, db_name, table_name1,
                    MDL_SHARED_UPGRADABLE, MDL_TRANSACTION);
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&m_request, long_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&m_request, long_timeout_nsec));
 
   /* Upgrade SU lock to X lock. */
-  EXPECT_FALSE(m_mdl_context.upgrade_shared_lock(m_request.ticket,
-                                                 MDL_EXCLUSIVE, long_timeout));
+  EXPECT_FALSE(m_mdl_context.upgrade_shared_lock_nsec(
+      m_request.ticket, MDL_EXCLUSIVE, long_timeout_nsec));
 
   /*
     Ensure that there is pending S lock, so release of X lock won't destroy
@@ -2379,7 +2388,7 @@ TEST_F(MDLTest, Deadlock) {
   /* Acquire SR lock which will be granted using "fast path". */
   MDL_REQUEST_INIT(&m_request, MDL_key::TABLE, db_name, table_name1,
                    MDL_SHARED_READ, MDL_TRANSACTION);
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&m_request, long_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&m_request, long_timeout_nsec));
 
   /* Now try to request X lock. This will blocked. */
   mdl_thread.start();
@@ -2396,7 +2405,7 @@ TEST_F(MDLTest, Deadlock) {
 
   MDL_REQUEST_INIT(&m_request, MDL_key::TABLE, db_name, table_name1,
                    MDL_SHARED_WRITE, MDL_TRANSACTION);
-  EXPECT_TRUE(m_mdl_context.acquire_lock(&m_request, long_timeout));
+  EXPECT_TRUE(m_mdl_context.acquire_lock_nsec(&m_request, long_timeout_nsec));
 
   /* Wrap-up. */
   m_mdl_context.release_transactional_locks();
@@ -2414,12 +2423,13 @@ TEST_F(MDLTest, DowngradeShared) {
                         NULL);
 
   /* Acquire global IX lock first to satisfy MDL asserts. */
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&m_global_request, long_timeout));
+  EXPECT_FALSE(
+      m_mdl_context.acquire_lock_nsec(&m_global_request, long_timeout_nsec));
 
   /* Acquire "obtrusive" X lock. */
   MDL_REQUEST_INIT(&m_request, MDL_key::TABLE, db_name, table_name1,
                    MDL_EXCLUSIVE, MDL_TRANSACTION);
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&m_request, long_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&m_request, long_timeout_nsec));
 
   /* Downgrade lock to S lock. */
   m_request.ticket->downgrade_lock(MDL_SHARED);
@@ -2514,7 +2524,8 @@ TEST_F(MDLTest, ConcurrentSharedTryExclusive) {
   first_grabbed.wait_for_notification();
 
   /* Acquire global IX lock to satisfy asserts in MDL subsystem. */
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&m_global_request, long_timeout));
+  EXPECT_FALSE(
+      m_mdl_context.acquire_lock_nsec(&m_global_request, long_timeout_nsec));
   EXPECT_NE(m_null_ticket, m_global_request.ticket);
 
   MDL_REQUEST_INIT(&m_request, MDL_key::TABLE, db_name, table_name1,
@@ -2733,7 +2744,7 @@ TEST_F(MDLTest, UnusedLowWater) {
   for (i = 0; i < TABLES; ++i) {
     MDL_REQUEST_INIT(&request, MDL_key::TABLE, db_name, table_names[i],
                      MDL_SHARED, MDL_TRANSACTION);
-    EXPECT_FALSE(m_mdl_context.acquire_lock(&request, long_timeout));
+    EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&request, long_timeout_nsec));
   }
 
   EXPECT_EQ(0, mdl_get_unused_locks_count());
@@ -2768,7 +2779,7 @@ TEST_F(MDLTest, UnusedMinRatio) {
   for (i = 0; i < TABLES; ++i) {
     MDL_REQUEST_INIT(&request, MDL_key::TABLE, db_name, table_names_a[i],
                      MDL_SHARED, MDL_TRANSACTION);
-    EXPECT_FALSE(m_mdl_context.acquire_lock(&request, long_timeout));
+    EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&request, long_timeout_nsec));
   }
 
   EXPECT_EQ(0, mdl_get_unused_locks_count());
@@ -2780,7 +2791,7 @@ TEST_F(MDLTest, UnusedMinRatio) {
   for (i = 0; i < TABLES; ++i) {
     MDL_REQUEST_INIT(&request, MDL_key::TABLE, db_name, table_names_b[i],
                      MDL_SHARED, MDL_TRANSACTION);
-    EXPECT_FALSE(m_mdl_context.acquire_lock(&request, long_timeout));
+    EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&request, long_timeout_nsec));
   }
 
   /* Now release part of the locks we hold. */
@@ -3547,7 +3558,8 @@ void MDL_SRO_SNRW_thread::run() {
       Lock acquisition should succeed and never deadlock. I.e. we should
       always acquire SNRW first and only then SRO.
     */
-    EXPECT_FALSE(m_mdl_context.acquire_locks(&request_list, long_timeout));
+    EXPECT_FALSE(
+        m_mdl_context.acquire_locks_nsec(&request_list, long_timeout_nsec));
     m_mdl_context.release_transactional_locks();
   }
 }
@@ -3617,7 +3629,7 @@ void MDL_weight_thread::run() {
   MDL_REQUEST_INIT(&request1, MDL_key::TABLE, db_name, table_name1,
                    MDL_SHARED_NO_READ_WRITE, MDL_TRANSACTION);
 
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&request1, long_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&request1, long_timeout_nsec));
 
   m_first_grabbed->notify();
   m_go_for_second->wait_for_notification();
@@ -3633,7 +3645,7 @@ void MDL_weight_thread::run() {
     thread being chosen as victim.
   */
   expected_error = ER_LOCK_DEADLOCK;
-  EXPECT_TRUE(m_mdl_context.acquire_lock(&request2, long_timeout));
+  EXPECT_TRUE(m_mdl_context.acquire_lock_nsec(&request2, long_timeout_nsec));
 
   m_mdl_context.release_transactional_locks();
 }
@@ -3656,7 +3668,7 @@ TEST_F(MDLTest, ForceDMLDeadlockWeight) {
   /* Now let us grab SNRW lock table_name2. */
   MDL_REQUEST_INIT(&m_request, MDL_key::TABLE, db_name, table_name2,
                    MDL_SHARED_NO_READ_WRITE, MDL_TRANSACTION);
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&m_request, long_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&m_request, long_timeout_nsec));
 
   /*
     Resume the concurrent thread. It should try to acquire SNRW lock on
@@ -3678,7 +3690,7 @@ TEST_F(MDLTest, ForceDMLDeadlockWeight) {
   */
   MDL_REQUEST_INIT(&m_request, MDL_key::TABLE, db_name, table_name1,
                    MDL_SHARED_NO_READ_WRITE, MDL_TRANSACTION);
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&m_request, long_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&m_request, long_timeout_nsec));
 
   m_mdl_context.release_transactional_locks();
 
@@ -3832,7 +3844,7 @@ TEST_F(MDLHtonNotifyTest, NotifyNamespaces) {
     MDL_REQUEST_INIT(&request, static_cast<MDL_key::enum_mdl_namespace>(i), "",
                      "",  // To work with GLOBAL/COMMIT spaces
                      MDL_EXCLUSIVE, MDL_TRANSACTION);
-    EXPECT_FALSE(m_mdl_context.acquire_lock(&request, long_timeout));
+    EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&request, long_timeout_nsec));
     m_mdl_context.release_transactional_locks();
 
     if (notify_or_not[i]) {
@@ -3857,7 +3869,7 @@ TEST_F(MDLHtonNotifyTest, NotifyLockTypes) {
   MDL_REQUEST_INIT(&request, MDL_key::SCHEMA, db_name, "",
                    MDL_INTENTION_EXCLUSIVE, MDL_TRANSACTION);
 
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&request, long_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&request, long_timeout_nsec));
   m_mdl_context.release_transactional_locks();
 
   EXPECT_EQ(0U, pre_acquire_count());
@@ -3872,7 +3884,7 @@ TEST_F(MDLHtonNotifyTest, NotifyLockTypes) {
     MDL_REQUEST_INIT(&request, MDL_key::TABLE, db_name, table_name1,
                      static_cast<enum_mdl_type>(i), MDL_TRANSACTION);
 
-    EXPECT_FALSE(m_mdl_context.acquire_lock(&request, long_timeout));
+    EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&request, long_timeout_nsec));
     m_mdl_context.release_transactional_locks();
 
     EXPECT_EQ(0U, pre_acquire_count());
@@ -3883,7 +3895,7 @@ TEST_F(MDLHtonNotifyTest, NotifyLockTypes) {
   MDL_REQUEST_INIT(&request, MDL_key::TABLE, db_name, table_name1,
                    MDL_EXCLUSIVE, MDL_TRANSACTION);
 
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&request, long_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&request, long_timeout_nsec));
   m_mdl_context.release_transactional_locks();
 
   EXPECT_EQ(1U, pre_acquire_count());
@@ -3906,7 +3918,7 @@ TEST_F(MDLHtonNotifyTest, NotifyAcquireRelease) {
   MDL_REQUEST_INIT(&request1, MDL_key::TABLE, db_name, table_name1,
                    MDL_EXCLUSIVE, MDL_TRANSACTION);
 
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&request1, long_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&request1, long_timeout_nsec));
   EXPECT_EQ(1U, pre_acquire_count());
   EXPECT_EQ(0U, post_release_count());
   EXPECT_TRUE(pre_acquire_key().is_equal(&request1.key));
@@ -3926,13 +3938,13 @@ TEST_F(MDLHtonNotifyTest, NotifyAcquireRelease) {
   MDL_REQUEST_INIT(&request2, MDL_key::TABLE, db_name, table_name1,
                    MDL_EXCLUSIVE, MDL_TRANSACTION);
 
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&request1, long_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&request1, long_timeout_nsec));
   EXPECT_EQ(1U, pre_acquire_count());
   EXPECT_EQ(0U, post_release_count());
   EXPECT_TRUE(pre_acquire_key().is_equal(&request1.key));
 
   // The second acquisition should not cause notification.
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&request2, long_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&request2, long_timeout_nsec));
   EXPECT_EQ(1U, pre_acquire_count());
   EXPECT_EQ(0U, post_release_count());
 
@@ -3951,7 +3963,7 @@ TEST_F(MDLHtonNotifyTest, NotifyAcquireRelease) {
   expected_error = ER_LOCK_REFUSED_BY_ENGINE;
   set_refuse_acquire();
 
-  EXPECT_TRUE(m_mdl_context.acquire_lock(&request1, long_timeout));
+  EXPECT_TRUE(m_mdl_context.acquire_lock_nsec(&request1, long_timeout_nsec));
   EXPECT_EQ(1U, pre_acquire_count());
   EXPECT_EQ(0U, post_release_count());
   EXPECT_FALSE(m_mdl_context.owns_equal_or_stronger_lock(
@@ -4000,7 +4012,7 @@ TEST_F(MDLHtonNotifyTest, NotifyAcquireFail) {
   */
   expected_error = ER_LOCK_WAIT_TIMEOUT;
 
-  EXPECT_TRUE(m_mdl_context.acquire_lock(&request, zero_timeout));
+  EXPECT_TRUE(m_mdl_context.acquire_lock_nsec(&request, zero_timeout));
   /*
     Again we treat failure to acquire X lock after successfull pre-acquire
     notification in the same way as lock release.
@@ -4025,9 +4037,9 @@ TEST_F(MDLHtonNotifyTest, NotifyUpgrade) {
                    MDL_SHARED_UPGRADABLE, MDL_TRANSACTION);
 
   // Check that we notify SE about upgrade.
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&request, long_timeout));
-  EXPECT_FALSE(m_mdl_context.upgrade_shared_lock(request.ticket, MDL_EXCLUSIVE,
-                                                 long_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&request, long_timeout_nsec));
+  EXPECT_FALSE(m_mdl_context.upgrade_shared_lock_nsec(
+      request.ticket, MDL_EXCLUSIVE, long_timeout_nsec));
 
   EXPECT_EQ(1U, pre_acquire_count());
   EXPECT_EQ(0U, post_release_count());
@@ -4036,8 +4048,8 @@ TEST_F(MDLHtonNotifyTest, NotifyUpgrade) {
       MDL_key::TABLE, db_name, table_name1, MDL_EXCLUSIVE));
 
   // Second attempt to upgrade should not cause additional notification.
-  EXPECT_FALSE(m_mdl_context.upgrade_shared_lock(request.ticket, MDL_EXCLUSIVE,
-                                                 long_timeout));
+  EXPECT_FALSE(m_mdl_context.upgrade_shared_lock_nsec(
+      request.ticket, MDL_EXCLUSIVE, long_timeout_nsec));
   EXPECT_EQ(1U, pre_acquire_count());
   EXPECT_EQ(0U, post_release_count());
 
@@ -4052,13 +4064,13 @@ TEST_F(MDLHtonNotifyTest, NotifyUpgrade) {
   MDL_REQUEST_INIT(&request, MDL_key::TABLE, db_name, table_name1,
                    MDL_SHARED_UPGRADABLE, MDL_TRANSACTION);
 
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&request, long_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&request, long_timeout_nsec));
 
   expected_error = ER_LOCK_REFUSED_BY_ENGINE;
   set_refuse_acquire();
 
-  EXPECT_TRUE(m_mdl_context.upgrade_shared_lock(request.ticket, MDL_EXCLUSIVE,
-                                                long_timeout));
+  EXPECT_TRUE(m_mdl_context.upgrade_shared_lock_nsec(
+      request.ticket, MDL_EXCLUSIVE, long_timeout_nsec));
   EXPECT_EQ(1U, pre_acquire_count());
   EXPECT_EQ(0U, post_release_count());
   EXPECT_FALSE(m_mdl_context.owns_equal_or_stronger_lock(
@@ -4085,12 +4097,12 @@ TEST_F(MDLHtonNotifyTest, NotifyUpgrade) {
   MDL_REQUEST_INIT(&request, MDL_key::TABLE, db_name, table_name1,
                    MDL_SHARED_UPGRADABLE, MDL_TRANSACTION);
 
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&request, long_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&request, long_timeout_nsec));
 
   expected_error = ER_LOCK_WAIT_TIMEOUT;
 
-  EXPECT_TRUE(m_mdl_context.upgrade_shared_lock(request.ticket, MDL_EXCLUSIVE,
-                                                zero_timeout));
+  EXPECT_TRUE(m_mdl_context.upgrade_shared_lock_nsec(
+      request.ticket, MDL_EXCLUSIVE, zero_timeout));
 
   /*
     Failure to upgrade lock after successful notification is treated as release.
@@ -4121,7 +4133,7 @@ TEST_F(MDLHtonNotifyTest, NotifyDowngrade) {
                    MDL_EXCLUSIVE, MDL_TRANSACTION);
 
   // Acquire X lock.
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&request, long_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&request, long_timeout_nsec));
   EXPECT_EQ(1U, pre_acquire_count());
   EXPECT_EQ(0U, post_release_count());
   EXPECT_TRUE(pre_acquire_key().is_equal(&request.key));
@@ -4158,7 +4170,7 @@ TEST_F(MDLHtonNotifyTest, NotifyClone) {
   MDL_REQUEST_INIT(&request1, MDL_key::TABLE, db_name, table_name1,
                    MDL_EXCLUSIVE, MDL_TRANSACTION);
 
-  EXPECT_FALSE(m_mdl_context.acquire_lock(&request1, long_timeout));
+  EXPECT_FALSE(m_mdl_context.acquire_lock_nsec(&request1, long_timeout_nsec));
   EXPECT_EQ(1U, pre_acquire_count());
   EXPECT_EQ(0U, post_release_count());
   EXPECT_TRUE(pre_acquire_key().is_equal(&request1.key));

--- a/unittest/gunit/mdl_sync-t.cc
+++ b/unittest/gunit/mdl_sync-t.cc
@@ -132,7 +132,8 @@ class MDLSyncThread : public Thread {
       MDL_REQUEST_INIT(&request, MDL_key::TABLE, "db", m_pre_table,
                        m_pre_mdl_type, MDL_TRANSACTION);
 
-      EXPECT_FALSE(m_mdl_context->acquire_lock(&request, 3600));
+      EXPECT_FALSE(
+          m_mdl_context->acquire_lock_nsec(&request, 3600000000000ULL));
 
       /* The above should not generate any warnings (e.g. about timeouts). */
       EXPECT_EQ(0, error_handler.handle_called());
@@ -153,7 +154,8 @@ class MDLSyncThread : public Thread {
       MDL_REQUEST_INIT(&request, MDL_key::TABLE, "db", m_main_table,
                        m_main_mdl_type, MDL_TRANSACTION);
 
-      EXPECT_FALSE(m_mdl_context->acquire_lock(&request, 3600));
+      EXPECT_FALSE(
+          m_mdl_context->acquire_lock_nsec(&request, 3600000000000ULL));
       EXPECT_TRUE(m_mdl_context->owns_equal_or_stronger_lock(
           MDL_key::TABLE, "db", m_main_table, m_main_mdl_type));
 


### PR DESCRIPTION
For a first review, I only added the code changes to this pull request for two reasons:
* a full test is still running, and I'll have to check the results (I do see a few non output only failures because timeouts, so looks like I missed some nsec-sec conversion in this diff - I'll fix that and update). And checking output changes / rerecording will take time.
* compared to the 5.6 patch, the code change for 8.0 is huge, and affects the service api - reviewing only the code changes is probably a good idea

Jira ticket: https://jira.percona.com/browse/FB8-104

Reference commit: https://github.com/facebook/mysql-5.6/commit/c21adb7

Currently lock_wait_timeout is an integer type variable which only have
seconds resolution. We would want to extend the variable to double/decimal
type, so it can have milliseconds or microseconds resolution, such as
lock_wait_timeout = 1.23. The integral part should still mean seconds to
keep backward compatibility.

The range of valid values expanded to [ 0 .. 604800 ] to allow timeouts below
1 second; such as lock_wait_timeout = 0.005.  Values that are too small
will effectively mean not waiting for locks.

This update also changes the output of lock_wait_timeout to be decimal;
note the extra .000000 appended to the seconds.

    SELECT @global.lock_wait_timeout;
    @global.lock_wait_timeout
    604800.000000