### PR TITLE
FB8-118: Port slow query log rotation

### DIFF
--- a/mysql-test/include/assert_number_of_files.inc
+++ b/mysql-test/include/assert_number_of_files.inc
@@ -1,0 +1,39 @@
+# ==== Purpose ====
+#
+# Assert that number of files matching given $file_spec is equal to expected.
+#
+# ==== Usage ====
+#
+# --let file_spec = PATH_REGEX
+# --let expected_number = INTEGER
+# --source include/assert_number_of_files.inc
+#
+# Parameters:
+#   $file_spec
+#     The path with wildcards e.g. $MYSQLTEST_VARDIR/abcd*
+#
+#   $expected_number
+#     The expected number of files
+
+--perl
+  use strict;
+  my $dir = $ENV{'MYSQL_TMP_DIR'} or die "MYSQL_TMP_DIR not set";
+  my $file_spec = $ENV{'file_spec'} or die "file_spec not set";
+  my @files = <$ENV{'file_spec'}>;
+  open (OUTPUT, ">$dir/number_of_files.inc") ;
+  print OUTPUT "--let \$number_of_files = ", scalar(@files), "\n";
+  close (OUTPUT);
+EOF
+--source $MYSQL_TMP_DIR/number_of_files.inc
+--remove_file $MYSQL_TMP_DIR/number_of_files.inc
+
+
+if ($expected_number != $number_of_files)
+{
+  --echo ====================== Test assertion failed: ======================
+  --echo The number of files ($number_of_files) is different that expected $expected_number
+  --echo ====================================================================
+  --die Test assertion failed in assert_number_of_files.inc
+}
+
+--echo include/assert_number_of_files.inc [The number of files matches expected $expected_number]

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -625,6 +625,10 @@ The following options may be given as the first argument:
  --max-seeks-for-key=# 
  Limit assumed max number of seeks when looking up rows
  based on a key
+ --max-slowlog-size=# 
+ Slow query log will be rotated automatically when the
+ size exceeds this value. The default is 0, don't limit
+ the size.
  --max-sort-length=# The number of bytes to use when sorting long values with
  PAD SPACE collations (only the first max_sort_length
  bytes of each value are used; the rest are ignored)
@@ -1297,6 +1301,10 @@ The following options may be given as the first argument:
  Log slow queries to given log file. Defaults logging to
  hostname-slow.log. Must be enabled to activate other slow
  log options
+ --slowlog-space-limit=# 
+ Maximum space to use for all slow query logs. Works only
+ with max_slowlog_size enabled. Default is 0, this feature
+ is disabled.
  --socket=name       Socket file to use for connection
  --sort-buffer-size=# 
  Each thread that needs to do a sort allocates a buffer of
@@ -1577,6 +1585,7 @@ max-points-in-geometry 65536
 max-prepared-stmt-count 16382
 max-relay-log-size 0
 max-seeks-for-key 18446744073709551615
+max-slowlog-size 0
 max-sort-length 1024
 max-sp-recursion-depth 0
 max-user-connections 0
@@ -1754,6 +1763,7 @@ slave-transaction-retries 10
 slave-type-conversions 
 slow-launch-time 2
 slow-query-log FALSE
+slowlog-space-limit 0
 sort-buffer-size 262144
 sporadic-binlog-dump-fail FALSE
 sql-log-bin-triggers TRUE

--- a/mysql-test/r/percona_slowlog_size_limits.result
+++ b/mysql-test/r/percona_slowlog_size_limits.result
@@ -1,0 +1,67 @@
+SET @old_slow_query_log = @@global.slow_query_log;
+SET @old_log_output = @@global.log_output;
+SET @old_slow_query_log_file = @@global.slow_query_log_file;
+SET @old_max_slowlog_size = @@global.max_slowlog_size;
+SET @old_slowlog_space_limit = @@global.slowlog_space_limit;
+SET long_query_time = 0;
+SET GLOBAL log_output = FILE;
+SET GLOBAL slow_query_log = 1;
+# Case 1 (PS-1484): Test if slowlog_space_limit is working correctly
+#                   with the default slow query log name
+SET GLOBAL max_slowlog_size = 4096;
+SET GLOBAL slowlog_space_limit = @@global.max_slowlog_size * 3;
+include/assert_number_of_files.inc [The number of files matches expected 3]
+# Case 2 (Bug 1416582): Slow query log is rotated before it should
+#                       when using max_slowlog_size
+SET GLOBAL max_slowlog_size = 10240000;
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/abcd';
+SET GLOBAL slow_query_log = 0;
+SET GLOBAL slow_query_log = 1;
+SET GLOBAL slow_query_log = 0;
+SET GLOBAL slow_query_log = 1;
+FLUSH LOGS;
+FLUSH LOGS;
+FLUSH LOGS;
+include/assert.inc [Slow query log number should not be incremented and log should be abcd.000001]
+# Case 3: Test if each slow_query_log_file call rotates slow log 
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/zxcv';
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/abcd';
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/zxcv';
+include/assert.inc [Slow query log should be zxcv.000002]
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/abcd';
+include/assert.inc [Slow query log should be abcd.000003]
+# Case 4: Test if slowlog_space_limit is working correctly
+SET GLOBAL max_slowlog_size = 4096;
+SET GLOBAL slowlog_space_limit = @@global.max_slowlog_size * 5;
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/abcd';
+include/assert_number_of_files.inc [The number of files matches expected 5]
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/zxcv';
+include/assert_number_of_files.inc [The number of files matches expected 5]
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/abcd';
+include/assert_number_of_files.inc [The number of files matches expected 5]
+# Case 5: Rotating log but should not delete previous logs
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/abcd';
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/abcd';
+include/assert_number_of_files.inc [The number of files matches expected 7]
+# Case 6: Calling "SET slowlog_space_limit" should reduce number of logs
+SET GLOBAL max_slowlog_size = 4096;
+SET GLOBAL slowlog_space_limit = @@global.max_slowlog_size * 2;
+include/assert_number_of_files.inc [The number of files matches expected 4]
+# Case 7: Delete all small logs with max_slowlog_size = 0
+SET GLOBAL max_slowlog_size = 0;
+SET GLOBAL slowlog_space_limit = 4096;
+include/assert_number_of_files.inc [The number of files matches expected 1]
+# Case 8: Rotate log should delete previous log
+SET GLOBAL max_slowlog_size = 10240000;
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/abcd';
+include/assert_number_of_files.inc [The number of files matches expected 1]
+# Case 9: Check if disable max_slowlog_size is working correctly
+SET GLOBAL max_slowlog_size = 0;
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/abcd';
+include/assert_number_of_files.inc [The number of files matches expected 2]
+include/assert.inc [Slow query log should stay as abcd]
+SET @@global.slow_query_log = @old_slow_query_log;
+SET @@global.log_output = @old_log_output;
+SET @@global.slow_query_log_file = @old_slow_query_log_file;
+SET @@global.max_slowlog_size = @old_max_slowlog_size;
+SET @@global.slowlog_space_limit = @old_slowlog_space_limit;

