### PR TITLE
FB8-199: Add an ability to insert sleeps in the dump thread before waiting for new events

### DIFF
--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -1210,6 +1210,9 @@ The following options may be given as the first argument:
  Use compression on master/slave protocol
  --slave-compression-lib[=name] 
  Compression library for replication stream
+ --slave-dump-thread-wait-sleep-usec[=#] 
+ Time (in microsecs) to sleep on the master's dump thread
+ before waiting for new data on the latest binlog.
  --slave-exec-mode=name 
  Modes for how replication events should be executed.
  Legal values are STRICT (default) and IDEMPOTENT. In
@@ -1734,6 +1737,7 @@ slave-checkpoint-group 512
 slave-checkpoint-period 300
 slave-compressed-protocol FALSE
 slave-compression-lib zlib
+slave-dump-thread-wait-sleep-usec 0
 slave-exec-mode STRICT
 slave-max-allowed-packet 1073741824
 slave-net-timeout 60

--- a/mysql-test/suite/binlog_nogtid/r/binlog_persist_only_variables.result
+++ b/mysql-test/suite/binlog_nogtid/r/binlog_persist_only_variables.result
@@ -25,7 +25,7 @@ VARIABLE_NAME LIKE '%slave%') AND
 'reset_seconds_behind_master', 'skip_flush_master_info'))
 ORDER BY VARIABLE_NAME;
 
-include/assert.inc ['Expect 86 variables in the table.']
+include/assert.inc ['Expect 87 variables in the table.']
 
 # Test SET PERSIST_ONLY
 SET PERSIST_ONLY binlog_cache_size = @@GLOBAL.binlog_cache_size;
@@ -106,6 +106,7 @@ SET PERSIST_ONLY slave_checkpoint_group = @@GLOBAL.slave_checkpoint_group;
 SET PERSIST_ONLY slave_checkpoint_period = @@GLOBAL.slave_checkpoint_period;
 SET PERSIST_ONLY slave_compressed_protocol = @@GLOBAL.slave_compressed_protocol;
 SET PERSIST_ONLY slave_compression_lib = @@GLOBAL.slave_compression_lib;
+SET PERSIST_ONLY slave_dump_thread_wait_sleep_usec = @@GLOBAL.slave_dump_thread_wait_sleep_usec;
 SET PERSIST_ONLY slave_exec_mode = @@GLOBAL.slave_exec_mode;
 SET PERSIST_ONLY slave_load_tmpdir = @@GLOBAL.slave_load_tmpdir;
 ERROR HY000: Variable 'slave_load_tmpdir' is a non persistent read only variable
@@ -128,16 +129,16 @@ SET PERSIST_ONLY sync_master_info = @@GLOBAL.sync_master_info;
 SET PERSIST_ONLY sync_relay_log = @@GLOBAL.sync_relay_log;
 SET PERSIST_ONLY sync_relay_log_info = @@GLOBAL.sync_relay_log_info;
 
-include/assert.inc ['Expect 76 persisted variables in persisted_variables table.']
+include/assert.inc ['Expect 77 persisted variables in persisted_variables table.']
 
 ############################################################
 # 2. Restart server, it must preserve the persisted variable
 #    settings. Verify persisted configuration.
 # restart
 
-include/assert.inc ['Expect 76 persisted variables in persisted_variables table.']
-include/assert.inc ['Expect 76 persisted variables shown as PERSISTED in variables_info table.']
-include/assert.inc ['Expect 76 persisted variables with matching peristed and global values.']
+include/assert.inc ['Expect 77 persisted variables in persisted_variables table.']
+include/assert.inc ['Expect 77 persisted variables shown as PERSISTED in variables_info table.']
+include/assert.inc ['Expect 77 persisted variables with matching peristed and global values.']
 
 ############################################################
 # 3. Test RESET PERSIST. Verify persisted variable settings
@@ -217,6 +218,7 @@ RESET PERSIST slave_checkpoint_group;
 RESET PERSIST slave_checkpoint_period;
 RESET PERSIST slave_compressed_protocol;
 RESET PERSIST slave_compression_lib;
