### PR TITLE
Fix counter leak in nonsuper_connections

### DIFF
--- a/mysql-test/r/max_nonsuper_connections.result
+++ b/mysql-test/r/max_nonsuper_connections.result
@@ -51,6 +51,27 @@ disconnect con4;
 disconnect con3;
 disconnect con2;
 disconnect con1;
+Verifying nonsuper_connections is decremented when db is denied
+ERROR 42000: Access denied for user 'test_user'@'localhost' to database 'bogus_db'
+ERROR 42000: Access denied for user 'test_user'@'localhost' to database 'bogus_db'
+ERROR 42000: Access denied for user 'test_user'@'localhost' to database 'bogus_db'
+ERROR 42000: Access denied for user 'test_user'@'localhost' to database 'bogus_db'
+ERROR 42000: Access denied for user 'test_user'@'localhost' to database 'bogus_db'
+ERROR 42000: Access denied for user 'test_user'@'localhost' to database 'bogus_db'
+ERROR 42000: Access denied for user 'test_user'@'localhost' to database 'bogus_db'
+ERROR 42000: Access denied for user 'test_user'@'localhost' to database 'bogus_db'
+ERROR 42000: Access denied for user 'test_user'@'localhost' to database 'bogus_db'
+ERROR 42000: Access denied for user 'test_user'@'localhost' to database 'bogus_db'
+ERROR 42000: Access denied for user 'test_user'@'localhost' to database 'bogus_db'
+ERROR 42000: Access denied for user 'test_user'@'localhost' to database 'bogus_db'
+ERROR 42000: Access denied for user 'test_user'@'localhost' to database 'bogus_db'
+ERROR 42000: Access denied for user 'test_user'@'localhost' to database 'bogus_db'
+ERROR 42000: Access denied for user 'test_user'@'localhost' to database 'bogus_db'
+ERROR 42000: Access denied for user 'test_user'@'localhost' to database 'bogus_db'
+ERROR 42000: Access denied for user 'test_user'@'localhost' to database 'bogus_db'
+ERROR 42000: Access denied for user 'test_user'@'localhost' to database 'bogus_db'
+ERROR 42000: Access denied for user 'test_user'@'localhost' to database 'bogus_db'
+ERROR 42000: Access denied for user 'test_user'@'localhost' to database 'bogus_db'
 connection default;
 connect  con$i, localhost, test_user,,test;
 connect  con$i, localhost, test_user,,test;

--- a/mysql-test/t/max_nonsuper_connections.test
+++ b/mysql-test/t/max_nonsuper_connections.test
@@ -99,6 +99,17 @@ while ($i)
   dec $i;
 }
 
+# Verify counter leak is fixed when permission to a database is denied
+--echo Verifying nonsuper_connections is decremented when db is denied
+--disable_query_log
+--let $i = 20
+--while ($i) {
+  --error ER_DBACCESS_DENIED_ERROR
+  --connect (con_denied_$i, localhost, test_user,,bogus_db)
+  --dec $i
+--}
+--enable_query_log
+
 # able to refill up max_nonsuper_connections
 connection default;
 let $i = 10;


### PR DESCRIPTION
Summary:
If a non-super user connects to mysqld with an invalid database name,
nonsuper_connections is incremented, but never decremented.

Originally Reviewed By: yizhang82

fbshipit-source-id: a9083cce39f

8.0 porting notes:
Since nonsuper_connections is already decremented by calling
release_user_connection(), changes to the code are not needed. Test is
ported though to make sure the leak won't appear again.