### PR TITLE
Support Create_time and Update_time in MyRocks table status

### DIFF
--- a/mysql-test/suite/rocksdb/include/bulk_load.inc
+++ b/mysql-test/suite/rocksdb/include/bulk_load.inc
@@ -121,12 +121,12 @@ set rocksdb_bulk_load=0;
 --remove_file $file
 
 # Make sure row count index stats are correct
---replace_column 6 # 7 # 8 # 9 #
+--replace_column 6 # 7 # 8 # 9 # 12 # 13 #
 SHOW TABLE STATUS WHERE name LIKE 't%';
 
 ANALYZE TABLE t1, t2, t3;
 
---replace_column 6 # 7 # 8 # 9 #
+--replace_column 6 # 7 # 8 # 9 # 12 # 13 #
 SHOW TABLE STATUS WHERE name LIKE 't%';
 
 # Make sure all the data is there.

--- a/mysql-test/suite/rocksdb/include/bulk_load_unsorted.inc
+++ b/mysql-test/suite/rocksdb/include/bulk_load_unsorted.inc
@@ -119,12 +119,12 @@ set rocksdb_bulk_load=0;
 --remove_file $file
 
 # Make sure row count index stats are correct
---replace_column 6 # 7 # 8 # 9 #
+--replace_column 6 # 7 # 8 # 9 # 12 # 13 #
 SHOW TABLE STATUS WHERE name LIKE 't%';
 
 ANALYZE TABLE t1, t2, t3;
 
---replace_column 6 # 7 # 8 # 9 #
+--replace_column 6 # 7 # 8 # 9 # 12 # 13 #
 SHOW TABLE STATUS WHERE name LIKE 't%';
 
 # Make sure all the data is there.

--- a/mysql-test/suite/rocksdb/r/bulk_load.result
+++ b/mysql-test/suite/rocksdb/r/bulk_load.result
@@ -38,9 +38,9 @@ pk	a	b
 set rocksdb_bulk_load=0;
 SHOW TABLE STATUS WHERE name LIKE 't%';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_bin	NULL		
-t2	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_bin	NULL		
-t3	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_bin	NULL	partitioned	
+t1	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_bin	NULL		
+t2	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_bin	NULL		
+t3	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_bin	NULL	partitioned	
 ANALYZE TABLE t1, t2, t3;
 Table	Op	Msg_type	Msg_text
 test.t1	analyze	status	OK
@@ -48,9 +48,9 @@ test.t2	analyze	status	OK
 test.t3	analyze	status	OK
 SHOW TABLE STATUS WHERE name LIKE 't%';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_bin	NULL		
-t2	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_bin	NULL		
-t3	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_bin	NULL	partitioned	
+t1	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_bin	NULL		
+t2	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_bin	NULL		
+t3	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_bin	NULL	partitioned	
 select count(pk) from t1;
 count(pk)
 5000000

--- a/mysql-test/suite/rocksdb/r/bulk_load_rev_cf.result
+++ b/mysql-test/suite/rocksdb/r/bulk_load_rev_cf.result
@@ -38,9 +38,9 @@ pk	a	b
 set rocksdb_bulk_load=0;
 SHOW TABLE STATUS WHERE name LIKE 't%';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_bin	NULL		
-t2	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_bin	NULL		
-t3	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_bin	NULL	partitioned	
+t1	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_bin	NULL		
+t2	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_bin	NULL		
+t3	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_bin	NULL	partitioned	
 ANALYZE TABLE t1, t2, t3;
 Table	Op	Msg_type	Msg_text
 test.t1	analyze	status	OK
@@ -48,9 +48,9 @@ test.t2	analyze	status	OK
 test.t3	analyze	status	OK
 SHOW TABLE STATUS WHERE name LIKE 't%';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_bin	NULL		
-t2	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_bin	NULL		
-t3	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_bin	NULL	partitioned	
+t1	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_bin	NULL		
+t2	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_bin	NULL		
+t3	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_bin	NULL	partitioned	
 select count(pk) from t1;
 count(pk)
 5000000

--- a/mysql-test/suite/rocksdb/r/bulk_load_rev_cf_and_data.result
+++ b/mysql-test/suite/rocksdb/r/bulk_load_rev_cf_and_data.result
@@ -38,9 +38,9 @@ pk	a	b
 set rocksdb_bulk_load=0;
 SHOW TABLE STATUS WHERE name LIKE 't%';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_bin	NULL		
-t2	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_bin	NULL		
-t3	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_bin	NULL	partitioned	
+t1	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_bin	NULL		
+t2	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_bin	NULL		
+t3	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_bin	NULL	partitioned	
 ANALYZE TABLE t1, t2, t3;
 Table	Op	Msg_type	Msg_text
 test.t1	analyze	status	OK