--- a/mysql-test/suite/sys_vars/inc/check_global_integer.inc
+++ b/mysql-test/suite/sys_vars/inc/check_global_integer.inc
@@ -1,0 +1,206 @@
+#############################################################################
+# ==== Purpose ====                                                         #
+#                                                                           #
+# Check if global integer $VARIABLE_NAME returns errors if it's outside a   #
+# range between $VARIABLE_MIN_VALUE (default: 0) and $VARIABLE_MAX_VALUE.   #
+#                                                                           #
+# Additionally we check the behaviour of this variable for:                 #
+# * Default values                                                          #
+# * Valid and invalid values                                                #
+# * Scope and access method                                                 #
+#                                                                           #
+# References: http://dev.mysql.com/doc/refman/8.0/en/                       #
+#                        server-system-variables.html                       #
+#                                                                           #
+# ==== Usage ====                                                           #
+#                                                                           #
+# --let $VARIABLE_NAME = 'NAME'                                             #
+# --let $VARIABLE_MAX_VALUE = NUMBER                                        #
+# [--let $VARIABLE_MIN_VALUE = NUMBER ]                                     #
+# [--let $VARIABLE_BLOCK_SIZE = NUMBER ]                                    #
+# --source suite/sys_vars/inc/check_global_integer.inc                      #
+#                                                                           #
+# ==== Examples ====                                                        #
+#                                                                           #
+# --let $VARIABLE_NAME = slowlog_space_limit                                #
+# --let $VARIABLE_MAX_VALUE = 18446744073709551615                          #
+# --source suite/sys_vars/inc/check_global_integer.inc                      #
+#                                                                           #
+# --let $VARIABLE_NAME = slave_pending_jobs_size_max                        #
+# --let $VARIABLE_MIN_VALUE = 1024                                          #
+# --let $VARIABLE_BLOCK_SIZE = 1024                                         #
+# --let $VARIABLE_MAX_VALUE = 18446744073709551615                          #
+# --source suite/sys_vars/inc/check_global_integer.inc                      #
+#############################################################################
+
+################################################################
+# Initialize auxiliary varaibles                               #
+################################################################
+
+--let $GLOBAL_VAR_NAME = @@global.$VARIABLE_NAME
+--let $SESSION_VAR_NAME = @@session.$VARIABLE_NAME
+
+--let $CHECK_MIN_VALUE = 0
+if ($VARIABLE_MIN_VALUE)
+{
+--let $CHECK_MIN_VALUE = $VARIABLE_MIN_VALUE
+}
+
+--let $CHECK_BLOCK_SIZE = 1
+if ($VARIABLE_BLOCK_SIZE)
+{
+  --let $CHECK_BLOCK_SIZE = $VARIABLE_BLOCK_SIZE
+} 
+--let $CHECK_MIN_VALUE_PLUS_BLOCK_SIZE = `SELECT $CHECK_MIN_VALUE + $CHECK_BLOCK_SIZE`
+
+################################################################
+# Saving initial values of $VARIABLE_NAME variable in          #
+# a temporary variable                                         #
+################################################################
+
+--eval SET @save_original_variable = $GLOBAL_VAR_NAME
+SELECT @save_original_variable;
+
+################################################################
+# Display the DEFAULT value of $VARIABLE_NAME                  #
+################################################################
+
+--eval SET $GLOBAL_VAR_NAME = $CHECK_MIN_VALUE_PLUS_BLOCK_SIZE
+--eval SET $GLOBAL_VAR_NAME = DEFAULT
+--eval SELECT $GLOBAL_VAR_NAME
+
+--error ER_GLOBAL_VARIABLE
+--eval SET $SESSION_VAR_NAME = $CHECK_MIN_VALUE + 2
+--error ER_GLOBAL_VARIABLE
+--eval SET $SESSION_VAR_NAME = DEFAULT
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+--eval SELECT $SESSION_VAR_NAME
+
+################################################################
+# Check if NULL or empty value is accepted                     #
+################################################################
+
+--error ER_WRONG_TYPE_FOR_VAR
+--eval SET $GLOBAL_VAR_NAME = NULL
+
+--error ER_WRONG_TYPE_FOR_VAR
+--eval SET $GLOBAL_VAR_NAME = ''
+
+--error ER_WRONG_TYPE_FOR_VAR
+--eval SET $GLOBAL_VAR_NAME = ' '
+
+--error ER_GLOBAL_VARIABLE
+--eval SET $SESSION_VAR_NAME = NULL
+
+--error ER_GLOBAL_VARIABLE
+--eval SET $SESSION_VAR_NAME = ''
+
+--error ER_GLOBAL_VARIABLE
+--eval SET $SESSION_VAR_NAME = ' '
+
+#############################################################################
+# Change the value of $VARIABLE_NAME to a valid value for GLOBAL scope      #
+#############################################################################
+
+--eval SET $GLOBAL_VAR_NAME = $CHECK_MIN_VALUE
+--eval SELECT $GLOBAL_VAR_NAME
+
+--eval SET $GLOBAL_VAR_NAME = $CHECK_MIN_VALUE_PLUS_BLOCK_SIZE
+--eval SELECT $GLOBAL_VAR_NAME
+
+if ($CHECK_MIN_VALUE == 0)
+{
+ if ($CHECK_BLOCK_SIZE == 1)
+ {
+  --eval SET $GLOBAL_VAR_NAME = TRUE
+  --eval SELECT $GLOBAL_VAR_NAME
+
+  --eval SET $GLOBAL_VAR_NAME = FALSE
+  --eval SELECT $GLOBAL_VAR_NAME
+ }
+}
+
+--eval SET $GLOBAL_VAR_NAME = $VARIABLE_MAX_VALUE
+--eval SELECT $GLOBAL_VAR_NAME
+
+--eval SET $GLOBAL_VAR_NAME = DEFAULT
+--eval SELECT $GLOBAL_VAR_NAME
+
+#############################################################################
+# Change the value of $VARIABLE_NAME to an invalid value for GLOBAL scope   #
+#############################################################################
+
+--eval SET $GLOBAL_VAR_NAME = -$CHECK_MIN_VALUE_PLUS_BLOCK_SIZE
+--eval SELECT $GLOBAL_VAR_NAME
+
+--error ER_WRONG_TYPE_FOR_VAR
+--eval SET $GLOBAL_VAR_NAME = 'ABC'
+--eval SELECT $GLOBAL_VAR_NAME
+
+--error ER_WRONG_TYPE_FOR_VAR
+--eval SET $GLOBAL_VAR_NAME = ON
+--eval SELECT $GLOBAL_VAR_NAME
+
+--error ER_WRONG_TYPE_FOR_VAR
+--eval SET $GLOBAL_VAR_NAME = 'OFF'
+--eval SELECT $GLOBAL_VAR_NAME
+
+--error ER_WRONG_TYPE_FOR_VAR
+--eval SET $GLOBAL_VAR_NAME = $CHECK_MIN_VALUE_PLUS_BLOCK_SIZE.14
+--eval SELECT $GLOBAL_VAR_NAME
+
+--error ER_WRONG_TYPE_FOR_VAR
+--eval SET $GLOBAL_VAR_NAME = NONE
+--eval SELECT $GLOBAL_VAR_NAME
+
+if ($VARIABLE_MAX_VALUE == 18446744073709551615)
+{
+--error ER_WRONG_TYPE_FOR_VAR
+}
+--eval SET $GLOBAL_VAR_NAME = -$VARIABLE_MAX_VALUE
+--eval SELECT $GLOBAL_VAR_NAME
+
+if ($VARIABLE_MAX_VALUE == 18446744073709551615)
+{
+--error ER_DATA_OUT_OF_RANGE
+}
+--eval SET $GLOBAL_VAR_NAME = $VARIABLE_MAX_VALUE + 1
+--eval SELECT $GLOBAL_VAR_NAME
+
+#############################################################################
+# Check if the value in GLOBAL Table matches value in variable              #
+#############################################################################
+
+--let $assert_text= Must return 1
+--let $assert_cond= $GLOBAL_VAR_NAME = VARIABLE_VALUE FROM performance_schema.global_variables WHERE VARIABLE_NAME="$VARIABLE_NAME"
+--source include/assert.inc
+
+#############################################################################
+# Check if $VARIABLE_NAME variable can be accessed with and without @@ sign #
+#############################################################################
+
+--eval SET GLOBAL $VARIABLE_NAME = $CHECK_MIN_VALUE_PLUS_BLOCK_SIZE
+--eval SET $GLOBAL_VAR_NAME = $CHECK_MIN_VALUE_PLUS_BLOCK_SIZE
+
+--error ER_PARSE_ERROR
+--eval SET global.$VARIABLE_NAME = $CHECK_MIN_VALUE_PLUS_BLOCK_SIZE
+
+--error ER_GLOBAL_VARIABLE
+--eval SET @@$VARIABLE_NAME = $CHECK_MIN_VALUE_PLUS_BLOCK_SIZE
+
+--error ER_GLOBAL_VARIABLE
+--eval SET $VARIABLE_NAME = $CHECK_MIN_VALUE_PLUS_BLOCK_SIZE
+
+--error ER_UNKNOWN_TABLE
+--eval SELECT global.$VARIABLE_NAME
+
+--error ER_BAD_FIELD_ERROR
+--eval SELECT GLOBAL $VARIABLE_NAME
+
+--eval SELECT @@$VARIABLE_NAME
+
+#############################################################################
+# Restoring the original value of $VARIABLE_NAME variable                   #
+#############################################################################
+
+--eval SET $GLOBAL_VAR_NAME = @save_original_variable

