### PR TITLE
FB8-206: Avoid executing status var functions during `SHOW STATUS` when not required

### DIFF
--- a/storage/perfschema/pfs_variable.cc
+++ b/storage/perfschema/pfs_variable.cc
@@ -31,6 +31,7 @@
   @file storage/perfschema/pfs_variable.cc
   Performance schema system variable and status variable (implementation).
 */
+#include "mf_wcomp.h"
 #include "my_dbug.h"
 #include "my_macros.h"
 #include "my_sys.h"
@@ -1362,6 +1363,18 @@ void PFS_status_variable_cache::manifest(THD *thd,
                                          System_status_var *status_vars,
                                          const char *prefix, bool nested_array,
                                          bool strict) {
+  const LEX *lex = thd->lex;
+  const char *const wild = lex->wild ? lex->wild->ptr() : nullptr;
+
+  // Find the length of the user's 'LIKE' parameter until the first wildcard
+  std::size_t before_wild_len = 0;
+  while (wild && wild[before_wild_len] != wild_one &&
+         wild[before_wild_len] != wild_many &&
+         wild[before_wild_len] != wild_prefix &&
+         wild[before_wild_len] != '\0') {
+    ++before_wild_len;
+  }
+
   for (const SHOW_VAR *show_var_iter = show_var_array;
        show_var_iter && show_var_iter->name; show_var_iter++) {
     // work buffer, must be aligned to handle long/longlong values
@@ -1376,6 +1389,16 @@ void PFS_status_variable_cache::manifest(THD *thd,
       SHOW_FUNC resolves to another SHOW_FUNC.
     */
     if (show_var_ptr->type == SHOW_FUNC) {
+      if (before_wild_len > 0) {
+        const auto len = strlen(show_var_ptr->name);
+        const auto min_len = std::min(before_wild_len, len);
+        if (my_strnncoll(system_charset_info,
+                         reinterpret_cast<const uchar *>(show_var_ptr->name),
+                         min_len, reinterpret_cast<const uchar *>(wild),
+                         min_len) != 0)
+          continue;
+      }
+
       show_var_tmp = *show_var_ptr;
       /*
         Execute the function reference in show_var_tmp->value, which returns


### PR DESCRIPTION
Jira issue: https://jira.percona.com/browse/FB8-206

Reference Patch: https://github.com/facebook/mysql-5.6/commit/bf0baf3f7af

Summary:
Status var functions were always executed irrespective of matching
string in the `LIKE` clause of `SHOW STATUS`. This caused execution of
some heavy status var functions like `show_jemalloc_*` every time `SHOW
STATUS` was invoked.

In this change we execute the status var function only for vars whose
names are strict prefixes of the wildcard specified in the `LIKE`
clause. Since we're checking for strict prefix match, we might get false
positives in some cases. We cannot use normal wildcard matching (like
other function-less status vars) because some var names are constructed
recursively in `show_status_array()` (e.g.
`Rpl_semi_sync_master_trx_wait_histogram%` is composed out of
`Rpl_semi_sync_master` and `trx_wait_histogram`).

Originally Reviewed By: midom, anirbanr-fb