@@ -48,9 +48,9 @@ test.t2	analyze	status	OK
 test.t3	analyze	status	OK
 SHOW TABLE STATUS WHERE name LIKE 't%';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_bin	NULL		
-t2	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_bin	NULL		
-t3	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_bin	NULL	partitioned	
+t1	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_bin	NULL		
+t2	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_bin	NULL		
+t3	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_bin	NULL	partitioned	
 select count(pk) from t1;
 count(pk)
 5000000

--- a/mysql-test/suite/rocksdb/r/bulk_load_rev_data.result
+++ b/mysql-test/suite/rocksdb/r/bulk_load_rev_data.result
@@ -38,9 +38,9 @@ pk	a	b
 set rocksdb_bulk_load=0;
 SHOW TABLE STATUS WHERE name LIKE 't%';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_bin	NULL		
-t2	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_bin	NULL		
-t3	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_bin	NULL	partitioned	
+t1	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_bin	NULL		
+t2	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_bin	NULL		
+t3	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_bin	NULL	partitioned	
 ANALYZE TABLE t1, t2, t3;
 Table	Op	Msg_type	Msg_text
 test.t1	analyze	status	OK
@@ -48,9 +48,9 @@ test.t2	analyze	status	OK
 test.t3	analyze	status	OK
 SHOW TABLE STATUS WHERE name LIKE 't%';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_bin	NULL		
-t2	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_bin	NULL		
-t3	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_bin	NULL	partitioned	
+t1	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_bin	NULL		
+t2	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_bin	NULL		
+t3	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_bin	NULL	partitioned	
 select count(pk) from t1;
 count(pk)
 5000000

--- a/mysql-test/suite/rocksdb/r/bulk_load_unsorted.result
+++ b/mysql-test/suite/rocksdb/r/bulk_load_unsorted.result
@@ -70,9 +70,9 @@ LOAD DATA INFILE <input_file> INTO TABLE t3;
 set rocksdb_bulk_load=0;
 SHOW TABLE STATUS WHERE name LIKE 't%';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_swedish_ci	NULL		
-t2	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_swedish_ci	NULL		
-t3	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_swedish_ci	NULL	partitioned	
+t1	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_swedish_ci	NULL		
+t2	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_swedish_ci	NULL		
+t3	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_swedish_ci	NULL	partitioned	
 ANALYZE TABLE t1, t2, t3;
 Table	Op	Msg_type	Msg_text
 test.t1	analyze	status	OK
@@ -80,9 +80,9 @@ test.t2	analyze	status	OK
 test.t3	analyze	status	OK
 SHOW TABLE STATUS WHERE name LIKE 't%';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_swedish_ci	NULL		
-t2	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_swedish_ci	NULL		
-t3	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_swedish_ci	NULL	partitioned	
+t1	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_swedish_ci	NULL		
+t2	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_swedish_ci	NULL		
+t3	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_swedish_ci	NULL	partitioned	
 select count(a) from t1;
 count(a)
 5000000

--- a/mysql-test/suite/rocksdb/r/bulk_load_unsorted_rev.result
+++ b/mysql-test/suite/rocksdb/r/bulk_load_unsorted_rev.result
@@ -70,9 +70,9 @@ LOAD DATA INFILE <input_file> INTO TABLE t3;
 set rocksdb_bulk_load=0;
 SHOW TABLE STATUS WHERE name LIKE 't%';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_swedish_ci	NULL		
-t2	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_swedish_ci	NULL		
-t3	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_swedish_ci	NULL	partitioned	
+t1	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_swedish_ci	NULL		
+t2	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_swedish_ci	NULL		
+t3	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_swedish_ci	NULL	partitioned	
 ANALYZE TABLE t1, t2, t3;
 Table	Op	Msg_type	Msg_text
 test.t1	analyze	status	OK
@@ -80,9 +80,9 @@ test.t2	analyze	status	OK
 test.t3	analyze	status	OK
 SHOW TABLE STATUS WHERE name LIKE 't%';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_swedish_ci	NULL		
-t2	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_swedish_ci	NULL		
-t3	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	NULL	NULL	NULL	latin1_swedish_ci	NULL	partitioned	
+t1	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_swedish_ci	NULL		
+t2	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_swedish_ci	NULL		
+t3	ROCKSDB	10	Fixed	5000000	#	#	#	#	0	NULL	#	#	NULL	latin1_swedish_ci	NULL	partitioned	
 select count(a) from t1;
 count(a)
 5000000

