### PR TITLE
FB8-183: Implement system status variable to track duration of global read lock (Metadata lock) and the COMMIT lock

### DIFF
--- a/mysql-test/r/commit_lock_wait_time.result
+++ b/mysql-test/r/commit_lock_wait_time.result
@@ -1,0 +1,22 @@
+create table t1 (a int) engine=innodb;
+insert into t1 values(1);
+show status like 'super_read_only_block_microsec';
+Variable_name	Value
+super_read_only_block_microsec	0
+insert into t1 values(1);
+set debug_sync='RESET';
+set debug_sync='ha_commit_trans_after_acquire_commit_lock WAIT_FOR go';
+insert into t1 values(1);
+select sleep(1.1);
+sleep(1.1)
+0
+include/assert.inc [super_read_only_block_microsec is bigger than 1100000]
+set debug_sync='now SIGNAL go';
+select sleep(1.1);
+sleep(1.1)
+0
+show status like 'super_read_only_block_microsec';
+Variable_name	Value
+super_read_only_block_microsec	0
+set debug_sync= 'RESET';
+drop table t1;

--- a/mysql-test/r/show_super_read_only_block.result
+++ b/mysql-test/r/show_super_read_only_block.result
@@ -1,0 +1,17 @@
+create database testdb1;
+use testdb1;
+create table t1 (a int);
+insert into t1 values(1);
+show status like 'super_read_only_block_microsec';
+Variable_name	Value
+super_read_only_block_microsec	0
+lock table t1 write;
+select sleep(1.1);
+sleep(1.1)
+0
+include/assert.inc [super_read_only_block_microsec is bigger than 1100000]
+unlock tables;
+show status like 'super_read_only_block_microsec';
+Variable_name	Value
+super_read_only_block_microsec	0
+drop database testdb1;

--- a/mysql-test/t/commit_lock_wait_time.test
+++ b/mysql-test/t/commit_lock_wait_time.test
@@ -1,0 +1,33 @@
+--source include/have_debug_sync.inc
+--source include/count_sessions.inc
+
+--connect (con1,localhost,root)
+--connection default
+create table t1 (a int) engine=innodb;
+insert into t1 values(1);
+show status like 'super_read_only_block_microsec';
+
+insert into t1 values(1);
+set debug_sync='RESET';
+set debug_sync='ha_commit_trans_after_acquire_commit_lock WAIT_FOR go';
+--send insert into t1 values(1)
+
+--connection con1
+select sleep(1.1);
+--let $exec = `show status like 'super_read_only_block_microsec'`
+--let $assert_text = super_read_only_block_microsec is bigger than 1100000
+--let $assert_cond = [select substring("$exec", 32)+0] > 1100000
+--source include/assert.inc
+
+set debug_sync='now SIGNAL go';
+select sleep(1.1);
+show status like 'super_read_only_block_microsec';
+
+set debug_sync= 'RESET';
+--disconnect con1
+
+--connection default
+--reap
+drop table t1;
+
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/t/show_super_read_only_block.test
+++ b/mysql-test/t/show_super_read_only_block.test
@@ -1,0 +1,24 @@
+create database testdb1;
+
+use testdb1;
+
+create table t1 (a int);
+
+insert into t1 values(1);
+
+show status like 'super_read_only_block_microsec';
+
+lock table t1 write;
+
+select sleep(1.1);
+
+--let $exec = `show status like 'super_read_only_block_microsec'`
+--let $assert_text = super_read_only_block_microsec is bigger than 1100000
+--let $assert_cond = [select substring("$exec", 32)+0] > 1100000
+--source include/assert.inc
+
+unlock tables;
+
+show status like 'super_read_only_block_microsec';
+
+drop database testdb1;

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -379,6 +379,14 @@ inline double my_timer_to_microseconds(ulonglong when) {
   ret /= (double)(my_timer.frequency);
   return ret;
 }
+/* Convert native timer units in a ulonglong into microseconds in a ulonglong */
+inline ulonglong my_timer_to_microseconds_ulonglong(ulonglong when) {
+  ulonglong ret = when;
+  ret *= 1000000ULL;
+  ret = static_cast<ulonglong>((ret + my_timer.frequency - 1) /
+                               my_timer.frequency);
+  return ret;
+}
 /* Convert microseconds in a double to native timer units in a ulonglong */
 inline ulonglong microseconds_to_my_timer(double when) {
   double ret = when;
@@ -738,6 +746,9 @@ extern MYSQL_PLUGIN_IMPORT struct System_variables global_system_variables;
 extern char default_logfile_name[FN_REFLEN];
 extern bool log_bin_supplied;
 extern char default_binlogfile_name[FN_REFLEN];
+
+extern std::atomic_ullong init_global_rolock_timer;
+extern std::atomic_ullong init_commit_lock_timer;
 
 #define mysql_tmpdir (my_tmpdir(&mysql_tmpdir_list))
 


### PR DESCRIPTION
Jira issue: https://jira.percona.com/browse/FB8-183

Reference Patch: https://github.com/facebook/mysql-5.6/commit/ba953ba

Summary:
In this change, we are adding status variable Global_Read_Only_Lock_WaitTime status variable which keep tracks of how long either global readonly lock or commit lock is held.
This is going to help with automation of failover.

Originally Reviewed By: Tema