### PR TITLE
FB8-180: Implemented TTL base cache eviction policy for "open table" and "table description" caches

### DIFF
--- a/mysql-test/r/flush_only_old_table_cache_entries.result
+++ b/mysql-test/r/flush_only_old_table_cache_entries.result
@@ -1,0 +1,7 @@
+SET @start_global_value = @@global.flush_only_old_table_cache_entries;
+SET @@global.debug= '+d,tdc_flush_unused_tables';
+SET debug_sync = 'now WAIT_FOR signal.disabled';
+SET @@global.flush_only_old_table_cache_entries = true;
+SET debug_sync = 'now WAIT_FOR signal.enabled';
+SET @@global.debug= '-d,tdc_flush_unused_tables';
+SET @@global.flush_only_old_table_cache_entries = @start_global_value;

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -327,6 +327,9 @@ The following options may be given as the first argument:
  (not repair) tables while the MySQL server is running.
  Disable with --skip-external-locking.
  --flush             Flush MyISAM tables to disk between SQL commands
+ --flush-only-old-table-cache-entries 
+ Enable/disable flushing table and definition cache
+ entries policy based on TTL specified by flush_time.
  --flush-time=#      A dedicated thread is created to flush all tables at the
  given interval
  --ft-boolean-syntax=name 
@@ -1480,6 +1483,7 @@ expire-logs-days 0
 explicit-defaults-for-timestamp TRUE
 external-locking FALSE
 flush FALSE
+flush-only-old-table-cache-entries FALSE
 flush-time 0
 ft-boolean-syntax + -><()~*:""&|
 ft-max-word-len 84

--- a/mysql-test/suite/sys_vars/r/flush_only_old_table_cache_entries_basic.result
+++ b/mysql-test/suite/sys_vars/r/flush_only_old_table_cache_entries_basic.result
@@ -1,0 +1,67 @@
+set @start_global_value = @@global.flush_only_old_table_cache_entries;
+select @@global.flush_only_old_table_cache_entries;
+@@global.flush_only_old_table_cache_entries
+0
+select @@session.flush_only_old_table_cache_entries;
+ERROR HY000: Variable 'flush_only_old_table_cache_entries' is a GLOBAL variable
+show global variables like 'flush_only_old_table_cache_entries';
+Variable_name	Value
+flush_only_old_table_cache_entries	OFF
+show session variables like 'flush_only_old_table_cache_entries';
+Variable_name	Value
+flush_only_old_table_cache_entries	OFF
+select * from performance_schema.global_variables where variable_name='flush_only_old_table_cache_entries';
+VARIABLE_NAME	VARIABLE_VALUE
+flush_only_old_table_cache_entries	OFF
+select * from performance_schema.session_variables where variable_name='flush_only_old_table_cache_entries';
+VARIABLE_NAME	VARIABLE_VALUE
+flush_only_old_table_cache_entries	OFF
+set global flush_only_old_table_cache_entries = ON;
+select @@global.flush_only_old_table_cache_entries;
+@@global.flush_only_old_table_cache_entries
+1
+set session flush_only_old_table_cache_entries = ON;
+ERROR HY000: Variable 'flush_only_old_table_cache_entries' is a GLOBAL variable and should be set with SET GLOBAL
+set @@global.flush_only_old_table_cache_entries = ON;
+select @@global.flush_only_old_table_cache_entries;
+@@global.flush_only_old_table_cache_entries
+1
+set @@global.flush_only_old_table_cache_entries = OFF;
+select @@global.flush_only_old_table_cache_entries;
+@@global.flush_only_old_table_cache_entries
+0
+set @@global.flush_only_old_table_cache_entries = 0;
+select @@global.flush_only_old_table_cache_entries;
+@@global.flush_only_old_table_cache_entries
+0
+set @@global.flush_only_old_table_cache_entries = 1;
+select @@global.flush_only_old_table_cache_entries;
+@@global.flush_only_old_table_cache_entries
+1
+set @@global.flush_only_old_table_cache_entries = TRUE;
+select @@global.flush_only_old_table_cache_entries;
+@@global.flush_only_old_table_cache_entries
+1
+set @@global.flush_only_old_table_cache_entries = FALSE;
+select @@global.flush_only_old_table_cache_entries;
+@@global.flush_only_old_table_cache_entries
+0
+set @@global.flush_only_old_table_cache_entries = 'ONN';
+ERROR 42000: Variable 'flush_only_old_table_cache_entries' can't be set to the value of 'ONN'
+set @@global.flush_only_old_table_cache_entries = "OFFF";
+ERROR 42000: Variable 'flush_only_old_table_cache_entries' can't be set to the value of 'OFFF'
+set @@global.flush_only_old_table_cache_entries = OF;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'OF' at line 1
+set @@global.flush_only_old_table_cache_entries = TTRUE;
+ERROR 42000: Variable 'flush_only_old_table_cache_entries' can't be set to the value of 'TTRUE'
+set @@global.flush_only_old_table_cache_entries = FELSE;
+ERROR 42000: Variable 'flush_only_old_table_cache_entries' can't be set to the value of 'FELSE'
+set @@global.flush_only_old_table_cache_entries = -1024;
+ERROR 42000: Variable 'flush_only_old_table_cache_entries' can't be set to the value of '-1024'
+set @@global.flush_only_old_table_cache_entries = 65536;
+ERROR 42000: Variable 'flush_only_old_table_cache_entries' can't be set to the value of '65536'
+set @@global.flush_only_old_table_cache_entries = 65530.34;
+ERROR 42000: Incorrect argument type to variable 'flush_only_old_table_cache_entries'
+set @@global.flush_only_old_table_cache_entries = test;
+ERROR 42000: Variable 'flush_only_old_table_cache_entries' can't be set to the value of 'test'
+set @@global.flush_only_old_table_cache_entries = @start_global_value;

