### PR TITLE
FB8-75: Periodic fsync in select into outfile controlled by sysvar

### DIFF
--- a/mysql-test/include/have_outfile.inc
+++ b/mysql-test/include/have_outfile.inc
@@ -1,5 +1,5 @@
 let $outfile= `SELECT LOAD_FILE(CONCAT(@tmpdir, '/outfile.test')) LIKE 'Outfile OK%'`;
-remove_file $MYSQLTEST_VARDIR/tmp/outfile.test;
+remove_file $MYSQL_TMP_DIR/outfile.test;
 
 if (!$outfile)
 {

--- a/mysql-test/include/test_outfile.inc
+++ b/mysql-test/include/test_outfile.inc
@@ -1,0 +1,1 @@
+eval select "Outfile OK" into outfile "$MYSQL_TMP_DIR/outfile.test";

--- a/mysql-test/r/all_persisted_variables.result
+++ b/mysql-test/r/all_persisted_variables.result
@@ -44,7 +44,7 @@ include/assert.inc ['Expect 500+ variables in the table. Due to open Bugs, we ar
 
 # Test SET PERSIST
 
-include/assert.inc ['Expect 392 persisted variables in the table. Due to open Bugs, we are checking for 386']
+include/assert.inc ['Expect 394 persisted variables in the table. Due to open Bugs, we are checking for 388']
 
 ************************************************************
 * 3. Restart server, it must preserve the persisted variable
@@ -52,9 +52,9 @@ include/assert.inc ['Expect 392 persisted variables in the table. Due to open Bu
 ************************************************************
 # restart
 
-include/assert.inc ['Expect 386 persisted variables in persisted_variables table.']
-include/assert.inc ['Expect 386 persisted variables shown as PERSISTED in variables_info table.']
-include/assert.inc ['Expect 386 persisted variables with matching peristed and global values.']
+include/assert.inc ['Expect 388 persisted variables in persisted_variables table.']
+include/assert.inc ['Expect 388 persisted variables shown as PERSISTED in variables_info table.']
+include/assert.inc ['Expect 388 persisted variables with matching peristed and global values.']
 
 ************************************************************
 * 4. Test RESET PERSIST IF EXISTS. Verify persisted variable

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -1140,6 +1140,12 @@ The following options may be given as the first argument:
  --secure-file-priv=name 
  Limit LOAD DATA, SELECT ... OUTFILE, and LOAD_FILE() to
  files within specified directory
+ --select-into-file-fsync-size[=#] 
+ Do an fsync to disk when the buffer grows by these many
+ bytes for SELECT INTO OUTFILE. Set 0 to disable.
+ --select-into-file-fsync-timeout[=#] 
+ The timeout/sleep in milliseconds after each fsync with
+ SELECT INTO OUTFILE
  --send-error-before-closing-timed-out-connection 
  Send error before closing connections due to timeout.
  (Defaults to on; use --skip-send-error-before-closing-timed-out-connection to disable.)
@@ -1715,6 +1721,8 @@ rpl-send-buffer-size 2097152
 rpl-stop-slave-timeout 31536000
 safe-user-create FALSE
 schema-definition-cache 256
+select-into-file-fsync-size 0
+select-into-file-fsync-timeout 0
 send-error-before-closing-timed-out-connection TRUE
 server-id 1
 server-id-bits 32

--- a/mysql-test/r/select_outfile_fsync_debug.result
+++ b/mysql-test/r/select_outfile_fsync_debug.result
@@ -1,0 +1,6 @@
+SET SESSION select_into_file_fsync_size=262144;
+SET GLOBAL debug = '+d,print_select_file_fsync_stats';
+CREATE TABLE t2 (a TEXT, b TEXT) ENGINE=INNODB;
+include/assert_grep.inc [Found expected number of select_to_file]
+DROP TABLE t2;
+SET GLOBAL debug = '-d,print_select_file_fsync_stats';

--- a/mysql-test/suite/sys_vars/r/select_into_file_fsync_size_basic.result
+++ b/mysql-test/suite/sys_vars/r/select_into_file_fsync_size_basic.result
@@ -1,0 +1,177 @@
+SET @start_global_value = @@global.select_into_file_fsync_size;
+SELECT @start_global_value;
+@start_global_value
+0
+SET @start_session_value = @@session.select_into_file_fsync_size;
+SELECT @start_session_value;
+@start_session_value
+0
+'#--------------------FN_DYNVARS_002_01-------------------------#'
+SET @@global.select_into_file_fsync_size = 1024;
+SET @@global.select_into_file_fsync_size = DEFAULT;
+SELECT @@global.select_into_file_fsync_size;
+@@global.select_into_file_fsync_size
+0
+SET @@session.select_into_file_fsync_size = 2048;
+SET @@session.select_into_file_fsync_size = DEFAULT;
+SELECT @@session.select_into_file_fsync_size;
+@@session.select_into_file_fsync_size
+0
+'#--------------------FN_DYNVARS_002_02-------------------------#'
+SET @@global.select_into_file_fsync_size = @start_global_value;
+SELECT @@global.select_into_file_fsync_size = 4096;
+@@global.select_into_file_fsync_size = 4096
+0
+SET @@session.select_into_file_fsync_size = @start_session_value;
+SELECT @@session.select_into_file_fsync_size = 2048;
+@@session.select_into_file_fsync_size = 2048
+0
+'#--------------------FN_DYNVARS_002_03-------------------------#'
+SET @@global.select_into_file_fsync_size = 16384;
+SELECT @@global.select_into_file_fsync_size;
+@@global.select_into_file_fsync_size
+16384
+SET @@global.select_into_file_fsync_size = 4096;
+SELECT @@global.select_into_file_fsync_size;
+@@global.select_into_file_fsync_size
+4096
+SET @@global.select_into_file_fsync_size = 8192;
+SELECT @@global.select_into_file_fsync_size;
+@@global.select_into_file_fsync_size
+8192
+'#--------------------FN_DYNVARS_002_04-------------------------#'
+SET @@session.select_into_file_fsync_size = 4096;
+SELECT @@session.select_into_file_fsync_size;
+@@session.select_into_file_fsync_size
+4096
+SET @@session.select_into_file_fsync_size = 8192;
+SELECT @@session.select_into_file_fsync_size;
+@@session.select_into_file_fsync_size
+8192
+SET @@session.select_into_file_fsync_size = 16384;
+SELECT @@session.select_into_file_fsync_size;
+@@session.select_into_file_fsync_size
+16384
+'#------------------FN_DYNVARS_002_05-----------------------#'
+SET @@global.select_into_file_fsync_size = -1;
+Warnings:
+Warning	1292	Truncated incorrect select_into_file_fsync_size value: '-1'
+SELECT @@global.select_into_file_fsync_size;
+@@global.select_into_file_fsync_size
+0
+SET @@global.select_into_file_fsync_size = -1024;
+Warnings:
+Warning	1292	Truncated incorrect select_into_file_fsync_size value: '-1024'
+SELECT @@global.select_into_file_fsync_size;
+@@global.select_into_file_fsync_size
+0
+SET @@global.select_into_file_fsync_size = 13;
+Warnings:
+Warning	1292	Truncated incorrect select_into_file_fsync_size value: '13'
+SELECT @@global.select_into_file_fsync_size;
+@@global.select_into_file_fsync_size
+0
+SET @@global.select_into_file_fsync_size = ON;
+ERROR 42000: Incorrect argument type to variable 'select_into_file_fsync_size'
+SELECT @@global.select_into_file_fsync_size;
+@@global.select_into_file_fsync_size
+0
+SET @@global.select_into_file_fsync_size = OFF;
+ERROR 42000: Incorrect argument type to variable 'select_into_file_fsync_size'
+SELECT @@global.select_into_file_fsync_size;
+@@global.select_into_file_fsync_size
+0
+SET @@global.select_into_file_fsync_size = test;
+ERROR 42000: Incorrect argument type to variable 'select_into_file_fsync_size'
+SELECT @@global.select_into_file_fsync_size;
+@@global.select_into_file_fsync_size
+0
+SET @@session.select_into_file_fsync_size = 23;
+Warnings:
+Warning	1292	Truncated incorrect select_into_file_fsync_size value: '23'
+SELECT @@session.select_into_file_fsync_size;
+@@session.select_into_file_fsync_size
+0
+SET @@session.select_into_file_fsync_size = -2;
+Warnings:
+Warning	1292	Truncated incorrect select_into_file_fsync_size value: '-2'
+SELECT @@session.select_into_file_fsync_size;
+@@session.select_into_file_fsync_size
+0
+SET @@session.select_into_file_fsync_size = 65550;
+Warnings:
+Warning	1292	Truncated incorrect select_into_file_fsync_size value: '65550'
+SELECT @@session.select_into_file_fsync_size;
+@@session.select_into_file_fsync_size
+65536
+SET @@session.select_into_file_fsync_size = ON;
+ERROR 42000: Incorrect argument type to variable 'select_into_file_fsync_size'
+SELECT @@session.select_into_file_fsync_size;
+@@session.select_into_file_fsync_size
+65536
+SET @@session.select_into_file_fsync_size = OFF;
+ERROR 42000: Incorrect argument type to variable 'select_into_file_fsync_size'
+SELECT @@session.select_into_file_fsync_size;
+@@session.select_into_file_fsync_size
+65536
+SET @@session.select_into_file_fsync_size = test;
+ERROR 42000: Incorrect argument type to variable 'select_into_file_fsync_size'
+SELECT @@session.select_into_file_fsync_size;
+@@session.select_into_file_fsync_size
+65536
+'#------------------FN_DYNVARS_002_06-----------------------#'
+SELECT @@global.select_into_file_fsync_size = VARIABLE_VALUE 
+FROM performance_schema.global_variables 
+WHERE VARIABLE_NAME='select_into_file_fsync_size';
+@@global.select_into_file_fsync_size = VARIABLE_VALUE
+1
+'#------------------FN_DYNVARS_002_07-----------------------#'
+SELECT @@session.select_into_file_fsync_size = VARIABLE_VALUE 
+FROM performance_schema.session_variables 
+WHERE VARIABLE_NAME='select_into_file_fsync_size';
+@@session.select_into_file_fsync_size = VARIABLE_VALUE
+1
+'#------------------FN_DYNVARS_002_08-----------------------#'
+SET @@global.select_into_file_fsync_size = TRUE;
+Warnings:
+Warning	1292	Truncated incorrect select_into_file_fsync_size value: '1'
+SELECT @@global.select_into_file_fsync_size;
+@@global.select_into_file_fsync_size
+0
+SET @@global.select_into_file_fsync_size = FALSE;
+SELECT @@global.select_into_file_fsync_size;
+@@global.select_into_file_fsync_size
+0
+'#---------------------FN_DYNVARS_001_09----------------------#'
+SET @@global.select_into_file_fsync_size = 16384;
+SET @@session.select_into_file_fsync_size = 8192;
+SELECT @@select_into_file_fsync_size = @@global.select_into_file_fsync_size;
+@@select_into_file_fsync_size = @@global.select_into_file_fsync_size
+0
+'#---------------------FN_DYNVARS_001_10----------------------#'
+SET @@select_into_file_fsync_size = 16384;
+SELECT @@select_into_file_fsync_size = @@local.select_into_file_fsync_size;
+@@select_into_file_fsync_size = @@local.select_into_file_fsync_size
+1
+SELECT @@local.select_into_file_fsync_size = @@session.select_into_file_fsync_size;
+@@local.select_into_file_fsync_size = @@session.select_into_file_fsync_size
+1
+'#---------------------FN_DYNVARS_001_11----------------------#'
+SET select_into_file_fsync_size = 1024;
+SELECT @@select_into_file_fsync_size;
+@@select_into_file_fsync_size
+1024
+SELECT local.select_into_file_fsync_size;
+ERROR 42S02: Unknown table 'local' in field list
+SELECT session.select_into_file_fsync_size;
+ERROR 42S02: Unknown table 'session' in field list
+SELECT select_into_file_fsync_size = @@session.select_into_file_fsync_size;
+ERROR 42S22: Unknown column 'select_into_file_fsync_size' in 'field list'
+SET @@global.select_into_file_fsync_size = @start_global_value;
+SELECT @@global.select_into_file_fsync_size;
+@@global.select_into_file_fsync_size
+0
+SET @@session.select_into_file_fsync_size = @start_session_value;
+SELECT @@session.select_into_file_fsync_size;
+@@session.select_into_file_fsync_size
+0

--- a/mysql-test/suite/sys_vars/r/select_into_file_fsync_timeout_basic.result
+++ b/mysql-test/suite/sys_vars/r/select_into_file_fsync_timeout_basic.result
@@ -1,0 +1,165 @@
+SET @start_global_value = @@global.select_into_file_fsync_timeout;
+SELECT @start_global_value;
+@start_global_value
+0
+SET @start_session_value = @@session.select_into_file_fsync_timeout;
+SELECT @start_session_value;
+@start_session_value
+0
+'#--------------------FN_DYNVARS_002_01-------------------------#'
+SET @@global.select_into_file_fsync_timeout = 1000;
+SET @@global.select_into_file_fsync_timeout = DEFAULT;
+SELECT @@global.select_into_file_fsync_timeout;
+@@global.select_into_file_fsync_timeout
+0
+SET @@session.select_into_file_fsync_timeout = 3000;
+SET @@session.select_into_file_fsync_timeout = DEFAULT;
+SELECT @@session.select_into_file_fsync_timeout;
+@@session.select_into_file_fsync_timeout
+0
+'#--------------------FN_DYNVARS_002_02-------------------------#'
+SET @@global.select_into_file_fsync_timeout = @start_global_value;
+SELECT @@global.select_into_file_fsync_timeout = 10;
+@@global.select_into_file_fsync_timeout = 10
+0
+SET @@session.select_into_file_fsync_timeout = @start_session_value;
+SELECT @@session.select_into_file_fsync_timeout = 20;
+@@session.select_into_file_fsync_timeout = 20
+0
+'#--------------------FN_DYNVARS_002_03-------------------------#'
+SET @@global.select_into_file_fsync_timeout = 5;
+SELECT @@global.select_into_file_fsync_timeout;
+@@global.select_into_file_fsync_timeout
+5
+SET @@global.select_into_file_fsync_timeout = 12;
+SELECT @@global.select_into_file_fsync_timeout;
+@@global.select_into_file_fsync_timeout
+12
+SET @@global.select_into_file_fsync_timeout = 100;
+SELECT @@global.select_into_file_fsync_timeout;
+@@global.select_into_file_fsync_timeout
+100
+'#--------------------FN_DYNVARS_002_04-------------------------#'
+SET @@session.select_into_file_fsync_timeout = 4;
+SELECT @@session.select_into_file_fsync_timeout;
+@@session.select_into_file_fsync_timeout
+4
+SET @@session.select_into_file_fsync_timeout = 8;
+SELECT @@session.select_into_file_fsync_timeout;
+@@session.select_into_file_fsync_timeout
+8
+SET @@session.select_into_file_fsync_timeout = 17;
+SELECT @@session.select_into_file_fsync_timeout;
+@@session.select_into_file_fsync_timeout
+17
+'#------------------FN_DYNVARS_002_05-----------------------#'
+SET @@global.select_into_file_fsync_timeout = -1;
+Warnings:
+Warning	1292	Truncated incorrect select_into_file_fsync_timeout value: '-1'
+SELECT @@global.select_into_file_fsync_timeout;
+@@global.select_into_file_fsync_timeout
+0
+SET @@global.select_into_file_fsync_timeout = -1024;
+Warnings:
+Warning	1292	Truncated incorrect select_into_file_fsync_timeout value: '-1024'
+SELECT @@global.select_into_file_fsync_timeout;
+@@global.select_into_file_fsync_timeout
+0
+SET @@global.select_into_file_fsync_timeout = 3747474747474747474;
+Warnings:
+Warning	1292	Truncated incorrect select_into_file_fsync_timeout value: '3747474747474747474'
+SELECT @@global.select_into_file_fsync_timeout;
+@@global.select_into_file_fsync_timeout
+4294967295
+SET @@global.select_into_file_fsync_timeout = ON;
+ERROR 42000: Incorrect argument type to variable 'select_into_file_fsync_timeout'
+SELECT @@global.select_into_file_fsync_timeout;
+@@global.select_into_file_fsync_timeout
+4294967295
+SET @@global.select_into_file_fsync_timeout = OFF;
+ERROR 42000: Incorrect argument type to variable 'select_into_file_fsync_timeout'
+SELECT @@global.select_into_file_fsync_timeout;
+@@global.select_into_file_fsync_timeout
+4294967295
+SET @@global.select_into_file_fsync_timeout = test;
+ERROR 42000: Incorrect argument type to variable 'select_into_file_fsync_timeout'
+SELECT @@global.select_into_file_fsync_timeout;
+@@global.select_into_file_fsync_timeout
+4294967295
+SET @@session.select_into_file_fsync_timeout = -1;
+Warnings:
+Warning	1292	Truncated incorrect select_into_file_fsync_timeout value: '-1'
+SELECT @@session.select_into_file_fsync_timeout;
+@@session.select_into_file_fsync_timeout
+0
+SET @@session.select_into_file_fsync_timeout = -2;
+Warnings:
+Warning	1292	Truncated incorrect select_into_file_fsync_timeout value: '-2'
+SELECT @@session.select_into_file_fsync_timeout;
+@@session.select_into_file_fsync_timeout
+0
+SET @@session.select_into_file_fsync_timeout = ON;
+ERROR 42000: Incorrect argument type to variable 'select_into_file_fsync_timeout'
+SELECT @@session.select_into_file_fsync_timeout;
+@@session.select_into_file_fsync_timeout
+0
+SET @@session.select_into_file_fsync_timeout = OFF;
+ERROR 42000: Incorrect argument type to variable 'select_into_file_fsync_timeout'
+SELECT @@session.select_into_file_fsync_timeout;
+@@session.select_into_file_fsync_timeout
+0
+SET @@session.select_into_file_fsync_timeout = test;
+ERROR 42000: Incorrect argument type to variable 'select_into_file_fsync_timeout'
+SELECT @@session.select_into_file_fsync_timeout;
+@@session.select_into_file_fsync_timeout
+0
+SET @@session.select_into_file_fsync_timeout = 85858585858585858585;
+ERROR 42000: Incorrect argument type to variable 'select_into_file_fsync_timeout'
+SELECT @@session.select_into_file_fsync_timeout;
+@@session.select_into_file_fsync_timeout
+0
+'#------------------FN_DYNVARS_002_06-----------------------#'
+SELECT @@global.select_into_file_fsync_timeout = VARIABLE_VALUE 
+FROM performance_schema.global_variables 
+WHERE VARIABLE_NAME='select_into_file_fsync_timeout';
+@@global.select_into_file_fsync_timeout = VARIABLE_VALUE
+1
+'#------------------FN_DYNVARS_002_07-----------------------#'
+SELECT @@session.select_into_file_fsync_timeout = VARIABLE_VALUE 
+FROM performance_schema.session_variables 
+WHERE VARIABLE_NAME='select_into_file_fsync_timeout';
+@@session.select_into_file_fsync_timeout = VARIABLE_VALUE
+1
+'#---------------------FN_DYNVARS_001_09----------------------#'
+SET @@global.select_into_file_fsync_timeout = 10;
+SET @@session.select_into_file_fsync_timeout = 1000;
+SELECT @@select_into_file_fsync_timeout = @@global.select_into_file_fsync_timeout;
+@@select_into_file_fsync_timeout = @@global.select_into_file_fsync_timeout
+0
+'#---------------------FN_DYNVARS_001_10----------------------#'
+SET @@select_into_file_fsync_timeout = 1000;
+SELECT @@select_into_file_fsync_timeout = @@local.select_into_file_fsync_timeout;
+@@select_into_file_fsync_timeout = @@local.select_into_file_fsync_timeout
+1
+SELECT @@local.select_into_file_fsync_timeout = @@session.select_into_file_fsync_timeout;
+@@local.select_into_file_fsync_timeout = @@session.select_into_file_fsync_timeout
+1
+'#---------------------FN_DYNVARS_001_11----------------------#'
+SET select_into_file_fsync_timeout = 1000;
+SELECT @@select_into_file_fsync_timeout;
+@@select_into_file_fsync_timeout
+1000
+SELECT local.select_into_file_fsync_timeout;
+ERROR 42S02: Unknown table 'local' in field list
+SELECT session.select_into_file_fsync_timeout;
+ERROR 42S02: Unknown table 'session' in field list
+SELECT select_into_file_fsync_timeout = @@session.select_into_file_fsync_timeout;
+ERROR 42S22: Unknown column 'select_into_file_fsync_timeout' in 'field list'
+SET @@global.select_into_file_fsync_timeout = @start_global_value;
+SELECT @@global.select_into_file_fsync_timeout;
+@@global.select_into_file_fsync_timeout
+0
+SET @@session.select_into_file_fsync_timeout = @start_session_value;
+SELECT @@session.select_into_file_fsync_timeout;
+@@session.select_into_file_fsync_timeout
+0

--- a/mysql-test/suite/sys_vars/t/select_into_file_fsync_size_basic.test
+++ b/mysql-test/suite/sys_vars/t/select_into_file_fsync_size_basic.test
@@ -1,0 +1,212 @@
+############## mysql-test\t\select_into_file_fsync_size_basic.test ###################
+#                                                                              #
+# Variable Name: select_into_file_fsync_size                                         #
+# Scope: GLOBAL & SESSION                                                      #
+# Access Type: Dynamic                                                         #
+# Data Type: Numeric                                                           #
+# Default Value: 0                                                             #
+# Multiples of 1024
+# Range: 0 - MAX
+#                                                                              #
+#                                                                              #
+# Creation Date: 2016-07-07                                                    #
+# Author:  Anirban Rahut                                                       #
+#                                                                              #
+# Description: Test Cases of Dynamic System Variable "select_into_file_fsync_size"   #
+#              that checks behavior of this variable in the following ways     #
+#              * Default Value                                                 #
+#              * Valid & Invalid values                                        #
+#              * Scope & Access method                                         #
+#              * Data Integrity                                                #
+#                                                                              #
+#                                                                              #
+################################################################################
+
+--source include/load_sysvars.inc
+
+#####################################################################
+#           START OF select_into_file_fsync_size TESTS                    #
+#####################################################################
+
+#############################################################
+#                 Save initial value                        #
+#############################################################
+
+SET @start_global_value = @@global.select_into_file_fsync_size;
+SELECT @start_global_value;
+SET @start_session_value = @@session.select_into_file_fsync_size;
+SELECT @start_session_value;
+
+
+--echo '#--------------------FN_DYNVARS_002_01-------------------------#'
+#####################################################################
+#     Display the DEFAULT value of select_into_file_fsync_size            #
+#####################################################################
+
+SET @@global.select_into_file_fsync_size = 1024;
+SET @@global.select_into_file_fsync_size = DEFAULT;
+SELECT @@global.select_into_file_fsync_size;
+
+SET @@session.select_into_file_fsync_size = 2048;
+SET @@session.select_into_file_fsync_size = DEFAULT;
+SELECT @@session.select_into_file_fsync_size;
+
+
+--echo '#--------------------FN_DYNVARS_002_02-------------------------#'
+#####################################################################
+#     Check the DEFAULT value of select_into_file_fsync_size              #
+#####################################################################
+
+SET @@global.select_into_file_fsync_size = @start_global_value;
+SELECT @@global.select_into_file_fsync_size = 4096;
+SET @@session.select_into_file_fsync_size = @start_session_value;
+SELECT @@session.select_into_file_fsync_size = 2048;
+
+
+--echo '#--------------------FN_DYNVARS_002_03-------------------------#'
+###############################################################################
+# Change the value of select_into_file_fsync_size to a valid value for GLOBAL Scope #
+###############################################################################
+
+SET @@global.select_into_file_fsync_size = 16384;
+SELECT @@global.select_into_file_fsync_size;
+SET @@global.select_into_file_fsync_size = 4096;
+SELECT @@global.select_into_file_fsync_size;
+SET @@global.select_into_file_fsync_size = 8192;
+SELECT @@global.select_into_file_fsync_size;
+
+
+--echo '#--------------------FN_DYNVARS_002_04-------------------------#'
+###############################################################################
+# Change the value of select_into_file_fsync_size to a valid value for SESSION Scope#
+###############################################################################
+
+SET @@session.select_into_file_fsync_size = 4096;
+SELECT @@session.select_into_file_fsync_size;
+SET @@session.select_into_file_fsync_size = 8192;
+SELECT @@session.select_into_file_fsync_size;
+SET @@session.select_into_file_fsync_size = 16384;
+SELECT @@session.select_into_file_fsync_size;
+
+
+--echo '#------------------FN_DYNVARS_002_05-----------------------#'
+#################################################################
+# Change the value of select_into_file_fsync_size to an invalid value #
+#################################################################
+# for global scope
+SET @@global.select_into_file_fsync_size = -1;
+SELECT @@global.select_into_file_fsync_size;
+SET @@global.select_into_file_fsync_size = -1024;
+SELECT @@global.select_into_file_fsync_size;
+SET @@global.select_into_file_fsync_size = 13;
+SELECT @@global.select_into_file_fsync_size;
+--Error ER_WRONG_TYPE_FOR_VAR
+SET @@global.select_into_file_fsync_size = ON;
+SELECT @@global.select_into_file_fsync_size;
+--Error ER_WRONG_TYPE_FOR_VAR
+SET @@global.select_into_file_fsync_size = OFF;
+SELECT @@global.select_into_file_fsync_size;
+--Error ER_WRONG_TYPE_FOR_VAR
+SET @@global.select_into_file_fsync_size = test;
+SELECT @@global.select_into_file_fsync_size;
+# for session scope
+SET @@session.select_into_file_fsync_size = 23;
+SELECT @@session.select_into_file_fsync_size;
+SET @@session.select_into_file_fsync_size = -2;
+SELECT @@session.select_into_file_fsync_size;
+SET @@session.select_into_file_fsync_size = 65550;
+SELECT @@session.select_into_file_fsync_size;
+
+--Error ER_WRONG_TYPE_FOR_VAR
+SET @@session.select_into_file_fsync_size = ON;
+SELECT @@session.select_into_file_fsync_size;
+--Error ER_WRONG_TYPE_FOR_VAR
+SET @@session.select_into_file_fsync_size = OFF;
+SELECT @@session.select_into_file_fsync_size;
+--Error ER_WRONG_TYPE_FOR_VAR
+SET @@session.select_into_file_fsync_size = test;
+SELECT @@session.select_into_file_fsync_size;
+
+
+
+--echo '#------------------FN_DYNVARS_002_06-----------------------#'
+####################################################################
+#   Check if the value in GLOBAL Table matches value in variable   #
+####################################################################
+
+SELECT @@global.select_into_file_fsync_size = VARIABLE_VALUE 
+FROM performance_schema.global_variables 
+WHERE VARIABLE_NAME='select_into_file_fsync_size';
+
+
+--echo '#------------------FN_DYNVARS_002_07-----------------------#'
+####################################################################
+#  Check if the value in SESSION Table matches value in variable   #
+####################################################################
+
+SELECT @@session.select_into_file_fsync_size = VARIABLE_VALUE 
+FROM performance_schema.session_variables 
+WHERE VARIABLE_NAME='select_into_file_fsync_size';
+
+
+--echo '#------------------FN_DYNVARS_002_08-----------------------#'
+####################################################################
+#     Check if TRUE and FALSE values can be used on variable       #
+####################################################################
+
+SET @@global.select_into_file_fsync_size = TRUE;
+SELECT @@global.select_into_file_fsync_size;
+SET @@global.select_into_file_fsync_size = FALSE;
+SELECT @@global.select_into_file_fsync_size;
+
+
+--echo '#---------------------FN_DYNVARS_001_09----------------------#'
+###############################################################################
+#  Check if global and session variables are independant of each other        #
+###############################################################################
+
+SET @@global.select_into_file_fsync_size = 16384;
+SET @@session.select_into_file_fsync_size = 8192;
+SELECT @@select_into_file_fsync_size = @@global.select_into_file_fsync_size;
+
+
+--echo '#---------------------FN_DYNVARS_001_10----------------------#'
+##############################################################################
+#    Check if accessing variable with SESSION,LOCAL and without SCOPE points #
+#    to same session variable                                                #
+##############################################################################
+
+SET @@select_into_file_fsync_size = 16384;
+SELECT @@select_into_file_fsync_size = @@local.select_into_file_fsync_size;
+SELECT @@local.select_into_file_fsync_size = @@session.select_into_file_fsync_size;
+
+
+--echo '#---------------------FN_DYNVARS_001_11----------------------#'
+###############################################################################
+#   Check if select_into_file_fsync_size can be accessed with and without @@ sign   #
+###############################################################################
+
+SET select_into_file_fsync_size = 1024;
+SELECT @@select_into_file_fsync_size;
+--Error ER_UNKNOWN_TABLE
+SELECT local.select_into_file_fsync_size;
+--Error ER_UNKNOWN_TABLE
+SELECT session.select_into_file_fsync_size;
+--Error ER_BAD_FIELD_ERROR
+SELECT select_into_file_fsync_size = @@session.select_into_file_fsync_size;
+
+
+####################################
+#     Restore initial value        #
+####################################
+
+SET @@global.select_into_file_fsync_size = @start_global_value;
+SELECT @@global.select_into_file_fsync_size;
+SET @@session.select_into_file_fsync_size = @start_session_value;
+SELECT @@session.select_into_file_fsync_size;
+
+
+###################################################
+#          END OF select_into_file_fsync_size TESTS     #
+###################################################
+

--- a/mysql-test/suite/sys_vars/t/select_into_file_fsync_timeout_basic.test
+++ b/mysql-test/suite/sys_vars/t/select_into_file_fsync_timeout_basic.test
@@ -1,0 +1,207 @@
+############## mysql-test\t\select_into_file_fsync_timeout_basic.test ###################
+#                                                                              #
+# Variable Name: select_into_file_fsync_timeout                                         #
+# Scope: GLOBAL & SESSION                                                      #
+# Access Type: Dynamic                                                         #
+# Data Type: Numeric                                                           #
+# Default Value: 0                                                             #
+# Range: 0 - MAX
+#                                                                              #
+#                                                                              #
+# Creation Date: 2016-07-07                                                    #
+# Author:  Anirban Rahut                                                       #
+#                                                                              #
+# Description: Test Cases of Dynamic System Variable "select_into_file_fsync_timeout"   #
+#              that checks behavior of this variable in the following ways     #
+#              * Default Value                                                 #
+#              * Valid & Invalid values                                        #
+#              * Scope & Access method                                         #
+#              * Data Integrity                                                #
+#                                                                              #
+#                                                                              #
+################################################################################
+
+--source include/load_sysvars.inc
+
+#####################################################################
+#           START OF select_into_file_fsync_timeout TESTS                    #
+#####################################################################
+
+#############################################################
+#                 Save initial value                        #
+#############################################################
+
+SET @start_global_value = @@global.select_into_file_fsync_timeout;
+SELECT @start_global_value;
+SET @start_session_value = @@session.select_into_file_fsync_timeout;
+SELECT @start_session_value;
+
+
+--echo '#--------------------FN_DYNVARS_002_01-------------------------#'
+#####################################################################
+#     Display the DEFAULT value of select_into_file_fsync_timeout            #
+#####################################################################
+
+SET @@global.select_into_file_fsync_timeout = 1000;
+SET @@global.select_into_file_fsync_timeout = DEFAULT;
+SELECT @@global.select_into_file_fsync_timeout;
+
+SET @@session.select_into_file_fsync_timeout = 3000;
+SET @@session.select_into_file_fsync_timeout = DEFAULT;
+SELECT @@session.select_into_file_fsync_timeout;
+
+
+--echo '#--------------------FN_DYNVARS_002_02-------------------------#'
+#####################################################################
+#     Check the DEFAULT value of select_into_file_fsync_timeout              #
+#####################################################################
+
+SET @@global.select_into_file_fsync_timeout = @start_global_value;
+SELECT @@global.select_into_file_fsync_timeout = 10;
+SET @@session.select_into_file_fsync_timeout = @start_session_value;
+SELECT @@session.select_into_file_fsync_timeout = 20;
+
+
+--echo '#--------------------FN_DYNVARS_002_03-------------------------#'
+###############################################################################
+# Change the value of select_into_file_fsync_timeout to a valid value for GLOBAL Scope #
+###############################################################################
+
+SET @@global.select_into_file_fsync_timeout = 5;
+SELECT @@global.select_into_file_fsync_timeout;
+SET @@global.select_into_file_fsync_timeout = 12;
+SELECT @@global.select_into_file_fsync_timeout;
+SET @@global.select_into_file_fsync_timeout = 100;
+SELECT @@global.select_into_file_fsync_timeout;
+
+
+--echo '#--------------------FN_DYNVARS_002_04-------------------------#'
+###############################################################################
+# Change the value of select_into_file_fsync_timeout to a valid value for SESSION Scope#
+###############################################################################
+
+SET @@session.select_into_file_fsync_timeout = 4;
+SELECT @@session.select_into_file_fsync_timeout;
+SET @@session.select_into_file_fsync_timeout = 8;
+SELECT @@session.select_into_file_fsync_timeout;
+SET @@session.select_into_file_fsync_timeout = 17;
+SELECT @@session.select_into_file_fsync_timeout;
+
+
+--echo '#------------------FN_DYNVARS_002_05-----------------------#'
+#################################################################
+# Change the value of select_into_file_fsync_timeout to an invalid value #
+#################################################################
+# for global scope
+SET @@global.select_into_file_fsync_timeout = -1;
+SELECT @@global.select_into_file_fsync_timeout;
+SET @@global.select_into_file_fsync_timeout = -1024;
+SELECT @@global.select_into_file_fsync_timeout;
+SET @@global.select_into_file_fsync_timeout = 3747474747474747474;
+SELECT @@global.select_into_file_fsync_timeout;
+--Error ER_WRONG_TYPE_FOR_VAR
+SET @@global.select_into_file_fsync_timeout = ON;
+SELECT @@global.select_into_file_fsync_timeout;
+--Error ER_WRONG_TYPE_FOR_VAR
+SET @@global.select_into_file_fsync_timeout = OFF;
+SELECT @@global.select_into_file_fsync_timeout;
+--Error ER_WRONG_TYPE_FOR_VAR
+SET @@global.select_into_file_fsync_timeout = test;
+SELECT @@global.select_into_file_fsync_timeout;
+# for session scope
+SET @@session.select_into_file_fsync_timeout = -1;
+SELECT @@session.select_into_file_fsync_timeout;
+SET @@session.select_into_file_fsync_timeout = -2;
+SELECT @@session.select_into_file_fsync_timeout;
+
+--Error ER_WRONG_TYPE_FOR_VAR
+
+SET @@session.select_into_file_fsync_timeout = ON;
+SELECT @@session.select_into_file_fsync_timeout;
+
+--Error ER_WRONG_TYPE_FOR_VAR
+
+SET @@session.select_into_file_fsync_timeout = OFF;
+SELECT @@session.select_into_file_fsync_timeout;
+
+--Error ER_WRONG_TYPE_FOR_VAR
+
+SET @@session.select_into_file_fsync_timeout = test;
+SELECT @@session.select_into_file_fsync_timeout;
+
+--Error ER_WRONG_TYPE_FOR_VAR
+
+SET @@session.select_into_file_fsync_timeout = 85858585858585858585;
+SELECT @@session.select_into_file_fsync_timeout;
+
+--Error ER_WRONG_VALUE_FOR_VAR
+
+
+--echo '#------------------FN_DYNVARS_002_06-----------------------#'
+####################################################################
+#   Check if the value in GLOBAL Table matches value in variable   #
+####################################################################
+
+SELECT @@global.select_into_file_fsync_timeout = VARIABLE_VALUE 
+FROM performance_schema.global_variables 
+WHERE VARIABLE_NAME='select_into_file_fsync_timeout';
+
+
+--echo '#------------------FN_DYNVARS_002_07-----------------------#'
+####################################################################
+#  Check if the value in SESSION Table matches value in variable   #
+####################################################################
+
+SELECT @@session.select_into_file_fsync_timeout = VARIABLE_VALUE 
+FROM performance_schema.session_variables 
+WHERE VARIABLE_NAME='select_into_file_fsync_timeout';
+
+--echo '#---------------------FN_DYNVARS_001_09----------------------#'
+###############################################################################
+#  Check if global and session variables are independant of each other        #
+###############################################################################
+
+SET @@global.select_into_file_fsync_timeout = 10;
+SET @@session.select_into_file_fsync_timeout = 1000;
+SELECT @@select_into_file_fsync_timeout = @@global.select_into_file_fsync_timeout;
+
+
+--echo '#---------------------FN_DYNVARS_001_10----------------------#'
+##############################################################################
+#    Check if accessing variable with SESSION,LOCAL and without SCOPE points #
+#    to same session variable                                                #
+##############################################################################
+
+SET @@select_into_file_fsync_timeout = 1000;
+SELECT @@select_into_file_fsync_timeout = @@local.select_into_file_fsync_timeout;
+SELECT @@local.select_into_file_fsync_timeout = @@session.select_into_file_fsync_timeout;
+
+
+--echo '#---------------------FN_DYNVARS_001_11----------------------#'
+###############################################################################
+#   Check if select_into_file_fsync_timeout can be accessed with and without @@ sign   #
+###############################################################################
+
+SET select_into_file_fsync_timeout = 1000;
+SELECT @@select_into_file_fsync_timeout;
+--Error ER_UNKNOWN_TABLE
+SELECT local.select_into_file_fsync_timeout;
+--Error ER_UNKNOWN_TABLE
+SELECT session.select_into_file_fsync_timeout;
+--Error ER_BAD_FIELD_ERROR
+SELECT select_into_file_fsync_timeout = @@session.select_into_file_fsync_timeout;
+
+
+####################################
+#     Restore initial value        #
+####################################
+
+SET @@global.select_into_file_fsync_timeout = @start_global_value;
+SELECT @@global.select_into_file_fsync_timeout;
+SET @@session.select_into_file_fsync_timeout = @start_session_value;
+SELECT @@session.select_into_file_fsync_timeout;
+
+
+###################################################
+#          END OF select_into_file_fsync_timeout TESTS     #
+###################################################

--- a/mysql-test/t/all_persisted_variables.test
+++ b/mysql-test/t/all_persisted_variables.test
@@ -39,7 +39,7 @@
 --source include/have_binlog_format_row.inc
 
 let $total_global_vars=`SELECT COUNT(*) FROM performance_schema.global_variables where variable_name NOT LIKE 'ndb_%'`;
-let $total_persistent_vars=392;
+let $total_persistent_vars=394;
 # Due to open bugs, there are fewer variables
 --let $total_persistent_vars_sans_bugs=`SELECT $total_persistent_vars - 6;`
 

--- a/mysql-test/t/select_outfile_fsync_debug-master.opt
+++ b/mysql-test/t/select_outfile_fsync_debug-master.opt
@@ -1,0 +1,1 @@
+--secure_file_priv=""

--- a/mysql-test/t/select_outfile_fsync_debug.test
+++ b/mysql-test/t/select_outfile_fsync_debug.test
@@ -1,0 +1,47 @@
+-- source include/have_debug.inc
+
+--disable_query_log
+-- source include/test_outfile.inc
+eval set @tmpdir='$MYSQL_TMP_DIR';
+-- source include/have_outfile.inc
+--enable_query_log
+
+# Save the initial number of concurrent sessions
+--source include/count_sessions.inc
+
+SET SESSION select_into_file_fsync_size=262144;
+SET GLOBAL debug = '+d,print_select_file_fsync_stats';
+
+# Create a table and populate it with some data
+CREATE TABLE t2 (a TEXT, b TEXT) ENGINE=INNODB;
+
+# Here we end up with 32768 rows in the table
+--disable_query_log
+INSERT INTO t2 (a, b) VALUES (REPEAT('a', 512), REPEAT('b', 512));
+INSERT INTO t2 (a, b) VALUES (REPEAT('A', 512), REPEAT('B', 512));
+let $i=14;
+while ($i) {
+  INSERT INTO t2 (a, b) SELECT a, b FROM t2;
+  dec $i;
+}
+
+--eval SELECT * INTO OUTFILE "$MYSQL_TMP_DIR/t2.txt" FROM t2;
+--enable_query_log
+
+--let $assert_file= $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $assert_only_after = CURRENT_TEST: select_outfile_fsync_debug
+--let $assert_count = 1
+--let $assert_select = \[select_to_file\]\[fsync_count\] 128
+--let $assert_text = Found expected number of select_to_file
+--source include/assert_grep.inc
+
+DROP TABLE t2;
+
+SET GLOBAL debug = '-d,print_select_file_fsync_stats';
+
+# Wait till we reached the initial number of concurrent sessions
+--source include/wait_until_count_sessions.inc
+
+--disable_query_log
+--remove_file $MYSQL_TMP_DIR/t2.txt
+--enable_query_log

--- a/sql/query_result.cc
+++ b/sql/query_result.cc
@@ -605,12 +605,35 @@ bool Query_result_export::send_data(List<Item> &items) {
   if (my_b_write(&cache, (uchar *)exchange->line.line_term->ptr(),
                  exchange->line.line_term->length()))
     goto err;
+
+  /* fsync the file after every select_into_file_fsync_size bytes
+       optionally sleep */
+  if (thd->variables.select_into_file_fsync_size != 0) {
+    my_off_t cur_fsize = my_b_tell(&cache);
+    if (cur_fsize - last_fsync_off >=
+        thd->variables.select_into_file_fsync_size) {
+      if (flush_io_cache(&cache) || mysql_file_sync(cache.file, MYF(MY_WME)))
+        goto err;
+#ifndef DBUG_OFF
+      n_fsyncs++;
+#endif
+      last_fsync_off = cur_fsize;
+      if (thd->variables.select_into_file_fsync_timeout)
+        my_sleep(thd->variables.select_into_file_fsync_timeout * 1000);
+    }
+  }
+
   DBUG_RETURN(false);
 err:
   DBUG_RETURN(true);
 }
 
 void Query_result_export::cleanup() {
+  DBUG_EXECUTE_IF("print_select_file_fsync_stats", {
+    // NO_LINT_DEBUG
+    fprintf(stderr, "[select_to_file][fsync_count] %u\n", n_fsyncs);
+  });
+
   thd->set_sent_row_count(row_count);
   Query_result_to_file::cleanup();
 }

--- a/sql/query_result.h
+++ b/sql/query_result.h
@@ -238,6 +238,10 @@ class Query_result_export final : public Query_result_to_file {
   bool is_unsafe_field_sep;
   bool fixed_row_size;
   const CHARSET_INFO *write_cs;  // output charset
+  my_off_t last_fsync_off = 0L;
+#ifndef DBUG_OFF
+  uint n_fsyncs = 0;
+#endif
  public:
   Query_result_export(THD *thd, sql_exchange *ex)
       : Query_result_to_file(thd, ex) {}

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -1402,6 +1402,20 @@ static Sys_var_charptr Sys_character_sets_dir(
     READ_ONLY NON_PERSIST GLOBAL_VAR(charsets_dir), CMD_LINE(REQUIRED_ARG),
     IN_FS_CHARSET, DEFAULT(0));
 
+static Sys_var_ulong Sys_select_into_file_fsync_size(
+    "select_into_file_fsync_size",
+    "Do an fsync to disk when the buffer grows by these many bytes "
+    "for SELECT INTO OUTFILE. Set 0 to disable.",
+    SESSION_VAR(select_into_file_fsync_size), CMD_LINE(OPT_ARG),
+    VALID_RANGE(0, ULONG_MAX), DEFAULT(0), BLOCK_SIZE(1024));
+
+static Sys_var_uint Sys_select_into_file_fsync_timeout(
+    "select_into_file_fsync_timeout",
+    "The timeout/sleep in milliseconds after each fsync with "
+    "SELECT INTO OUTFILE",
+    SESSION_VAR(select_into_file_fsync_timeout), CMD_LINE(OPT_ARG),
+    VALID_RANGE(0, UINT_MAX), DEFAULT(0), BLOCK_SIZE(1));
+
 static bool check_not_null(sys_var *, THD *, set_var *var) {
   return var->value && var->value->is_null();
 }

--- a/sql/system_variables.h
+++ b/sql/system_variables.h
@@ -368,6 +368,9 @@ struct System_variables {
   bool sql_require_primary_key;
 
   bool sql_log_bin_triggers;
+
+  ulong select_into_file_fsync_size;
+  uint select_into_file_fsync_timeout;
 };
 
 /**


### PR DESCRIPTION
Jira ticket: https://jira.percona.com/browse/FB8-75

Reference commit: https://github.com/facebook/mysql-5.6/commit/14b1086

-------- 14b1086 --------

Added flush and fsync for SELECT INTO OUTFILE.

Two variables are added, GLOBAL variables with SESSION override.
select_into_file_fsync_size, which controls the size of the buffer
after which a fsync will be done. Needs to be a multiple of 1024

After each fsync you can optionally sleep for
select_into_file_fsync_timeout milliseconds.

TODO: Record main.all_persisted_variables +2