### PR TITLE
Fix group-by plan with min/max aggregates and multiple infixes

### DIFF
--- a/mysql-test/r/group_min_max.result
+++ b/mysql-test/r/group_min_max.result
@@ -875,6 +875,7 @@ a	b	b	p122	e112
 b	b	b	p222	e212
 c	b	b	p322	e312
 d	b	b	p422	e412
+e	a	b	NULL	NULL
 select a1,a2,b,max(c),min(c) from t2 where (a2 = 'a') and (b = 'b' or b = 'a') group by a1;
 a1	a2	b	max(c)	min(c)
 a	a	b	h112	a111
@@ -895,6 +896,7 @@ a	p122	e112
 b	p222	e212
 c	p322	e312
 d	p422	e412
+e	NULL	NULL
 select a1,max(c),min(c)      from t2 where (a2 = 'a') and (b = 'b' or b = 'a') group by a1;
 a1	max(c)	min(c)
 a	h112	a111
@@ -1025,12 +1027,16 @@ a	a	NULL	a777
 c	a	NULL	c777
 select a1,a2,b,min(c) from t2 where (a2 = 'a' or a2 = 'b') and b is NULL group by a1;
 a1	a2	b	min(c)
+a	a	NULL	a777
+c	a	NULL	c777
 select a1,a2,b,max(c) from t2 where (a2 = 'a') and b is NULL group by a1;
 a1	a2	b	max(c)
 a	a	NULL	a999
 c	a	NULL	c999
 select a1,a2,b,max(c) from t2 where (a2 = 'a' or a2 = 'b') and b is NULL group by a1;
 a1	a2	b	max(c)
+a	a	NULL	a999
+c	a	NULL	c999
 select a1,a2,b,min(c) from t2 where b is NULL group by a1,a2;
 a1	a2	b	min(c)
 a	a	NULL	a777

--- a/mysql-test/suite/innodb/r/group_min_max.result
+++ b/mysql-test/suite/innodb/r/group_min_max.result
@@ -876,6 +876,7 @@ a	b	b	p122	e112
 b	b	b	p222	e212
 c	b	b	p322	e312
 d	b	b	p422	e412
+e	a	b	NULL	NULL
 select a1,a2,b,max(c),min(c) from t2 where (a2 = 'a') and (b = 'b' or b = 'a') group by a1;
 a1	a2	b	max(c)	min(c)
 a	a	b	h112	a111
@@ -896,6 +897,7 @@ a	p122	e112
 b	p222	e212
 c	p322	e312
 d	p422	e412
+e	NULL	NULL
 select a1,max(c),min(c)      from t2 where (a2 = 'a') and (b = 'b' or b = 'a') group by a1;
 a1	max(c)	min(c)
 a	h112	a111
@@ -1026,12 +1028,16 @@ a	a	NULL	a777
 c	a	NULL	c777
 select a1,a2,b,min(c) from t2 where (a2 = 'a' or a2 = 'b') and b is NULL group by a1;
 a1	a2	b	min(c)
+a	a	NULL	a777
+c	a	NULL	c777
 select a1,a2,b,max(c) from t2 where (a2 = 'a') and b is NULL group by a1;
 a1	a2	b	max(c)
 a	a	NULL	a999
 c	a	NULL	c999
 select a1,a2,b,max(c) from t2 where (a2 = 'a' or a2 = 'b') and b is NULL group by a1;
 a1	a2	b	max(c)
+a	a	NULL	a999
+c	a	NULL	c999
 select a1,a2,b,min(c) from t2 where b is NULL group by a1,a2;
 a1	a2	b	min(c)
 a	a	NULL	a777

--- a/mysql-test/suite/rocksdb/r/group_min_max.result
+++ b/mysql-test/suite/rocksdb/r/group_min_max.result
@@ -876,6 +876,7 @@ a	b	b	p122	e112
 b	b	b	p222	e212
 c	b	b	p322	e312
 d	b	b	p422	e412
+e	b	b	NULL	NULL
 select a1,a2,b,max(c),min(c) from t2 where (a2 = 'a') and (b = 'b' or b = 'a') group by a1;
 a1	a2	b	max(c)	min(c)
 a	a	b	h112	a111
@@ -896,6 +897,7 @@ a	p122	e112
 b	p222	e212
 c	p322	e312
 d	p422	e412
+e	NULL	NULL
 select a1,max(c),min(c)      from t2 where (a2 = 'a') and (b = 'b' or b = 'a') group by a1;
 a1	max(c)	min(c)
 a	h112	a111
@@ -1026,12 +1028,16 @@ a	a	NULL	a777
 c	a	NULL	c777
 select a1,a2,b,min(c) from t2 where (a2 = 'a' or a2 = 'b') and b is NULL group by a1;
 a1	a2	b	min(c)
+a	b	NULL	a777
+c	b	NULL	c777
 select a1,a2,b,max(c) from t2 where (a2 = 'a') and b is NULL group by a1;
 a1	a2	b	max(c)
 a	a	NULL	a999
 c	a	NULL	c999
 select a1,a2,b,max(c) from t2 where (a2 = 'a' or a2 = 'b') and b is NULL group by a1;
 a1	a2	b	max(c)
+a	b	NULL	a999
+c	b	NULL	c999
 select a1,a2,b,min(c) from t2 where b is NULL group by a1,a2;
 a1	a2	b	min(c)
 a	a	NULL	a777

--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -14396,6 +14396,7 @@ int QUICK_GROUP_MIN_MAX_SELECT::get_next()
     /* Reset various per-group variables. */
     reset_group();
 
+    bool infix_exists = false;
     while (!append_next_infix())
     {
       if (have_min)
@@ -14438,7 +14439,20 @@ int QUICK_GROUP_MIN_MAX_SELECT::get_next()
       /* Break early on error. */
       if (result != HA_ERR_KEY_NOT_FOUND && result != HA_ERR_END_OF_FILE && result != 0)
         break;
+
+      if (result == 0)
+        infix_exists = true;
     }
+
+    // In the MIN/MAX case, get_next needs to emit a row if any keys were found
+    // while iterating through the infixes. Reset result back to 0 unless
+    // there was a serious error that needs to be propogated.
+    if ((have_min || have_max) &&
+        infix_exists &&
+        (result == HA_ERR_KEY_NOT_FOUND || result == HA_ERR_END_OF_FILE)) {
+      result = 0;
+    }
+
   } while ((result == HA_ERR_KEY_NOT_FOUND || result == HA_ERR_END_OF_FILE) &&
            is_last_prefix != 0);
 


### PR DESCRIPTION
Wrong query results were being returned by group by plans that contained min/max aggregates as well as multiple infixes within a group.

The problem is that the same variable `result` is re-used when iterating through the infixes combinations, as well as for reporting if any keys were found in the current prefix. If the last infix happens to be not found, then the outer loop for prefixes will assume that no keys were found under this prefix.

The fix is to record during infix iteration if at least one key was found. If so, reset result back to zero so that the current distinct prefix gets emitted.

Fixes https://github.com/facebook/mysql-5.6/issues/1036