### PR TITLE
Issue #1044: rocksdb.ttl_primary_read_filtering fails sporadically

### DIFF
--- a/mysql-test/suite/rocksdb/r/ttl_primary_read_filtering.result
+++ b/mysql-test/suite/rocksdb/r/ttl_primary_read_filtering.result
@@ -76,6 +76,7 @@ select variable_value-@a from information_schema.global_status where variable_na
 variable_value-@a
 4
 DROP TABLE t1;
+set global ROCKSDB_COMPACT_CF= 'default';
 CREATE TABLE t1 (
 a int,
 b int,

--- a/mysql-test/suite/rocksdb/t/ttl_primary_read_filtering.test
+++ b/mysql-test/suite/rocksdb/t/ttl_primary_read_filtering.test
@@ -103,6 +103,9 @@ select variable_value-@a from information_schema.global_status where variable_na
 
 DROP TABLE t1;
 
+# Compact away the dropped data
+set global ROCKSDB_COMPACT_CF= 'default';
+
 # Read filtering index scan tests (None of these queries should return any results)
 CREATE TABLE t1 (
   a int,


### PR DESCRIPTION
Make the test stable: after DROP TABLE, make sure the compaction is
run and finishes.

If we don't do this, the post-drop compaction may run during the next
testcase. It will cause a record from the next testcase to be compacted
away when the test logic doesn't expect it and the test will fail