--- a/mysql-test/suite/sys_vars/r/max_slowlog_size_basic.result
+++ b/mysql-test/suite/sys_vars/r/max_slowlog_size_basic.result
@@ -1,0 +1,103 @@
+SET @save_original_variable = @@global.max_slowlog_size;
+SELECT @save_original_variable;
+@save_original_variable
+0
+SET @@global.max_slowlog_size = 4096;
+SET @@global.max_slowlog_size = DEFAULT;
+SELECT @@global.max_slowlog_size;
+@@global.max_slowlog_size
+0
+SET @@session.max_slowlog_size = 0 + 2;
+ERROR HY000: Variable 'max_slowlog_size' is a GLOBAL variable and should be set with SET GLOBAL
+SET @@session.max_slowlog_size = DEFAULT;
+ERROR HY000: Variable 'max_slowlog_size' is a GLOBAL variable and should be set with SET GLOBAL
+SELECT @@session.max_slowlog_size;
+ERROR HY000: Variable 'max_slowlog_size' is a GLOBAL variable
+SET @@global.max_slowlog_size = NULL;
+ERROR 42000: Incorrect argument type to variable 'max_slowlog_size'
+SET @@global.max_slowlog_size = '';
+ERROR 42000: Incorrect argument type to variable 'max_slowlog_size'
+SET @@global.max_slowlog_size = ' ';
+ERROR 42000: Incorrect argument type to variable 'max_slowlog_size'
+SET @@session.max_slowlog_size = NULL;
+ERROR HY000: Variable 'max_slowlog_size' is a GLOBAL variable and should be set with SET GLOBAL
+SET @@session.max_slowlog_size = '';
+ERROR HY000: Variable 'max_slowlog_size' is a GLOBAL variable and should be set with SET GLOBAL
+SET @@session.max_slowlog_size = ' ';
+ERROR HY000: Variable 'max_slowlog_size' is a GLOBAL variable and should be set with SET GLOBAL
+SET @@global.max_slowlog_size = 0;
+SELECT @@global.max_slowlog_size;
+@@global.max_slowlog_size
+0
+SET @@global.max_slowlog_size = 4096;
+SELECT @@global.max_slowlog_size;
+@@global.max_slowlog_size
+4096
+SET @@global.max_slowlog_size = 1073741824;
+SELECT @@global.max_slowlog_size;
+@@global.max_slowlog_size
+1073741824
+SET @@global.max_slowlog_size = DEFAULT;
+SELECT @@global.max_slowlog_size;
+@@global.max_slowlog_size
+0
+SET @@global.max_slowlog_size = -4096;
+Warnings:
+Warning	1292	Truncated incorrect max_slowlog_size value: '-4096'
+SELECT @@global.max_slowlog_size;
+@@global.max_slowlog_size
+0
+SET @@global.max_slowlog_size = 'ABC';
+ERROR 42000: Incorrect argument type to variable 'max_slowlog_size'
+SELECT @@global.max_slowlog_size;
+@@global.max_slowlog_size
+0
+SET @@global.max_slowlog_size = ON;
+ERROR 42000: Incorrect argument type to variable 'max_slowlog_size'
+SELECT @@global.max_slowlog_size;
+@@global.max_slowlog_size
+0
+SET @@global.max_slowlog_size = 'OFF';
+ERROR 42000: Incorrect argument type to variable 'max_slowlog_size'
+SELECT @@global.max_slowlog_size;
+@@global.max_slowlog_size
+0
+SET @@global.max_slowlog_size = 4096.14;
+ERROR 42000: Incorrect argument type to variable 'max_slowlog_size'
+SELECT @@global.max_slowlog_size;
+@@global.max_slowlog_size
+0
+SET @@global.max_slowlog_size = NONE;
+ERROR 42000: Incorrect argument type to variable 'max_slowlog_size'
+SELECT @@global.max_slowlog_size;
+@@global.max_slowlog_size
+0
+SET @@global.max_slowlog_size = -1073741824;
+Warnings:
+Warning	1292	Truncated incorrect max_slowlog_size value: '-1073741824'
+SELECT @@global.max_slowlog_size;
+@@global.max_slowlog_size
+0
+SET @@global.max_slowlog_size = 1073741824 + 1;
+Warnings:
+Warning	1292	Truncated incorrect max_slowlog_size value: '1073741825'
+SELECT @@global.max_slowlog_size;
+@@global.max_slowlog_size
+1073741824
+include/assert.inc [Must return 1]
+SET GLOBAL max_slowlog_size = 4096;
+SET @@global.max_slowlog_size = 4096;
+SET global.max_slowlog_size = 4096;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'global.max_slowlog_size = 4096' at line 1
+SET @@max_slowlog_size = 4096;
+ERROR HY000: Variable 'max_slowlog_size' is a GLOBAL variable and should be set with SET GLOBAL
+SET max_slowlog_size = 4096;
+ERROR HY000: Variable 'max_slowlog_size' is a GLOBAL variable and should be set with SET GLOBAL
+SELECT global.max_slowlog_size;
+ERROR 42S02: Unknown table 'global' in field list
+SELECT GLOBAL max_slowlog_size;
+ERROR 42S22: Unknown column 'GLOBAL' in 'field list'
+SELECT @@max_slowlog_size;
+@@max_slowlog_size
+4096
+SET @@global.max_slowlog_size = @save_original_variable;

