### PR TITLE
WIP FB8-159: Changing thread priorities

### DIFF
--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -1357,6 +1357,9 @@ The following options may be given as the first argument:
  --thread-handling=name 
  Define threads usage for handling queries, one of
  one-thread-per-connection, no-threads, loaded-dynamically
+ --thread-nice-value[=name] 
+ Input format is threadId:niceValue nice value range is
+ -20 to 19
  --thread-stack=#    The stack size for each thread
  --tls-version=name  TLS version, permitted values are TLSv1, TLSv1.1, TLSv1.2
  --tmp-table-size=#  If an internal in-memory temporary table in the MEMORY
@@ -1769,6 +1772,7 @@ tc-heuristic-recover OFF
 temptable-max-ram 1073741824
 thread-cache-size 9
 thread-handling one-thread-per-connection
+thread-nice-value 
 thread-stack 262144
 tmp-table-size 16777216
 transaction-alloc-block-size 8192

--- a/mysql-test/suite/sys_vars/r/thread_nice_value_basic.result
+++ b/mysql-test/suite/sys_vars/r/thread_nice_value_basic.result
@@ -1,0 +1,21 @@
+SET @start_global_value = @@GLOBAL.thread_nice_value;
+SELECT @start_global_value;
+@start_global_value
+
+select @@GLOBAL.thread_nice_value;
+@@GLOBAL.thread_nice_value
+
+SET @@GLOBAL.thread_nice_value = '';
+ERROR 42000: Variable 'thread_nice_value' can't be set to the value of ''
+SET @@GLOBAL.thread_nice_value = ':';
+ERROR 42000: Variable 'thread_nice_value' can't be set to the value of ':'
+SET @@GLOBAL.thread_nice_value = ' : -3';
+ERROR 42000: Variable 'thread_nice_value' can't be set to the value of ' : -3'
+SET @@GLOBAL.thread_nice_value = '0:30';
+ERROR 42000: Variable 'thread_nice_value' can't be set to the value of '0:30'
+SET @@GLOBAL.thread_nice_value = '0:10';
+ERROR HY000: Thread 0 was not found
+SET @start_global_value = @@GLOBAL.thread_nice_value;
+SELECT @start_global_value;
+@start_global_value
+

--- a/mysql-test/suite/sys_vars/t/thread_nice_value_basic.test
+++ b/mysql-test/suite/sys_vars/t/thread_nice_value_basic.test
@@ -1,0 +1,46 @@
+################## mysql-test\t\thread_nice_value_basic.test ###############
+#                                                                             #
+# Variable Name: thread_nice_value                                            #
+# Scope:Global                                                                #
+#                                                                             #
+# Creation Date: 2018-03-08                                                   #
+#                                                                             #
+#                                                                             #
+# Description: This test requires thread id and capabilities. Capabilities    #
+#             are set from mysqld_safe. Testing the values that cant be set.  #
+#                                                                             #
+###############################################################################
+
+SET @start_global_value = @@GLOBAL.thread_nice_value;
+SELECT @start_global_value;
+
+########################################################################
+#          Display the DEFAULT value of thread_nice_value            #
+########################################################################
+select @@GLOBAL.thread_nice_value;
+
+
+########################################################################
+#          Invalid input types                                         #
+########################################################################
+--Error ER_WRONG_VALUE_FOR_VAR
+SET @@GLOBAL.thread_nice_value = '';
+
+--Error ER_WRONG_VALUE_FOR_VAR
+SET @@GLOBAL.thread_nice_value = ':';
+
+--Error ER_WRONG_VALUE_FOR_VAR
+SET @@GLOBAL.thread_nice_value = ' : -3';
+
+--Error ER_WRONG_VALUE_FOR_VAR
+SET @@GLOBAL.thread_nice_value = '0:30';
+
+--Error ER_THRNICE_THREAD_NOT_FOUND
+SET @@GLOBAL.thread_nice_value = '0:10';
+
+################################
+#     Restore initial value    #
+################################
+
+SET @start_global_value = @@GLOBAL.thread_nice_value;
+SELECT @start_global_value;

--- a/scripts/mysqld_safe.sh
+++ b/scripts/mysqld_safe.sh
@@ -750,6 +750,11 @@ directory and restart this script from there as follows:
 See http://dev.mysql.com/doc/mysql/en/mysqld-safe.html for more information"
   exit 1
 fi
+setcap 'cap_sys_nice=eip' $ledir/$MYSQLD
+if [ $? -ne 0 ]
+then
+  echo "Failed to set capabilities"
+fi
 
 if test -z "$pid_file"
 then

--- a/share/errmsg-utf8.txt
+++ b/share/errmsg-utf8.txt
@@ -18728,6 +18728,15 @@ ER_RPL_FAILED_IN_RLI_INIT_INFO
 ER_SEMISYNC_FORCE_SHUTDOWN
    eng "Force shutdown: Semi-sync master is being switched off while there are active un-acked transactions"
 
+ER_THRNICE_THREAD_NOT_FOUND
+   eng "Thread %ld was not found"
+
+ER_THRNICE_SETPRIORITY_FAILED
+   eng "setpriority() failed, returned val is %d, error %s"
+
+ER_THRNICE_INVALID_RANGE
+   eng "Nice value %ld is outside the valid range of -19 to 20"
+
 #
 # End of 8.0 FB MySQL error messages.
 # (Please read comments from the header of this section before adding error

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -1390,6 +1390,9 @@ bool THD::store_globals() {
   set_my_thread_var_id(m_thread_id);
 #endif
   real_id = my_thread_self();  // For debugging
+#ifdef HAVE_SYS_GETTID
+  system_thread_id = syscall(SYS_gettid);
+#endif
 
   return false;
 }

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -2083,6 +2083,10 @@ class THD : public MDL_context_owner,
                          value that is only to be used for temporary THDs not present in
                          the global THD list.
                        */
+#ifdef HAVE_SYS_GETTID
+  pid_t system_thread_id;
+#endif
+
  private:
   my_thread_id m_thread_id;
 
@@ -3991,6 +3995,13 @@ class THD : public MDL_context_owner,
   */
   void claim_memory_ownership();
 
+  bool is_thd_priority_alt() { return thd_priority_alt; }
+  void mark_thd_priority_as_alt() {
+    mysql_mutex_lock(&LOCK_thd_data);
+    thd_priority_alt = true;
+    mysql_mutex_unlock(&LOCK_thd_data);
+  }
+
   bool is_a_srv_session() const { return is_a_srv_session_thd; }
   void mark_as_srv_session() { is_a_srv_session_thd = true; }
 #ifndef DBUG_OFF
@@ -4007,6 +4018,9 @@ class THD : public MDL_context_owner,
     aggregates THD.
   */
   bool is_a_srv_session_thd;
+
+  /*Variable to mark weather nice value of this thread changed or not*/
+  bool thd_priority_alt = false;
 
   /**
     Creating or dropping plugin native table through a plugin service.


### PR DESCRIPTION
Jira issue: https://jira.percona.com/browse/FB8-159

Reference Patch: https://github.com/facebook/mysql-5.6/commit/2971de1

Summary: To change os priorities of thread from mysql

Originally Reviewed By: anirbanr-fb

fbshipit-source-id: fd355ee

TODO: Because of conflicts I removed changes in `mysql-test/t/all_persisted_variables.test`. This test has to be modified at `let $total_persistent_vars=XXX;` (+1 increase) and it should be re-recorded.