### PR TITLE
FB8-139: TraceID support in MySQLD

### DIFF
--- a/mysql-test/r/slow_log_extra_big.result
+++ b/mysql-test/r/slow_log_extra_big.result
@@ -21,9 +21,13 @@ count(*)
 select count(*) from big_table_slow where id < 100;
 count(*)
 49
+set session long_query_time = 10000;
+select count(*) from big_table_slow where id > 300;
+count(*)
+50
 # Cleanup
 set global slow_query_log_file = @my_slow_logname;
-set global long_query_time=@my_long_query_time;
+set global long_query_time = @my_long_query_time;
 drop table big_table_slow;
 #
 # This is a hack to check the log result.
@@ -38,5 +42,6 @@ Rows_sent	Rows_examined	Errno	Killed	Bytes_received	Bytes_sent	Read_first	Read_l
 1	1	0	0	0	307	0	0	1	0	0	0	0	0	0	0	0	0
 1	150	0	0	0	58	0	0	1	150	0	0	0	0	0	0	0	0
 1	49	0	0	0	57	1	0	1	49	0	0	0	0	0	0	0	0
+1	50	0	0	0	57	0	0	1	50	0	0	0	0	0	0	0	0
 if the following is not 1 you need to adjust the file_lines_count variable
 1

--- a/mysql-test/t/slow_log_extra_big.test
+++ b/mysql-test/t/slow_log_extra_big.test
@@ -50,19 +50,25 @@ select count(*) from big_table_slow where id >100;
 
 select count(*) from big_table_slow where id < 100;
 
+connect (con2, localhost,root,,);
+set session long_query_time = 10000;
+query_attrs_add traceid foobar;
+select count(*) from big_table_slow where id > 300;
+query_attrs_delete traceid;
+
 # Wait for all output lines to show up in the slow log file
-let $file_lines_count= 6;
+let $file_lines_count= 7;
 let $file_lines_pattern= ^# Query_time;
-let $file_lines_filename=
-    $MYSQLTEST_VARDIR/mysqld.1/data/slow_log_extra_big-slow.log;
+let $file_lines_filename= $MYSQLTEST_VARDIR/mysqld.1/data/slow_log_extra_big-slow.log;
 --source include/wait_for_file_lines.inc
 
 --echo # Cleanup
 
 connection default;
 set global slow_query_log_file = @my_slow_logname;
-set global long_query_time=@my_long_query_time;
+set global long_query_time = @my_long_query_time;
 
+disconnect con2;
 disconnect con1;
 disconnect con;
 --source include/wait_until_count_sessions.inc
@@ -72,5 +78,10 @@ drop table big_table_slow;
 let $slow_log_output_filename = $file_lines_filename;
 let $slow_log_output_count = $file_lines_count;
 --source include/validate_slow_log_output.inc
+
+# Check if our Trace_Id is included the log results
+let SEARCH_FILE = $file_lines_filename;
+let SEARCH_PATTERN= Trace_Id: foobar;
+--source include/search_pattern_in_file.inc
 
 --exit