--- a/mysql-test/suite/sys_vars/r/slowlog_space_limit_basic.result
+++ b/mysql-test/suite/sys_vars/r/slowlog_space_limit_basic.result
@@ -1,0 +1,109 @@
+SET @save_original_variable = @@global.slowlog_space_limit;
+SELECT @save_original_variable;
+@save_original_variable
+0
+SET @@global.slowlog_space_limit = 1;
+SET @@global.slowlog_space_limit = DEFAULT;
+SELECT @@global.slowlog_space_limit;
+@@global.slowlog_space_limit
+0
+SET @@session.slowlog_space_limit = 0 + 2;
+ERROR HY000: Variable 'slowlog_space_limit' is a GLOBAL variable and should be set with SET GLOBAL
+SET @@session.slowlog_space_limit = DEFAULT;
+ERROR HY000: Variable 'slowlog_space_limit' is a GLOBAL variable and should be set with SET GLOBAL
+SELECT @@session.slowlog_space_limit;
+ERROR HY000: Variable 'slowlog_space_limit' is a GLOBAL variable
+SET @@global.slowlog_space_limit = NULL;
+ERROR 42000: Incorrect argument type to variable 'slowlog_space_limit'
+SET @@global.slowlog_space_limit = '';
+ERROR 42000: Incorrect argument type to variable 'slowlog_space_limit'
+SET @@global.slowlog_space_limit = ' ';
+ERROR 42000: Incorrect argument type to variable 'slowlog_space_limit'
+SET @@session.slowlog_space_limit = NULL;
+ERROR HY000: Variable 'slowlog_space_limit' is a GLOBAL variable and should be set with SET GLOBAL
+SET @@session.slowlog_space_limit = '';
+ERROR HY000: Variable 'slowlog_space_limit' is a GLOBAL variable and should be set with SET GLOBAL
+SET @@session.slowlog_space_limit = ' ';
+ERROR HY000: Variable 'slowlog_space_limit' is a GLOBAL variable and should be set with SET GLOBAL
+SET @@global.slowlog_space_limit = 0;
+SELECT @@global.slowlog_space_limit;
+@@global.slowlog_space_limit
+0
+SET @@global.slowlog_space_limit = 1;
+SELECT @@global.slowlog_space_limit;
+@@global.slowlog_space_limit
+1
+SET @@global.slowlog_space_limit = TRUE;
+SELECT @@global.slowlog_space_limit;
+@@global.slowlog_space_limit
+1
+SET @@global.slowlog_space_limit = FALSE;
+SELECT @@global.slowlog_space_limit;
+@@global.slowlog_space_limit
+0
+SET @@global.slowlog_space_limit = 18446744073709551615;
+SELECT @@global.slowlog_space_limit;
+@@global.slowlog_space_limit
+18446744073709551615
+SET @@global.slowlog_space_limit = DEFAULT;
+SELECT @@global.slowlog_space_limit;
+@@global.slowlog_space_limit
+0
+SET @@global.slowlog_space_limit = -1;
+Warnings:
+Warning	1292	Truncated incorrect slowlog_space_limit value: '-1'
+SELECT @@global.slowlog_space_limit;
+@@global.slowlog_space_limit
+0
+SET @@global.slowlog_space_limit = 'ABC';
+ERROR 42000: Incorrect argument type to variable 'slowlog_space_limit'
+SELECT @@global.slowlog_space_limit;
+@@global.slowlog_space_limit
+0
+SET @@global.slowlog_space_limit = ON;
+ERROR 42000: Incorrect argument type to variable 'slowlog_space_limit'
+SELECT @@global.slowlog_space_limit;
+@@global.slowlog_space_limit
+0
+SET @@global.slowlog_space_limit = 'OFF';
+ERROR 42000: Incorrect argument type to variable 'slowlog_space_limit'
+SELECT @@global.slowlog_space_limit;
+@@global.slowlog_space_limit
+0
+SET @@global.slowlog_space_limit = 1.14;
+ERROR 42000: Incorrect argument type to variable 'slowlog_space_limit'
+SELECT @@global.slowlog_space_limit;
+@@global.slowlog_space_limit
+0
+SET @@global.slowlog_space_limit = NONE;
+ERROR 42000: Incorrect argument type to variable 'slowlog_space_limit'
+SELECT @@global.slowlog_space_limit;
+@@global.slowlog_space_limit
+0
+SET @@global.slowlog_space_limit = -18446744073709551615;
+ERROR 42000: Incorrect argument type to variable 'slowlog_space_limit'
+SELECT @@global.slowlog_space_limit;
+@@global.slowlog_space_limit
+0
+SET @@global.slowlog_space_limit = 18446744073709551615 + 1;
+ERROR 22003: BIGINT UNSIGNED value is out of range in '(18446744073709551615 + 1)'
+SELECT @@global.slowlog_space_limit;
+@@global.slowlog_space_limit
+0
+include/assert.inc [Must return 1]
+SET GLOBAL slowlog_space_limit = 1;
+SET @@global.slowlog_space_limit = 1;
+SET global.slowlog_space_limit = 1;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'global.slowlog_space_limit = 1' at line 1
+SET @@slowlog_space_limit = 1;
+ERROR HY000: Variable 'slowlog_space_limit' is a GLOBAL variable and should be set with SET GLOBAL
+SET slowlog_space_limit = 1;
+ERROR HY000: Variable 'slowlog_space_limit' is a GLOBAL variable and should be set with SET GLOBAL
+SELECT global.slowlog_space_limit;
+ERROR 42S02: Unknown table 'global' in field list
+SELECT GLOBAL slowlog_space_limit;
+ERROR 42S22: Unknown column 'GLOBAL' in 'field list'
+SELECT @@slowlog_space_limit;
+@@slowlog_space_limit
+1
+SET @@global.slowlog_space_limit = @save_original_variable;