--- a/mysql-test/suite/rocksdb/r/issue255.result
+++ b/mysql-test/suite/rocksdb/r/issue255.result
@@ -2,7 +2,7 @@ CREATE TABLE t1 (pk BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT);
 INSERT INTO t1 VALUES (5);
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	#	Fixed	#	#	#	#	#	#	6	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	#	Fixed	#	#	#	#	#	#	6	#	#	NULL	latin1_swedish_ci	NULL		
 INSERT INTO t1 VALUES ('538647864786478647864');
 Warnings:
 Warning	1264	Out of range value for column 'pk' at row 1
@@ -12,7 +12,7 @@ pk
 9223372036854775807
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	10	Fixed	2	22	44	0	0	0	9223372036854775807	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	10	Fixed	2	22	44	0	0	0	9223372036854775807	#	#	NULL	latin1_swedish_ci	NULL		
 INSERT INTO t1 VALUES ();
 ERROR 23000: Duplicate entry '9223372036854775807' for key 'PRIMARY'
 SELECT * FROM t1;
@@ -21,7 +21,7 @@ pk
 9223372036854775807
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	#	Fixed	#	#	#	#	#	#	9223372036854775807	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	#	Fixed	#	#	#	#	#	#	9223372036854775807	#	#	NULL	latin1_swedish_ci	NULL		
 INSERT INTO t1 VALUES ();
 ERROR 23000: Duplicate entry '9223372036854775807' for key 'PRIMARY'
 SELECT * FROM t1;
@@ -30,13 +30,13 @@ pk
 9223372036854775807
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	#	Fixed	#	#	#	#	#	#	9223372036854775807	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	#	Fixed	#	#	#	#	#	#	9223372036854775807	#	#	NULL	latin1_swedish_ci	NULL		
 DROP TABLE t1;
 CREATE TABLE t1 (pk TINYINT NOT NULL PRIMARY KEY AUTO_INCREMENT);
 INSERT INTO t1 VALUES (5);
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	#	Fixed	#	#	#	#	#	#	6	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	#	Fixed	#	#	#	#	#	#	6	#	#	NULL	latin1_swedish_ci	NULL		
 INSERT INTO t1 VALUES (1000);
 Warnings:
 Warning	1264	Out of range value for column 'pk' at row 1
@@ -46,7 +46,7 @@ pk
 127
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	#	Fixed	#	#	#	#	#	#	127	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	#	Fixed	#	#	#	#	#	#	127	#	#	NULL	latin1_swedish_ci	NULL		
 INSERT INTO t1 VALUES ();
 ERROR 23000: Duplicate entry '127' for key 'PRIMARY'
 SELECT * FROM t1;
@@ -55,7 +55,7 @@ pk
 127
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	#	Fixed	#	#	#	#	#	#	127	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	#	Fixed	#	#	#	#	#	#	127	#	#	NULL	latin1_swedish_ci	NULL		
 INSERT INTO t1 VALUES ();
 ERROR 23000: Duplicate entry '127' for key 'PRIMARY'
 SELECT * FROM t1;
@@ -64,5 +64,5 @@ pk
 127
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	#	Fixed	#	#	#	#	#	#	127	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	#	Fixed	#	#	#	#	#	#	127	#	#	NULL	latin1_swedish_ci	NULL		
 DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -1418,7 +1418,7 @@ create table t1 (i int primary key auto_increment) engine=RocksDB;
 insert into t1 values (null),(null);
 show table status like 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	10	Fixed	1000	0	#	0	0	0	3	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	10	Fixed	1000	0	#	0	0	0	3	#	#	NULL	latin1_swedish_ci	NULL		
 drop table t1;
 #
 # Fix Issue #4: Crash when using pseudo-unique keys
@@ -2613,7 +2613,7 @@ CREATE TABLE t1(a INT AUTO_INCREMENT KEY);
 INSERT INTO t1 VALUES(0),(-1),(0);
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	10	Fixed	1000	0	0	0	0	0	3	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	10	Fixed	1000	0	0	0	0	0	3	#	#	NULL	latin1_swedish_ci	NULL		
 SELECT * FROM t1;
 a
 -1
@@ -2624,7 +2624,7 @@ CREATE TABLE t1(a INT AUTO_INCREMENT KEY);
 INSERT INTO t1 VALUES(0),(10),(0);
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	10	Fixed	1000	0	0	0	0	0	12	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	10	Fixed	1000	0	0	0	0	0	12	#	#	NULL	latin1_swedish_ci	NULL		
 SELECT * FROM t1;
 a
 1

