### PR TITLE
Fix for FB8-139: TraceID support in MySQLD

### DIFF
--- a/mysql-test/r/slow_log_extra_big.result
+++ b/mysql-test/r/slow_log_extra_big.result
@@ -45,3 +45,5 @@ Rows_sent	Rows_examined	Errno	Killed	Bytes_received	Bytes_sent	Read_first	Read_l
 1	50	0	0	0	57	0	0	1	50	0	0	0	0	0	0	0	0
 if the following is not 1 you need to adjust the file_lines_count variable
 1
+Count: 1    select count(*) from big_table_slow where id>N and id<N
+

--- a/mysql-test/t/slow_log_extra_big.test
+++ b/mysql-test/t/slow_log_extra_big.test
@@ -84,4 +84,8 @@ let SEARCH_FILE = $file_lines_filename;
 let SEARCH_PATTERN= Trace_Id: foobar;
 --source include/search_pattern_in_file.inc
 
+# Try to detect a broken slow log
+--replace_regex /Time=.*//
+--exec $MYSQLDUMPSLOW $file_lines_filename -g 'from big_table_slow where id>100 and id<200'
+
 --exit

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -747,7 +747,7 @@ bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
         " Created_tmp_disk_tables: %lu"
         " Created_tmp_tables: %lu"
         " Start: %s End: %s"
-        " Trace_Id: %s Instruction_Cost: %lu\n";
+        " Trace_Id: %s Instruction_Cost: %lu";
 
     // If the query start status is valid - i.e. the current thread's
     // status values should be no less than the query start status,


### PR DESCRIPTION
Summary:

Reference Patch: https://github.com/facebook/mysql-5.6/commit/40ef633540662d0753bc04094fe10f85b79019ae

1. Remove redundant EOL in query attributes
2. Detect a broken slow log in `main.slow_log_extra_big`

Squash with D14387874