### PR TITLE
Fix FB8-232 (Unable to build fb-mysql-8.0.13 with -DWITH_VALGRIND=ON)

### DIFF
--- a/storage/innobase/buf/buf0buddy.cc
+++ b/storage/innobase/buf/buf0buddy.cc
@@ -324,7 +324,7 @@ static buf_buddy_free_t *buf_buddy_alloc_zip(buf_pool_t *buf_pool, ulint i) {
 
   if (buf) {
     /* Trash the page other than the BUF_BUDDY_STAMP_NONFREE. */
-    UNIV_MEM_TRASH(buf, ~i, BUF_BUDDY_STAMP_OFFSET);
+    UNIV_MEM_TRASH(static_cast<void *>(buf), ~i, BUF_BUDDY_STAMP_OFFSET);
     UNIV_MEM_TRASH(BUF_BUDDY_STAMP_OFFSET + 4 + buf->stamp.bytes, ~i,
                    (BUF_BUDDY_LOW << i) - (BUF_BUDDY_STAMP_OFFSET + 4));
     ut_ad(mach_read_from_4(buf->stamp.bytes + BUF_BUDDY_STAMP_OFFSET) ==


### PR DESCRIPTION
https://jira.percona.com/browse/FB8-232

Fixed problem with 'trashing' non-POD object of type 'buf_buddy_free_t'
in 'buf_buddy_alloc_zip()'.