### PR TITLE
FB8-106: Add more information to duplicate key error

### DIFF
--- a/mysql-test/r/improved_dup_key_error.result
+++ b/mysql-test/r/improved_dup_key_error.result
@@ -1,0 +1,10 @@
+CREATE TABLE t1(pk INT PRIMARY KEY);
+INSERT INTO t1 VALUES(1);
+SET @start_improved_dup_key_error = @@global.improved_dup_key_error;
+INSERT INTO t1 VALUES(1);
+ERROR 23000: Duplicate entry '1' for key 'PRIMARY'
+SET @@global.improved_dup_key_error = 1;
+INSERT INTO t1 VALUES(1);
+ERROR 23000: Duplicate entry '1' for key 't1.PRIMARY' [INSERT INTO t1 VALUES(1)]
+SET @@global.improved_dup_key_error = @start_improved_dup_key_error;
+DROP TABLE t1;

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -376,6 +376,10 @@ The following options may be given as the first argument:
  Maximum amount of memory available for generating
  histograms
  --host-cache-size=# How many host names should be cached to avoid resolving.
+ --improved-dup-key-error 
+ Include the table name in the error text when receiving a
+ duplicate key error and log the query into a new
+ duplicate key query log file.
  --information-schema-stats-expiry=# 
  The number of seconds after which mysqld server will
  fetch data from storage engine and replace the data in
@@ -1491,6 +1495,7 @@ gtid-mode OFF
 help TRUE
 histogram-generation-max-mem-size 20000000
 host-cache-size 279
+improved-dup-key-error FALSE
 information-schema-stats-expiry 86400
 init-connect 
 init-file (No default value)

--- a/mysql-test/r/warnings.result
+++ b/mysql-test/r/warnings.result
@@ -341,5 +341,15 @@ SHOW WARNINGS;
 Level	Code	Message
 Error	1062	Duplicate entry '11' for key 'a'
 
+set @save_improved_dup_key_error = @@global.improved_dup_key_error;
+set @@global.improved_dup_key_error = 1;
+SHOW TABLES WHERE f1(11) = 11;
+ERROR 23000: Duplicate entry '11' for key 't1.a' [INSERT INTO t1 VALUES( NAME_CONST('x',11))]
+
+SHOW WARNINGS;
+Level	Code	Message
+Error	1062	Duplicate entry '11' for key 't1.a' [INSERT INTO t1 VALUES( NAME_CONST('x',11))]
+
+set @@global.improved_dup_key_error = @save_improved_dup_key_error;
 DROP TABLE t1;
 DROP FUNCTION f1;

--- a/mysql-test/suite/sys_vars/r/improved_dup_key_error_basic.result
+++ b/mysql-test/suite/sys_vars/r/improved_dup_key_error_basic.result
@@ -1,0 +1,42 @@
+SET @start_improved_dup_key_error = @@global.improved_dup_key_error;
+SELECT @start_improved_dup_key_error;
+@start_improved_dup_key_error
+0
+SET @@global.improved_dup_key_error = DEFAULT;
+SELECT @@global.improved_dup_key_error;
+@@global.improved_dup_key_error
+0
+SET @@global.improved_dup_key_error = false;
+SELECT @@global.improved_dup_key_error;
+@@global.improved_dup_key_error
+0
+SET @@global.improved_dup_key_error = true;
+SELECT @@global.improved_dup_key_error;
+@@global.improved_dup_key_error
+1
+SET @@global.improved_dup_key_error = 1;
+SELECT @@global.improved_dup_key_error;
+@@global.improved_dup_key_error
+1
+SET @@global.improved_dup_key_error = 0;
+SELECT @@global.improved_dup_key_error;
+@@global.improved_dup_key_error
+0
+SET @@global.improved_dup_key_error = -1;
+ERROR 42000: Variable 'improved_dup_key_error' can't be set to the value of '-1'
+SELECT @@global.improved_dup_key_error;
+@@global.improved_dup_key_error
+0
+SET @@global.improved_dup_key_error = 100;
+ERROR 42000: Variable 'improved_dup_key_error' can't be set to the value of '100'
+SELECT @@global.improved_dup_key_error;
+@@global.improved_dup_key_error
+0
+SET @@session.improved_dup_key_error = 10;
+ERROR HY000: Variable 'improved_dup_key_error' is a GLOBAL variable and should be set with SET GLOBAL
+SELECT @@session.improved_dup_key_error;
+ERROR HY000: Variable 'improved_dup_key_error' is a GLOBAL variable
+SET @@global.improved_dup_key_error = @start_improved_dup_key_error;
+SELECT @@global.improved_dup_key_error;
+@@global.improved_dup_key_error
+0

