### PR TITLE
FB8-117: Add thread ID option for SQL SET command

### DIFF
--- a/mysql-test/r/set_thread_var.result
+++ b/mysql-test/r/set_thread_var.result
@@ -1,0 +1,40 @@
+CREATE USER mysqluser1;
+SET max_join_size = 1000;
+include/assert.inc [Check if max_join_size is correct]
+SET max_join_size = 2000;
+include/assert.inc [Check if max_join_size is correct]
+SET SESSION $mysqluser1 max_join_size = 1001;
+include/assert.inc [Check if max_join_size is correct]
+SET SESSION $conn_root max_join_size = 2001;
+include/assert.inc [Check if max_join_size is correct]
+SET SESSION max_join_size = 2002;
+include/assert.inc [Check if max_join_size is correct]
+include/assert.inc [Check if max_join_size is correct]
+SET SESSION $conn_mysqluser1 max_join_size = 1002, SESSION $conn_root max_join_size = 2003;
+include/assert.inc [Check if max_join_size is correct]
+include/assert.inc [Check if max_join_size is correct]
+SET SESSION $conn_root max_join_size = 1003, SESSION $conn_root max_join_size = 2004;
+ERROR 42000: Access denied; you need (at least one of) the SUPER or SYSTEM_VARIABLES_ADMIN privilege(s) for this operation
+include/assert.inc [Check if max_join_size is correct]
+SET SESSION $mysqluser1 max_join_size = 1003;
+include/assert.inc [Check if max_join_size is correct]
+SET SESSION max_join_size = 1004;
+include/assert.inc [Check if max_join_size is correct]
+include/assert.inc [Check if max_join_size is correct]
+SET SESSION $conn_mysqluser1 max_join_size = 1005, max_error_count = 30, SESSION $conn_root max_join_size = 2004, max_error_count = 31;
+include/assert.inc [Check if max_join_size is correct]
+include/assert.inc [Check if max_join_size is correct]
+SET SESSION 999 max_join_size = 9999;
+ERROR HY000: Unknown thread id: 999
+SET GLOBAL 1 max_join_size = 1000;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '1 max_join_size = 1000' at line 1
+SET SESSION -1 max_join_size = 1000;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '-1 max_join_size = 1000' at line 1
+SET SESSION 1 TRANSACTION READ WRITE;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'READ WRITE' at line 1
+SET GLOBAL TRANSACTION READ ONLY;
+SET SESSION TRANSACTION READ ONLY;
+include/assert.inc [Check if SET SESSION/GLOBAL TRANSACTION READ ONLY works correctly]
+SET GLOBAL TRANSACTION READ WRITE;
+SET SESSION TRANSACTION READ WRITE;
+DROP USER mysqluser1;