--- a/mysql-test/suite/rocksdb/r/show_table_status.result
+++ b/mysql-test/suite/rocksdb/r/show_table_status.result
@@ -7,12 +7,12 @@ set global rocksdb_force_flush_memtable_now = true;
 CREATE TABLE t3 (a INT, b CHAR(8), pk INT PRIMARY KEY) ENGINE=rocksdb CHARACTER SET utf8;
 SHOW TABLE STATUS WHERE name IN ( 't1', 't2', 't3' );
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	10	Fixed	1000	#	#	0	0	0	NULL	NULL	NULL	NULL	latin1_swedish_ci	NULL		
-t2	ROCKSDB	10	Fixed	1000	#	#	0	0	0	NULL	NULL	NULL	NULL	latin1_swedish_ci	NULL		
-t3	ROCKSDB	10	Fixed	1000	#	#	0	0	0	NULL	NULL	NULL	NULL	utf8_general_ci	NULL		
+t1	ROCKSDB	10	Fixed	1000	#	#	0	0	0	NULL	#	#	NULL	latin1_swedish_ci	NULL		
+t2	ROCKSDB	10	Fixed	1000	#	#	0	0	0	NULL	#	#	NULL	latin1_swedish_ci	NULL		
+t3	ROCKSDB	10	Fixed	1000	#	#	0	0	0	NULL	#	#	NULL	utf8_general_ci	NULL		
 SHOW TABLE STATUS WHERE name LIKE 't2';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t2	ROCKSDB	10	Fixed	1000	#	#	0	0	0	NULL	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t2	ROCKSDB	10	Fixed	1000	#	#	0	0	0	NULL	#	#	NULL	latin1_swedish_ci	NULL		
 DROP TABLE t1, t2, t3;
 CREATE DATABASE `db_new..............................................end`;
 USE `db_new..............................................end`;
@@ -22,3 +22,113 @@ SELECT TABLE_SCHEMA, TABLE_NAME FROM information_schema.table_statistics WHERE T
 TABLE_SCHEMA	db_new..............................................end
 TABLE_NAME	t1_new..............................................end
 DROP DATABASE `db_new..............................................end`;
+#
+# MDEV-17171: Bug: RocksDB Tables do not have "Creation Date"
+#
+use test;
+create table t1 (a int) engine=rocksdb;
+select create_time is not null, update_time, check_time 
+from information_schema.tables where table_schema=database() and table_name='t1';
+create_time is not null	update_time	check_time
+1	NULL	NULL
+insert into t1 values (1);
+select create_time is not null, update_time is not null, check_time 
+from information_schema.tables where table_schema=database() and table_name='t1';
+create_time is not null	update_time is not null	check_time
+1	1	NULL
+flush tables;
+select create_time is not null, update_time is not null, check_time 
+from information_schema.tables where table_schema=database() and table_name='t1';
+create_time is not null	update_time is not null	check_time
+1	1	NULL
+select create_time, update_time into @create_tm, @update_tm
+from information_schema.tables 
+where table_schema=database() and table_name='t1';
+select sleep(3);
+sleep(3)
+0
+insert into t1 values (2);
+select 
+create_time=@create_tm /* should not change */ , 
+timestampdiff(second, @update_tm, update_time) > 2,
+check_time
+from information_schema.tables 
+where table_schema=database() and table_name='t1';
+create_time=@create_tm	1
+timestampdiff(second, @update_tm, update_time) > 2	1
+check_time	NULL
+#
+# Check how create_time survives ALTER TABLE.
+# First, an ALTER TABLE that re-creates the table:
+alter table t1 add b int;
+select sleep(2);
+sleep(2)	0
+select
+create_time<>@create_tm /* should change */,
+create_time IS NOT NULL,
+update_time IS NULL
+from information_schema.tables 
+where table_schema=database() and table_name='t1';
+create_time<>@create_tm	1
+create_time IS NOT NULL	1
+update_time IS NULL	1
+insert into t1 values (5,5);
+select create_time, update_time into @create_tm, @update_tm
+from information_schema.tables 
+where table_schema=database() and table_name='t1';
+select sleep(2);
+sleep(2)	0
+# Then, an in-place ALTER TABLE:
+alter table t1 add key (a);
+# create_time will change as .frm file is rewritten:
+select
+create_time=@create_tm,
+update_time
+from information_schema.tables 
+where table_schema=database() and table_name='t1';
+create_time=@create_tm	0
+update_time	NULL
+# Check TRUNCATE TABLE
+insert into t1 values (10,10);
+select create_time, update_time into @create_tm, @update_tm
+from information_schema.tables 
+where table_schema=database() and table_name='t1';
+select sleep(2);
+sleep(2)	0
+truncate table t1;
+select
+create_time=@create_tm /* should not change */,
+update_time
+from information_schema.tables 
+where table_schema=database() and table_name='t1';
+create_time=@create_tm	1
+update_time	NULL
+#
+# Check what is left after server restart
+#
+# Save t1's creation time
+create table t2 as
+select create_time
+from information_schema.tables
+where table_schema=database() and table_name='t1';
+select sleep(2);
+sleep(2)	0
+select
+create_time=(select create_time from t2)  /* should not change */,
+update_time
+from information_schema.tables
+where table_schema=database() and table_name='t1';
+create_time=(select create_time from t2)	1
+update_time	NULL
+drop table t1, t2;
+#
+# Check how it works for partitioned tables
+#
+create table t1 (pk int primary key) partition by hash(pk) partitions 2;
+insert into t1 values (1);
+select create_time IS NOT NULL , update_time IS NOT NULL
+from information_schema.tables 
+where table_schema=database() and table_name='t1';
+create_time IS NOT NULL	1
+update_time IS NOT NULL	1
+drop table t1;