--- a/mysql-test/suite/sys_vars/t/improved_dup_key_error_basic.test
+++ b/mysql-test/suite/sys_vars/t/improved_dup_key_error_basic.test
@@ -1,0 +1,32 @@
+SET @start_improved_dup_key_error = @@global.improved_dup_key_error;
+SELECT @start_improved_dup_key_error;
+
+SET @@global.improved_dup_key_error = DEFAULT;
+SELECT @@global.improved_dup_key_error;
+
+SET @@global.improved_dup_key_error = false;
+SELECT @@global.improved_dup_key_error;
+
+SET @@global.improved_dup_key_error = true;
+SELECT @@global.improved_dup_key_error;
+
+SET @@global.improved_dup_key_error = 1;
+SELECT @@global.improved_dup_key_error;
+
+SET @@global.improved_dup_key_error = 0;
+SELECT @@global.improved_dup_key_error;
+
+--Error ER_WRONG_VALUE_FOR_VAR
+SET @@global.improved_dup_key_error = -1;
+SELECT @@global.improved_dup_key_error;
+--Error ER_WRONG_VALUE_FOR_VAR
+SET @@global.improved_dup_key_error = 100;
+SELECT @@global.improved_dup_key_error;
+
+--ERROR ER_GLOBAL_VARIABLE
+SET @@session.improved_dup_key_error = 10;
+--ERROR ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.improved_dup_key_error;
+
+SET @@global.improved_dup_key_error = @start_improved_dup_key_error;
+SELECT @@global.improved_dup_key_error;

--- a/mysql-test/t/improved_dup_key_error.test
+++ b/mysql-test/t/improved_dup_key_error.test
@@ -1,0 +1,21 @@
+# Create a table
+CREATE TABLE t1(pk INT PRIMARY KEY);
+
+# Insert some data
+INSERT INTO t1 VALUES(1);
+
+# Save current value of variable
+SET @start_improved_dup_key_error = @@global.improved_dup_key_error;
+
+--error ER_DUP_ENTRY
+INSERT INTO t1 VALUES(1);
+
+# Now turn on the variable and try again
+SET @@global.improved_dup_key_error = 1;
+
+--error ER_DUP_ENTRY
+INSERT INTO t1 VALUES(1);
+
+SET @@global.improved_dup_key_error = @start_improved_dup_key_error;
+
+DROP TABLE t1;

--- a/mysql-test/t/warnings.test
+++ b/mysql-test/t/warnings.test
@@ -272,5 +272,19 @@ SHOW WARNINGS;
 
 --echo
 