--- a/mysql-test/t/set_thread_var.test
+++ b/mysql-test/t/set_thread_var.test
@@ -1,0 +1,152 @@
+--source include/count_sessions.inc
+
+#
+# test SET VARIABLES with thread id
+#
+
+--let $conn_root = `SELECT CONNECTION_ID()`
+
+# Create a regular user
+CREATE USER mysqluser1;
+
+--connect (user1,localhost,mysqluser1)
+--let $conn_mysqluser1 = `SELECT CONNECTION_ID()`
+
+# Set a variable for current thd
+SET max_join_size = 1000;
+
+--let $assert_text = Check if max_join_size is correct
+--let $assert_cond = @@max_join_size = 1000
+--source include/assert.inc
+
+
+# Connect as root
+--connection default
+
+# Set a variable for current thd
+SET max_join_size = 2000;
+
+--let $assert_text = Check if max_join_size is correct
+--let $assert_cond = @@max_join_size = 2000
+--source include/assert.inc
+
+# Set variable for user1 thd from root thd
+--replace_regex /SESSION [0-9]*/SESSION $mysqluser1/
+--eval SET SESSION $conn_mysqluser1 max_join_size = 1001
+
+--let $assert_text = Check if max_join_size is correct
+--let $assert_cond = @@max_join_size = 2000
+--source include/assert.inc
+
+# Set variable for root thd from root thd
+--replace_regex /SESSION [0-9]*/SESSION $conn_root/
+--eval SET SESSION $conn_root max_join_size = 2001
+
+--let $assert_text = Check if max_join_size is correct
+--let $assert_cond = @@max_join_size = 2001
+--source include/assert.inc
+
+# Set variable for root thd from root thd without session ID
+SET SESSION max_join_size = 2002;
+
+--let $assert_text = Check if max_join_size is correct
+--let $assert_cond = @@max_join_size = 2002
+--source include/assert.inc
+
+
+--connection user1
+
+--let $assert_text = Check if max_join_size is correct
+--let $assert_cond = @@max_join_size = 1001
+--source include/assert.inc
+
+
+# Reconnect as root
+--connection default
+
+# Set variable for both current thd and user1 from root thd
+--replace_regex /SESSION [0-9]* max_join_size = 1002, SESSION [0-9]* max_join_size = 2003/SESSION $conn_mysqluser1 max_join_size = 1002, SESSION $conn_root max_join_size = 2003/
+--eval SET SESSION $conn_mysqluser1 max_join_size = 1002, SESSION $conn_root max_join_size = 2003
+
+--let $assert_text = Check if max_join_size is correct
+--let $assert_cond = @@max_join_size = 2003
+--source include/assert.inc
+
+
+--connection user1
+
+--let $assert_text = Check if max_join_size is correct
+--let $assert_cond = @@max_join_size = 1002
+--source include/assert.inc
+
+# Set variable for root thd from user1 thd
+--replace_regex /SESSION [0-9]*/SESSION $conn_root/ /thread [0-9]*/thread $root/
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+--eval SET SESSION $conn_mysqluser1 max_join_size = 1003, SESSION $conn_root max_join_size = 2004
+
+--let $assert_text = Check if max_join_size is correct
+--let $assert_cond = @@max_join_size = 1002
+--source include/assert.inc
+
+# Set variable for user1 thd from user1 thd
+--replace_regex /SESSION [0-9]*/SESSION $mysqluser1/
+--eval SET SESSION $conn_mysqluser1 max_join_size = 1003
+
+--let $assert_text = Check if max_join_size is correct
+--let $assert_cond = @@max_join_size = 1003
+--source include/assert.inc
+
+# Set variable for user1 thd from user1 thd without session ID
+SET SESSION max_join_size = 1004;
+
+--let $assert_text = Check if max_join_size is correct
+--let $assert_cond = @@max_join_size = 1004
+--source include/assert.inc
+
+
+--connection default
+
+--let $assert_text = Check if max_join_size is correct
+--let $assert_cond = @@max_join_size = 2003
+--source include/assert.inc
+
+# Set multiple variables for both current thd and user1 from root thd
+--replace_regex /SESSION [0-9]* max_join_size = 1005/SESSION $conn_mysqluser1 max_join_size = 1005/ /SESSION [0-9]* max_join_size = 2004/SESSION $conn_root max_join_size = 2004/
+--eval SET SESSION $conn_mysqluser1 max_join_size = 1005, max_error_count = 30, SESSION $conn_root max_join_size = 2004, max_error_count = 31
+
+--let $assert_text = Check if max_join_size is correct
+--let $assert_cond = @@max_join_size = 2004 AND @@max_error_count = 31
+--source include/assert.inc
+
+
+--connection user1
+
+--let $assert_text = Check if max_join_size is correct
+--let $assert_cond = @@max_join_size = 1005 AND @@max_error_count = 30
+--source include/assert.inc
+
+--error ER_NO_SUCH_THREAD
+--eval SET SESSION 999 max_join_size = 9999
+
+--error ER_PARSE_ERROR
+--eval SET GLOBAL 1 max_join_size = 1000
+
+--error ER_PARSE_ERROR
+--eval SET SESSION -1 max_join_size = 1000
+
+--error ER_PARSE_ERROR
+--eval SET SESSION 1 TRANSACTION READ WRITE
+
+--connection default
+SET GLOBAL TRANSACTION READ ONLY;
+SET SESSION TRANSACTION READ ONLY;
+--let $assert_text = Check if SET SESSION/GLOBAL TRANSACTION READ ONLY works correctly
+--let $assert_cond = @@GLOBAL.transaction_read_only = 1 AND @@transaction_read_only = 1
+--source include/assert.inc
+SET GLOBAL TRANSACTION READ WRITE;
+SET SESSION TRANSACTION READ WRITE;
+
+# cleanup
+DROP USER mysqluser1;
+--disconnect user1
+--source include/wait_until_count_sessions.inc

