### PR TITLE
Fix FB8-231 (abi_check CMake target fails after introducing SESSION_TRACK_RESP_ATTR)

### DIFF
--- a/include/mysql.h.pp
+++ b/include/mysql.h.pp
@@ -210,7 +210,8 @@ enum enum_session_state_type {
   SESSION_TRACK_STATE_CHANGE,
   SESSION_TRACK_GTIDS,
   SESSION_TRACK_TRANSACTION_CHARACTERISTICS,
-  SESSION_TRACK_TRANSACTION_STATE
+  SESSION_TRACK_TRANSACTION_STATE,
+  SESSION_TRACK_RESP_ATTR = 32
 };
 bool my_net_init(struct NET *net, struct Vio * vio);
 void my_net_local_init(struct NET *net);

--- a/include/mysql_com.h
+++ b/include/mysql_com.h
@@ -1083,7 +1083,7 @@ enum enum_session_state_type {
   // Leave space before RPC_ID session tracking for other upstream values
   // NOTE: This feature is not yet ported but we need the enum to avoid
   // asserting in debug version
-  SESSION_TRACK_RESP_ATTR = 32, /* Response attributes */
+  SESSION_TRACK_RESP_ATTR = 32 /* Response attributes */
 };
 
 /** start of ::enum_session_state_type */


### PR DESCRIPTION
https://jira.percona.com/browse/FB8-231

Fixed problem with 'SESSION_TRACK_RESP_ATTR' not added to 'include/mysql.h.pp'
that used to cause CMake error.