### PR TITLE
FB8-221: Change SET GLOBAL [super_]read_only to not acquire the global read lock

### DIFF
--- a/mysql-test/r/global_read_lock.result
+++ b/mysql-test/r/global_read_lock.result
@@ -1,0 +1,134 @@
+DROP TABLE IF EXISTS t1;
+SET @save_legacy_global_read_lock_mode = @@global.legacy_global_read_lock_mode;
+CREATE TABLE t1(a INT) Engine=InnoDB;
+SET @@global.legacy_global_read_lock_mode = 0;
+SET @save_read_only=@@global.read_only;
+SET @save_super_read_only=@@global.super_read_only;
+BEGIN WORK;
+SELECT * FROM t1;
+a
+INSERT INTO t1 SELECT sleep(10);
+SELECT command, info FROM information_schema.processlist ORDER BY command, info;
+command	info
+Daemon	NULL
+Query	INSERT INTO t1 SELECT sleep(10)
+Query	SELECT command, info FROM information_schema.processlist ORDER BY command, info
+Sleep	NULL
+SET GLOBAL super_read_only=1;
+SELECT command, info FROM information_schema.processlist ORDER BY command, info;
+command	info
+Daemon	NULL
+Query	INSERT INTO t1 SELECT sleep(10)
+Query	SELECT command, info FROM information_schema.processlist ORDER BY command, info
+Sleep	NULL
+CREATE TABLE t2 (a INT) Engine=InnoDB;
+ERROR HY000: The MySQL server is running with the --super-read-only option so it cannot execute this statement
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+1
+COMMIT;
+ERROR HY000: The MySQL server is running with the --super-read-only option so it cannot execute this statement
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+0
+SET @@global.super_read_only = @save_super_read_only;
+SET @@global.read_only = @save_read_only;
+SET @save_read_only=@@global.read_only;
+SET @save_super_read_only=@@global.super_read_only;
+SELECT * FROM t1;
+a
+INSERT INTO t1 SELECT sleep(10);
+SELECT command, info FROM information_schema.processlist ORDER BY command, info;
+command	info
+Daemon	NULL
+Query	INSERT INTO t1 SELECT sleep(10)
+Query	SELECT command, info FROM information_schema.processlist ORDER BY command, info
+Sleep	NULL
+SET GLOBAL super_read_only=1;
+SELECT command, info FROM information_schema.processlist ORDER BY command, info;
+command	info
+Daemon	NULL
+Query	INSERT INTO t1 SELECT sleep(10)
+Query	SELECT command, info FROM information_schema.processlist ORDER BY command, info
+Sleep	NULL
+CREATE TABLE t2 (a INT) Engine=InnoDB;
+ERROR HY000: The MySQL server is running with the --super-read-only option so it cannot execute this statement
+ERROR HY000: The MySQL server is running with the --super-read-only option so it cannot execute this statement
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+0
+SET @@global.super_read_only = @save_super_read_only;
+SET @@global.read_only = @save_read_only;
+SET @@global.legacy_global_read_lock_mode = 1;
+SET @save_read_only=@@global.read_only;
+SET @save_super_read_only=@@global.super_read_only;
+BEGIN WORK;
+SELECT * FROM t1;
+a
+INSERT INTO t1 SELECT sleep(10);
+SELECT command, info FROM information_schema.processlist ORDER BY command, info;
+command	info
+Daemon	NULL
+Query	INSERT INTO t1 SELECT sleep(10)
+Query	SELECT command, info FROM information_schema.processlist ORDER BY command, info
+Sleep	NULL
+SET GLOBAL super_read_only=1;
+SELECT command, info FROM information_schema.processlist ORDER BY command, info;
+command	info
+Daemon	NULL
+Query	INSERT INTO t1 SELECT sleep(10)
+Query	SELECT command, info FROM information_schema.processlist ORDER BY command, info
+Query	SET GLOBAL super_read_only=1
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+1
+COMMIT;
+ERROR HY000: The MySQL server is running with the --super-read-only option so it cannot execute this statement
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+0
+SET @@global.super_read_only = @save_super_read_only;
+SET @@global.read_only = @save_read_only;
+SET @save_read_only=@@global.read_only;
+SET @save_super_read_only=@@global.super_read_only;
+SELECT * FROM t1;
+a
+INSERT INTO t1 SELECT sleep(10);
+SELECT command, info FROM information_schema.processlist ORDER BY command, info;
+command	info
+Daemon	NULL
+Query	INSERT INTO t1 SELECT sleep(10)
+Query	SELECT command, info FROM information_schema.processlist ORDER BY command, info
+Sleep	NULL
+SET GLOBAL super_read_only=1;
+SELECT command, info FROM information_schema.processlist ORDER BY command, info;
+command	info
+Daemon	NULL
+Query	INSERT INTO t1 SELECT sleep(10)
+Query	SELECT command, info FROM information_schema.processlist ORDER BY command, info
+Query	SET GLOBAL super_read_only=1
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+1
+SET @@global.super_read_only = @save_super_read_only;
+SET @@global.read_only = @save_read_only;
+SET @@global.legacy_global_read_lock_mode = 0;
+SET @save_read_only=@@global.read_only;
+SET @save_super_read_only=@@global.super_read_only;
+BEGIN;
+LOCK TABLES t1 WRITE;
+INSERT INTO t1 VALUES(100);
+The In_use column should be 1 to indicate the lock
+SHOW OPEN TABLES like 't1';
+Database	Table	In_use	Name_locked
+test	t1	1	0
+SET GLOBAL super_read_only=1;
+UNLOCK TABLES;
+The In_use column should be 0 to indicate the lock was removed
+SHOW OPEN TABLES like 't1';
+Database	Table	In_use	Name_locked
+test	t1	0	0
+SET @@global.legacy_global_read_lock_mode = @save_legacy_global_read_lock_mode;
+SET @@global.super_read_only = @save_super_read_only;
+SET @@global.read_only = @save_read_only;
+DROP TABLE t1;

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -446,6 +446,11 @@ The following options may be given as the first argument:
  --lc-time-names=name 
  Set the language used for the month names and the days of
  the week.