--- a/mysys/CMakeLists.txt
+++ b/mysys/CMakeLists.txt
@@ -99,6 +99,7 @@ SET(MYSYS_SOURCES
   my_user.cc
   my_write.cc
   pack.cc
+  perf_counters.cc
   print_version.cc
   psi_noop.cc
   ptr_cmp.cc

--- a/mysys/perf_counters.cc
+++ b/mysys/perf_counters.cc
@@ -1,0 +1,190 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+#include "perf_counters.h"
+#include <cassert>
+#include <memory>
+#include <string>
+#include <utility>
+
+#if defined(FB_DYNO) && FB_DYNO
+#include <dyno_counters.h>
+#endif
+
+#include <ctime>
+
+static inline uint64_t diff_timespec(const timespec &ts1,
+                                     const timespec &ts2) noexcept {
+  return ((ts1.tv_sec - ts2.tv_sec) * 1000000000ULL + ts1.tv_nsec -
+          ts2.tv_nsec);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+namespace utils {
+
+template <class T>
+using unique_ptr = std::unique_ptr<T>;
+
+class SimplePerfCounterFactory : public PerfCounterFactory {
+  std::shared_ptr<PerfCounter> makeSharedPerfCounter(
+      PerfCounterMode mode, PerfCounterType c_type) const override;
+
+  std::unique_ptr<PerfCounter> makePerfCounter(
+      PerfCounterMode mode, PerfCounterType c_type) const override;
+};
+
+class ThreadPerfCounterImpl : public PerfCounter {
+ private:
+  PerfCounterType _counter_type;
+  timespec _time_beg;
+  bool _started;
+
+  uint64_t get_impl(timespec *time_cur) const noexcept;
+
+ public:
+  explicit ThreadPerfCounterImpl(PerfCounterType counterType)
+      : _counter_type(counterType), _started(false) {}
+
+  void start() noexcept override;
+  void stop() noexcept override { _started = false; }
+  uint64_t get() const noexcept override {
+    timespec time_cur;
+    return get_impl(&time_cur);
+  }
+
+  uint64_t getAndRestart() noexcept override {
+    timespec time_cur;
+    const uint64_t diff_cost = get_impl(&time_cur);
+    _time_beg = time_cur;
+    _started = true;
+    return diff_cost;
+  }
+  uint64_t getAndStop() noexcept override {
+    const uint64_t diff_cost = get();
+    _started = false;
+    return diff_cost;
+  }
+  float getMultiplexFactor() const noexcept override { return 1.0; }
+};
+
+void ThreadPerfCounterImpl::start() noexcept {
+  const int cpu_res = clock_gettime(CLOCK_THREAD_CPUTIME_ID, &_time_beg);
+  _started = (cpu_res == 0);
+}
+
+uint64_t ThreadPerfCounterImpl::get_impl(timespec *time_cur) const noexcept {
+  if (!_started) return 0;
+
+  const int cpu_cur = clock_gettime(CLOCK_THREAD_CPUTIME_ID, time_cur);
+  if (cpu_cur != 0) return 0;
+
+  const uint64_t diff_ns = diff_timespec((*time_cur), _time_beg);
+  // assuming 2.4 GHz.
+  return ((diff_ns * 1.0) / 0.41666);
+}
+
+class ProcessPerfCounterImpl : public PerfCounter {
+ public:
+  explicit ProcessPerfCounterImpl(PerfCounterType) {}
+
+  void start() noexcept override {}
+  void stop() noexcept override {}
+  uint64_t get() const noexcept override { return 0; }
+  uint64_t getAndRestart() noexcept override { return 0; }
+  uint64_t getAndStop() noexcept override { return 0; }
+  float getMultiplexFactor() const noexcept override { return 1.0; }
+};
+
+template <PerfCounterMode>
+struct CounterModeToType;
+
+template <>
+struct CounterModeToType<PerfCounterMode::THREAD> {
+  using type = ThreadPerfCounterImpl;
+};
+
+template <>
+struct CounterModeToType<PerfCounterMode::PROCESS> {
+  using type = ProcessPerfCounterImpl;
+};
+
+template <template <typename> class T, class D, class... Args>
+struct PerfCounterMaker;
+
+template <class D, class... Args>
+struct PerfCounterMaker<std::shared_ptr, D, Args...> {
+  static std::shared_ptr<D> make(Args &&... args) {
+    return std::make_shared<D>(std::forward<Args>(args)...);
+  }
+};
+
+template <class D, class... Args>
+struct PerfCounterMaker<unique_ptr, D, Args...> {
+  static std::unique_ptr<D> make(Args &&... args) {
+    return std::unique_ptr<D>(new D(std::forward<Args>(args)...));
+  }
+};
+
+template <template <typename> class T, PerfCounterMode mode, class... Args>
+T<PerfCounter> makePerfCounterBase(PerfCounterType counterType,
+                                   Args &&... args) {
+  return PerfCounterMaker<
+      T, typename CounterModeToType<mode>::type, PerfCounterType,
+      Args...>::make(std::forward<PerfCounterType>(counterType),
+                     std::forward<Args>(args)...);
+}
+
+template <PerfCounterMode mode, class... Args>
+std::shared_ptr<PerfCounter> makeSharedPerfCounter(PerfCounterType counterType,
+                                                   Args &&... args) {
+  return makePerfCounterBase<std::shared_ptr, mode, Args...>(
+      counterType, std::forward<Args>(args)...);
+}
+
+template <PerfCounterMode mode, class... Args>
+std::unique_ptr<PerfCounter> makePerfCounter(PerfCounterType counterType,
+                                             Args &&... args) {
+  return makePerfCounterBase<unique_ptr, mode, Args...>(
+      counterType, std::forward<Args>(args)...);
+}
+
+std::shared_ptr<PerfCounter> SimplePerfCounterFactory::makeSharedPerfCounter(
+    PerfCounterMode mode, PerfCounterType c_type) const {
+  switch (mode) {
+    case PerfCounterMode::THREAD:
+      return utils::makeSharedPerfCounter<PerfCounterMode::THREAD>(c_type);
+    case PerfCounterMode::PROCESS:
+      return utils::makeSharedPerfCounter<PerfCounterMode::PROCESS>(c_type);
+    default:
+      assert(0);
+  }
+  return nullptr;
+}
+
+std::unique_ptr<PerfCounter> SimplePerfCounterFactory::makePerfCounter(
+    PerfCounterMode mode, PerfCounterType c_type) const {
+  switch (mode) {
+    case PerfCounterMode::THREAD:
+      return utils::makePerfCounter<PerfCounterMode::THREAD>(c_type);
+    case PerfCounterMode::PROCESS:
+      return utils::makePerfCounter<PerfCounterMode::PROCESS>(c_type);
+    default:
+      assert(0);
+  }
+  return nullptr;
+}
+
+std::shared_ptr<PerfCounterFactory> PerfCounterFactory::getFactory(
+    const std::string &factory_name) {
+#if defined(FB_DYNO) && FB_DYNO
+  // this should bleed into FB code and FB libraries
+  if (factory_name == "dyno") {
+    return DynoPerfCounterFactory();
+  }
+#endif
+
+  if (factory_name == "simple") {
+    return std::shared_ptr<PerfCounterFactory>(new SimplePerfCounterFactory);
+  }
+  return nullptr;
+}
+
+}  // namespace utils

--- a/mysys/perf_counters.h
+++ b/mysys/perf_counters.h
@@ -1,0 +1,65 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#ifndef PERF_COUNTERS_H_INCLUDED
+#define PERF_COUNTERS_H_INCLUDED
+
+#include <cstdint>
+
+#include <memory>
+#include <string>
+
+namespace utils {
+
+enum class PerfCounterMode {
+  THREAD = 1,
+  PROCESS = 2,
+};
+
+enum class PerfCounterType {
+  INSTRUCTIONS = 1,
+  CPU_CYCLES = 2,
+};
+
+class PerfCounter {
+ public:
+  virtual ~PerfCounter() noexcept {}
+
+  // call start() in order to start counter
+  virtual void start() noexcept = 0;
+
+  // call stop() in order to stop counter
+  virtual void stop() noexcept = 0;
+
+  // get() will return the accumulated counter value
+  // since start() or getAndRestart() call.
+  // get() will not reset the counter,
+  // so consecutive get() calls will return increasing values
+  virtual uint64_t get() const noexcept = 0;
+
+  // similar to get() but getAndRestart() resets the counter.
+  virtual uint64_t getAndRestart() noexcept = 0;
+
+  // similar to get() but getAndStop() stops the counter.
+  virtual uint64_t getAndStop() noexcept = 0;
+
+  // returns the multiplex factor
+  virtual float getMultiplexFactor() const noexcept = 0;
+};
+
+class PerfCounterFactory {
+ public:
+  static std::shared_ptr<PerfCounterFactory> getFactory(
+      const std::string &factory_name);
+
+  virtual std::shared_ptr<PerfCounter> makeSharedPerfCounter(
+      PerfCounterMode mode, PerfCounterType c_type) const = 0;
+
+  virtual std::unique_ptr<PerfCounter> makePerfCounter(
+      PerfCounterMode mode, PerfCounterType c_type) const = 0;
+
+  virtual ~PerfCounterFactory() noexcept {};
+};
+
+}  // namespace utils
+
+#endif  // #ifndef PERF_COUNTERS_H_INCLUDED

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -694,6 +694,7 @@ bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
   size_t buff_len;
   end = buff;
 
+  const bool tid_present = !(thd->trace_id.empty());
   mysql_mutex_lock(&LOCK_log);
   DBUG_ASSERT(is_open());
 
@@ -745,7 +746,8 @@ bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
         " Sort_rows: %lu Sort_scan_count: %lu"
         " Created_tmp_disk_tables: %lu"
         " Created_tmp_tables: %lu"
-        " Start: %s End: %s";
+        " Start: %s End: %s"
+        " Trace_Id: %s Instruction_Cost: %lu\n";
 
     // If the query start status is valid - i.e. the current thread's
     // status values should be no less than the query start status,
@@ -806,7 +808,9 @@ bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
                   query_start->created_tmp_disk_tables),
           (ulong)(thd->status_var.created_tmp_tables -
                   query_start->created_tmp_tables),
-          start_time_buff, end_time_buff);
+          start_time_buff, end_time_buff,
+          (tid_present ? thd->trace_id.c_str() : "NA"),
+          (tid_present ? thd->pc_val : 0));
     } else {
       error = my_b_printf(
           &log_file, log_str, query_time_buff, lock_time_buff,
@@ -828,7 +832,8 @@ bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
           (ulong)thd->status_var.filesort_scan_count,
           (ulong)thd->status_var.created_tmp_disk_tables,
           (ulong)thd->status_var.created_tmp_tables, start_time_buff,
-          end_time_buff);
+          end_time_buff, (tid_present ? thd->trace_id.c_str() : "NA"),
+          (tid_present ? thd->pc_val : 0));
     }
     if (error == (uint)-1) goto err;
 