+RESET PERSIST slave_dump_thread_wait_sleep_usec;
 RESET PERSIST slave_exec_mode;
 RESET PERSIST slave_load_tmpdir;
 ERROR HY000: Variable slave_load_tmpdir does not exist in persisted config file

--- a/mysql-test/suite/binlog_nogtid/r/binlog_persist_variables.result
+++ b/mysql-test/suite/binlog_nogtid/r/binlog_persist_variables.result
@@ -25,7 +25,7 @@ VARIABLE_NAME LIKE '%slave%') AND
 'reset_seconds_behind_master', 'skip_flush_master_info'))
 ORDER BY VARIABLE_NAME;
 
-include/assert.inc ['Expect 86 variables in the table.']
+include/assert.inc ['Expect 87 variables in the table.']
 
 # Test SET PERSIST
 SET PERSIST binlog_cache_size = @@GLOBAL.binlog_cache_size;
@@ -110,6 +110,7 @@ SET PERSIST slave_checkpoint_group = @@GLOBAL.slave_checkpoint_group;
 SET PERSIST slave_checkpoint_period = @@GLOBAL.slave_checkpoint_period;
 SET PERSIST slave_compressed_protocol = @@GLOBAL.slave_compressed_protocol;
 SET PERSIST slave_compression_lib = @@GLOBAL.slave_compression_lib;
+SET PERSIST slave_dump_thread_wait_sleep_usec = @@GLOBAL.slave_dump_thread_wait_sleep_usec;
 SET PERSIST slave_exec_mode = @@GLOBAL.slave_exec_mode;
 SET PERSIST slave_load_tmpdir = @@GLOBAL.slave_load_tmpdir;
 ERROR HY000: Variable 'slave_load_tmpdir' is a read only variable
@@ -133,16 +134,16 @@ SET PERSIST sync_master_info = @@GLOBAL.sync_master_info;
 SET PERSIST sync_relay_log = @@GLOBAL.sync_relay_log;
 SET PERSIST sync_relay_log_info = @@GLOBAL.sync_relay_log_info;
 
-include/assert.inc ['Expect 71 persisted variables in persisted_variables table.']
+include/assert.inc ['Expect 72 persisted variables in persisted_variables table.']
 
 ############################################################
 # 2. Restart server, it must preserve the persisted variable
 #    settings. Verify persisted configuration.
 # restart
 
-include/assert.inc ['Expect 71 persisted variables in persisted_variables table.']
-include/assert.inc ['Expect 71 persisted variables shown as PERSISTED in variables_info table.']
-include/assert.inc ['Expect 71 persisted variables with matching peristed and global values.']
+include/assert.inc ['Expect 72 persisted variables in persisted_variables table.']
+include/assert.inc ['Expect 72 persisted variables shown as PERSISTED in variables_info table.']
+include/assert.inc ['Expect 72 persisted variables with matching peristed and global values.']
 
 ############################################################
 # 3. Test RESET PERSIST IF EXISTS. Verify persisted variable
@@ -239,6 +240,7 @@ RESET PERSIST IF EXISTS slave_checkpoint_group;
 RESET PERSIST IF EXISTS slave_checkpoint_period;
 RESET PERSIST IF EXISTS slave_compressed_protocol;
 RESET PERSIST IF EXISTS slave_compression_lib;
+RESET PERSIST IF EXISTS slave_dump_thread_wait_sleep_usec;
 RESET PERSIST IF EXISTS slave_exec_mode;
 RESET PERSIST IF EXISTS slave_load_tmpdir;
 Warnings:

--- a/mysql-test/suite/binlog_nogtid/t/binlog_persist_only_variables.test
+++ b/mysql-test/suite/binlog_nogtid/t/binlog_persist_only_variables.test
@@ -59,7 +59,7 @@ INSERT INTO rplvars (varname, varvalue)
 
 # If this count differs, it means a variable has been added or removed.
 # In that case, this testcase needs to be updated accordingly.
---let $var_count=86
+--let $var_count=87
 --echo
 --let $assert_text= 'Expect $var_count variables in the table.'
 --let $assert_cond= [SELECT COUNT(*) as count FROM rplvars, count, 1] = $var_count