--- a/mysql-test/suite/sys_vars/t/flush_only_old_table_cache_entries_basic.test
+++ b/mysql-test/suite/sys_vars/t/flush_only_old_table_cache_entries_basic.test
@@ -1,0 +1,57 @@
+set @start_global_value = @@global.flush_only_old_table_cache_entries;
+
+select @@global.flush_only_old_table_cache_entries;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+select @@session.flush_only_old_table_cache_entries;
+show global variables like 'flush_only_old_table_cache_entries';
+show session variables like 'flush_only_old_table_cache_entries';
+select * from performance_schema.global_variables where variable_name='flush_only_old_table_cache_entries';
+select * from performance_schema.session_variables where variable_name='flush_only_old_table_cache_entries';
+
+#
+# show that it's writable
+#
+set global flush_only_old_table_cache_entries = ON;
+select @@global.flush_only_old_table_cache_entries;
+--error ER_GLOBAL_VARIABLE
+set session flush_only_old_table_cache_entries = ON;
+
+#
+# Change the value of variable to a valid value for GLOBAL Scope #
+#
+set @@global.flush_only_old_table_cache_entries = ON;
+select @@global.flush_only_old_table_cache_entries;
+set @@global.flush_only_old_table_cache_entries = OFF;
+select @@global.flush_only_old_table_cache_entries;
+set @@global.flush_only_old_table_cache_entries = 0;
+select @@global.flush_only_old_table_cache_entries;
+set @@global.flush_only_old_table_cache_entries = 1;
+select @@global.flush_only_old_table_cache_entries;
+set @@global.flush_only_old_table_cache_entries = TRUE;
+select @@global.flush_only_old_table_cache_entries;
+set @@global.flush_only_old_table_cache_entries = FALSE;
+select @@global.flush_only_old_table_cache_entries;
+
+#
+# Change the value of flush_only_old_table_cache_entries to an invalid value #
+#
+--error ER_WRONG_VALUE_FOR_VAR
+set @@global.flush_only_old_table_cache_entries = 'ONN';
+--error ER_WRONG_VALUE_FOR_VAR
+set @@global.flush_only_old_table_cache_entries = "OFFF";
+--error ER_PARSE_ERROR
+set @@global.flush_only_old_table_cache_entries = OF;
+--error ER_WRONG_VALUE_FOR_VAR
+set @@global.flush_only_old_table_cache_entries = TTRUE;
+--error ER_WRONG_VALUE_FOR_VAR
+set @@global.flush_only_old_table_cache_entries = FELSE;
+--error ER_WRONG_VALUE_FOR_VAR
+set @@global.flush_only_old_table_cache_entries = -1024;
+--error ER_WRONG_VALUE_FOR_VAR
+set @@global.flush_only_old_table_cache_entries = 65536;
+--error ER_WRONG_TYPE_FOR_VAR
+set @@global.flush_only_old_table_cache_entries = 65530.34;
+--error ER_WRONG_VALUE_FOR_VAR
+set @@global.flush_only_old_table_cache_entries = test;
+
+set @@global.flush_only_old_table_cache_entries = @start_global_value;

