### PR TITLE
Fix merge_small_tests-t, merge_large_tests-t, and routertest_component_bootstrap

### DIFF
--- a/router/tests/component/test_bootstrap.cc
+++ b/router/tests/component/test_bootstrap.cc
@@ -687,8 +687,8 @@ TEST_F(RouterBootstrapTest, BootstrapFailWhenServerResponseExceedsReadTimeout) {
       "-d", bootstrap_dir.name(), "--connect-timeout=1", "--read-timeout=1"};
 
   bootstrap_failover(mock_servers, router_options, EXIT_FAILURE,
-                     {"Error: Error executing MySQL query: Lost connection to "
-                      "MySQL server during query \\(2013\\)"});
+                     {"Error: Error executing MySQL query: Read timeout is "
+                      "reached \\(2066\\)"});
 }
 
 class RouterAccountHostTest : public CommonBootstrapTest {};

--- a/sql/mdl.h
+++ b/sql/mdl.h
@@ -1657,6 +1657,14 @@ class MDL_context {
   */
   uint m_rand_state;
 
+  /**
+    MDL_lock::object_lock_notify_conflicting_locks() checks THD of
+    conflicting lock on nullptr value and doesn't call the virtual
+    method MDL_context_owner::notify_shared_lock() in case condition
+    satisfied. This field allows unit tests to work with THD set to nullptr.
+  */
+  bool m_ignore_owner_thd;
+
  private:
   MDL_ticket *find_ticket(MDL_request *mdl_req, enum_mdl_duration *duration);
   void release_locks_stored_before(enum_mdl_duration duration,
@@ -1698,6 +1706,10 @@ class MDL_context {
   }
   void lock_deadlock_victim() { mysql_prlock_rdlock(&m_LOCK_waiting_for); }
   void unlock_deadlock_victim() { mysql_prlock_unlock(&m_LOCK_waiting_for); }
+  void set_ignore_owner_thd(bool ignore_owner_thd) {
+    m_ignore_owner_thd = ignore_owner_thd;
+  }
+  bool get_ignore_owner_thd() { return m_ignore_owner_thd; }
 
  private:
   MDL_context(const MDL_context &rhs);      /* not implemented */

--- a/unittest/gunit/mdl-t.cc
+++ b/unittest/gunit/mdl-t.cc
@@ -112,6 +112,7 @@ class MDLTest : public ::testing::Test, public Test_MDL_context_owner {
     max_write_lock_count = ULONG_MAX;
     mdl_init();
     m_mdl_context.init(this);
+    m_mdl_context.set_ignore_owner_thd(true);
     EXPECT_FALSE(m_mdl_context.has_locks());
     m_charset = system_charset_info;
     system_charset_info = &my_charset_utf8_bin;
@@ -2181,6 +2182,7 @@ TEST_F(MDLTest, NotifyScenarios) {
   /* Acquire S lock which will be granted using "fast path". */
   mdl_thread1.enable_release_on_notify();
   mdl_thread1.start();
+  mdl_thread1.get_mdl_context().set_ignore_owner_thd(true);
   first_shared_grabbed.wait_for_notification();
 
   /*
@@ -2195,6 +2197,7 @@ TEST_F(MDLTest, NotifyScenarios) {
     should be successfully granted after that.
   */
   mdl_thread2.start();
+  mdl_thread2.get_mdl_context().set_ignore_owner_thd(true);
   first_shared_released.wait_for_notification();
   first_exclusive_grabbed.wait_for_notification();
 
@@ -2222,6 +2225,7 @@ TEST_F(MDLTest, NotifyScenarios) {
   mdl_thread3.enable_release_on_notify();
   /* Acquire S lock which will be granted using "fast path". */
   mdl_thread3.start();
+  mdl_thread3.get_mdl_context().set_ignore_owner_thd(true);
   second_shared_grabbed.wait_for_notification();
 
   /*
@@ -2230,6 +2234,7 @@ TEST_F(MDLTest, NotifyScenarios) {
     should be successfully granted after that.
   */
   mdl_thread4.start();
+  mdl_thread4.get_mdl_context().set_ignore_owner_thd(true);
   second_shared_released.wait_for_notification();
   second_exclusive_grabbed.wait_for_notification();
 

--- a/unittest/gunit/mysys_pathfuncs-t.cc
+++ b/unittest/gunit/mysys_pathfuncs-t.cc
@@ -152,7 +152,7 @@ TEST(Mysys, CreateTempFile) {
   File fileno = create_temp_file(dst, "/tmp", prefix, 42, UNLINK_FILE, 0);
   EXPECT_GE(fileno, 0);
   my_close(fileno, 0);
-  EXPECT_THAT(dst, MatchesRegex("/tmp/[a]+fd=[0-9]+"));
+  EXPECT_THAT(dst, MatchesRegex("/tmp/[a]+[a-z0-9=]+"));
   aset(dst, 0xaa);
 
   char *env_tmpdir = getenv("TMPDIR");

--- a/unittest/gunit/parsertest.h
+++ b/unittest/gunit/parsertest.h
@@ -75,7 +75,7 @@ class ParserTest : public ::testing::Test {
           static_cast<char *>(my_malloc(PSI_NOT_INSTRUMENTED, 3, MYF(0)));
       sprintf(db, "db");
       LEX_CSTRING db_lex_cstr = {db, strlen(db)};
-      thd()->reset_db(db_lex_cstr);
+      thd()->reset_db(db_lex_cstr, /* lock_held_skip_metadata */ true);
     }
 
     lex_start(thd());

--- a/unittest/gunit/test_mdl_context_owner.h
+++ b/unittest/gunit/test_mdl_context_owner.h
@@ -37,15 +37,7 @@ class Test_MDL_context_owner : public MDL_context_owner {
 
   virtual int is_killed() const final { return 0; }
   virtual bool is_connected() { return true; }
-  virtual THD *get_thd() {
-    /*
-      MDL_lock::object_lock_notify_conflicting_locks() checks THD of
-      conflicting lock on nullptr value and doesn't call the virtual
-      method MDL_context_owner::notify_shared_lock() in case condition
-      satisfied. To workaround it return the value 1 casted to THD*.
-    */
-    return (THD *)1;
-  }
+  virtual THD *get_thd() { return nullptr; }
 
   virtual bool notify_hton_pre_acquire_exclusive(const MDL_key *, bool *) {
     return false;


### PR DESCRIPTION
Fix unit tests after merging https://github.com/facebook/mysql-5.6/commit/3847e40e2641 and https://github.com/facebook/mysql-5.6/commit/9e2db8e1c0db

Changes:
1. Allow `MDL_context::acquire_lock_nsec` to work with `thd == nullptr`
2. Remove an upstream hack in `Test_MDL_context_owner::get_thd` that returns `(THD *)1`
3. Update error code for `BootstrapFailWhenServerResponseExceedsReadTimeout`
4. Fix `Mysys.CreateTempFile` when access to `/tmp` is denied