@@ -91,7 +91,7 @@ while ( $varid <= $countvars )
   --inc $varid
 }
 
---let $var_count=76
+--let $var_count=77
 --echo
 --let $assert_text= 'Expect $var_count persisted variables in persisted_variables table.'
 --let $assert_cond= [SELECT COUNT(*) as count FROM performance_schema.persisted_variables, count, 1] = $var_count

--- a/mysql-test/suite/binlog_nogtid/t/binlog_persist_variables.test
+++ b/mysql-test/suite/binlog_nogtid/t/binlog_persist_variables.test
@@ -60,7 +60,7 @@ INSERT INTO rplvars (varname, varvalue)
 
 # If this count differs, it means a variable has been added or removed.
 # In that case, this testcase needs to be updated accordingly.
---let $var_count=86
+--let $var_count=87
 --echo
 --let $assert_text= 'Expect $var_count variables in the table.'
 --let $assert_cond= [SELECT COUNT(*) as count FROM rplvars, count, 1] = $var_count
@@ -83,7 +83,7 @@ while ( $varid <= $countvars )
   --inc $varid
 }
 
---let $var_count=71
+--let $var_count=72
 --echo
 --let $assert_text= 'Expect $var_count persisted variables in persisted_variables table.'
 --let $assert_cond= [SELECT COUNT(*) as count FROM performance_schema.persisted_variables, count, 1] = $var_count

--- a/mysql-test/suite/rpl/r/rpl_slave_dump_thread_wait_sleep_usec.result
+++ b/mysql-test/suite/rpl/r/rpl_slave_dump_thread_wait_sleep_usec.result
@@ -1,0 +1,22 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+[connection slave]
+SET @saved_slave_dump_thread_wait_sleep_usec = @@global.slave_dump_thread_wait_sleep_usec;
+SET @@global.slave_dump_thread_wait_sleep_usec = 5000000;
+include/stop_slave.inc
+include/start_slave.inc
+[connection master]
+SET @@GLOBAL.DEBUG= '+d,reached_dump_thread_wait_sleep';
+CREATE TABLE t1 (a INT);
+SET DEBUG_SYNC="now wait_for reached";
+SET DEBUG_SYNC="now signal continue";
+SET @@GLOBAL.DEBUG= '-d,reached_dump_thread_wait_sleep';
+DROP TABLE t1;
+[connection slave]
+SET @@global.slave_dump_thread_wait_sleep_usec = @saved_slave_dump_thread_wait_sleep_usec;
+include/stop_slave.inc
+include/start_slave.inc
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_slave_dump_thread_wait_sleep_usec.test
+++ b/mysql-test/suite/rpl/t/rpl_slave_dump_thread_wait_sleep_usec.test
@@ -1,0 +1,26 @@
+--source include/have_debug_sync.inc
+--source include/master-slave.inc
+
+--source include/rpl_connection_slave.inc
+SET @saved_slave_dump_thread_wait_sleep_usec = @@global.slave_dump_thread_wait_sleep_usec;
+SET @@global.slave_dump_thread_wait_sleep_usec = 5000000; # 5 secs
+# restart slave to send "dump_thread_wait_sleep_usec" from slave to server
+--source include/stop_slave.inc
+--source include/start_slave.inc
+
+--source include/rpl_connection_master.inc
+SET @@GLOBAL.DEBUG= '+d,reached_dump_thread_wait_sleep';
+CREATE TABLE t1 (a INT);
+SET DEBUG_SYNC="now wait_for reached";
+SET DEBUG_SYNC="now signal continue";
+
+# Cleanup
+SET @@GLOBAL.DEBUG= '-d,reached_dump_thread_wait_sleep';
+DROP TABLE t1;
+
+--source include/rpl_connection_slave.inc
+SET @@global.slave_dump_thread_wait_sleep_usec = @saved_slave_dump_thread_wait_sleep_usec;
+--source include/stop_slave.inc
+--source include/start_slave.inc
+
+--source include/rpl_end.inc