--- a/sql/parse_tree_helpers.cc
+++ b/sql/parse_tree_helpers.cc
@@ -164,6 +164,7 @@ bool set_system_variable(THD *thd, struct sys_var_with_base *var_with_base,
                                         &var_with_base->base_name, val)))
     return true;
 
+  var->thd_id = lex->thread_id_opt;
   return lex->var_list.push_back(var);
 }
 
@@ -358,12 +359,14 @@ bool sp_create_assignment_instr(THD *thd, const char *expr_end_ptr) {
   }
 
   /* Remember option_type of the currently parsed LEX. */
-  enum_var_type inner_option_type = lex->option_type;
+  const enum_var_type inner_option_type = lex->option_type;
+  const ulong thd_id_opt = lex->thread_id_opt;
 
   if (sp->restore_lex(thd)) return true;
 
   /* Copy option_type to outer lex in case it has changed. */
   thd->lex->option_type = inner_option_type;
+  thd->lex->thread_id_opt = thd_id_opt;
 
   return false;
 }

--- a/sql/parse_tree_nodes.h
+++ b/sql/parse_tree_nodes.h
@@ -1162,19 +1162,21 @@ class PT_option_value_no_option_type_password_for
 };
 
 class PT_option_value_type : public Parse_tree_node {
-  typedef Parse_tree_node super;
-
-  enum_var_type type;
+  enum_var_type option_type;
+  ulong thread_id;
   PT_option_value_following_option_type *value;
 
  public:
-  PT_option_value_type(enum_var_type type_arg,
+  PT_option_value_type(enum_var_type option_type_arg, ulong thread_id_arg,
                        PT_option_value_following_option_type *value_arg)
-      : type(type_arg), value(value_arg) {}
+      : option_type(option_type_arg),
+        thread_id(thread_id_arg),
+        value(value_arg) {}
 
-  virtual bool contextualize(Parse_context *pc) {
-    pc->thd->lex->option_type = type;
-    return super::contextualize(pc) || value->contextualize(pc);
+  virtual bool contextualize(Parse_context *pc) override {
+    pc->thd->lex->option_type = option_type;
+    pc->thd->lex->thread_id_opt = thread_id;
+    return Parse_tree_node::contextualize(pc) || value->contextualize(pc);
   }
 };
 
@@ -1350,17 +1352,26 @@ class PT_start_option_value_list_following_option_type_eq
     : public PT_start_option_value_list_following_option_type {
   typedef PT_start_option_value_list_following_option_type super;
 
+  enum_var_type option_type;
+  ulong thread_id;
   PT_option_value_following_option_type *head;
   POS head_pos;
   PT_option_value_list_head *opt_tail;
 
  public:
   PT_start_option_value_list_following_option_type_eq(
+      enum_var_type option_type_arg, ulong thread_id_arg,
       PT_option_value_following_option_type *head_arg, const POS &head_pos_arg,
       PT_option_value_list_head *opt_tail_arg)
-      : head(head_arg), head_pos(head_pos_arg), opt_tail(opt_tail_arg) {}
+      : option_type(option_type_arg),
+        thread_id(thread_id_arg),
+        head(head_arg),
+        head_pos(head_pos_arg),
+        opt_tail(opt_tail_arg) {}
 
-  virtual bool contextualize(Parse_context *pc) {
+  virtual bool contextualize(Parse_context *pc) override {
+    pc->thd->lex->option_type = option_type;
+    pc->thd->lex->thread_id_opt = thread_id;
     if (super::contextualize(pc) || head->contextualize(pc)) return true;
 
     if (sp_create_assignment_instr(pc->thd, head_pos.raw.end)) return true;
@@ -1377,17 +1388,21 @@ class PT_start_option_value_list_following_option_type_transaction
     : public PT_start_option_value_list_following_option_type {
   typedef PT_start_option_value_list_following_option_type super;
 
+  enum_var_type type;
   PT_transaction_characteristics *characteristics;
   POS characteristics_pos;
 
  public:
   PT_start_option_value_list_following_option_type_transaction(
+      enum_var_type type_arg,
       PT_transaction_characteristics *characteristics_arg,
       const POS &characteristics_pos_arg)
-      : characteristics(characteristics_arg),
+      : type(type_arg),
+        characteristics(characteristics_arg),
         characteristics_pos(characteristics_pos_arg) {}
 
   virtual bool contextualize(Parse_context *pc) {
+    pc->thd->lex->option_type = type;
     if (super::contextualize(pc) || characteristics->contextualize(pc))
       return true;
 
@@ -1403,17 +1418,14 @@ class PT_start_option_value_list_following_option_type_transaction
 class PT_start_option_value_list_type : public PT_start_option_value_list {
   typedef PT_start_option_value_list super;
 
-  enum_var_type type;
   PT_start_option_value_list_following_option_type *list;
 
  public:
   PT_start_option_value_list_type(
-      enum_var_type type_arg,
       PT_start_option_value_list_following_option_type *list_arg)
-      : type(type_arg), list(list_arg) {}
+      : list(list_arg) {}
 
-  virtual bool contextualize(Parse_context *pc) {
-    pc->thd->lex->option_type = type;
+  virtual bool contextualize(Parse_context *pc) override {
     return super::contextualize(pc) || list->contextualize(pc);
   }
 };

--- a/sql/set_var.cc
+++ b/sql/set_var.cc
@@ -51,7 +51,8 @@
 #include "sql/item.h"
 #include "sql/item_func.h"
 #include "sql/log.h"
-#include "sql/mysqld.h"  // system_charset_info
+#include "sql/mysqld.h"              // system_charset_info
+#include "sql/mysqld_thd_manager.h"  // Global_THD_manager
 #include "sql/persisted_variable.h"
 #include "sql/protocol_classic.h"
 #include "sql/session_tracker.h"
@@ -70,6 +71,7 @@
 #include "sql_string.h"
 
 using std::string;
+using set_var_list_map = std::unordered_map<ulong, List<set_var_base>>;
 
 static collation_unordered_map<string, sys_var *> *system_variable_hash;
 static PolyLock_mutex PLock_global_system_variables(
@@ -734,6 +736,62 @@ sys_var *intern_find_sys_var(const char *str, size_t length) {
 }
 
 /**
+  Helper function to set variables.
+  Use the thd -> list<var> map to iterate over all threads
+  For each thread, for each variable in its list, perform the specified function
+  @param THD            Current thread
+  @param thd_var_map    Map of threads to list of variables to be updated
+  @param func           Function to be executed for each variable
+  @retval
+    0   ok
+  @retval
+    1   ERROR
+*/
+
+static int process_set_variable_map(THD *thd, set_var_list_map &thd_var_map,
+                                    int (*func)(THD *, set_var_base *)) {
+  DBUG_ENTER("process_set_variable_map");
+  int error = 0;
+
+  for (auto var_iter : thd_var_map) {
+    ulong thd_id = var_iter.first;
+    THD *change_thd = thd;
+    // Thread id of the current thread is 0
+    if (thd_id) {
+      Find_thd_with_id find_thd_with_id(thd_id);
+      change_thd =
+          Global_THD_manager::get_instance()->find_thd(&find_thd_with_id);
+      if (!change_thd) {
+        my_error(ER_NO_SUCH_THREAD, MYF(0), thd_id);
+        DBUG_RETURN(1);
+      }
+
+      Security_context *sctx = thd->security_context();
+      if (!sctx->check_access(SUPER_ACL) &&
+          !sctx->has_global_grant(STRING_WITH_LEN("SYSTEM_VARIABLES_ADMIN"))
+               .first) {
+        mysql_mutex_unlock(&change_thd->LOCK_thd_data);
+        my_error(ER_SPECIFIC_ACCESS_DENIED_ERROR, MYF(0),
+                 "SUPER or SYSTEM_VARIABLES_ADMIN");
+        DBUG_RETURN(1);
+      }
+    }
+
+    List_iterator_fast<set_var_base> it(var_iter.second);
+    set_var_base *var;
+    while ((var = it++)) {
+      if ((error = func(change_thd, var))) break;
+    }
+
+    if (thd_id) mysql_mutex_unlock(&change_thd->LOCK_thd_data);
+
+    if (error) break;
+  }
+
+  DBUG_RETURN(error);
+}
+
+/**
   Execute update of all variables.
 
   First run a check of all variables that all updates will go ok.
@@ -756,32 +814,52 @@ sys_var *intern_find_sys_var(const char *str, size_t length) {
 */
 
 int sql_set_variables(THD *thd, List<set_var_base> *var_list, bool opened) {
+  DBUG_ENTER("sql_set_variables");
   int error;
   List_iterator_fast<set_var_base> it(*var_list);
-  DBUG_ENTER("sql_set_variables");
-
   LEX *lex = thd->lex;
   set_var_base *var;
+  const ulong current_thd_id = thd->thread_id();
+  /*
+    This map stores a list of variables to be updated for each thread specified
+    by the user, essentially grouping variabled by thread ID. Variable updates
+    are processed per thread.
+  */
+  set_var_list_map thd_var_map;
+
   while ((var = it++)) {
-    if ((error = var->resolve(thd))) goto err;
+    ulong thd_id_opt = var->thd_id;
+    if (thd_id_opt == current_thd_id) thd_id_opt = 0;
+    thd_var_map[thd_id_opt].push_back(var);
   }
+
+  if ((error = process_set_variable_map(thd, thd_var_map,
+                                        [](THD *each_thd, set_var_base *var) {
+                                          return var->resolve(each_thd);
+                                        })))
+    goto err;
+
   if ((error = thd->is_error())) goto err;
 
   if (opened && lock_tables(thd, lex->query_tables, lex->table_count, 0)) {
     error = 1;
     goto err;
   }
-  it.rewind();
-  while ((var = it++)) {
-    if ((error = var->check(thd))) goto err;
-  }
+
+  if ((error = process_set_variable_map(thd, thd_var_map,
+                                        [](THD *each_thd, set_var_base *var) {
+                                          return var->check(each_thd);
+                                        })))
+    goto err;
+
   if ((error = thd->is_error())) goto err;
 
-  it.rewind();
-  while ((var = it++)) {
-    if ((error = var->update(thd)))  // Returns 0, -1 or 1
-      goto err;
-  }
+  if ((error = process_set_variable_map(
+           thd, thd_var_map, [](THD *each_thd, set_var_base *var) {
+             return var->update(each_thd); /* Returns 0, -1 or 1 */
+           })))
+    goto err;
+
   if (!error) {
     /* At this point SET statement is considered a success. */
     Persisted_variables_cache *pv = NULL;

--- a/sql/set_var.h
+++ b/sql/set_var.h
@@ -105,6 +105,7 @@ class sys_var {
  public:
   sys_var *next;
   LEX_CSTRING name;
+  ulong thd_id;
   enum flag_enum {
     GLOBAL = 0x0001,
     SESSION = 0x0002,
@@ -358,6 +359,8 @@ class set_var_base {
     between the two phases.
   */
   virtual int light_check(THD *thd) { return (resolve(thd) || check(thd)); }
+
+  ulong thd_id = 0;
 };
 
 /**

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -469,6 +469,7 @@ void LEX::reset() {
   binlog_need_explicit_defaults_ts = false;
   m_extended_show = false;
   option_type = OPT_DEFAULT;
+  thread_id_opt = 0;
 
   clear_privileges();
 }

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -3801,6 +3801,7 @@ struct LEX : public Query_tables_list {
   bool contains_plaintext_password;
   enum_keep_diagnostics keep_diagnostics;
   uint32 next_binlog_file_nr;
+  ulong thread_id_opt; /* thread id option */
 
  private:
   bool m_broken;  ///< see mark_broken()

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -1335,6 +1335,8 @@ void warn_about_deprecated_national(THD *thd)
         now
         opt_checksum_type
         opt_ignore_lines
+        opt_var_tid
+        option_type_with_thread_id
 
 %type <ulonglong_number>
         ulonglong_num real_ulonglong_num size_number
@@ -14300,9 +14302,9 @@ start_option_value_list:
           {
             $$= NEW_PTN PT_start_option_value_list_transaction($2, @2);
           }
-        | option_type start_option_value_list_following_option_type
+        | start_option_value_list_following_option_type
           {
-            $$= NEW_PTN PT_start_option_value_list_type($1, $2);
+            $$= NEW_PTN PT_start_option_value_list_type($1);
           }
         | PASSWORD equal TEXT_STRING opt_replace_password
           {
@@ -14390,18 +14392,20 @@ thread_id_list_options:
 
 // Start of option value list, option_type was given
 start_option_value_list_following_option_type:
-          option_value_following_option_type option_value_list_continued
-          {
-            $$=
-              NEW_PTN PT_start_option_value_list_following_option_type_eq($1,
-                                                                          @1,
-                                                                          $2);
-          }
-        | TRANSACTION_SYM transaction_characteristics
+          option_type_with_thread_id option_value_following_option_type option_value_list_continued
           {
             $$= NEW_PTN
-              PT_start_option_value_list_following_option_type_transaction($2,
-                                                                           @2);
+              PT_start_option_value_list_following_option_type_eq(OPT_SESSION, $1, $2, @2, $3);
+          }
+        | option_type option_value_following_option_type option_value_list_continued
+          {
+            $$= NEW_PTN
+              PT_start_option_value_list_following_option_type_eq($1, 0, $2, @2, $3);
+          }
+        | option_type TRANSACTION_SYM transaction_characteristics
+          {
+            $$= NEW_PTN
+              PT_start_option_value_list_following_option_type_transaction($1, $3, @3);
           }
         ;
 
@@ -14425,9 +14429,13 @@ option_value_list:
 
 // Wrapper around option values following the first option value in the stmt.
 option_value:
-          option_type option_value_following_option_type
+          option_type_with_thread_id option_value_following_option_type
           {
-            $$= NEW_PTN PT_option_value_type($1, $2);
+            $$= NEW_PTN PT_option_value_type(OPT_SESSION, $1, $2);
+          }
+        | option_type option_value_following_option_type
+          {
+            $$= NEW_PTN PT_option_value_type($1, 0, $2);
           }
         | option_value_no_option_type { $$= $1; }
         ;
@@ -14438,6 +14446,20 @@ option_type:
         | PERSIST_ONLY_SYM { $$=OPT_PERSIST_ONLY; }
         | LOCAL_SYM   { $$=OPT_SESSION; }
         | SESSION_SYM { $$=OPT_SESSION; }
+        ;
+
+opt_var_tid:
+         ulong_num
+          {
+            if ($1 <= 0)
+              MYSQL_YYABORT;
+            $$=$1;
+          }
+        ;
+
+option_type_with_thread_id:
+          LOCAL_SYM   opt_var_tid { $$= $2; }
+        | SESSION_SYM opt_var_tid { $$= $2; }
         ;
 
 opt_var_type:


### PR DESCRIPTION
Summary:

Jira issue: https://jira.percona.com/browse/FB8-117

Reference Patch: https://github.com/facebook/mysql-5.6/commit/19f5aad

Added thread ID option to the SQL SET command. The syntax of the command is as follows:

`SET SESSION [THREAD_ID] var_name = var_value [, [SESSION [THREAD_ID]] var_name = var_value]`

Notes:
- The thread ID can be specified only with the SESSION keyword
- If no thread ID is provided, it is assumed to be the current thread
- Similarly, if own thread ID is provided, it is equivalent to `SET var_name = var_value`
- If the thread with given ID does not exist, it will fail
- For commands like `SET SESSION THREAD_ID var1 = var_value1, var2 = var_value2, var3 = var_value3` the SESSION THREAD_ID will apply to all three variables as explained in https://dev.mysql.com/doc/refman/5.6/en/set-variable.html