+ --legacy-global-read-lock-mode 
+ Uses the legacy global read lock mode which will block
+ setting global read lock when a long transaction is
+ running
+ (Defaults to on; use --skip-legacy-global-read-lock-mode to disable.)
  --local-infile      Enable LOAD DATA LOCAL INFILE
  --lock-wait-timeout=# 
  Timeout in seconds to wait for a lock before returning an
@@ -1517,6 +1522,7 @@ keyring-migration-user (No default value)
 large-pages FALSE
 lc-messages en_US
 lc-time-names en_US
+legacy-global-read-lock-mode TRUE
 local-infile FALSE
 lock-wait-timeout 31536000
 log-bin (No default value)

--- a/mysql-test/r/read_only_innodb.result
+++ b/mysql-test/r/read_only_innodb.result
@@ -46,6 +46,23 @@ a
 1
 COMMIT;
 UNLOCK TABLES;
+DELETE from t1;
+FLUSH STATUS;
+SET @save_legacy_global_read_lock_mode = @@global.legacy_global_read_lock_mode;
+SET @@global.legacy_global_read_lock_mode = 1;
+connection con1;
+INSERT INTO t1 (a) SELECT sleep(3) ;
+connection default;
+set global read_only=1;
+connection con1
+# Check if the query is done. Expected a=0
+SELECT * FROM t1;
+a
+0
+connection default;
+SET GLOBAL read_only=0;
+SET @@global.legacy_global_read_lock_mode = @save_legacy_global_read_lock_mode;
+UNLOCK TABLES;
 DROP TABLE t1;
 DROP USER test@localhost;
 echo End of 5.1 tests 

--- a/mysql-test/r/read_only_innodb_basic.result
+++ b/mysql-test/r/read_only_innodb_basic.result
@@ -1,0 +1,156 @@
+set @start_read_only= @@global.read_only;
+create user test@localhost;
+grant CREATE, SELECT, DROP on *.* to test@localhost;
+connect (con1,localhost,test,,test);
+connection default;
+set global read_only=0;
+connection con1;
+create table t1 (a int) engine=InnoDb;
+insert into t1 values(1);
+create table t2 engine=InnoDb select * from t1;
+connection default;
+set global read_only=1;
+create table t3 (a int) engine=InnoDb;
+drop table t3;
+connection con1;
+select @@global.read_only;
+@@global.read_only
+1
+create table t3 (a int) engine=InnoDb;
+ERROR HY000: The MySQL server is running with the --read-only option so it cannot execute this statement
+insert into t1 values(1);
+ERROR HY000: The MySQL server is running with the --read-only option so it cannot execute this statement
+update t1 set a=1 where 1=0;
+ERROR HY000: The MySQL server is running with the --read-only option so it cannot execute this statement
+update t1,t2 set t1.a=t2.a+1 where t1.a=t2.a;
+ERROR HY000: The MySQL server is running with the --read-only option so it cannot execute this statement
+delete t1,t2 from t1,t2 where t1.a=t2.a;
+ERROR HY000: The MySQL server is running with the --read-only option so it cannot execute this statement
+create temporary table t3 (a int);
+create temporary table t4 (a int) select * from t3;
+insert into t3 values(1);
+insert into t4 select * from t3;
+update t1,t3 set t1.a=t3.a+1 where t1.a=t3.a;
+ERROR HY000: The MySQL server is running with the --read-only option so it cannot execute this statement
+update t1,t3 set t3.a=t1.a+1 where t1.a=t3.a;
+update t4,t3 set t4.a=t3.a+1 where t4.a=t3.a;
+delete t1 from t1,t3 where t1.a=t3.a;
+ERROR HY000: The MySQL server is running with the --read-only option so it cannot execute this statement
+delete t3 from t1,t3 where t1.a=t3.a;
+delete t4 from t3,t4 where t4.a=t3.a;
+create temporary table t1 (a int);
+insert into t1 values(1);
+update t1,t3 set t1.a=t3.a+1 where t1.a=t3.a;
+delete t1 from t1,t3 where t1.a=t3.a;
+drop table t1;
+insert into t1 values(1);
+ERROR HY000: The MySQL server is running with the --read-only option so it cannot execute this statement
+connection default;
+set global read_only=0;
+lock table t1 write;
+connection con1;
+lock table t2 write;
+connection default;
+set global read_only=1;
+ERROR HY000: Can't execute the given command because you have active locked tables or an active transaction
+unlock tables ;
+send set global read_only=1;
+set global read_only=1;
+connection con1;
+unlock tables ;
+select @@global.read_only;
+@@global.read_only
+1
+connection default;
+reap;
+connection default;
+set global read_only=0;
+lock table t1 read;
+connection con1;
+lock table t2 read;
+connection default;
+set global read_only=1;
+ERROR HY000: Can't execute the given command because you have active locked tables or an active transaction
+unlock tables ;
+send set global read_only=1;
+set global read_only=1;
+connection con1;
+unlock tables ;
+select @@global.read_only;
+@@global.read_only
+1
+connection default;
+reap;
+connection default;
+set global read_only=0;
+BEGIN;
+connection con1;
+BEGIN;
+connection default;
+set global read_only=1;
+ERROR HY000: Can't execute the given command because you have active locked tables or an active transaction
+ROLLBACK;
+set global read_only=1;
+connection con1;
+select @@global.read_only;
+@@global.read_only
+1
+ROLLBACK;
+connection default;
+set global read_only=0;
+flush tables with read lock;
+set global read_only=1;
+unlock tables;
+connect (root2,localhost,root,,test);
+connection default;
+set global read_only=0;
+flush tables with read lock;
+connection root2;
+set global read_only=1;
+connection default;
+select @@global.read_only;
+@@global.read_only
+1
+unlock tables;
+drop temporary table ttt;
+ERROR 42S02: Unknown table 'test.ttt'
+drop temporary table if exists ttt;
+Warnings:
+Note	1051	Unknown table 'test.ttt'
+connection default;
+set global read_only=0;
+drop table t1,t2;
+drop user test@localhost;
+#
+# Bug#27440 read_only allows create and drop database
+#
+set global read_only= 1;
+drop database if exists mysqltest_db1;
+drop database if exists mysqltest_db2;
+delete from mysql.user where User like 'mysqltest_%';
+delete from mysql.db where User like 'mysqltest_%';
+delete from mysql.tables_priv where User like 'mysqltest_%';
+delete from mysql.columns_priv where User like 'mysqltest_%';
+flush privileges;
+create user mysqltest_u1@'%';
+grant all on mysqltest_db2.* to `mysqltest_u1`@`%`;
+create database mysqltest_db1;
+grant all on mysqltest_db1.* to `mysqltest_u1`@`%`;
+flush privileges;
+connect (con_bug27440,127.0.0.1,mysqltest_u1,,test,MASTER_MYPORT,);
+connection con_bug27440;
+create database mysqltest_db2;
+ERROR HY000: The MySQL server is running with the --read-only option so it cannot execute this statement
+show databases like '%mysqltest_db2%';
+Database (%mysqltest_db2%)
+drop database mysqltest_db1;
+ERROR HY000: The MySQL server is running with the --read-only option so it cannot execute this statement
+disconnect con_bug27440;
+connection default;
+delete from mysql.user where User like 'mysqltest_%';
+delete from mysql.db where User like 'mysqltest_%';
+delete from mysql.tables_priv where User like 'mysqltest_%';
+delete from mysql.columns_priv where User like 'mysqltest_%';
+flush privileges;
+drop database mysqltest_db1;
+set global read_only= @start_read_only;