--- a/mysql-test/suite/sys_vars/r/slave_dump_thread_wait_sleep_usec_basic.result
+++ b/mysql-test/suite/sys_vars/r/slave_dump_thread_wait_sleep_usec_basic.result
@@ -1,0 +1,87 @@
+SET @start_value = @@global.slave_dump_thread_wait_sleep_usec;
+SELECT @start_value;
+@start_value
+0
+'#--------------------FN_DYNVARS_019_01------------------------#'
+SET @@global.slave_dump_thread_wait_sleep_usec = 100;
+SET @@global.slave_dump_thread_wait_sleep_usec = DEFAULT;
+SELECT @@global.slave_dump_thread_wait_sleep_usec;
+@@global.slave_dump_thread_wait_sleep_usec
+0
+'#---------------------FN_DYNVARS_019_02-------------------------#'
+SET @@global.slave_dump_thread_wait_sleep_usec = @start_value;
+SELECT @@global.slave_dump_thread_wait_sleep_usec = 5;
+@@global.slave_dump_thread_wait_sleep_usec = 5
+0
+'#--------------------FN_DYNVARS_019_03------------------------#'
+SET @@global.slave_dump_thread_wait_sleep_usec = 2;
+SELECT @@global.slave_dump_thread_wait_sleep_usec;
+@@global.slave_dump_thread_wait_sleep_usec
+2
+SET @@global.slave_dump_thread_wait_sleep_usec = 10000;
+SELECT @@global.slave_dump_thread_wait_sleep_usec;
+@@global.slave_dump_thread_wait_sleep_usec
+10000
+SET @@global.slave_dump_thread_wait_sleep_usec = 212204;
+SELECT @@global.slave_dump_thread_wait_sleep_usec;
+@@global.slave_dump_thread_wait_sleep_usec
+212204
+'#--------------------FN_DYNVARS_019_04-------------------------#'
+SET @@global.slave_dump_thread_wait_sleep_usec = 1;
+SELECT @@global.slave_dump_thread_wait_sleep_usec;
+@@global.slave_dump_thread_wait_sleep_usec
+1
+SET @@global.slave_dump_thread_wait_sleep_usec = -1024;
+Warnings:
+Warning	1292	Truncated incorrect slave_dump_thread_wait_sleep_use value: '-1024'
+SELECT @@global.slave_dump_thread_wait_sleep_usec;
+@@global.slave_dump_thread_wait_sleep_usec
+0
+SET @@global.slave_dump_thread_wait_sleep_usec = 315360000000001;
+Warnings:
+Warning	1292	Truncated incorrect slave_dump_thread_wait_sleep_use value: '315360000000001'
+SELECT @@global.slave_dump_thread_wait_sleep_usec;
+@@global.slave_dump_thread_wait_sleep_usec
+31536000000000
+SET @@global.slave_dump_thread_wait_sleep_usec = 212204.10;
+ERROR 42000: Incorrect argument type to variable 'slave_dump_thread_wait_sleep_usec'
+SET @@global.slave_dump_thread_wait_sleep_usec = ON;
+ERROR 42000: Incorrect argument type to variable 'slave_dump_thread_wait_sleep_usec'
+'#-------------------FN_DYNVARS_019_05----------------------------#'
+SET @@session.slave_dump_thread_wait_sleep_usec = 0;
+ERROR HY000: Variable 'slave_dump_thread_wait_sleep_usec' is a GLOBAL variable and should be set with SET GLOBAL
+SELECT @@session.slave_dump_thread_wait_sleep_usec;
+ERROR HY000: Variable 'slave_dump_thread_wait_sleep_usec' is a GLOBAL variable
+'#----------------------FN_DYNVARS_019_06------------------------#'
+SELECT @@global.slave_dump_thread_wait_sleep_usec = VARIABLE_VALUE 
+FROM performance_schema.global_variables
+WHERE VARIABLE_NAME='slave_dump_thread_wait_sleep_usec';
+@@global.slave_dump_thread_wait_sleep_usec = VARIABLE_VALUE
+1
+'#---------------------FN_DYNVARS_019_07----------------------#'
+SET @@global.slave_dump_thread_wait_sleep_usec = TRUE;
+SELECT @@global.slave_dump_thread_wait_sleep_usec;
+@@global.slave_dump_thread_wait_sleep_usec
+1
+SET @@global.slave_dump_thread_wait_sleep_usec = FALSE;
+SELECT @@global.slave_dump_thread_wait_sleep_usec;
+@@global.slave_dump_thread_wait_sleep_usec
+0
+'#---------------------FN_DYNVARS_019_08----------------------#'
+SET @@global.slave_dump_thread_wait_sleep_usec = 5;
+SELECT @@slave_dump_thread_wait_sleep_usec = @@global.slave_dump_thread_wait_sleep_usec;
+@@slave_dump_thread_wait_sleep_usec = @@global.slave_dump_thread_wait_sleep_usec
+1
+'#---------------------FN_DYNVARS_019_09----------------------#'
+SET slave_dump_thread_wait_sleep_usec = 1;
+ERROR HY000: Variable 'slave_dump_thread_wait_sleep_usec' is a GLOBAL variable and should be set with SET GLOBAL
+SET global.slave_dump_thread_wait_sleep_usec = 1;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'global.slave_dump_thread_wait_sleep_usec = 1' at line 1
+SELECT global.slave_dump_thread_wait_sleep_usec;
+ERROR 42S02: Unknown table 'global' in field list
+SELECT slave_dump_thread_wait_sleep_usec = @@session.slave_dump_thread_wait_sleep_usec;
+ERROR 42S22: Unknown column 'slave_dump_thread_wait_sleep_usec' in 'field list'
+SET @@global.slave_dump_thread_wait_sleep_usec = @start_value;
+SELECT @@global.slave_dump_thread_wait_sleep_usec;
+@@global.slave_dump_thread_wait_sleep_usec
+0

