### PR TITLE
FB8-230: fix gcc-8 RelWithDebInfo compilation

### DIFF
--- a/sql-common/client.cc
+++ b/sql-common/client.cc
@@ -7650,8 +7650,8 @@ int STDCALL mysql_options(MYSQL *mysql, enum mysql_option option,
     case MYSQL_OPT_COMP_LIB: {
       mysql_options(mysql, MYSQL_OPT_CONNECT_ATTR_DELETE, "compression_lib");
       const char *lib_name = "zlib";
-      if (reinterpret_cast<enum mysql_compression_lib &>(arg) ==
-          MYSQL_COMPRESSION_ZSTD) {
+      if (static_cast<mysql_compression_lib>(*reinterpret_cast<const ulong *>(
+              arg)) == MYSQL_COMPRESSION_ZSTD) {
         lib_name = "zstd";
       }
       mysql_options4(mysql, MYSQL_OPT_CONNECT_ATTR_ADD, "compression_lib",

--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -7810,7 +7810,8 @@ static int connect_to_master(THD *thd, MYSQL *mysql, Master_info *mi,
   ulong client_flag = CLIENT_REMEMBER_OPTIONS;
   if (opt_slave_compressed_protocol) {
     client_flag |= CLIENT_COMPRESS; /* We will use compression */
-    mysql_options(mysql, MYSQL_OPT_COMP_LIB, (void *)opt_slave_compression_lib);
+    mysql_options(mysql, MYSQL_OPT_COMP_LIB,
+                  (void *)&opt_slave_compression_lib);
   }
 
   /* Always reset public key to remove cached copy */

--- a/unittest/gunit/mdl-t.cc
+++ b/unittest/gunit/mdl-t.cc
@@ -4340,7 +4340,7 @@ static void lock_bench(MDL_context &ctx, const Name_vec &names) {
     MDL_request request;
     MDL_REQUEST_INIT(&request, MDL_key::TABLE, "S", name.c_str(),
                      MDL_INTENTION_EXCLUSIVE, MDL_TRANSACTION);
-    ctx.acquire_lock(&request, 2);
+    ctx.acquire_lock_nsec(&request, 2000000000ULL);
   }
   ctx.release_transactional_locks();
 }


### PR DESCRIPTION
1. Fix `mysql_options()`: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
2. Fix `acquire_lock` which was replaced with `acquire_lock_nsec` in https://github.com/facebook/mysql-5.6/commit/598239afd0f9