--- a/mysql-test/suite/sys_vars/inc/correctboolvalue.inc
+++ b/mysql-test/suite/sys_vars/inc/correctboolvalue.inc
@@ -1,0 +1,25 @@
+##
+# $input the value of a boolean type
+# $output the value of int type
+##
+--let $int_value=$value
+if ($value==on)
+{
+  --let $int_value=1
+}
+
+if ($value==off)
+{
+  --let $int_value=0
+}
+
+# MySQL allows 'true' and 'false' on bool values
+if ($value==true)
+{
+  --let $int_value=1
+}
+
+if ($value==false)
+{
+  --let $int_value=0
+}

--- a/mysql-test/suite/sys_vars/inc/sys_var.inc
+++ b/mysql-test/suite/sys_vars/inc/sys_var.inc
@@ -1,0 +1,121 @@
+##
+# $sys_var name of the variable
+# $read_only - true if read-only
+# $session - true if this is session, false if global-only
+# valid_values table should contain valid values
+# invalid_values
+##
+
+--eval SET @start_global_value = @@global.$sys_var
+SELECT @start_global_value;
+if ($session)
+{
+  --eval SET @start_session_value = @@session.$sys_var
+  SELECT @start_session_value;
+}
+
+if (!$read_only)
+{
+  --echo '# Setting to valid values in global scope#'
+
+  --let $i=1
+  --let $value=query_get_value(select value from valid_values, value, $i)
+  while ($value != 'No such row')
+  {
+    --echo "Trying to set variable @@global.$sys_var to $value"
+    --eval SET @@global.$sys_var   = $value
+    --eval SELECT @@global.$sys_var
+    --let $v=`SELECT @@global.$sys_var`
+    --source ./correctboolvalue.inc
+    if (!$sticky)
+    {
+      if ($v != $int_value)
+      {
+        --echo Set @@global.$sys_var to $value but it remained set to $v
+        --die Wrong variable value
+      }
+    }
+
+    --echo "Setting the global scope variable back to default"
+    --eval SET @@global.$sys_var = DEFAULT
+    --eval SELECT @@global.$sys_var
+
+    --inc $i
+    --let $value=query_get_value(select value from valid_values, value, $i)
+  }
+
+  if ($session)
+  {
+    --echo '# Setting to valid values in session scope#'
+
+    --let $i=1
+    --let $value=query_get_value(select value from valid_values, value, $i)
+    while ($value != 'No such row')
+    {
+      --echo "Trying to set variable @@session.$sys_var to $value"
+      --eval SET @@session.$sys_var   = $value
+      --eval SELECT @@session.$sys_var
+      --let $v=`SELECT @@session.$sys_var`
+      --source ./correctboolvalue.inc
+      if (!$sticky)
+      {
+        if ($v != $int_value)
+        {
+          --echo Set @@session.$sys_var to $value but it remained set to $v
+          --die Wrong variable value
+        }
+      }
+      --echo "Setting the session scope variable back to default"
+      --eval SET @@session.$sys_var = DEFAULT
+      --eval SELECT @@session.$sys_var
+
+      --inc $i
+      --let $value=query_get_value(select value from valid_values, value, $i)
+    }
+  }
+  if (!$session)
+  {
+    --echo "Trying to set variable @@session.$sys_var to 444."
+    --echo "It should fail because it is not session."
+    --Error ER_GLOBAL_VARIABLE
+    --eval SET @@session.$sys_var   = 444
+  }
+
+  --echo '# Testing with invalid values in global scope #'
+  ####################################################################
+  #  Change the value of query_prealloc_size   to an invalid value   #
+  ####################################################################
+  --let $i=1
+  --let $value=query_get_value(select value from invalid_values, value, $i)
+  while ($value != 'No such row')
+  {
+    --echo "Trying to set variable @@global.$sys_var to $value"
+    --Error ER_WRONG_VALUE_FOR_VAR, ER_WRONG_TYPE_FOR_VAR
+    --eval SET @@global.$sys_var   = $value
+    --eval SELECT @@global.$sys_var
+    --inc $i
+    --let $value=query_get_value(select value from invalid_values, value, $i)
+  }
+}
+
+if ($read_only)
+{
+  --echo "Trying to set variable @@global.$sys_var to 444."
+  --echo "It should fail because it is readonly."
+  --Error ER_INCORRECT_GLOBAL_LOCAL_VAR
+  --eval SET @@global.$sys_var   = 444
+}
+
+####################################
+#     Restore initial value        #
+####################################
+if (!$read_only)
+{
+  --eval SET @@global.$sys_var = @start_global_value
+  --eval SELECT @@global.$sys_var
+  if ($session)
+  {
+    --eval SET @@session.$sys_var = @start_session_value
+    --eval SELECT @@session.$sys_var
+  }
+}