--- a/mysql-test/suite/sys_vars/t/slave_dump_thread_wait_sleep_usec_basic.test
+++ b/mysql-test/suite/sys_vars/t/slave_dump_thread_wait_sleep_usec_basic.test
@@ -1,0 +1,127 @@
+--source include/load_sysvars.inc
+
+###############################################################
+#           START OF slave_dump_thread_wait_sleep_usec TESTS                    #
+###############################################################
+
+#######################################################################
+# Saving initial value of slave_dump_thread_wait_sleep_usec in a temporary variable     #
+#######################################################################
+
+SET @start_value = @@global.slave_dump_thread_wait_sleep_usec;
+SELECT @start_value;
+
+--echo '#--------------------FN_DYNVARS_019_01------------------------#'
+#######################################################################
+#              Display the DEFAULT value of slave_dump_thread_wait_sleep_usec           #
+#######################################################################
+
+SET @@global.slave_dump_thread_wait_sleep_usec = 100;
+SET @@global.slave_dump_thread_wait_sleep_usec = DEFAULT;
+SELECT @@global.slave_dump_thread_wait_sleep_usec;
+
+
+--echo '#---------------------FN_DYNVARS_019_02-------------------------#'
+############################################### 
+#     Verify default value of variable        #
+###############################################
+
+SET @@global.slave_dump_thread_wait_sleep_usec = @start_value;
+SELECT @@global.slave_dump_thread_wait_sleep_usec = 5;
+
+
+--echo '#--------------------FN_DYNVARS_019_03------------------------#'
+#######################################################################
+#        Change the value of slave_dump_thread_wait_sleep_usec to a valid value         #
+#######################################################################
+
+SET @@global.slave_dump_thread_wait_sleep_usec = 2;
+SELECT @@global.slave_dump_thread_wait_sleep_usec;
+SET @@global.slave_dump_thread_wait_sleep_usec = 10000;
+SELECT @@global.slave_dump_thread_wait_sleep_usec;
+SET @@global.slave_dump_thread_wait_sleep_usec = 212204;
+SELECT @@global.slave_dump_thread_wait_sleep_usec;
+
+
+--echo '#--------------------FN_DYNVARS_019_04-------------------------#'
+##########################################################################
+#         Change the value of slave_dump_thread_wait_sleep_usec to invalid value           #
+##########################################################################
+
+SET @@global.slave_dump_thread_wait_sleep_usec = 1;
+SELECT @@global.slave_dump_thread_wait_sleep_usec;
+SET @@global.slave_dump_thread_wait_sleep_usec = -1024;
+SELECT @@global.slave_dump_thread_wait_sleep_usec;
+SET @@global.slave_dump_thread_wait_sleep_usec = 315360000000001;
+SELECT @@global.slave_dump_thread_wait_sleep_usec;
+--Error ER_WRONG_TYPE_FOR_VAR
+SET @@global.slave_dump_thread_wait_sleep_usec = 212204.10;
+--Error ER_WRONG_TYPE_FOR_VAR
+SET @@global.slave_dump_thread_wait_sleep_usec = ON;
+
+
+--echo '#-------------------FN_DYNVARS_019_05----------------------------#'
+##########################################################################
+#       Test if accessing session slave_dump_thread_wait_sleep_usec gives error            #
+##########################################################################
+
+--Error ER_GLOBAL_VARIABLE
+SET @@session.slave_dump_thread_wait_sleep_usec = 0;
+--Error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.slave_dump_thread_wait_sleep_usec;
+
+
+--echo '#----------------------FN_DYNVARS_019_06------------------------#'
+####################################################################
+# Check if the value in GLOBAL Tables matches values in variable   #
+####################################################################
+
+SELECT @@global.slave_dump_thread_wait_sleep_usec = VARIABLE_VALUE 
+FROM performance_schema.global_variables
+WHERE VARIABLE_NAME='slave_dump_thread_wait_sleep_usec';
+
+--echo '#---------------------FN_DYNVARS_019_07----------------------#'
+################################################################### 
+#      Check if TRUE and FALSE values can be used on variable     #
+################################################################### 
+
+SET @@global.slave_dump_thread_wait_sleep_usec = TRUE;
+SELECT @@global.slave_dump_thread_wait_sleep_usec;
+SET @@global.slave_dump_thread_wait_sleep_usec = FALSE;
+SELECT @@global.slave_dump_thread_wait_sleep_usec;
+
+
+--echo '#---------------------FN_DYNVARS_019_08----------------------#'
+###############################################################################
+#    Check if accessing variable without SCOPE points to same global variable #
+###############################################################################
+
+SET @@global.slave_dump_thread_wait_sleep_usec = 5;
+SELECT @@slave_dump_thread_wait_sleep_usec = @@global.slave_dump_thread_wait_sleep_usec;
+
+--echo '#---------------------FN_DYNVARS_019_09----------------------#'
+#########################################################################
+#   Check if slave_dump_thread_wait_sleep_usec can be accessed with and without @@ sign   #
+#########################################################################
+
+--Error ER_GLOBAL_VARIABLE
+SET slave_dump_thread_wait_sleep_usec = 1;
+--Error ER_PARSE_ERROR
+SET global.slave_dump_thread_wait_sleep_usec = 1;
+--Error ER_UNKNOWN_TABLE
+SELECT global.slave_dump_thread_wait_sleep_usec;
+--Error ER_BAD_FIELD_ERROR
+SELECT slave_dump_thread_wait_sleep_usec = @@session.slave_dump_thread_wait_sleep_usec;
+
+##############################
+#   Restore initial value    #
+##############################
+
+SET @@global.slave_dump_thread_wait_sleep_usec = @start_value;
+SELECT @@global.slave_dump_thread_wait_sleep_usec;
+
+
+#########################################################
+#              END OF slave_dump_thread_wait_sleep_usec TESTS             #
+#########################################################
+

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -962,6 +962,7 @@ bool opt_skip_slave_start = 0;  ///< If set, slave is not autostarted
 bool opt_enable_named_pipe = 0;
 bool opt_local_infile, opt_slave_compressed_protocol;
 ulong opt_slave_compression_lib;
