### PR TITLE
Fix binlog_cache_write_failure after FB8-136: Wait on disk full for binlog cache

### DIFF
--- a/mysql-test/suite/binlog/r/binlog_cache_write_failure.result
+++ b/mysql-test/suite/binlog/r/binlog_cache_write_failure.result
@@ -5,6 +5,7 @@ RESET MASTER;
 CREATE TABLE t1(c1 varchar(8192));
 CREATE TABLE t2(c1 varchar(8192));
 CREATE TABLE t3(c1 varchar(8192));
+SET @saved_binlog_cache_size = @@global.binlog_cache_size;
 SET GLOBAL binlog_cache_size = 4096;
 
 # Case 1 Simulate my_b_flush_io_cache failure when truncating binlog
@@ -42,47 +43,6 @@ SET SESSION debug = "-d,simulate_error_during_flush_cache_to_file";
 BEGIN;
 INSERT INTO t1 VALUES (repeat('a', 8192));
 SET SESSION debug = "+d,simulate_error_during_flush_cache_to_file";
-
-# Case 4 Simulate write failure when reinitializing binlog cache for
-#        copying to binlog. The error should be ignored and cache
-#        is cleared correctly if binlog_error_action is IGNORE_ERROR
-#
-TRUNCATE t1;
-include/save_binlog_position.inc
-SET GLOBAL binlog_error_action = IGNORE_ERROR;
-BEGIN;
-INSERT INTO t1 VALUES (repeat('a', 8192));
-SET SESSION debug = "+d,simulate_tmpdir_partition_full";
-COMMIT;
-Warnings:
-Error	3	Error writing file <tmp_file_name> (Errcode: ##)
-Error	1026	Error writing file <tmp_file_name> (Errcode: ##)
-SET SESSION debug = "-d,simulate_tmpdir_partition_full";
-include/assert_grep.inc [An error occurred during flush stage of the commit. 'binlog_error_action' is set to 'IGNORE_ERROR'.]
-# restart
-include/show_binlog_events.inc
-Log_name	Pos	Event_type	Server_id	End_log_pos	Info
-binlog.000001	#	Stop	#	#	
-
-# Case 5 Simulate write failure when reinitializing binlog cache for
-#        copying to binlog with ABORT_SERVER
-#
-SET GLOBAL binlog_cache_size = 4096;
-select @@global.binlog_cache_size;
-@@global.binlog_cache_size
-4096
-TRUNCATE t2;
-include/save_binlog_position.inc
-SET GLOBAL binlog_error_action = ABORT_SERVER;
-BEGIN;
-INSERT INTO t2 VALUES (repeat('b', 8192));
-SET SESSION debug = "+d,simulate_tmpdir_partition_full";
-COMMIT;
-ERROR HY000: Binary logging not possible. Message: An error occurred during flush stage of the commit. 'binlog_error_action' is set to 'ABORT_SERVER'. Hence aborting the server.
-# restart
-select * from t2;
-c1
-include/assert.inc [Count of elements in t2 should be 0.]
-include/show_binlog_events.inc
 DROP TABLE t1, t2, t3;
 RESET MASTER;
+SET @@global.binlog_cache_size = @saved_binlog_cache_size;

--- a/mysql-test/suite/binlog/t/binlog_cache_write_failure.test
+++ b/mysql-test/suite/binlog/t/binlog_cache_write_failure.test
@@ -42,6 +42,7 @@ CREATE TABLE t1(c1 varchar(8192));
 CREATE TABLE t2(c1 varchar(8192));
 CREATE TABLE t3(c1 varchar(8192));
 
+SET @saved_binlog_cache_size = @@global.binlog_cache_size;
 SET GLOBAL binlog_cache_size = 4096;
 connect(con1,localhost,root,,);
 
@@ -92,87 +93,11 @@ INSERT INTO t1 VALUES (repeat('a', 8192));
 SET SESSION debug = "+d,simulate_error_during_flush_cache_to_file";
 --disconnect con1
 
---echo
---echo # Case 4 Simulate write failure when reinitializing binlog cache for
---echo #        copying to binlog. The error should be ignored and cache
---echo #        is cleared correctly if binlog_error_action is IGNORE_ERROR
---echo #
---connect(con1,localhost,root,,)
-TRUNCATE t1;
---source include/save_binlog_position.inc
-
-SET GLOBAL binlog_error_action = IGNORE_ERROR;
-BEGIN;
-INSERT INTO t1 VALUES (repeat('a', 8192));
-
-SET SESSION debug = "+d,simulate_tmpdir_partition_full";
---replace_regex /.*Error writing file.*/Error writing file <tmp_file_name> (Errcode: ##)/
-COMMIT;
-SET SESSION debug = "-d,simulate_tmpdir_partition_full";
-#SET SESSION debug = "-d,simulate_no_free_space_error";
-
-# Check that transaction is committed
---let $assert_cond = COUNT(*) = 1 FROM t1;
---let $assert_text = Count of elements in t1 should be 1.
-
-# Check that error is present in error log
---let $assert_file= $MYSQLTEST_VARDIR/log/mysqld.1.err
---let $assert_only_after = CURRENT_TEST: binlog.binlog_cache_write_failure
---let $assert_count = 1
---let $assert_select = An error occurred during flush stage of the commit. 'binlog_error_action' is set to 'IGNORE_ERROR'.
---let $assert_text = An error occurred during flush stage of the commit. 'binlog_error_action' is set to 'IGNORE_ERROR'.
---source include/assert_grep.inc
-
-# Restart so that binary log is enabled again and we can do the below test
---disconnect con1
---connection default
---source include/restart_mysqld.inc
-
-# Nothing should be logged
---let $binlog_start= $binlog_position
---source include/show_binlog_events.inc
-
---echo
---echo # Case 5 Simulate write failure when reinitializing binlog cache for
---echo #        copying to binlog with ABORT_SERVER
---echo #
-SET GLOBAL binlog_cache_size = 4096;
-
---connect(con1,localhost,root,,)
-
-select @@global.binlog_cache_size;
-TRUNCATE t2;
---source include/save_binlog_position.inc
-
-SET GLOBAL binlog_error_action = ABORT_SERVER;
-BEGIN;
-INSERT INTO t2 VALUES (repeat('b', 8192));
-
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
-SET SESSION debug = "+d,simulate_tmpdir_partition_full";
---error ER_BINLOG_LOGGING_IMPOSSIBLE
-COMMIT;
-
---exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---enable_reconnect
---source include/wait_until_connected_again.inc
-
-# Restart so that binary log is enabled again and we can do the below test
---source include/restart_mysqld.inc
-select * from t2;
-# Check that transaction is not committed
---let $assert_cond = COUNT(*) = 0 FROM t2;
---let $assert_text = Count of elements in t2 should be 0.
---source include/assert.inc
-
-# Nothing should be logged
---let $binlog_start= $binlog_position
---source include/show_binlog_events.inc
 
 # Cleanup
---disconnect con1
 --connection default
 --enable_reconnect
 DROP TABLE t1, t2, t3;
 RESET MASTER;
 
+SET @@global.binlog_cache_size = @saved_binlog_cache_size;


### PR DESCRIPTION
Adding `MY_WAIT_IF_FULL` flag in `open_cached_file()` in `FB8-136` has broken `binlog.binlog_cache_write_failure`.
This patch removes Case #4 and Case #5 from `binlog.binlog_cache_write_failure` since we’ve changed the behavior of waiting on disk full within the server.

Squash with: D14312146