--- a/mysql-test/suite/rocksdb/r/truncate_table.result
+++ b/mysql-test/suite/rocksdb/r/truncate_table.result
@@ -9,19 +9,19 @@ DROP TABLE t1;
 CREATE TABLE t1 (a INT KEY AUTO_INCREMENT, c CHAR(8)) ENGINE=rocksdb;
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	10	Fixed	#	#	#	0	0	0	1	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	10	Fixed	#	#	#	0	0	0	1	#	#	NULL	latin1_swedish_ci	NULL		
 INSERT INTO t1 (c) VALUES ('a'),('b'),('c');
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	10	Fixed	#	#	#	0	0	0	4	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	10	Fixed	#	#	#	0	0	0	4	#	#	NULL	latin1_swedish_ci	NULL		
 TRUNCATE TABLE t1;
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	10	Fixed	#	#	#	0	0	0	1	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	10	Fixed	#	#	#	0	0	0	1	#	#	NULL	latin1_swedish_ci	NULL		
 INSERT INTO t1 (c) VALUES ('d');
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	10	Fixed	#	#	#	0	0	0	2	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	10	Fixed	#	#	#	0	0	0	2	#	#	NULL	latin1_swedish_ci	NULL		
 SELECT a,c FROM t1;
 a	c
 1	d

--- a/mysql-test/suite/rocksdb/t/issue255.test
+++ b/mysql-test/suite/rocksdb/t/issue255.test
@@ -3,24 +3,25 @@
 CREATE TABLE t1 (pk BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT);
 
 INSERT INTO t1 VALUES (5);
---replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 #
+--replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 # 12 # 13 #
 SHOW TABLE STATUS LIKE 't1';
 
 INSERT INTO t1 VALUES ('538647864786478647864');
---replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 #
+--replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 # 12 # 13 #
 SELECT * FROM t1;
+--replace_column 12 # 13 #
 SHOW TABLE STATUS LIKE 't1';
 
 --error ER_DUP_ENTRY
 INSERT INTO t1 VALUES ();
 SELECT * FROM t1;
---replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 #
+--replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 # 12 # 13 #
 SHOW TABLE STATUS LIKE 't1';
 
 --error ER_DUP_ENTRY
 INSERT INTO t1 VALUES ();
 SELECT * FROM t1;
---replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 #
+--replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 # 12 # 13 #
 SHOW TABLE STATUS LIKE 't1';
 
 DROP TABLE t1;
@@ -28,24 +29,24 @@ DROP TABLE t1;
 CREATE TABLE t1 (pk TINYINT NOT NULL PRIMARY KEY AUTO_INCREMENT);
 
 INSERT INTO t1 VALUES (5);
---replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 #
+--replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 # 12 # 13 #
 SHOW TABLE STATUS LIKE 't1';
 
 INSERT INTO t1 VALUES (1000);
 SELECT * FROM t1;
---replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 #
+--replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 # 12 # 13 #
 SHOW TABLE STATUS LIKE 't1';
 
 --error ER_DUP_ENTRY
 INSERT INTO t1 VALUES ();
 SELECT * FROM t1;
---replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 #
+--replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 # 12 # 13 #
 SHOW TABLE STATUS LIKE 't1';
 
 --error ER_DUP_ENTRY
 INSERT INTO t1 VALUES ();
 SELECT * FROM t1;
---replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 #
+--replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 # 12 # 13 #
 SHOW TABLE STATUS LIKE 't1';
 
 DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/t/rocksdb.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb.test
@@ -1198,7 +1198,7 @@ drop table t1;
 create table t1 (i int primary key auto_increment) engine=RocksDB;
 
 insert into t1 values (null),(null);
