### PR TITLE
FB8-128: track Semisync_ack Engine_commit time in slow query log

### DIFF
--- a/mysql-test/r/slow_log_engine_fields.result
+++ b/mysql-test/r/slow_log_engine_fields.result
@@ -1,0 +1,4 @@
+SET SESSION long_query_time = 0;
+CREATE TABLE t1 (A INT);
+INSERT INTO t1 VALUES (1),(2),(3);
+DROP TABLE t1;

--- a/mysql-test/t/slow_log_engine_fields-master.opt
+++ b/mysql-test/t/slow_log_engine_fields-master.opt
@@ -1,0 +1,1 @@
+--slow-query-log=1 --log-slow-extra=1

--- a/mysql-test/t/slow_log_engine_fields.test
+++ b/mysql-test/t/slow_log_engine_fields.test
@@ -1,0 +1,16 @@
+SET SESSION long_query_time = 0;
+
+CREATE TABLE t1 (A INT);
+INSERT INTO t1 VALUES (1),(2),(3);
+
+--let SEARCH_FILE = $MYSQLTEST_VARDIR/mysqld.1/mysqld-slow.log
+
+# Check if Semisync_ack_time is included in slow log results
+--let SEARCH_PATTERN= Semisync_ack_time:
+--source include/search_pattern_in_file.inc
+
+# Check if Engine_commit_time is included in slow log results
+--let SEARCH_PATTERN= Engine_commit_time:
+--source include/search_pattern_in_file.inc
+
+DROP TABLE t1;

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -8716,8 +8716,12 @@ commit_stage:
     DBUG_EXECUTE_IF("semi_sync_3-way_deadlock",
                     DEBUG_SYNC(thd, "before_process_commit_stage_queue"););
 
-    if (flush_error == 0 && sync_error == 0)
+    ulonglong start_time;
+    if (flush_error == 0 && sync_error == 0) {
+      start_time = my_timer_now();
       sync_error = call_after_sync_hook(commit_queue);
+      thd->semisync_ack_time = my_timer_since(start_time);
+    }
 
     /*
       process_commit_stage_queue will call update_on_commit or
@@ -8734,7 +8738,9 @@ commit_stage:
       Gtid_set, and adding and removing intervals requires a mutex,
       which would reduce performance.
     */
+    start_time = my_timer_now();
     process_commit_stage_queue(thd, commit_queue);
+    thd->engine_commit_time = my_timer_since(start_time);
     mysql_mutex_unlock(&LOCK_commit);
     /*
       Process after_commit after LOCK_commit is released for avoiding

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -745,7 +745,7 @@ bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
         " Sort_rows: %lu Sort_scan_count: %lu"
         " Created_tmp_disk_tables: %lu"
         " Created_tmp_tables: %lu"
-        " Start: %s End: %s\n";
+        " Start: %s End: %s";
 
     // If the query start status is valid - i.e. the current thread's
     // status values should be no less than the query start status,
@@ -831,6 +831,17 @@ bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
           end_time_buff);
     }
     if (error == (uint)-1) goto err;
+
+    static const char *times =
+        " Semisync_ack_time: %s Engine_commit_time: %s\n";
+    /* Semisync ack time and Engine commit time  */
+    sprintf(query_time_buff, "%.6f",
+            my_timer_to_seconds(thd->semisync_ack_time));
+    sprintf(lock_time_buff, "%.6f",
+            my_timer_to_seconds(thd->engine_commit_time));
+    if (my_b_printf(&log_file, times, query_time_buff, lock_time_buff) ==
+        (uint)-1)
+      goto err;
   }
   if (thd->db().str && strcmp(thd->db().str, db)) {  // Database changed
     if (my_b_printf(&log_file, "use %s;\n", thd->db().str) == (uint)-1)

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -1263,6 +1263,10 @@ class THD : public MDL_context_owner,
   struct timeval start_time;
   struct timeval user_time;
   ulonglong start_utime, utime_after_lock;
+  /* record the semisync ack time */
+  ulonglong semisync_ack_time = 0;
+  /* record the engine commit time */
+  ulonglong engine_commit_time = 0;
 
   /**
     Type of lock to be used for all DML statements, except INSERT, in cases


### PR DESCRIPTION
Jira issue: https://jira.percona.com/browse/FB8-128

Reference Patch: https://github.com/facebook/mysql-5.6/commit/2dd16b3

Closes https://github.com/facebook/mysql-5.6/pull/681

Originally Reviewed By: lth