--- a/mysql-test/t/flush_only_old_table_cache_entries-master.opt
+++ b/mysql-test/t/flush_only_old_table_cache_entries-master.opt
@@ -1,0 +1,1 @@
+--flush-time=1

--- a/mysql-test/t/flush_only_old_table_cache_entries.test
+++ b/mysql-test/t/flush_only_old_table_cache_entries.test
@@ -1,0 +1,16 @@
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+
+SET @start_global_value = @@global.flush_only_old_table_cache_entries;
+SET @@global.debug= '+d,tdc_flush_unused_tables';
+
+# Check if flush_only_old_table_cache_entries is disabled
+SET debug_sync = 'now WAIT_FOR signal.disabled';
+
+# Check if flush_only_old_table_cache_entries is enabled
+SET @@global.flush_only_old_table_cache_entries = true;
+SET debug_sync = 'now WAIT_FOR signal.enabled';
+
+# Clean up
+SET @@global.debug= '-d,tdc_flush_unused_tables';
+SET @@global.flush_only_old_table_cache_entries = @start_global_value;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1070,6 +1070,7 @@ bool opt_log_unsafe_statements;
 bool opt_log_global_var_changes;
 bool is_slave = false;
 bool read_only_slave;
+bool flush_only_old_table_cache_entries = false;
 
 #ifdef HAVE_INITGROUPS
 volatile sig_atomic_t calling_initgroups = 0; /**< Used in SIGSEGV handler. */

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -384,6 +384,7 @@ inline ulonglong microseconds_to_my_timer(double when) {
 
 extern bool is_slave;
 extern bool read_only_slave;
+extern bool flush_only_old_table_cache_entries;
 extern ulong stored_program_cache_size;
 extern ulong back_log;
 extern "C" MYSQL_PLUGIN_IMPORT ulong server_id;

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -537,6 +537,9 @@ static TABLE_SHARE *process_found_table_share(THD *thd MY_ATTRIBUTE((unused)),
     share->prev = 0;
   }
 
+  /* update access time */
+  share->set_last_access_time();
+
   /* Free cache if too big */
   while (table_def_cache->size() > table_def_size && oldest_unused_share->next)
     table_def_cache->erase(to_string(oldest_unused_share->table_cache_key));
@@ -832,6 +835,9 @@ TABLE_SHARE *get_table_share(THD *thd, const char *db, const char *table_name,
 #else
   share->m_psi = NULL;
 #endif
+
+  /* update access time */
+  share->set_last_access_time();
 
   DBUG_PRINT("exit", ("share: %p  ref_count: %u", share, share->ref_count()));
 
@@ -9526,7 +9532,34 @@ err:
 
 void tdc_flush_unused_tables() {
   table_cache_manager.lock_all_and_tdc();
-  table_cache_manager.free_all_unused_tables();
+
+  if (flush_only_old_table_cache_entries) {
+    DBUG_EXECUTE_IF("tdc_flush_unused_tables", {
+      static constexpr char act[] = "now SIGNAL signal.enabled";
+      DBUG_ASSERT(!debug_sync_set_action(current_thd, STRING_WITH_LEN(act)));
+    };);
+
+    const time_point flush_cutpoint =
+        std::chrono::system_clock::now() - std::chrono::seconds(flush_time);
+    table_cache_manager.free_old_unused_tables(flush_cutpoint);
+
+    /* Free table shares which were not freed implicitly by loop above. */
+    for (TABLE_SHARE *s = oldest_unused_share; s->next; s = s->next) {
+      if (should_be_evicted(s->last_accessed, flush_cutpoint)) {
+        table_def_cache->erase(to_string(s->table_cache_key));
+      }
+    }
+  } else {
+    DBUG_EXECUTE_IF("tdc_flush_unused_tables", {
+      static constexpr char act[] = "now SIGNAL signal.disabled";
+      DBUG_ASSERT(!debug_sync_set_action(current_thd, STRING_WITH_LEN(act)));
+    };);
+
+    table_cache_manager.free_all_unused_tables();
+    /* Free table shares which were not freed implicitly by loop above. */
+    while (oldest_unused_share->next)
+      table_def_cache->erase(to_string(oldest_unused_share->table_cache_key));
+  }
   table_cache_manager.unlock_all_and_tdc();
 }
 

--- a/sql/sql_manager.cc
+++ b/sql/sql_manager.cc
@@ -50,6 +50,7 @@
 #include "sql/log.h"
 #include "sql/mysqld.h"    // flush_time
 #include "sql/sql_base.h"  // tdc_flush_unused_tables
+#include "sql/sql_class.h"
 
 static bool volatile manager_thread_in_use;
 static bool abort_manager;
@@ -63,8 +64,14 @@ static void *handle_manager(void *arg MY_ATTRIBUTE((unused))) {
   int error = 0;
   struct timespec abstime;
   bool reset_flush_time = true;
+
   my_thread_init();
   DBUG_ENTER("handle_manager");
+
+  THD *thd = new THD;
+  thd->set_new_thread_id();
+  thd->thread_stack = (char *)&thd;
+  thd->store_globals();
 
   manager_thread = my_thread_self();
   manager_thread_in_use = 1;
@@ -95,6 +102,8 @@ static void *handle_manager(void *arg MY_ATTRIBUTE((unused))) {
     }
   }
   manager_thread_in_use = 0;
+  thd->release_resources();
+  delete thd;
   DBUG_LEAVE;  // Can't use DBUG_RETURN after my_thread_end
   my_thread_end();
   return (NULL);

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -1848,6 +1848,13 @@ static Sys_var_ulong Sys_flush_time(
     GLOBAL_VAR(flush_time), CMD_LINE(REQUIRED_ARG),
     VALID_RANGE(0, LONG_TIMEOUT), DEFAULT(0), BLOCK_SIZE(1));
 
+static Sys_var_bool Sys_flush_only_old_cache_entries(
+    "flush_only_old_table_cache_entries",
+    "Enable/disable flushing table and definition cache entries "
+    "policy based on TTL specified by flush_time.",
+    GLOBAL_VAR(flush_only_old_table_cache_entries), CMD_LINE(OPT_ARG),
+    DEFAULT(false));
+
 static bool check_ftb_syntax(sys_var *, THD *, set_var *var) {
   return ft_boolean_check_syntax_string(
       (uchar *)(var->save_result.string_value.str));

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -3137,6 +3137,9 @@ int open_table_from_share(THD *thd, TABLE_SHARE *share, const char *alias,
   /* Increment the opened_tables counter, only when open flags set. */
   if (db_stat) thd->status_var.opened_tables++;
 
+  /* set creation time */
+  outparam->set_last_access_time();
+
   DBUG_RETURN(0);
 
 err:
@@ -7774,3 +7777,15 @@ void TABLE::set_pos_in_table_list(TABLE_LIST *table_list) noexcept {
 }
 
 //////////////////////////////////////////////////////////////////////////
+
+void TABLE_SHARE::set_last_access_time() noexcept {
+  this->last_accessed = std::chrono::system_clock::now();
+}
+
+void TABLE::set_last_access_time() noexcept {
+  this->last_accessed = std::chrono::system_clock::now();
+}
+
+bool should_be_evicted(time_point last_accessed, time_point cutpoint) noexcept {
+  return last_accessed < cutpoint;
+}

--- a/sql/table.h
+++ b/sql/table.h
@@ -25,6 +25,7 @@
 
 #include <string.h>
 #include <sys/types.h>
+#include <chrono>  // last access time
 #include <string>
 
 #include "binary_log_types.h"
@@ -118,6 +119,8 @@ class Common_table_expr;
 typedef Mem_root_array_YY<LEX_CSTRING> Create_col_name_list;
 
 typedef int64 query_id_t;
+
+using time_point = std::chrono::system_clock::time_point;
 
 enum class enum_json_diff_operation;
 
@@ -931,6 +934,9 @@ struct TABLE_SHARE {
   uint foreign_key_parents{0};
   TABLE_SHARE_FOREIGN_KEY_PARENT_INFO *foreign_key_parent{nullptr};
 
+  /* last time table_share was accessed via get_table_share() function */
+  time_point last_accessed;
+
   /**
     Set share's table cache key and update its db and table name appropriately.
 
@@ -1090,6 +1096,9 @@ struct TABLE_SHARE {
 
   /** Release resources and free memory occupied by the table share. */
   void destroy();
+
+  /* reset time for TTL based LRU eviction policy */
+  void set_last_access_time() noexcept;
 
   /**
     How many TABLE objects use this TABLE_SHARE.
@@ -1592,6 +1601,9 @@ struct TABLE {
   /* used in RBR Triggers */
   bool master_had_triggers{false};
   bool disable_sql_log_bin_triggers{false};
+
+  /* last time table was accessed via get_table() function */
+  time_point last_accessed;
 
  private:
   /// Cost model object for operations on this table
@@ -2119,6 +2131,9 @@ struct TABLE {
   void prepare_triggers_for_insert_stmt_or_event();
   bool prepare_triggers_for_delete_stmt_or_event();
   bool prepare_triggers_for_update_stmt_or_event();
+
+  /* reset time for TTL based LRU eviction policy */
+  void set_last_access_time() noexcept;
 };
 
 static inline void empty_record(TABLE *table) {
@@ -3973,5 +3988,7 @@ bool create_table_share_for_upgrade(THD *thd, const char *path,
                                     const char *table,
                                     bool is_fix_view_cols_and_deps);
 //////////////////////////////////////////////////////////////////////////
+
+bool should_be_evicted(time_point last_accessed, time_point cutpoint) noexcept;
 
 #endif /* TABLE_INCLUDED */

--- a/sql/table_cache.cc
+++ b/sql/table_cache.cc
@@ -129,6 +129,26 @@ void Table_cache::free_all_unused_tables() {
   }
 }
 
+void Table_cache::free_old_unused_tables(time_point cutpoint) {
+  assert_owner();
+
+  if (!m_unused_tables) return;
+  std::vector<TABLE *> old_tables;
+
+  for (TABLE *t = m_unused_tables;;) {
+    if (should_be_evicted(t->last_accessed, cutpoint)) {
+      old_tables.push_back(t);
+    }
+    t = t->next;
+    if (t == m_unused_tables)  // circular double-linked list
+      break;
+  }
+  for (TABLE *table_to_free : old_tables) {
+    remove_table(table_to_free);
+    intern_close_table(table_to_free);
+  }
+}
+
 #ifndef DBUG_OFF
 /**
   Print debug information for the contents of the table cache.
@@ -322,6 +342,13 @@ void Table_cache_manager::free_all_unused_tables() {
 
   for (uint i = 0; i < table_cache_instances; i++)
     m_table_cache[i].free_all_unused_tables();
+}
+
+void Table_cache_manager::free_old_unused_tables(time_point cutpoint) {
+  assert_owner_all_and_tdc();
+
+  for (uint i = 0; i < table_cache_instances; i++)
+    m_table_cache[i].free_old_unused_tables(cutpoint);
 }
 
 #ifndef DBUG_OFF

--- a/sql/table_cache.h
+++ b/sql/table_cache.h
@@ -155,6 +155,7 @@ class Table_cache {
   uint cached_tables() const { return m_table_count; }
 
   void free_all_unused_tables();
+  void free_old_unused_tables(time_point cutpoint);
 
 #ifndef DBUG_OFF
   void print_tables();
@@ -197,6 +198,7 @@ class Table_cache_manager {
                   TABLE_SHARE *share);
 
   void free_all_unused_tables();
+  void free_old_unused_tables(time_point cutpoint);
 
 #ifndef DBUG_OFF
   void print_tables();
@@ -477,6 +479,9 @@ TABLE *Table_cache::get_table(THD *thd, const char *key, size_t key_length,
     DBUG_ASSERT(table->db_stat && table->file);
     /* The children must be detached from the table. */
     DBUG_ASSERT(!table->file->extra(HA_EXTRA_IS_ATTACHED_CHILDREN));
+
+    // update access time
+    table->set_last_access_time();
   }
 
   return table;


### PR DESCRIPTION
Jira issue: https://jira.percona.com/browse/FB8-180

Reference Patch:  https://github.com/facebook/mysql-5.6/commit/ec9e122

Summary:
MySQL has variable "flush_time". If it is set to a nonzero value, all tables are closed every "flush_time" seconds to free up resources and synchronize unflushed data to disk. This option is best used only on systems with minimal resources.
I added variable "flush_only_old_cache_entries" which were open more than "flush_time" seconds.

Originally Reviewed By: anirbanr-fb

TODO: Because of conflicts I removed changes in `mysql-test/t/all_persisted_variables.test`. This test has to be modified at `let $total_persistent_vars=XXX;` (+1 increase) and it should be re-recorded.