### PR TITLE
FB8-236, FB8-237: fix compilation issues

### DIFF
--- a/include/mysql/psi/psi_abi_statement_v1.h.pp
+++ b/include/mysql/psi/psi_abi_statement_v1.h.pp
@@ -53,6 +53,9 @@ struct PSI_statement_locker_state_v1 {
   unsigned long long m_lock_time;
   unsigned long long m_rows_sent;
   unsigned long long m_rows_examined;
+  unsigned long long m_rows_deleted;
+  unsigned long long m_rows_inserted;
+  unsigned long long m_rows_updated;
   unsigned long m_created_tmp_disk_tables;
   unsigned long m_created_tmp_tables;
   unsigned long m_select_full_join;

--- a/unittest/gunit/CMakeLists.txt
+++ b/unittest/gunit/CMakeLists.txt
@@ -246,6 +246,7 @@ ADD_LIBRARY(gunit_small STATIC
   tap_event_listener.cc
   thread_utils.cc
   fake_table.cc
+  fake_mdl.cc
 )
 SET_TARGET_PROPERTIES(gunit_small
   PROPERTIES COMPILE_DEFINITIONS "${DISABLE_PSI_DEFINITIONS}"

--- a/unittest/gunit/fake_mdl.cc
+++ b/unittest/gunit/fake_mdl.cc
@@ -1,0 +1,33 @@
+/* Copyright (c) 2019 Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License, version 2.0,
+   as published by the Free Software Foundation.
+
+   This program is also distributed with certain software (including
+   but not limited to OpenSSL) that is licensed under separate terms,
+   as designated in a particular file or component or in included license
+   documentation.  The authors of MySQL hereby grant you an additional
+   permission to link the program and your derivative works with the
+   separately licensed software that they have included with MySQL.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License, version 2.0, for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
+
+#include <sql/auth/sql_security_ctx.h>
+#include <include/my_sqlcommand.h>
+
+/**
+  We need it for merge_test_small.cc
+*/
+bool slave_high_priority_ddl = 0;
+ulonglong slave_high_priority_lock_wait_timeout_nsec = 1.0;
+
+bool support_high_priority(enum enum_sql_command) noexcept { return false; };
+bool Security_context::check_access(ulong, bool) { return false; };


### PR DESCRIPTION
FB8-236: abi_check CMake target fails after introducing SUM_ROWS_DELETED
https://jira.percona.com/browse/FB8-236
Fix missing variables m_rows_deleted, m_rows_inserted, m_rows_updated in psi_abi_statement_v1.h.pp

FB8-237: merge_small_tests CMake target fails after introducing high priority DDLs
https://jira.percona.com/browse/FB8-237
Disable high priority DDL for unit tests.