### PR TITLE
Update rocksdb submodule and switch to gtest-1.8.1 in MyRocks as well to be in sync

### DIFF
--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -22,7 +22,7 @@ STRING(REGEX MATCHALL "[^\n]+" ROCKSDB_LIB_SOURCES ${SCRIPT_OUTPUT})
 INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/rocksdb
   ${CMAKE_SOURCE_DIR}/rocksdb/include
-  ${CMAKE_SOURCE_DIR}/rocksdb/third-party/gtest-1.7.0/fused-src
+  ${CMAKE_SOURCE_DIR}/rocksdb/third-party/gtest-1.8.1/fused-src
 )
 
 # This is a strong requirement coming from RocksDB. No conditional checks here.


### PR DESCRIPTION
Note: RocksDB PR https://github.com/facebook/rocksdb/pull/5332 upgraded gtest from 1.7.0 to 1.8.1; we need to follow up with a change to CMakeLists.txt in MyRocks to be in sync.