### PR TITLE
FB8-92: Checking for NULL while preparing write set according to binlog_row_image

### DIFF
--- a/mysql-test/suite/rpl/t/rpl_row_img_sanity.test
+++ b/mysql-test/suite/rpl/t/rpl_row_img_sanity.test
@@ -394,6 +394,7 @@ while (`SELECT HEX(@img_types) != HEX('')`)
     -- connection master
     CREATE TABLE t (c1 int, c2 int, c3 blob, primary key(c1));
     INSERT INTO t VALUES (1,2,"a");
+    INSERT INTO t VALUES (2,4,NULL);
 
 
     --source include/sync_slave_sql_with_master.inc
@@ -420,6 +421,18 @@ while (`SELECT HEX(@img_types) != HEX('')`)
     if (`SELECT @@binlog_row_image = "COMPLETE"`)
     {
       -- let $row_img_expected_master= 1:1 2:4 3:'a' | 2:6
+    }
+    -- let $row_img_expected_slave = $row_img_expected_master
+    -- source include/rpl_row_img_parts_master_slave.inc
+
+    -- let $row_img_query= INSERT INTO t VALUES (2, 4, "") ON DUPLICATE KEY UPDATE c2 = values(c2), c3 = values(c3);
+    if (`SELECT @@binlog_row_image = "MINIMAL"`)
+    {
+      -- let $row_img_expected_master= 1:2 | 3:''
+    }
+    if (`SELECT @@binlog_row_image = "COMPLETE"`)
+    {
+      -- let $row_img_expected_master= 1:2 2:4 3:NULL | 3:''
     }
     -- let $row_img_expected_slave = $row_img_expected_master
     -- source include/rpl_row_img_parts_master_slave.inc

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -10842,6 +10842,7 @@ void THD::binlog_prepare_row_images(TABLE *table, bool is_update) {
 
         /* compare content, only if fields are not set to NULL */
         else if (!field->is_null() &&
+                 !field->is_null_in_record(table->record[1]) &&
                  !field->cmp_binary_offset(table->s->rec_buff_length))
           bitmap_clear_bit(&table->tmp_write_set, field->field_index);
       }


### PR DESCRIPTION
Summary:

Jira issue: https://jira.percona.com/browse/FB8-92

Reference Patch: https://github.com/facebook/mysql-5.6/commit/f3dc487

Field::cmp_binary_offset returns 0 when comparing a NULL text
field and an empty string leading to the field not being logged when the
value is changed from NULL to empty string. This fix first checks if
both AI and BI fields are not NULL before comparing them.

Originally Reviewed By: santoshbanda