### PR TITLE
FB8-240: merge_small_tests fails in RelWithDebInfo after introducing high priority DDLs

### DIFF
--- a/unittest/gunit/fake_mdl.cc
+++ b/unittest/gunit/fake_mdl.cc
@@ -20,8 +20,9 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
-#include <sql/auth/sql_security_ctx.h>
 #include <include/my_sqlcommand.h>
+#include <sql/auth/sql_security_ctx.h>
+#include "sql/sql_class.h"
 
 /**
   We need it for merge_test_small.cc
@@ -31,3 +32,7 @@ ulonglong slave_high_priority_lock_wait_timeout_nsec = 1.0;
 
 bool support_high_priority(enum enum_sql_command) noexcept { return false; };
 bool Security_context::check_access(ulong, bool) { return false; };
+
+void THD::enter_stage(const PSI_stage_info *, PSI_stage_info *, const char *,
+                      const char *, const unsigned int){};
+Vio *Protocol_classic::get_vio() { return nullptr; };


### PR DESCRIPTION
https://jira.percona.com/browse/FB8-240

Fix RelWithDebInfo compilation after introducing high priority DDLs at https://github.com/facebook/mysql-5.6/commit/2924b1fb01f6 by using dummy implementations of some functions.