--- a/mysql-test/suite/sys_vars/t/max_slowlog_size_basic.test
+++ b/mysql-test/suite/sys_vars/t/max_slowlog_size_basic.test
@@ -1,0 +1,4 @@
+--let $VARIABLE_NAME = max_slowlog_size
+--let $VARIABLE_BLOCK_SIZE = 4096
+--let $VARIABLE_MAX_VALUE = 1073741824
+--source suite/sys_vars/inc/check_global_integer.inc

--- a/mysql-test/suite/sys_vars/t/slowlog_space_limit_basic.test
+++ b/mysql-test/suite/sys_vars/t/slowlog_space_limit_basic.test
@@ -1,0 +1,3 @@
+--let $VARIABLE_NAME = slowlog_space_limit
+--let $VARIABLE_MAX_VALUE = 18446744073709551615
+--source suite/sys_vars/inc/check_global_integer.inc

--- a/mysql-test/t/percona_slowlog_size_limits.test
+++ b/mysql-test/t/percona_slowlog_size_limits.test
@@ -1,0 +1,224 @@
+#
+# Test slowlog size limiting and rotation
+#
+
+SET @old_slow_query_log = @@global.slow_query_log;
+SET @old_log_output = @@global.log_output;
+SET @old_slow_query_log_file = @@global.slow_query_log_file;
+SET @old_max_slowlog_size = @@global.max_slowlog_size;
+SET @old_slowlog_space_limit = @@global.slowlog_space_limit;
+SET long_query_time = 0;
+SET GLOBAL log_output = FILE;
+SET GLOBAL slow_query_log = 1;
+
+
+--echo # Case 1 (PS-1484): Test if slowlog_space_limit is working correctly
+--echo #                   with the default slow query log name
+SET GLOBAL max_slowlog_size = 4096;
+SET GLOBAL slowlog_space_limit = @@global.max_slowlog_size * 3;
+
+# avoid 100 selects 1 in .result
+--let $i=100
+--disable_query_log
+--disable_result_log
+while($i) {
+  --eval select $i
+  --dec $i
+}
+--enable_query_log
+--enable_result_log
+
+--let slow_query_base= `SELECT @old_slow_query_log_file`
+--let file_spec = $slow_query_base.*
+--let expected_number = 3
+--source include/assert_number_of_files.inc
+
+
+--echo # Case 2 (Bug 1416582): Slow query log is rotated before it should
+--echo #                       when using max_slowlog_size
+SET GLOBAL max_slowlog_size = 10240000;
+
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/abcd'
+
+# start/stop slog log should not cause log number increment
+SET GLOBAL slow_query_log = 0;
+SET GLOBAL slow_query_log = 1;
+SET GLOBAL slow_query_log = 0;
+SET GLOBAL slow_query_log = 1;
+
+# FLUSH LOGS should not cause log number increment
+FLUSH LOGS;
+FLUSH LOGS;
+FLUSH LOGS;
+
+--let $assert_text= Slow query log number should not be incremented and log should be abcd.000001
+--let $assert_cond= @@GLOBAL.slow_query_log_file = "$MYSQLTEST_VARDIR/abcd.000001"
+--source include/assert.inc
+
+
+--echo # Case 3: Test if each slow_query_log_file call rotates slow log 
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/zxcv'
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/abcd'
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/zxcv'
+
+--let $assert_text= Slow query log should be zxcv.000002
+--let $assert_cond= @@GLOBAL.slow_query_log_file = "$MYSQLTEST_VARDIR/zxcv.000002"
+--source include/assert.inc
+
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/abcd'
+
+--let $assert_text= Slow query log should be abcd.000003
+--let $assert_cond= @@GLOBAL.slow_query_log_file = "$MYSQLTEST_VARDIR/abcd.000003"
+--source include/assert.inc
+
+
+--echo # Case 4: Test if slowlog_space_limit is working correctly
+SET GLOBAL max_slowlog_size = 4096;
+SET GLOBAL slowlog_space_limit = @@global.max_slowlog_size * 5;
+
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/abcd'
+
+# avoid 100 selects 1 in .result
+--let $i=100
+--disable_query_log
+--disable_result_log
+while($i) {
+  --eval select $i
+  --dec $i
+}
+--enable_query_log
+--enable_result_log
+
+--let file_spec = $MYSQLTEST_VARDIR/abcd*
+--let expected_number = 5
+--source include/assert_number_of_files.inc
+
+
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/zxcv'
+
+--let $i=100
+--disable_query_log
+--disable_result_log
+while($i) {
+  --eval select $i
+  --dec $i
+}
+--enable_query_log
+--enable_result_log
+
+--let file_spec = $MYSQLTEST_VARDIR/zxcv*
+--let expected_number = 5
+--source include/assert_number_of_files.inc
+
+
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/abcd'
+
+# avoid 100 selects 1 in .result
+--let $i=100
+--disable_query_log
+--disable_result_log
+while($i) {
+  --eval select $i
+  --dec $i
+}
+--enable_query_log
+--enable_result_log
+
+--let file_spec = $MYSQLTEST_VARDIR/abcd*
+--let expected_number = 5
+--source include/assert_number_of_files.inc
+
+--echo # Case 5: Rotating log but should not delete previous logs
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/abcd'
+
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/abcd'
+
+--let file_spec = $MYSQLTEST_VARDIR/abcd*
+--let expected_number = 7
+--source include/assert_number_of_files.inc
+
+
+--echo # Case 6: Calling "SET slowlog_space_limit" should reduce number of logs
+SET GLOBAL max_slowlog_size = 4096;
+SET GLOBAL slowlog_space_limit = @@global.max_slowlog_size * 2;
+
+--let file_spec = $MYSQLTEST_VARDIR/abcd*
+--let expected_number = 4
+--source include/assert_number_of_files.inc
+
+
+--echo # Case 7: Delete all small logs with max_slowlog_size = 0
+SET GLOBAL max_slowlog_size = 0;
+SET GLOBAL slowlog_space_limit = 4096;
+
+# avoid 100 selects 1 in .result
+--let $i=100
+--disable_query_log
+--disable_result_log
+while($i) {
+  --eval select $i
+  --dec $i
+}
+--enable_query_log
+--enable_result_log
+
+--let file_spec = $MYSQLTEST_VARDIR/abcd*
+--let expected_number = 1
+--source include/assert_number_of_files.inc
+
+
+--echo # Case 8: Rotate log should delete previous log
+SET GLOBAL max_slowlog_size = 10240000;
+
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/abcd'
+
+--let file_spec = $MYSQLTEST_VARDIR/abcd*
+--let expected_number = 1
+--source include/assert_number_of_files.inc
+
+
+--echo # Case 9: Check if disable max_slowlog_size is working correctly
+SET GLOBAL max_slowlog_size = 0;
+
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/abcd'
+
+# avoid 100 selects 1 in .result
+--let $i=100
+--disable_query_log
+--disable_result_log
+while($i) {
+  --eval select $i
+  --dec $i
+}
+--enable_query_log
+--enable_result_log
+
+--let file_spec = $MYSQLTEST_VARDIR/abcd*
+--let expected_number = 2
+--source include/assert_number_of_files.inc
+
+--let $assert_text= Slow query log should stay as abcd
+--let $assert_cond= @@GLOBAL.slow_query_log_file = "$MYSQLTEST_VARDIR/abcd"
+--source include/assert.inc
+
+
+SET @@global.slow_query_log = @old_slow_query_log;
+SET @@global.log_output = @old_log_output;
+SET @@global.slow_query_log_file = @old_slow_query_log_file;
+SET @@global.max_slowlog_size = @old_max_slowlog_size;
+SET @@global.slowlog_space_limit = @old_slowlog_space_limit;
+
+--remove_files_wildcard $MYSQLTEST_VARDIR abcd*
+--remove_files_wildcard $MYSQLTEST_VARDIR zxcv*

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -61,6 +61,7 @@
 #include <utility>
 
 #include "binary_log_types.h"
