### PR TITLE
Lintian complains on scripts

### DIFF
--- a/mysql-test/suite/rocksdb/slow_query_log.awk
+++ b/mysql-test/suite/rocksdb/slow_query_log.awk
@@ -1,4 +1,4 @@
-#!/bin/awk
+#!/usr/bin/awk
 
 /Query_time:/ {
   results["Rows_examined:"] = "uninit";

--- a/mysql-test/suite/rocksdb_hotbackup/include/create_slocket_socket.sh
+++ b/mysql-test/suite/rocksdb_hotbackup/include/create_slocket_socket.sh
@@ -1,2 +1,4 @@
+#!/bin/bash
+
 src_data_dir="${MYSQLTEST_VARDIR}/mysqld.1/data/"
 python -c "import socket as s; sock = s.socket(s.AF_UNIX); sock.bind('${src_data_dir}/slocket')"

--- a/mysql-test/suite/rocksdb_hotbackup/include/create_table.sh
+++ b/mysql-test/suite/rocksdb_hotbackup/include/create_table.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -e
 
 COPY_LOG=$1

--- a/mysql-test/suite/rocksdb_hotbackup/include/load_data.sh
+++ b/mysql-test/suite/rocksdb_hotbackup/include/load_data.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -e
 
 # Insert 100 batches of 100 records each to a table with following schema:

--- a/mysql-test/suite/rocksdb_hotbackup/include/load_data_and_run.sh
+++ b/mysql-test/suite/rocksdb_hotbackup/include/load_data_and_run.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -e
 
 # Initially loads a chunk of data.

--- a/mysql-test/suite/rocksdb_hotbackup/include/load_data_slocket.sh
+++ b/mysql-test/suite/rocksdb_hotbackup/include/load_data_slocket.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -e
 
 # Insert 10 batches of 10 records each to a table with following schema:

--- a/mysql-test/suite/rocksdb_hotbackup/include/remove_slocket_socket.sh
+++ b/mysql-test/suite/rocksdb_hotbackup/include/remove_slocket_socket.sh
@@ -1,2 +1,4 @@
+#!/bin/bash
+
 src_data_dir="${MYSQLTEST_VARDIR}/mysqld.1/data/"
 rm "${src_data_dir}/slocket"

--- a/mysql-test/suite/rocksdb_hotbackup/include/setup_replication_gtid.sh
+++ b/mysql-test/suite/rocksdb_hotbackup/include/setup_replication_gtid.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -e
 
 binlog_line=($(grep -o "Last binlog file position [0-9]*, file name .*\.[0-9]*" ${MYSQLTEST_VARDIR}/log/mysqld.2.err | tail -1))


### PR DESCRIPTION
Hi,
Lintian, the Debian package checker (https://lintian.debian.org/) complains on:
- executable-not-elf-or-script
- script-not-executable

Also, regarding d0dc352, path for awk seems to be wrong.
