### PR TITLE
Fix FB8-234 (Server crashes in AIO destructor)

### DIFF
--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -5991,7 +5991,9 @@ AIO::AIO(latch_id_t id, ulint n, ulint segments)
 #ifdef LINUX_NATIVE_AIO
       ,
       m_aio_ctx(),
-      m_events(m_slots.size())
+      m_events(m_slots.size()),
+      m_pending(nullptr),
+      m_count(nullptr)
 #elif defined(_WIN32)
       ,
       m_handles()
@@ -6155,12 +6157,14 @@ AIO::~AIO() {
     m_events.clear();
     ut_free(m_aio_ctx);
 #ifdef UNIV_DEBUG
-    for (size_t idx = 0; idx < m_slots.size(); ++idx) {
-      ut_ad(m_pending[idx] == NULL);
-    }
-    for (size_t idx = 0; idx < m_n_segments; ++idx) {
-      ut_ad(m_count[idx] == 0);
-    }
+    if (m_pending != nullptr)
+      for (size_t idx = 0; idx < m_slots.size(); ++idx) {
+        ut_ad(m_pending[idx] == NULL);
+      }
+    if (m_count != nullptr)
+      for (size_t idx = 0; idx < m_n_segments; ++idx) {
+        ut_ad(m_count[idx] == 0);
+      }
 #endif
     ut_free(m_pending);
     ut_free(m_count);


### PR DESCRIPTION
https://jira.percona.com/browse/FB8-234

Fixed problem with 'ut_ad(m_pending[idx] == NULL)' and
'ut_ad(m_count[idx] == 0' assertions inside 'AIO' class destructor.
In case when a call to 'linux_create_io_ctx()' inside
'init_linux_native_aio()' was unsuccessful, 'm_pending' and 'm_count' arrays
may have remained uninitialized.

This commit should be squashed with "Merge aio page read requests"
(commit facebook/mysql-5.6@92a2c00)