+#include "binlog.h"
 #include "lex_string.h"
 #include "m_ctype.h"
 #include "m_string.h"
@@ -109,6 +110,9 @@
 
 using std::max;
 using std::min;
+
+ulong max_slowlog_size;
+ulonglong slowlog_space_limit;
 
 enum enum_slow_query_log_table_field {
   SQLT_FIELD_START_TIME = 0,
@@ -356,6 +360,14 @@ class File_query_log {
                   struct System_status_var *query_start_status);
 
  private:
+  /* slow log rotation and purging functions */
+  int set_rotated_name(bool need_lock);
+  int rotate(ulong max_size);
+  int purge_logs_by_size();
+
+  ulong cur_slowlog_ext, last_removed_ext;
+  ulonglong total_slowlog_size; /* total size except active slow log */
+
   /** Type of log file. */
   const enum_log_table_type m_log_type;
 
@@ -389,7 +401,13 @@ class File_query_log {
 };
 
 File_query_log::File_query_log(enum_log_table_type log_type)
-    : m_log_type(log_type), name(NULL), write_error(false), log_open(false) {
+    : cur_slowlog_ext(0),
+      last_removed_ext(0),
+      total_slowlog_size(0),
+      m_log_type(log_type),
+      name(NULL),
+      write_error(false),
+      log_open(false) {
   mysql_mutex_init(key_LOG_LOCK_log, &LOCK_log, MY_MUTEX_INIT_SLOW);
 #ifdef HAVE_PSI_INTERFACE
   if (log_type == QUERY_LOG_GENERAL)
@@ -491,10 +509,19 @@ bool File_query_log::set_file(const char *new_name) {
 
   name = nn;
 
-  // We can do this here since we're not actually resolving symlinks etc.
-  fn_format(log_file_name, name, mysql_data_home, "", MY_UNPACK_FILENAME);
+  bool res = false;
 
-  return false;
+  mysql_mutex_lock(&LOCK_log);
+  cur_slowlog_ext = 0;
+  last_removed_ext = 0;
+  if (set_rotated_name(false)) {
+    res = true;
+  } else {
+    if (purge_logs_by_size()) res = true;
+  }
+  mysql_mutex_unlock(&LOCK_log);
+
+  return res;
 }
 
 bool File_query_log::open() {
@@ -682,6 +709,149 @@ err:
   return true;
 }
 
+static bool is_n_digit_number(const char *str, int n_digit, ulong *res) {
+  if (!isdigit(*str)) return false;
+
+  const char *start = str++;
+  while (isdigit(*str)) str++;
+  if (*str != 0 || str - start != n_digit) return false;
+
+  if (res) *res = atol(start);
+  return true;
+}
+
+static size_t get_last_extension(const char *const name) {
+  DBUG_ENTER("get_last_extension");
+  char buff[FN_REFLEN];
+  ulong max_found = 0, number = 0;
+  size_t buf_length, length;
+
+  length = dirname_part(buff, name, &buf_length);
+  const char *const start = name + length;
+  const char *const end = strend(start);
+  length = (size_t)(end - start);
+
+  MY_DIR *const dir_info = my_dir(buff, MYF(MY_DONT_SORT));
+  const struct fileinfo *file_info = dir_info->dir_entry;
+
+  for (uint i = dir_info->number_off_files; i--; file_info++) {
+    if (strncmp(file_info->name, start, length) == 0 &&
+        file_info->name[length] == '.' &&
+        is_n_digit_number(file_info->name + length + 1, 6, &number)) {
+      set_if_bigger(max_found, (ulong)number);
+    }
+  }
+
+  my_dirend(dir_info);
+  DBUG_RETURN(max_found);
+}
+
+int File_query_log::set_rotated_name(bool need_lock) {
+  DBUG_ENTER("File_query_log::set_rotated_name");
+  mysql_mutex_assert_owner(&LOCK_log);
+  total_slowlog_size = 0;
+
+  if (!max_slowlog_size) {
+    fn_format(log_file_name, name, mysql_data_home, "", MY_UNPACK_FILENAME);
+    DBUG_RETURN(0);
+  }
+
+  if (cur_slowlog_ext == 0) {
+    fn_format(log_file_name, name, mysql_data_home, "", MY_UNPACK_FILENAME);
+    cur_slowlog_ext = get_last_extension(log_file_name) + 1;
+  } else {
+    cur_slowlog_ext++;
+  }
+
+  if (cur_slowlog_ext > 0) {
+    /* check if reached the maximum possible extension number */
+    if (cur_slowlog_ext >= MAX_LOG_UNIQUE_FN_EXT) {
+      LogErr(ERROR_LEVEL, ER_BINLOG_FILE_EXTENSION_NUMBER_EXHAUSTED,
+             cur_slowlog_ext);
+      DBUG_RETURN(1);
+    }
+
+    if (snprintf(log_file_name, sizeof(log_file_name), "%s.%06lu", name,
+                 cur_slowlog_ext) >= static_cast<int>(sizeof(log_file_name))) {
+      my_printf_error(ER_NO_UNIQUE_LOGFILE,
+                      ER_THD(current_thd, ER_NO_UNIQUE_LOGFILE),
+                      MYF(ME_FATALERROR), name);
+      LogErr(ERROR_LEVEL, ER_FAILED_TO_GENERATE_UNIQUE_LOGFILE, name);
+      DBUG_RETURN(1);
+    }
+
+    if (update_Sys_slow_log_path(log_file_name, need_lock)) {
+      LogErr(ERROR_LEVEL, ER_FAILED_TO_GENERATE_UNIQUE_LOGFILE, name);
+      DBUG_RETURN(1);
+    }
+  }
+
+  DBUG_RETURN(0);
+}
+
+int File_query_log::rotate(const ulong max_size) {
+  int error;
+  DBUG_ENTER("File_query_log::rotate");
+  mysql_mutex_assert_owner(&LOCK_log);
+
+  if (my_b_tell(&log_file) > max_size) {
+    if ((error = set_rotated_name(true))) DBUG_RETURN(error);
+
+    close();
+
+    if (open()) DBUG_RETURN(1);
+  }
+
+  DBUG_RETURN(0);
+}
+
+int File_query_log::purge_logs_by_size() {
+  DBUG_ENTER("File_query_log::purge_logs_by_size");
+  mysql_mutex_assert_owner(&LOCK_log);
+
+  if (slowlog_space_limit == 0 || cur_slowlog_ext <= 1 ||
+      last_removed_ext == cur_slowlog_ext - 1)
+    DBUG_RETURN(0);
+
+  const ulonglong last_log_size = my_b_tell(&log_file);
+
+  if (total_slowlog_size > 0 &&
+      total_slowlog_size < slowlog_space_limit - last_log_size)
+    DBUG_RETURN(0);
+
+  char buff[FN_REFLEN];
+  int error = 0;
+  MY_STAT stat_area;
+  long iter_log_ext = cur_slowlog_ext - 1;
+  total_slowlog_size = 1;
+
+  while (true) {
+    snprintf(buff, sizeof(buff), "%s.%06lu", name, iter_log_ext);
+
+    if (!mysql_file_stat(m_log_file_key, buff, &stat_area, MYF(0))) {
+      last_removed_ext = iter_log_ext;
+      DBUG_RETURN(0);
+    }
+
+    total_slowlog_size += stat_area.st_size;
+    if (total_slowlog_size >= slowlog_space_limit - last_log_size) break;
+    if (--iter_log_ext == 0) DBUG_RETURN(0);
+  };
+
+  while (iter_log_ext > 0) {
+    snprintf(buff, sizeof(buff), "%s.%06lu", name, iter_log_ext);
+
+    if ((error = unlink(buff))) {
+      if (my_errno() == ENOENT) error = 0;
+      break;
+    }
+    --iter_log_ext;
+  }
+
+  total_slowlog_size = 0;
+  DBUG_RETURN(error);
+}
+
 bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
                                 ulonglong query_start_utime,
                                 const char *user_host, size_t,
@@ -697,6 +867,9 @@ bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
   const bool tid_present = !(thd->trace_id.empty());
   mysql_mutex_lock(&LOCK_log);
   DBUG_ASSERT(is_open());
+
+  if (max_slowlog_size > 0)
+    if (rotate(max_slowlog_size)) goto err;
 
   if (!(specialflag & SPECIAL_SHORT_LOG_FORMAT)) {
     char my_timestamp[iso8601_size];
@@ -895,6 +1068,7 @@ bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
       my_b_write(&log_file, (uchar *)";\n", 2) || flush_io_cache(&log_file))
     goto err;
 
+  if (purge_logs_by_size()) goto err;
   mysql_mutex_unlock(&LOCK_log);
   return false;
 

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -127,6 +127,8 @@ bool is_secure_file_path(const char *path);
 ulong sql_rnd_with_mutex();
 
 struct System_status_var *get_thd_status_var(THD *thd);
+bool update_Sys_slow_log_path(const char *const log_file_name,
+                              const bool need_lock);
 
 // These are needed for unit testing.
 void set_remaining_args(int argc, char **argv);
@@ -234,6 +236,8 @@ extern bool locked_in_memory;
 extern bool opt_using_transactions;
 extern ulong current_pid;
 extern ulong expire_logs_days;
+extern ulong max_slowlog_size;
+extern ulonglong slowlog_space_limit;
 extern ulong binlog_expire_logs_seconds;
 extern uint sync_binlog_period, sync_relaylog_period, sync_relayloginfo_period,
     sync_masterinfo_period, opt_mts_checkpoint_period, opt_mts_checkpoint_group;

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -2626,6 +2626,21 @@ static Sys_var_ulong Sys_max_relay_log_size(
     NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(0),
     ON_UPDATE(fix_max_relay_log_size));
 
+static Sys_var_ulong Sys_max_slowlog_size(
+    "max_slowlog_size",
+    "Slow query log will be rotated automatically when the size exceeds "
+    "this value. The default is 0, don't limit the size.",
+    GLOBAL_VAR(max_slowlog_size), CMD_LINE(REQUIRED_ARG),
+    VALID_RANGE(0, 1024 * 1024L * 1024L), DEFAULT(0L), BLOCK_SIZE(IO_SIZE));
+
+static Sys_var_ulonglong Sys_slowlog_space_limit(
+    "slowlog_space_limit",
+    "Maximum space to use for all slow query logs. "
+    "Works only with max_slowlog_size enabled. "
+    "Default is 0, this feature is disabled.",
+    GLOBAL_VAR(slowlog_space_limit), CMD_LINE(REQUIRED_ARG),
+    VALID_RANGE(0, ULLONG_MAX), DEFAULT(0), BLOCK_SIZE(1));
+
 static Sys_var_ulong Sys_max_sort_length(
     "max_sort_length",
     "The number of bytes to use when sorting long values with PAD SPACE "
@@ -5299,6 +5314,14 @@ static Sys_var_charptr Sys_slow_log_path(
     GLOBAL_VAR(opt_slow_logname), CMD_LINE(REQUIRED_ARG), IN_FS_CHARSET,
     DEFAULT(0), NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(check_log_path),
     ON_UPDATE(fix_slow_log_file));
+
+bool update_Sys_slow_log_path(const char *const log_file_name,
+                              const bool need_lock) {
+  if (need_lock) mysql_mutex_lock(&LOCK_global_system_variables);
+  const bool res = Sys_slow_log_path.global_update_value(log_file_name);
+  if (need_lock) mysql_mutex_unlock(&LOCK_global_system_variables);
+  return res;
+}
 
 static Sys_var_have Sys_have_compress(
     "have_compress", "have_compress",

--- a/sql/sys_vars.h
+++ b/sql/sys_vars.h
@@ -810,6 +810,19 @@ class Sys_var_charptr : public sys_var {
 
   bool global_update(THD *thd, set_var *var);
 
+  bool global_update_value(const char *const ptr) {
+    char *new_val;
+    if (ptr) {
+      new_val = my_strdup(key_memory_Sys_var_charptr_value, ptr, MYF(MY_WME));
+      if (!new_val) return true;
+    } else
+      new_val = nullptr;
+    if (flags & ALLOCATED) my_free(global_var(char *));
+    flags |= ALLOCATED;
+    global_var(char *) = new_val;
+    return false;
+  }
+
   void session_save_default(THD *, set_var *var) {
     char *ptr = (char *)(intptr)option.def_value;
     var->save_result.string_value.str = ptr;


### PR DESCRIPTION
Summary:

Jira issue: https://jira.percona.com/browse/FB8-118

Reference Patch: https://github.com/facebook/mysql-5.6/commit/3445f81

Porting notes:
1. fixed PS-1484: slowlog rotation and expiration doesn't work with the default slow query log name
2. `max_slowlog_files` was replaced with `slowlog_space_limit`

This diff is a combination of the following two commits from Percona:
https://github.com/percona/percona-server/commit/725a238c
https://github.com/percona/percona-server/commit/85c461c8

Adds two new variables `max_slowlog_size` and `max_slowlog_files` as documented here:
https://www.percona.com/doc/percona-server/LATEST/flexibility/slowlog_rotation.html

TODO: Because of conflicts I removed changes in `mysql-test/t/all_persisted_variables.test`. This test has to be modified at `let $total_persistent_vars=XXX;` (+2 increase) and it should be re-recorded.