---replace_column 7 #
+--replace_column 7 # 12 # 13 #
 show table status like 't1';
 drop table t1;
 
@@ -1903,11 +1903,13 @@ DROP TABLE t1;
 # value is 4 while MyRocks will show it as 3.
 CREATE TABLE t1(a INT AUTO_INCREMENT KEY);
 INSERT INTO t1 VALUES(0),(-1),(0);
+--replace_column 12 # 13 #
 SHOW TABLE STATUS LIKE 't1';
 SELECT * FROM t1;
 DROP TABLE t1;
 CREATE TABLE t1(a INT AUTO_INCREMENT KEY);
 INSERT INTO t1 VALUES(0),(10),(0);
+--replace_column 12 # 13 #
 SHOW TABLE STATUS LIKE 't1';
 SELECT * FROM t1;
 DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/t/show_table_status.test
+++ b/mysql-test/suite/rocksdb/t/show_table_status.test
@@ -1,5 +1,5 @@
 --source include/have_rocksdb.inc
-
+--source include/have_partition.inc
 # 
 # SHOW TABLE STATUS statement
 #
@@ -24,7 +24,7 @@ set global rocksdb_force_flush_memtable_now = true;
 
 CREATE TABLE t3 (a INT, b CHAR(8), pk INT PRIMARY KEY) ENGINE=rocksdb CHARACTER SET utf8;
 
---replace_column 6 # 7 #
+--replace_column 6 # 7 # 12 # 13 #
 SHOW TABLE STATUS WHERE name IN ( 't1', 't2', 't3' );
 
 # Some statistics don't get updated as quickly.  The Data_length and
@@ -48,7 +48,7 @@ set global rocksdb_force_flush_memtable_now = true;
 
 # We expect the number of rows to be 10000. Data_len and Avg_row_len
 # may vary, depending on built-in compression library.
---replace_column 6 # 7 #
+--replace_column 6 # 7 # 12 # 13 #
 SHOW TABLE STATUS WHERE name LIKE 't2';
 DROP TABLE t1, t2, t3;
 
@@ -62,3 +62,114 @@ CREATE TABLE `t1_new..............................................end`(a int) en
 INSERT INTO `t1_new..............................................end` VALUES (1);
 --query_vertical SELECT TABLE_SCHEMA, TABLE_NAME FROM information_schema.table_statistics WHERE TABLE_NAME = 't1_new..............................................end'
 DROP DATABASE `db_new..............................................end`;
+
+--echo #
+--echo # MDEV-17171: Bug: RocksDB Tables do not have "Creation Date"
+--echo #
+
+use test;
+create table t1 (a int) engine=rocksdb;
+
+select create_time is not null, update_time, check_time 
+from information_schema.tables where table_schema=database() and table_name='t1';
+
+insert into t1 values (1);
+select create_time is not null, update_time is not null, check_time 
+from information_schema.tables where table_schema=database() and table_name='t1';
+
+flush tables;
+select create_time is not null, update_time is not null, check_time 
+from information_schema.tables where table_schema=database() and table_name='t1';
+
+select create_time, update_time into @create_tm, @update_tm
+from information_schema.tables 
+where table_schema=database() and table_name='t1';
+
+select sleep(3);
+insert into t1 values (2);
+
+--vertical_results
+select 
+  create_time=@create_tm /* should not change */ , 
+  timestampdiff(second, @update_tm, update_time) > 2,
+  check_time
+from information_schema.tables 
+where table_schema=database() and table_name='t1';
+
+--echo #
+--echo # Check how create_time survives ALTER TABLE.
+--echo # First, an ALTER TABLE that re-creates the table:
+alter table t1 add b int;
+select sleep(2);
+
+select
+  create_time<>@create_tm /* should change */,
+  create_time IS NOT NULL,
+  update_time IS NULL
+from information_schema.tables 
+where table_schema=database() and table_name='t1';
+
+insert into t1 values (5,5);
+
+select create_time, update_time into @create_tm, @update_tm
+from information_schema.tables 
+where table_schema=database() and table_name='t1';
+
+select sleep(2);
+--echo # Then, an in-place ALTER TABLE:
+alter table t1 add key (a);
+
+--echo # create_time will change as .frm file is rewritten:
+select
+  create_time=@create_tm,
+  update_time
+from information_schema.tables 
+where table_schema=database() and table_name='t1';
+
+--echo # Check TRUNCATE TABLE
+insert into t1 values (10,10);
+select create_time, update_time into @create_tm, @update_tm
+from information_schema.tables 
+where table_schema=database() and table_name='t1';
+
+select sleep(2);
+truncate table t1;
+
+select
+  create_time=@create_tm /* should not change */,
+  update_time
+from information_schema.tables 
+where table_schema=database() and table_name='t1';
+
+
+--echo #
+--echo # Check what is left after server restart
+--echo #
+
+--echo # Save t1's creation time
+create table t2 as
+select create_time
+from information_schema.tables
+where table_schema=database() and table_name='t1';
+
+--source include/restart_mysqld.inc
+
+select sleep(2);
+select
+  create_time=(select create_time from t2)  /* should not change */,
+  update_time
+from information_schema.tables
+where table_schema=database() and table_name='t1';
+
+drop table t1, t2;
+
+--echo #
+--echo # Check how it works for partitioned tables
+--echo #
+create table t1 (pk int primary key) partition by hash(pk) partitions 2;
+insert into t1 values (1);
+
+select create_time IS NOT NULL , update_time IS NOT NULL
+from information_schema.tables 
+where table_schema=database() and table_name='t1';
+drop table t1;