@@ -1761,9 +1766,10 @@ bool log_slow_applicable(THD *thd) {
          opt_log_queries_not_using_indexes &&
          !(sql_command_flags[thd->lex->sql_command] & CF_STATUS_COMMAND));
     bool log_this_query =
-        ((thd->server_status & SERVER_QUERY_WAS_SLOW) || warn_no_index) &&
-        (thd->get_examined_row_count() >=
-         thd->variables.min_examined_row_limit);
+        (((thd->server_status & SERVER_QUERY_WAS_SLOW) || warn_no_index) &&
+         (thd->get_examined_row_count() >=
+          thd->variables.min_examined_row_limit)) ||
+        !thd->trace_id.empty();
     bool suppress_logging = log_throttle_qni.log(thd, warn_no_index);
 
     if (!suppress_logging && log_this_query) DBUG_RETURN(true);

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -2917,9 +2917,12 @@ void THD::set_query_attrs(const char *attrs, size_t length) {
 
 int THD::parse_query_info_attr() {
   static const std::string query_info_key = "query_info";
+  static const std::string traceid_key = "traceid";
 
   for (const auto &kvp : query_attrs_list) {
-    if (kvp.first == query_info_key) {
+    if (kvp.first == traceid_key)
+      this->trace_id = kvp.second;
+    else if (kvp.first == query_info_key) {
       ptree root;
       try {
         std::istringstream query_info_attr(kvp.second);

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -141,6 +141,10 @@ class Dictionary_client;
 class DD_kill_immunizer;
 }  // namespace dd
 
+namespace utils {
+class PerfCounter;
+}
+
 class Internal_error_handler;
 class Modification_plan;
 class Query_result;
@@ -3802,6 +3806,8 @@ class THD : public MDL_context_owner,
   uint64_t num_queries;
   std::string query_type;
   std::string trace_id;
+  uint64_t pc_val;
+  std::shared_ptr<utils::PerfCounter> query_perf;
 
  private:
   /** The current internal error handler for this thread, or NULL. */

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -68,6 +68,7 @@
 #include "mysql/psi/mysql_statement.h"
 #include "mysql/service_mysql_alloc.h"
 #include "mysqld_error.h"
+#include "mysys/perf_counters.h"
 #include "mysys_err.h"  // EE_CAPACITY_EXCEEDED
 #include "nullable.h"
 #include "pfs_thread_provider.h"
@@ -1488,6 +1489,10 @@ static void check_secondary_engine_statement(THD *thd,
   mysql_parse(thd, parser_state, true /* force_primary_storage_engine */);
 }
 
+static std::string perf_counter_factory_name() { return "simple"; };
+static std::shared_ptr<utils::PerfCounterFactory> pc_factory =
+    utils::PerfCounterFactory::getFactory(perf_counter_factory_name());
+
 /**
   Perform one connection-level (COM_XXXX) command.
 
@@ -1769,6 +1774,15 @@ bool dispatch_command(THD *thd, const COM_DATA *com_data,
       const unsigned int attrslen = com_data->com_query.query_attrs_length;
       thd->set_query_attrs(attrs, attrslen);
       thd->parse_query_info_attr();
+
+      if (!thd->trace_id.empty()) {
+        if (!thd->query_perf) {
+          thd->query_perf = pc_factory->makeSharedPerfCounter(
+              utils::PerfCounterMode::THREAD,
+              utils::PerfCounterType::INSTRUCTIONS);
+        }
+        thd->query_perf->start();
+      }
 
       if (alloc_query(thd, com_data->com_query.query,
                       com_data->com_query.length))
@@ -2175,6 +2189,11 @@ done:
      execution of the command at thie point. */
   mysql_audit_notify(thd, AUDIT_EVENT(MYSQL_AUDIT_COMMAND_END), command,
                      command_name[command].str);
+
+  DBUG_ASSERT(thd->trace_id.empty() || command == COM_QUERY);
+  if (command == COM_QUERY && !thd->trace_id.empty()) {
+    thd->pc_val = thd->query_perf->getAndStop();
+  }
 
   log_slow_statement(thd, query_start_status_ptr);
 


### PR DESCRIPTION
Summary:

Jira issue: https://jira.percona.com/browse/FB8-139

Reference Patch: https://github.com/facebook/mysql-5.6/commit/18c1e44

Enables traces to be passed in as query attributes by
clients and traces (instruction costs) to be collected on server
side.

Originally Reviewed By: abhinav04sharma