+set @save_improved_dup_key_error = @@global.improved_dup_key_error;
+set @@global.improved_dup_key_error = 1;
+
+--error ER_DUP_ENTRY
+SHOW TABLES WHERE f1(11) = 11;
+
+--echo
+
+SHOW WARNINGS;
+
+--echo
+
+set @@global.improved_dup_key_error = @save_improved_dup_key_error;
+
 DROP TABLE t1;
 DROP FUNCTION f1;

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -3900,17 +3900,21 @@ const char *table_case_name(const HA_CREATE_INFO *info, const char *name) {
   @param msg      Error message template to which key value should be
                   added.
   @param errflag  Flags for my_error() call.
+  @param query    The query that caused the error
+  @param org_table_name  The original table name (if any)
 */
 
-void print_keydup_error(TABLE *table, KEY *key, const char *msg, myf errflag) {
+void print_keydup_error(TABLE *table, KEY *key, const char *msg, myf errflag,
+                        const THD *thd, const char *org_table_name) {
   /* Write the duplicated key in the error message */
   char key_buff[MAX_KEY_LENGTH];
+  std::string key_name;
   String str(key_buff, sizeof(key_buff), system_charset_info);
 
   if (key == NULL) {
     /* Key is unknown */
+    key_name = "*UNKNOWN*";
     str.copy("", 0, system_charset_info);
-    my_printf_error(ER_DUP_ENTRY, msg, errflag, str.c_ptr(), "*UNKNOWN*");
   } else {
     /* Table is opened and defined at this point */
     key_unpack(&str, table, key);
@@ -3919,20 +3923,53 @@ void print_keydup_error(TABLE *table, KEY *key, const char *msg, myf errflag) {
       str.length(max_length - 4);
       str.append(STRING_WITH_LEN("..."));
     }
-    my_printf_error(ER_DUP_ENTRY, msg, errflag, str.c_ptr_safe(), key->name);
+
+    if (opt_improved_dup_key_error) {
+      if (org_table_name != nullptr)
+        key_name = org_table_name;
+      else
+        key_name = table->s->table_name.str;
+
+      key_name += ".";
+    }
+
+    key_name += key->name;
   }
+
+  if (opt_improved_dup_key_error) {
+    // Replace any newlines in the query with spaces
+    const char *query_str = thd->query().str;
+    std::string query = query_str != nullptr ? query_str : "<unknown>";
+    std::transform(
+        query.begin(), query.end(), query.begin(),
+        [](std::string::value_type ch) { return ch == '\n' ? ' ' : ch; });
+
+    // Add " [<query>]" (or at least the first 512 bytes) to the format
+    // Note:  The total error message buffer size is only 512 bytes, so some
+    //        of the query string could be cut off.  We don't really care -
+    //        we are just trying to get as much as the query string as
+    //        we can.
+    std::string msg_fmt = std::string(msg) + " [%-.512s]";
+
+    my_printf_error(ER_DUP_ENTRY, msg_fmt.c_str(), errflag, str.c_ptr_safe(),
+                    key_name.c_str(), query.c_str());
+  } else
+    my_printf_error(ER_DUP_ENTRY, msg, errflag, str.c_ptr_safe(),
+                    key_name.c_str());
 }
 
 /**
   Construct and emit duplicate key error message using information
   from table's record buffer.
 
-  @sa print_keydup_error(table, key, msg, errflag).
+  @sa print_keydup_error(table, key, msg, errflag, thd, org_table_name).
 */
 
-void print_keydup_error(TABLE *table, KEY *key, myf errflag) {
+void print_keydup_error(TABLE *table, KEY *key, myf errflag, const THD *thd,
+                        const char *org_table_name) {
   print_keydup_error(table, key,
-                     ER_THD(current_thd, ER_DUP_ENTRY_WITH_KEY_NAME), errflag);
+                     ER_THD(current_thd, ER_DUP_ENTRY_WITH_KEY_NAME), errflag,
+                     thd, org_table_name);
 }
 
 /**
@@ -4035,7 +4072,7 @@ void handler::print_error(int error, myf errflag) {
       if ((int)key_nr >= 0) {
         print_keydup_error(table,
                            key_nr == MAX_KEY ? NULL : &table->key_info[key_nr],
-                           errflag);
+                           errflag, ha_thd());
         DBUG_VOID_RETURN;
       }
       textno = ER_DUP_KEY;

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -6089,8 +6089,10 @@ const char *get_canonical_filename(handler *file, const char *path,
 
 const char *table_case_name(const HA_CREATE_INFO *info, const char *name);
 
-void print_keydup_error(TABLE *table, KEY *key, const char *msg, myf errflag);
-void print_keydup_error(TABLE *table, KEY *key, myf errflag);
+void print_keydup_error(TABLE *table, KEY *key, const char *msg, myf errflag,
+                        const THD *thd, const char *org_table_name = nullptr);
+void print_keydup_error(TABLE *table, KEY *key, myf errflag, const THD *thd,
+                        const char *org_table_name = nullptr);
 
 void ha_set_normalized_disabled_se_str(const std::string &disabled_se_str);
 bool ha_is_storage_engine_disabled(handlerton *se_engine);

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -921,6 +921,7 @@ bool opt_general_log, opt_slow_log, opt_general_log_raw;
 ulonglong log_output_options;
 bool opt_log_queries_not_using_indexes = 0;
 ulong opt_log_throttle_queries_not_using_indexes = 0;
+bool opt_improved_dup_key_error = false;
 bool opt_disable_networking = 0, opt_skip_show_db = 0;
 bool opt_skip_name_resolve = 0;
 bool opt_character_set_client_handshake = 1;

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -150,6 +150,7 @@ enum enum_server_operational_state {
 enum_server_operational_state get_server_state();
 
 extern const char *mysql_compression_lib_names[3];
+extern bool opt_improved_dup_key_error;
 extern bool opt_large_files, server_id_supplied;
 extern bool opt_bin_log;
 extern bool opt_log_slave_updates;

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -16082,7 +16082,7 @@ static int copy_data_between_tables(
             err_msg = ER_THD(thd, ER_DUP_ENTRY_AUTOINCREMENT_CASE);
           print_keydup_error(to,
                              key_nr == MAX_KEY ? NULL : &to->key_info[key_nr],
-                             err_msg, MYF(0));
+                             err_msg, MYF(0), thd, from->s->table_name.str);
         } else
           to->file->print_error(error, MYF(0));
         break;

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -6461,3 +6461,9 @@ static Sys_var_charptr Sys_read_only_error_msg_extra(
     "which will be appended to read_only error messages.",
     GLOBAL_VAR(opt_read_only_error_msg_extra), CMD_LINE(OPT_ARG),
     IN_SYSTEM_CHARSET, DEFAULT(""), NO_MUTEX_GUARD, NOT_IN_BINLOG);
+
+static Sys_var_bool Sys_improved_dup_key_error(
+    "improved_dup_key_error",
+    "Include the table name in the error text when receiving a duplicate "
+    "key error and log the query into a new duplicate key query log file.",
+    GLOBAL_VAR(opt_improved_dup_key_error), CMD_LINE(OPT_ARG), DEFAULT(false));

--- a/storage/innobase/handler/ha_innodb.h
+++ b/storage/innobase/handler/ha_innodb.h
@@ -67,6 +67,8 @@ struct INNOBASE_SHARE {
 /** Prebuilt structures in an InnoDB table handle used within MySQL */
 struct row_prebuilt_t;
 
+struct ha_innobase_inplace_ctx;
+
 namespace dd {
 namespace cache {
 class Dictionary_client;
@@ -409,6 +411,10 @@ class ha_innobase : public handler {
                                   bool commit, const dd::Table *old_dd_tab,
                                   dd::Table *new_dd_tab);
   /** @} */
+  MY_ATTRIBUTE((warn_unused_result)) bool commit_try_rebuild(
+      Alter_inplace_info *ha_alter_info, ha_innobase_inplace_ctx *ctx,
+      TABLE *altered_table, const TABLE *old_table, trx_t *trx,
+      const char *table_name);
 
   bool check_if_incompatible_data(HA_CREATE_INFO *info, uint table_changes);
 

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -5903,7 +5903,7 @@ oom:
               &ha_alter_info->key_info_buffer[m_prebuilt->trx->error_key_num];
         }
       }
-      print_keydup_error(altered_table, dup_key, MYF(0));
+      print_keydup_error(altered_table, dup_key, MYF(0), m_user_thd);
       break;
     case DB_ONLINE_LOG_TOO_BIG:
       DBUG_ASSERT(ctx->online);
@@ -6442,7 +6442,7 @@ when rebuilding the table.
 @retval true Failure
 @retval false Success
 */
-inline MY_ATTRIBUTE((warn_unused_result)) bool commit_try_rebuild(
+MY_ATTRIBUTE((warn_unused_result)) bool ha_innobase::commit_try_rebuild(
     Alter_inplace_info *ha_alter_info, ha_innobase_inplace_ctx *ctx,
     TABLE *altered_table, const TABLE *old_table, trx_t *trx,
     const char *table_name) {
@@ -6533,7 +6533,8 @@ inline MY_ATTRIBUTE((warn_unused_result)) bool commit_try_rebuild(
             dup_key = &ha_alter_info->key_info_buffer[err_key];
           }
         }
-        print_keydup_error(altered_table, dup_key, MYF(0));
+        print_keydup_error(altered_table, dup_key, MYF(0), m_user_thd,
+                           old_table->s->table_name.str);
         DBUG_RETURN(true);
       case DB_ONLINE_LOG_TOO_BIG:
         my_error(ER_INNODB_ONLINE_LOG_TOO_BIG, MYF(0),


### PR DESCRIPTION
Jira issue: https://jira.percona.com/browse/FB8-106

Reference Patch: https://github.com/facebook/mysql-5.6/commit/2c7f717
Reference Patch: https://github.com/facebook/mysql-5.6/commit/f3a0ed0

Summary: The current error information for duplicate key lists the key value and key name.  In some scenarios this may not be sufficient.  Add a variable that, when enabled, includes the tableame for the key and the query text (or up to 512 bytes of it) into the error message.  The new variable, improved_dup_key_error, will change the output error message to contain this new information.

Originally Reviewed By: hermanlee

TODO: Because of conflicts I removed changes in `mysql-test/t/all_persisted_variables.test`. This test has to be modified at `let $total_persistent_vars=XXX;` (+1 increase) and it should be re-recorded.