--- a/mysql-test/suite/rocksdb/t/truncate_table.test
+++ b/mysql-test/suite/rocksdb/t/truncate_table.test
@@ -29,22 +29,22 @@ DROP TABLE t1;
 CREATE TABLE t1 (a INT KEY AUTO_INCREMENT, c CHAR(8)) ENGINE=rocksdb;
 
 #--replace_column 2 # 3 # 4 # 5 # 6 # 7 # 8 # 9 # 10 # 12 # 13 # 14 # 15 # 16 # 17 # 18 #
---replace_column 5 # 6 # 7 #
+--replace_column 5 # 6 # 7 # 12 # 13 #
 SHOW TABLE STATUS LIKE 't1';
 
 INSERT INTO t1 (c) VALUES ('a'),('b'),('c');
 #--replace_column 2 # 3 # 4 # 5 # 6 # 7 # 8 # 9 # 10 # 12 # 13 # 14 # 15 # 16 # 17 # 18 #
---replace_column 5 # 6 # 7 #
+--replace_column 5 # 6 # 7 # 12 # 13 #
 SHOW TABLE STATUS LIKE 't1';
 
 TRUNCATE TABLE t1;
 #--replace_column 2 # 3 # 4 # 5 # 6 # 7 # 8 # 9 # 10 # 12 # 13 # 14 # 15 # 16 # 17 # 18 #
---replace_column 5 # 6 # 7 #
+--replace_column 5 # 6 # 7 # 12 # 13 #
 SHOW TABLE STATUS LIKE 't1';
 
 INSERT INTO t1 (c) VALUES ('d');
 #--replace_column 2 # 3 # 4 # 5 # 6 # 7 # 8 # 9 # 10 # 12 # 13 # 14 # 15 # 16 # 17 # 18 #
