### PR TITLE
Fix FB8-233 (clang-8 warnings in fb-mysql-8.0.13 source tree)

### DIFF
--- a/include/my_basename.h
+++ b/include/my_basename.h
@@ -52,8 +52,8 @@ constexpr int basename_prefix_find(const char *const path, const int index) {
 }
 
 #define LOG_SUBSYSTEM_TAG         \
-  basename_prefix_eval(__FILE__ + \
-                       basename_prefix_find(__FILE__, sizeof(__FILE__) - 1))
+  basename_prefix_eval(&(__FILE__[\
+                      basename_prefix_find(__FILE__, sizeof(__FILE__) - 1)]))
 
 #endif
 

--- a/plugin/x/src/sha256_password_cache.h
+++ b/plugin/x/src/sha256_password_cache.h
@@ -50,8 +50,8 @@ class SHA256_password_cache final
   SHA256_password_cache();
   SHA256_password_cache(SHA256_password_cache &) = delete;
   SHA256_password_cache &operator=(const SHA256_password_cache &) = delete;
-  SHA256_password_cache(SHA256_password_cache &&) = default;
-  SHA256_password_cache &operator=(SHA256_password_cache &&) = default;
+  SHA256_password_cache(SHA256_password_cache &&) = delete;
+  SHA256_password_cache &operator=(SHA256_password_cache &&) = delete;
 
   void enable() override;
   void disable() override;

--- a/router/src/http/src/http_server_plugin.h
+++ b/router/src/http/src/http_server_plugin.h
@@ -112,8 +112,8 @@ class HttpServer {
   HttpServer(const HttpServer &) = delete;
   HttpServer &operator=(const HttpServer &) = delete;
 
-  HttpServer(HttpServer &&) = default;
-  HttpServer &operator=(HttpServer &&) = default;
+  HttpServer(HttpServer &&) = delete;
+  HttpServer &operator=(HttpServer &&) = delete;
 
   void join_all();
 


### PR DESCRIPTION
https://jira.percona.com/browse/FB8-233

* Fixed "adding 'int' to a string does not append to the string" warnings.
* Fixed "explicitly defaulted move constructor is implicitly deleted" warnings.
* Fixed "explicitly defaulted move assignment operator is implicitly deleted"
  warnings.