+ulonglong opt_slave_dump_thread_wait_sleep_usec;
 bool opt_safe_user_create = 0;
 bool opt_show_slave_auth_info;
 bool opt_log_slave_updates = 0;

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -172,6 +172,7 @@ extern bool opt_safe_user_create;
 extern bool opt_local_infile, opt_myisam_use_mmap;
 extern bool opt_slave_compressed_protocol;
 extern ulong opt_slave_compression_lib;
+extern ulonglong opt_slave_dump_thread_wait_sleep_usec;
 extern ulong slave_exec_mode_options;
 extern Rpl_global_filter rpl_global_filter;
 extern int32_t opt_regexp_time_limit;

--- a/sql/rpl_binlog_sender.cc
+++ b/sql/rpl_binlog_sender.cc
@@ -432,6 +432,9 @@ int Binlog_sender::get_binlog_end_pos(File_reader *reader, my_off_t *end_pos) {
   DBUG_ENTER("Binlog_sender::get_binlog_end_pos()");
   my_off_t read_pos = reader->position();
 
+  long long dump_thread_wait_sleep_usec = 0;
+  get_user_var_int("dump_thread_wait_sleep_usec", &dump_thread_wait_sleep_usec, nullptr);
+
   do {
     /*
       MYSQL_BIN_LOG::binlog_end_pos is atomic. We should only acquire the
@@ -454,6 +457,19 @@ int Binlog_sender::get_binlog_end_pos(File_reader *reader, my_off_t *end_pos) {
 
     /* Some data may be in net buffer, it should be flushed before waiting */
     if (!m_wait_new_events || flush_net()) DBUG_RETURN(1);
+
+    // case: sleep before locking and waiting for new data
+    if (unlikely(dump_thread_wait_sleep_usec != 0)) {
+      DBUG_EXECUTE_IF("reached_dump_thread_wait_sleep", {
+        static constexpr char act[] =
+            "now "
+            "signal reached "
+            "wait_for continue";
+        DBUG_ASSERT(opt_debug_sync_timeout > 0);
+        DBUG_ASSERT(!debug_sync_set_action(current_thd, STRING_WITH_LEN(act)));
+      };);
+      usleep(dump_thread_wait_sleep_usec);
+    }
 
     if (unlikely(wait_new_events(read_pos))) DBUG_RETURN(1);
   } while (unlikely(!m_thd->killed));

--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -2327,7 +2327,11 @@ int io_thread_init_commands(MYSQL *mysql, Master_info *mi) {
   int ret = 0;
   DBUG_EXECUTE_IF("fake_5_5_version_slave", return ret;);
 
-  sprintf(query, "SET @slave_uuid= '%s'", server_uuid);
+  snprintf(query, sizeof(query),
+           "SET "
+           "@slave_uuid= '%s',"
+           "@dump_thread_wait_sleep_usec= %llu",
+           server_uuid, opt_slave_dump_thread_wait_sleep_usec);
   if (mysql_real_query(mysql, query, static_cast<ulong>(strlen(query))) &&
       !check_io_slave_killed(mi->info_thd, mi, NULL))
     goto err;

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -3462,6 +3462,14 @@ static Sys_var_set Slave_type_conversions(
     GLOBAL_VAR(slave_type_conversions_options), CMD_LINE(REQUIRED_ARG),
     slave_type_conversions_name, DEFAULT(0));
 
+static Sys_var_ulonglong Sys_slave_dump_thread_wait_sleep_usec(
+    "slave_dump_thread_wait_sleep_usec",
+    "Time (in microsecs) to sleep on the master's dump thread before "
+    "waiting for new data on the latest binlog.",
+    GLOBAL_VAR(opt_slave_dump_thread_wait_sleep_usec), CMD_LINE(OPT_ARG),
+    VALID_RANGE(0, LONG_TIMEOUT * 1000000ULL), DEFAULT(0), BLOCK_SIZE(1),
+    NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(nullptr), ON_UPDATE(nullptr));
+
 static Sys_var_bool Sys_slave_sql_verify_checksum(
     "slave_sql_verify_checksum",
     "Force checksum verification of replication events after reading them "


### PR DESCRIPTION
Summary:
Jira issue: https://jira.percona.com/browse/FB8-199

Reference Patch: https://github.com/facebook/mysql-5.6/commit/af3dc25310e

In some scenarios it might make sense to sleep before locking and
waiting for an update in the latest binlog file to reduce contention.

Originally Reviewed By: midom

Todo: Because of conflicts I removed changes in `mysql-test/t/all_persisted_variables.test`. This test has to be modified at `let $total_persistent_vars=XXX;` (+1 increase) and it should be re-recorded.