---replace_column 5 # 6 # 7 #
+--replace_column 5 # 6 # 7 # 12 # 13 #
 SHOW TABLE STATUS LIKE 't1';
 
 --sorted_result

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -2464,6 +2464,8 @@ class Rdb_transaction {
   bool m_is_delayed_snapshot = false;
   bool m_is_two_phase = false;
 
+  std::unordered_set<Rdb_tbl_def*> modified_tables;
+
  private:
   /*
     Number of write operations this transaction had when we took the last
@@ -3154,6 +3156,25 @@ class Rdb_transaction {
   virtual void start_tx() = 0;
   virtual void start_stmt() = 0;
 
+ protected:
+  // Non-virtual functions with actions to be done on transaction start and
+  // commit.
+  void on_commit() {
+    time_t tm;
+    tm = time(nullptr);
+    for (auto &it : modified_tables) {
+      it->m_update_time = tm;
+    }
+    modified_tables.clear();
+  }
+  void on_rollback() {
+    modified_tables.clear();
+  }
+ public:
+  void log_table_write_op(Rdb_tbl_def *tbl) {
+    modified_tables.insert(tbl);
+  }
+
   void set_initial_savepoint() {
     /*
       Set the initial savepoint. If the first statement in the transaction
@@ -3337,7 +3358,9 @@ class Rdb_transaction_impl : public Rdb_transaction {
       goto error;
     }
 
+    on_commit();
   error:
+    on_rollback();
     /* Save the transaction object to be reused */
     release_tx();
 
@@ -3353,6 +3376,7 @@ class Rdb_transaction_impl : public Rdb_transaction {
 
  public:
   void rollback() override {
+    on_rollback();
     m_write_count = 0;
     m_insert_count = 0;
     m_update_count = 0;
@@ -3674,7 +3698,9 @@ class Rdb_writebatch_impl : public Rdb_transaction {
       res = true;
       goto error;
     }
+    on_commit();
   error:
+    on_rollback();
     reset();
 
     m_write_count = 0;
@@ -3706,6 +3732,7 @@ class Rdb_writebatch_impl : public Rdb_transaction {
   }
 
   void rollback() override {
+    on_rollback();
     m_write_count = 0;
     m_insert_count = 0;
     m_update_count = 0;
@@ -10223,6 +10250,8 @@ int ha_rocksdb::update_write_row(const uchar *const old_data,
     row_info.tx->incr_insert_count();
   }
 
+  row_info.tx->log_table_write_op(m_tbl_def);
+
   if (do_bulk_commit(row_info.tx)) {
     DBUG_RETURN(HA_ERR_ROCKSDB_BULK_LOAD);
   }
@@ -10697,6 +10726,7 @@ int ha_rocksdb::delete_row(const uchar *const buf) {
   }
 
   tx->incr_delete_count();
+  tx->log_table_write_op(m_tbl_def);
 
   if (do_bulk_commit(tx)) {
     DBUG_RETURN(HA_ERR_ROCKSDB_BULK_LOAD);
@@ -10853,6 +10883,12 @@ int ha_rocksdb::info(uint flag) {
         k->rec_per_key[j] = x;
       }
     }
+
+    stats.create_time = m_tbl_def->get_create_time();
+  }
+
+  if (flag & HA_STATUS_TIME) {
+    stats.update_time = m_tbl_def->m_update_time;
   }
 
   if (flag & HA_STATUS_ERRKEY) {

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -3582,6 +3582,26 @@ bool Rdb_tbl_def::put_dict(Rdb_dict_manager *const dict,
   return false;
 }
 
+time_t Rdb_tbl_def::get_create_time() {
+  time_t create_time = m_create_time;
+
+  if (create_time == CREATE_TIME_UNKNOWN) {
+    // Read it from the .frm file. It's not a problem if several threads do this
+    // concurrently
+    char path[FN_REFLEN];
+    snprintf(path, sizeof(path), "%s/%s/%s%s", mysql_data_home,
+             m_dbname.c_str(), m_tablename.c_str(), reg_ext);
+    unpack_filename(path,path);
+    MY_STAT f_stat;
+    if (my_stat(path, &f_stat, MYF(0)))
+      create_time = f_stat.st_ctime;
+    else
+      create_time = 0; // will be shown as SQL NULL
+    m_create_time = create_time;
+  }
+  return create_time;
+}
+
 // Length that each index flag takes inside the record.
 // Each index in the array maps to the enum INDEX_FLAG
 static const std::array<uint, 1> index_flag_lengths = {

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -1097,7 +1097,9 @@ class Rdb_tbl_def {
       : m_key_descr_arr(nullptr),
         m_hidden_pk_val(0),
         m_auto_incr_val(0),
-        m_tbl_stats() {
+        m_tbl_stats(),
+        m_update_time(0),
+        m_create_time(CREATE_TIME_UNKNOWN) {
     set_name(name);
   }
 
@@ -1105,7 +1107,9 @@ class Rdb_tbl_def {
       : m_key_descr_arr(nullptr),
         m_hidden_pk_val(0),
         m_auto_incr_val(0),
-        m_tbl_stats() {
+        m_tbl_stats(),
+        m_update_time(0),
+        m_create_time(CREATE_TIME_UNKNOWN) {
     set_name(std::string(name, len));
   }
 
@@ -1113,7 +1117,9 @@ class Rdb_tbl_def {
       : m_key_descr_arr(nullptr),
         m_hidden_pk_val(0),
         m_auto_incr_val(0),
-        m_tbl_stats() {
+        m_tbl_stats(),
+        m_update_time(0),
+        m_create_time(CREATE_TIME_UNKNOWN) {
     set_name(std::string(slice.data() + pos, slice.size() - pos));
   }
 
@@ -1164,6 +1170,14 @@ class Rdb_tbl_def {
   const std::string &base_tablename() const { return m_tablename; }
   const std::string &base_partition() const { return m_partition; }
   GL_INDEX_ID get_autoincr_gl_index_id();
+
+  time_t get_create_time();
+  std::atomic<time_t> m_update_time;  // in-memory only value
+ private:
+  const time_t CREATE_TIME_UNKNOWN = 1;
+  // CREATE_TIME_UNKNOWN means "didn't try to read, yet"
+  // 0 means "no data available"
+  std::atomic<time_t> m_create_time;
 };
 
 /*


### PR DESCRIPTION
- Create_time is read from frm file, like InnoDB. Prior to this diff, create_time was NULL.
- Update_time is in-memory only (like in InnoDB).