--- a/mysql-test/suite/sys_vars/r/legacy_global_read_lock_mode_basic.result
+++ b/mysql-test/suite/sys_vars/r/legacy_global_read_lock_mode_basic.result
@@ -1,0 +1,97 @@
+CREATE TABLE valid_values (value VARCHAR(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(1), (0), ('on'), ('off'), ('true'), ('false');
+CREATE TABLE invalid_values (value VARCHAR(255)) ENGINE=myisam;
+INSERT INTO invalid_values VALUES('aaa'), ('bbb'), (3.14);
+SET @start_global_value = @@global.LEGACY_GLOBAL_READ_LOCK_MODE;
+SELECT @start_global_value;
+@start_global_value
+1
+'# Setting to valid values in global scope#'
+"Trying to set variable @@global.LEGACY_GLOBAL_READ_LOCK_MODE to 1"
+SET @@global.LEGACY_GLOBAL_READ_LOCK_MODE   = 1;
+SELECT @@global.LEGACY_GLOBAL_READ_LOCK_MODE;
+@@global.LEGACY_GLOBAL_READ_LOCK_MODE
+1
+"Setting the global scope variable back to default"
+SET @@global.LEGACY_GLOBAL_READ_LOCK_MODE = DEFAULT;
+SELECT @@global.LEGACY_GLOBAL_READ_LOCK_MODE;
+@@global.LEGACY_GLOBAL_READ_LOCK_MODE
+1
+"Trying to set variable @@global.LEGACY_GLOBAL_READ_LOCK_MODE to 0"
+SET @@global.LEGACY_GLOBAL_READ_LOCK_MODE   = 0;
+SELECT @@global.LEGACY_GLOBAL_READ_LOCK_MODE;
+@@global.LEGACY_GLOBAL_READ_LOCK_MODE
+0
+"Setting the global scope variable back to default"
+SET @@global.LEGACY_GLOBAL_READ_LOCK_MODE = DEFAULT;
+SELECT @@global.LEGACY_GLOBAL_READ_LOCK_MODE;
+@@global.LEGACY_GLOBAL_READ_LOCK_MODE
+1
+"Trying to set variable @@global.LEGACY_GLOBAL_READ_LOCK_MODE to on"
+SET @@global.LEGACY_GLOBAL_READ_LOCK_MODE   = on;
+SELECT @@global.LEGACY_GLOBAL_READ_LOCK_MODE;
+@@global.LEGACY_GLOBAL_READ_LOCK_MODE
+1
+"Setting the global scope variable back to default"
+SET @@global.LEGACY_GLOBAL_READ_LOCK_MODE = DEFAULT;
+SELECT @@global.LEGACY_GLOBAL_READ_LOCK_MODE;
+@@global.LEGACY_GLOBAL_READ_LOCK_MODE
+1
+"Trying to set variable @@global.LEGACY_GLOBAL_READ_LOCK_MODE to off"
+SET @@global.LEGACY_GLOBAL_READ_LOCK_MODE   = off;
+SELECT @@global.LEGACY_GLOBAL_READ_LOCK_MODE;
+@@global.LEGACY_GLOBAL_READ_LOCK_MODE
+0
+"Setting the global scope variable back to default"
+SET @@global.LEGACY_GLOBAL_READ_LOCK_MODE = DEFAULT;
+SELECT @@global.LEGACY_GLOBAL_READ_LOCK_MODE;
+@@global.LEGACY_GLOBAL_READ_LOCK_MODE
+1
+"Trying to set variable @@global.LEGACY_GLOBAL_READ_LOCK_MODE to true"
+SET @@global.LEGACY_GLOBAL_READ_LOCK_MODE   = true;
+SELECT @@global.LEGACY_GLOBAL_READ_LOCK_MODE;
+@@global.LEGACY_GLOBAL_READ_LOCK_MODE
+1
+"Setting the global scope variable back to default"
+SET @@global.LEGACY_GLOBAL_READ_LOCK_MODE = DEFAULT;
+SELECT @@global.LEGACY_GLOBAL_READ_LOCK_MODE;
+@@global.LEGACY_GLOBAL_READ_LOCK_MODE
+1
+"Trying to set variable @@global.LEGACY_GLOBAL_READ_LOCK_MODE to false"
+SET @@global.LEGACY_GLOBAL_READ_LOCK_MODE   = false;
+SELECT @@global.LEGACY_GLOBAL_READ_LOCK_MODE;
+@@global.LEGACY_GLOBAL_READ_LOCK_MODE
+0
+"Setting the global scope variable back to default"
+SET @@global.LEGACY_GLOBAL_READ_LOCK_MODE = DEFAULT;
+SELECT @@global.LEGACY_GLOBAL_READ_LOCK_MODE;
+@@global.LEGACY_GLOBAL_READ_LOCK_MODE
+1
+"Trying to set variable @@session.LEGACY_GLOBAL_READ_LOCK_MODE to 444."
+"It should fail because it is not session."
+SET @@session.LEGACY_GLOBAL_READ_LOCK_MODE   = 444;
+ERROR HY000: Variable 'legacy_global_read_lock_mode' is a GLOBAL variable and should be set with SET GLOBAL
+'# Testing with invalid values in global scope #'
+"Trying to set variable @@global.LEGACY_GLOBAL_READ_LOCK_MODE to aaa"
+SET @@global.LEGACY_GLOBAL_READ_LOCK_MODE   = aaa;
+Got one of the listed errors
+SELECT @@global.LEGACY_GLOBAL_READ_LOCK_MODE;
+@@global.LEGACY_GLOBAL_READ_LOCK_MODE
+1
+"Trying to set variable @@global.LEGACY_GLOBAL_READ_LOCK_MODE to bbb"
+SET @@global.LEGACY_GLOBAL_READ_LOCK_MODE   = bbb;
+Got one of the listed errors
+SELECT @@global.LEGACY_GLOBAL_READ_LOCK_MODE;
+@@global.LEGACY_GLOBAL_READ_LOCK_MODE
+1
+"Trying to set variable @@global.LEGACY_GLOBAL_READ_LOCK_MODE to 3.14"
+SET @@global.LEGACY_GLOBAL_READ_LOCK_MODE   = 3.14;
+Got one of the listed errors
+SELECT @@global.LEGACY_GLOBAL_READ_LOCK_MODE;
+@@global.LEGACY_GLOBAL_READ_LOCK_MODE
+1
+SET @@global.LEGACY_GLOBAL_READ_LOCK_MODE = @start_global_value;
+SELECT @@global.LEGACY_GLOBAL_READ_LOCK_MODE;
+@@global.LEGACY_GLOBAL_READ_LOCK_MODE
+1
+DROP TABLE valid_values, invalid_values;

--- a/mysql-test/suite/sys_vars/t/legacy_global_read_lock_mode_basic.test
+++ b/mysql-test/suite/sys_vars/t/legacy_global_read_lock_mode_basic.test
@@ -1,0 +1,14 @@
+--source include/have_myisam.inc
+
+CREATE TABLE valid_values (value VARCHAR(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(1), (0), ('on'), ('off'), ('true'), ('false');
+
+CREATE TABLE invalid_values (value VARCHAR(255)) ENGINE=myisam;
+INSERT INTO invalid_values VALUES('aaa'), ('bbb'), (3.14);
+
+--let $sys_var=LEGACY_GLOBAL_READ_LOCK_MODE
+--let $read_only=0
+--let $session=0
+--source ../inc/sys_var.inc
+
+DROP TABLE valid_values, invalid_values;

--- a/mysql-test/t/global_read_lock.inc
+++ b/mysql-test/t/global_read_lock.inc
@@ -1,0 +1,85 @@
+# Save the current settings for read_only and super_read_only
+connection default;
+SET @save_read_only=@@global.read_only;
+SET @save_super_read_only=@@global.super_read_only;
+
+# In one thread start a statement that takes 10 seconds
+connection con1;
+if ($with_transactions) {
+  BEGIN WORK;
+}
+SELECT * FROM t1;
+send INSERT INTO t1 SELECT sleep(10);
+
+# Back on the original thread show the process list
+connection default;
+
+let $wait_condition= SELECT COUNT(*)= 1 FROM information_schema.processlist
+    WHERE info='INSERT INTO t1 SELECT sleep(10)';
+--source include/wait_condition.inc
+
+SELECT command, info FROM information_schema.processlist ORDER BY command, info;
+
+# In the second thread set super_read_only on.  Setting this used to block on
+# the long running statement above.  Now, in the default mode, it should
+# succeed and the statement should fail when it tries to commit.  In legacy
+# mode this should block.
+connection con2;
+send SET GLOBAL super_read_only=1;
+
+# Back on the original thread show the process list again and show that
+# SET GLOBAL super_read_only is not waiting (unless in legacy mode)
+connection default;
+
+let $wait_condition= SELECT COUNT(*)=$legacy_mode FROM information_schema.processlist
+    WHERE info='SET GLOBAL super_read_only=1';
+--source include/wait_condition.inc
+
+SELECT command, info FROM information_schema.processlist ORDER BY command, info;
+
+if (!$legacy_mode) {
+  # Also try to create a table - this should fail when running in default mode
+  # because READ ONLY is on
+  --error ER_OPTION_PREVENTS_STATEMENT
+  CREATE TABLE t2 (a INT) Engine=InnoDB;
+}
+
+# Wait for the SET GLOBAL super_read_only statement to finish
+connection con2;
+reap;
+
+if (!$with_transactions) {
+  # Wait for the long running statement to finish
+  # (error expected when not in legacy mode)
+  connection con1;
+  if ($legacy_mode) {
+    reap;
+  }
+
+  if (!$legacy_mode) {
+    --error ER_OPTION_PREVENTS_STATEMENT
+    reap;
+  }
+}
+
+if ($with_transactions) {
+  # Wait for the long running statement to finish (no error expected)
+  connection con1;
+  reap;
+
+  # The changes should be visible to the current connection if using
+  # transactions
+  SELECT COUNT(*) FROM t1;
+
+  # But should fail when the transaction is committed (read_only mode is on)
+  --error ER_OPTION_PREVENTS_STATEMENT
+  COMMIT;
+}
+
+# The changes should not exist
+SELECT COUNT(*) FROM t1;
+
+# Reset the super_read_only and read_only variables
+connection default;
+SET @@global.super_read_only = @save_super_read_only;
+SET @@global.read_only = @save_read_only;

--- a/mysql-test/t/global_read_lock.test
+++ b/mysql-test/t/global_read_lock.test
@@ -1,0 +1,81 @@
+# Attempting to set read_only or super_read_only on would occassionally block
+# if there was a long running modification statement (INSERT, UPDATE, DELETE,
+# REPLACE, etc.).  This was because of contention on the global read lock.
+# The code to handle setting the read_only flags has been modified to not
+# acquire the global read lock
+
+--source include/count_sessions.inc
+
+SET @save_legacy_global_read_lock_mode = @@global.legacy_global_read_lock_mode;
+
+# Create the tables we need
+CREATE TABLE t1(a INT) Engine=InnoDB;
+
+connect(con1,localhost,root,,);
+connect(con2,localhost,root,,);
+
+SET @@global.legacy_global_read_lock_mode = 0;
+--let $legacy_mode=0
+--let $with_transactions=1
+--source global_read_lock.inc
+
+# Now do it without the BEGIN statement - make sure the statement fails
+# (instead of the COMMIT following the statement)
+--let $with_transactions=0
+--source global_read_lock.inc
+
+# Now run both tests again with legacy_global_read_lock_mode on to make
+# sure we get the old behavior
+--let $legacy_mode=1
+SET @@global.legacy_global_read_lock_mode = 1;
+--let $with_transactions=1
+--source global_read_lock.inc
+
+--let $with_transactions=0
+--source global_read_lock.inc
+
+# Also test to make sure we don't leak a lock during the following commands:
+# con1 - BEGIN
+# con1 - LOCK TABLE ...
+# con1 - INSERT INTO t1 ...
+# con2 - SET GLOBAL super_read_only=1
+# con1 - UNLOCK TABLES
+#
+# Save the current settings for read_only and super_read_only
+connection default;
+SET @@global.legacy_global_read_lock_mode = 0;
+SET @save_read_only=@@global.read_only;
+SET @save_super_read_only=@@global.super_read_only;
+
+connection con1;
+BEGIN;
+LOCK TABLES t1 WRITE;
+INSERT INTO t1 VALUES(100);
+
+echo The In_use column should be 1 to indicate the lock;
+connection default;
+SHOW OPEN TABLES like 't1';
+
+connection con2;
+SET GLOBAL super_read_only=1;
+
+connection con1;
+UNLOCK TABLES;
+
+echo The In_use column should be 0 to indicate the lock was removed;
+connection default;
+SHOW OPEN TABLES like 't1';
+
+SET @@global.legacy_global_read_lock_mode = @save_legacy_global_read_lock_mode;
+SET @@global.super_read_only = @save_super_read_only;
+SET @@global.read_only = @save_read_only;
+
+# Cleanup connections
+connection default;
+disconnect con1;
+disconnect con2;
+--source include/wait_until_count_sessions.inc
+
+# Get rid of the databases
+DROP TABLE t1;
+

--- a/mysql-test/t/read_only_innodb.test
+++ b/mysql-test/t/read_only_innodb.test
@@ -78,7 +78,41 @@ BEGIN;
 SELECT * FROM t1;
 COMMIT;
 
+#
+# Test long running write statement
+#
+
 connection default;
+UNLOCK TABLES;
+DELETE from t1;
+FLUSH STATUS;
+
+SET @save_legacy_global_read_lock_mode = @@global.legacy_global_read_lock_mode;
+SET @@global.legacy_global_read_lock_mode = 1;
+
+--echo connection con1;
+connection con1;
+send INSERT INTO t1 (a) SELECT sleep(3) ;
+
+--echo connection default;
+connection default;
+
+let $wait_condition= SELECT COUNT(*)= 1 FROM information_schema.processlist
+    WHERE info='INSERT INTO t1 (a) SELECT sleep(3)';
+--source include/wait_condition.inc
+
+set global read_only=1;
+
+--echo connection con1
+--echo # Check if the query is done. Expected a=0
+SELECT * FROM t1;
+
+--echo connection default;
+connection default;
+SET GLOBAL read_only=0;
+
+SET @@global.legacy_global_read_lock_mode = @save_legacy_global_read_lock_mode;
+
 UNLOCK TABLES;
 DROP TABLE t1;
 DROP USER test@localhost;

--- a/mysql-test/t/read_only_innodb_basic.test
+++ b/mysql-test/t/read_only_innodb_basic.test
@@ -1,8 +1,5 @@
-
-# Skipping the test when binlog format is mix/statement due to Bug#22173401
---source include/have_binlog_format_row.inc
-
 # Test of the READ_ONLY global variable:
+# The same as read_only.test but test with InnoDb engine
 # check that it blocks updates unless they are only on temporary tables.
 
 set @start_read_only= @@global.read_only;
@@ -10,14 +7,9 @@ set @start_read_only= @@global.read_only;
 # Save the initial number of concurrent sessions
 --source include/count_sessions.inc
 
---disable_warnings
-DROP TABLE IF EXISTS t1,t2,t3;
---enable_warnings
-
 # READ_ONLY does nothing to SUPER users
 # so we use a non-SUPER one:
 
-set @orig_sql_mode= @@sql_mode;
 create user test@localhost;
 grant CREATE, SELECT, DROP on *.* to test@localhost;
 
@@ -32,11 +24,11 @@ set global read_only=0;
 --echo connection con1;
 connection con1;
 
-create table t1 (a int);
+create table t1 (a int) engine=InnoDb;
 
 insert into t1 values(1);
 
-create table t2 select * from t1;
+create table t2 engine=InnoDb select * from t1;
 
 --echo connection default;
 connection default;
@@ -45,7 +37,7 @@ set global read_only=1;
 
 # We check that SUPER can:
 
-create table t3 (a int);
+create table t3 (a int) engine=InnoDb;
 drop table t3;
 
 --echo connection con1;
@@ -54,7 +46,7 @@ connection con1;
 select @@global.read_only;
 
 --error ER_OPTION_PREVENTS_STATEMENT
-create table t3 (a int);
+create table t3 (a int) engine=InnoDb;
 
 --error ER_OPTION_PREVENTS_STATEMENT
 insert into t1 values(1);
@@ -124,8 +116,6 @@ insert into t1 values(1);
 
 --echo connection default;
 connection default;
-set @save_legacy_global_read_lock_mode = @@global.legacy_global_read_lock_mode;
-set @@global.legacy_global_read_lock_mode = 1;
 set global read_only=0;
 lock table t1 write;
 
@@ -145,7 +135,6 @@ send set global read_only=1;
 
 --echo connection con1;
 connection con1;
-select @@global.read_only;
 unlock tables ;
 let $wait_condition= SELECT @@global.read_only= 1;
 --source include/wait_condition.inc
@@ -155,8 +144,6 @@ select @@global.read_only;
 connection default;
 --echo reap;
 reap;
-
-set @@global.legacy_global_read_lock_mode = @save_legacy_global_read_lock_mode;
 
 # LOCK TABLE ... READ / READ_ONLY
 # - is an error in the same connection
@@ -176,19 +163,22 @@ connection default;
 --error ER_LOCK_OR_ACTIVE_TRANSACTION
 set global read_only=1;
 unlock tables ;
-
-# after unlock tables in current connection
-# the next command must be executed successfully
-set global read_only=1;
-select @@global.read_only;
+# The following call blocks until con1 releases the read lock.
+# Blocking is a limitation, and could be improved.
+--echo send set global read_only=1;
+send set global read_only=1;
 
 --echo connection con1;
 connection con1;
-select @@global.read_only;
 unlock tables ;
+let $wait_condition= SELECT @@global.read_only= 1;
+--source include/wait_condition.inc
+select @@global.read_only;
 
 --echo connection default;
 connection default;
+--echo reap;
+reap;
 
 # pending transaction / READ_ONLY
 # - is an error in the same connection
@@ -281,7 +271,7 @@ delete from mysql.tables_priv where User like 'mysqltest_%';
 delete from mysql.columns_priv where User like 'mysqltest_%';
 flush privileges;
 
-create user `mysqltest_u1`@`%`;
+create user mysqltest_u1@'%';
 grant all on mysqltest_db2.* to `mysqltest_u1`@`%`;
 create database mysqltest_db1;
 grant all on mysqltest_db1.* to `mysqltest_u1`@`%`;
@@ -306,67 +296,6 @@ delete from mysql.columns_priv where User like 'mysqltest_%';
 flush privileges;
 drop database mysqltest_db1;
 set global read_only= @start_read_only;
-
-
---echo #
---echo # WL#5968 Implement START TRANSACTION READ (WRITE|ONLY);
---echo #
-
---echo #
---echo # Test interaction with read_only system variable.
-
---disable_warnings
-DROP TABLE IF EXISTS t1;
---enable_warnings
-
-CREATE TABLE t1(a INT);
-INSERT INTO t1 VALUES (1), (2);
-
-CREATE USER user1;
-connect (con1, localhost, user1);
-connection default;
-
-SET GLOBAL read_only= 1;
-
---echo # All allowed with super privilege
-START TRANSACTION;
-COMMIT;
-
-START TRANSACTION READ ONLY;
-COMMIT;
-
-START TRANSACTION READ WRITE;
-COMMIT;
-
---echo # We allow implicit RW transaction without super privilege
---echo # for compatibility reasons
-connection con1;
-START TRANSACTION;
---echo # Check that table updates are still disallowed.
---error ER_OPTION_PREVENTS_STATEMENT
-INSERT INTO t1 VALUES (3);
---error ER_OPTION_PREVENTS_STATEMENT
-UPDATE t1 SET a= 1;
---error ER_OPTION_PREVENTS_STATEMENT
-DELETE FROM t1;
-COMMIT;
-
-START TRANSACTION READ ONLY;
-COMMIT;
-
---echo # Explicit RW trans is not allowed without super privilege
---error ER_OPTION_PREVENTS_STATEMENT
-START TRANSACTION READ WRITE;
-COMMIT;
-disconnect con1;
---source include/wait_until_disconnected.inc
-connection default;
-DROP USER user1;
-
-SET GLOBAL read_only= 0;
-DROP TABLE t1;
-
-set sql_mode= @orig_sql_mode;
 
 # Wait till all disconnects are completed
 --source include/wait_until_count_sessions.inc

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1236,6 +1236,7 @@ char glob_hostname[FN_REFLEN];
 char mysql_real_data_home[FN_REFLEN], lc_messages_dir[FN_REFLEN],
     reg_ext[FN_EXTLEN], mysql_charsets_dir[FN_REFLEN], *opt_init_file,
     *opt_tc_log_file;
+bool legacy_global_read_lock_mode = false;
 char *lc_messages_dir_ptr;
 char mysql_unpacked_real_data_home[FN_REFLEN];
 size_t mysql_unpacked_real_data_home_len;
@@ -7901,31 +7902,41 @@ static int show_connection_errors_tcpwrap(THD *, SHOW_VAR *var, char *buff) {
   return 0;
 }
 
-static int show_connection_errors_net_ER_NET_ERROR_ON_WRITE(THD *, SHOW_VAR *var, char *buff) {
+static int show_connection_errors_net_ER_NET_ERROR_ON_WRITE(THD *,
+                                                            SHOW_VAR *var,
+                                                            char *buff) {
   var->type = SHOW_LONG;
   var->value = buff;
   long *value = reinterpret_cast<long *>(buff);
-  *value = static_cast<long>(connection_errors_net_ER_NET_ERROR_ON_WRITE.load());
+  *value =
+      static_cast<long>(connection_errors_net_ER_NET_ERROR_ON_WRITE.load());
   return 0;
 }
 
-static int show_connection_errors_net_ER_NET_PACKETS_OUT_OF_ORDER(THD *, SHOW_VAR *var, char *buff) {
+static int show_connection_errors_net_ER_NET_PACKETS_OUT_OF_ORDER(THD *,
+                                                                  SHOW_VAR *var,
+                                                                  char *buff) {
   var->type = SHOW_LONG;
   var->value = buff;
   long *value = reinterpret_cast<long *>(buff);
-  *value = static_cast<long>(connection_errors_net_ER_NET_PACKETS_OUT_OF_ORDER.load());
+  *value = static_cast<long>(
+      connection_errors_net_ER_NET_PACKETS_OUT_OF_ORDER.load());
   return 0;
 }
 
-static int show_connection_errors_net_ER_NET_PACKET_TOO_LARGE(THD *, SHOW_VAR *var, char *buff) {
+static int show_connection_errors_net_ER_NET_PACKET_TOO_LARGE(THD *,
+                                                              SHOW_VAR *var,
+                                                              char *buff) {
   var->type = SHOW_LONG;
   var->value = buff;
   long *value = reinterpret_cast<long *>(buff);
-  *value = static_cast<long>(connection_errors_net_ER_NET_PACKET_TOO_LARGE.load());
+  *value =
+      static_cast<long>(connection_errors_net_ER_NET_PACKET_TOO_LARGE.load());
   return 0;
 }
 
-static int show_connection_errors_net_ER_NET_READ_ERROR(THD *, SHOW_VAR *var, char *buff) {
+static int show_connection_errors_net_ER_NET_READ_ERROR(THD *, SHOW_VAR *var,
+                                                        char *buff) {
   var->type = SHOW_LONG;
   var->value = buff;
   long *value = reinterpret_cast<long *>(buff);
@@ -7933,27 +7944,36 @@ static int show_connection_errors_net_ER_NET_READ_ERROR(THD *, SHOW_VAR *var, ch
   return 0;
 }
 
-static int show_connection_errors_net_ER_NET_READ_INTERRUPTED(THD *, SHOW_VAR *var, char *buff) {
+static int show_connection_errors_net_ER_NET_READ_INTERRUPTED(THD *,
+                                                              SHOW_VAR *var,
+                                                              char *buff) {
   var->type = SHOW_LONG;
   var->value = buff;
   long *value = reinterpret_cast<long *>(buff);
-  *value = static_cast<long>(connection_errors_net_ER_NET_READ_INTERRUPTED.load());
+  *value =
+      static_cast<long>(connection_errors_net_ER_NET_READ_INTERRUPTED.load());
   return 0;
 }
 
-static int show_connection_errors_net_ER_NET_UNCOMPRESS_ERROR(THD *, SHOW_VAR *var, char *buff) {
+static int show_connection_errors_net_ER_NET_UNCOMPRESS_ERROR(THD *,
+                                                              SHOW_VAR *var,
+                                                              char *buff) {
   var->type = SHOW_LONG;
   var->value = buff;
   long *value = reinterpret_cast<long *>(buff);
-  *value = static_cast<long>(connection_errors_net_ER_NET_UNCOMPRESS_ERROR.load());
+  *value =
+      static_cast<long>(connection_errors_net_ER_NET_UNCOMPRESS_ERROR.load());
   return 0;
 }
 
-static int show_connection_errors_net_ER_NET_WRITE_INTERRUPTED(THD *, SHOW_VAR *var, char *buff) {
+static int show_connection_errors_net_ER_NET_WRITE_INTERRUPTED(THD *,
+                                                               SHOW_VAR *var,
+                                                               char *buff) {
   var->type = SHOW_LONG;
   var->value = buff;
   long *value = reinterpret_cast<long *>(buff);
-  *value = static_cast<long>(connection_errors_net_ER_NET_WRITE_INTERRUPTED.load());
+  *value =
+      static_cast<long>(connection_errors_net_ER_NET_WRITE_INTERRUPTED.load());
   return 0;
 }
 

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -714,6 +714,7 @@ extern struct st_VioSSLFd *ssl_acceptor_fd;
 extern bool opt_large_pages;
 extern uint opt_large_page_size;
 extern char lc_messages_dir[FN_REFLEN];
+extern bool legacy_global_read_lock_mode;
 extern char *lc_messages_dir_ptr;
 extern const char *log_error_dest;
 extern MYSQL_PLUGIN_IMPORT char reg_ext[FN_EXTLEN];

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -3005,6 +3005,12 @@ static Sys_var_ulong Sys_read_buff_size(
     VALID_RANGE(IO_SIZE * 2, INT_MAX32), DEFAULT(128 * 1024),
     BLOCK_SIZE(IO_SIZE));
 
+static Sys_var_bool Sys_legacy_global_read_lock_mode(
+    "legacy_global_read_lock_mode",
+    "Uses the legacy global read lock mode which will block setting global "
+    "read lock when a long transaction is running",
+    GLOBAL_VAR(legacy_global_read_lock_mode), CMD_LINE(OPT_ARG), DEFAULT(true));
+
 static bool check_read_only(sys_var *self, THD *thd, set_var *var) {
   /* Prevent self dead-lock */
   if (thd->locked_tables_mode || thd->in_active_multi_stmt_transaction()) {
@@ -3091,8 +3097,10 @@ static bool fix_read_only(sys_var *self, THD *thd, enum_var_type) {
   read_only = opt_readonly;
   mysql_mutex_unlock(&LOCK_global_system_variables);
 
-  if (thd->global_read_lock.lock_global_read_lock(thd))
+  if (legacy_global_read_lock_mode &&
+      thd->global_read_lock.lock_global_read_lock(thd)) {
     goto end_with_mutex_unlock;
+  }
 
   if ((result = thd->global_read_lock.make_global_read_lock_block_commit(thd)))
     goto end_with_read_lock;
@@ -3147,7 +3155,8 @@ static bool fix_super_read_only(sys_var *, THD *thd, enum_var_type type) {
   super_read_only = opt_super_readonly;
   mysql_mutex_unlock(&LOCK_global_system_variables);
 
-  if (thd->global_read_lock.lock_global_read_lock(thd))
+  if (legacy_global_read_lock_mode &&
+      thd->global_read_lock.lock_global_read_lock(thd))
     goto end_with_mutex_unlock;
 
   if ((result = thd->global_read_lock.make_global_read_lock_block_commit(thd)))


### PR DESCRIPTION
Summary:

Jira ticket: https://jira.percona.com/browse/FB8-221

Reference commit: https://github.com/facebook/mysql-5.6/commit/d8657c3d
Reference commit: https://github.com/facebook/mysql-5.6/commit/a3f808d
Reference commit: https://github.com/facebook/mysql-5.6/commit/f2dfbd0

-------- a3f808d --------

Change SET GLOBAL [super_]read_only to not acquire the global read lock

Currently calling SET GLOBAL [super_]read_only acquires the global read lock before setting the flag and this will block on a long running DML statement.  We think it is safe in our environment to not acquire this lock.

This behavior can be changed back to the original by SET @global.legacy_global_read_lock_mode=1