### PR TITLE
Log create/alter/drop table to slow query log

### DIFF
--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -559,6 +559,7 @@ The following options may be given as the first argument:
  --log-datagram-usecs=# 
  Log queries longer than log-datagram-usecs to a unix
  local datagram socket
+ --log-ddl           Log ddls in slow query log.
  --log-error[=name]  Error log file
  --log-error-services=name 
  Services that should be called when an error event is
@@ -613,6 +614,11 @@ The following options may be given as the first argument:
  transactions that affect more than one storage engine,
  when binary log is disabled).
  --log-tc-size=#     Size of transaction coordinator log.
+ --log-throttle-ddl[=#] 
+ Log at most this many DDL entries per minute to the slow
+ log. Any further warnings will be condensed into a single
+ summary line. A value of 0 disables throttling. Option
+ has no effect unless --log_ddl is set.
  --log-throttle-queries-not-using-indexes=# 
  Log at most this many 'not using index' warnings per
  minute to the slow log. Any further warnings will be
@@ -1728,6 +1734,7 @@ log-bin-use-v1-row-events FALSE
 log-column-names FALSE
 log-datagram FALSE
 log-datagram-usecs 0
+log-ddl FALSE
 log-error stderr
 log-error-services log_filter_internal; log_sink_internal
 log-error-suppression-list 
@@ -1746,6 +1753,7 @@ log-slow-slave-statements FALSE
 log-statements-unsafe-for-binlog TRUE
 log-tc tc.log
 log-tc-size #####
+log-throttle-ddl 0
 log-throttle-queries-not-using-indexes 0
 log-timestamps UTC
 long-query-time 10

--- a/mysql-test/r/slow_log_ddl.result
+++ b/mysql-test/r/slow_log_ddl.result
@@ -1,0 +1,42 @@
+set global log_output = 'TABLE';
+truncate mysql.slow_log;
+set @my_log_ddl = @@global.log_ddl;
+set global log_ddl = true;
+create table t1 (
+id1 int unsigned not null default '0',
+primary key (id1));
+alter table t1 add id2 int unsigned;
+create index sec_key on t1(id2);
+drop index sec_key on t1;
+truncate table t1;
+rename table t1 to t2;
+drop table t2;
+select @@global.log_throttle_ddl;
+@@global.log_throttle_ddl
+0
+set @my_log_throttle_ddl = @@global.log_throttle_ddl;
+set global log_throttle_ddl = 1;
+create table t2 (
+id1 int unsigned not null default '0',
+primary key (id1));
+create table t3 (
+id1 int unsigned not null default '0',
+primary key (id1));
+create table t4 (
+id1 int unsigned not null default '0',
+primary key (id1));
+include/assert.inc [There is one slow log entry for create table t1]
+include/assert.inc [There is one slow log entry for alter table t1]
+include/assert.inc [There is one slow log entry for create index for t1]
+include/assert.inc [There is one slow log entry for drop index from t1]
+include/assert.inc [There is one slow log entry for truncate table t1]
+include/assert.inc [There is one slow log entry for rename table t1 to t2]
+include/assert.inc [There is one slow log entry for drop table t2]
+include/assert.inc [There is one slow log entry for create table t2]
+include/assert.inc [There is no slow log entry for create table t3]
+include/assert.inc [There is one slow log entry for create table t4]
+drop table t2, t3, t4;
+truncate mysql.slow_log;
+set global log_output = default;
+set @@global.log_ddl = @my_log_ddl;
+set @@global.log_throttle_ddl = @my_log_throttle_ddl;

--- a/mysql-test/suite/sys_vars/r/log_ddl_basic.result
+++ b/mysql-test/suite/sys_vars/r/log_ddl_basic.result
@@ -1,0 +1,42 @@
+SET @start_log_ddl = @@global.log_ddl;
+SELECT @start_log_ddl;
+@start_log_ddl
+0
+SET @@global.log_ddl = DEFAULT;
+SELECT @@global.log_ddl;
+@@global.log_ddl
+0
+SET @@global.log_ddl = false;
+SELECT @@global.log_ddl;
+@@global.log_ddl
+0
+SET @@global.log_ddl = true;
+SELECT @@global.log_ddl;
+@@global.log_ddl
+1
+SET @@global.log_ddl = 1;
+SELECT @@global.log_ddl;
+@@global.log_ddl
+1
+SET @@global.log_ddl = 0;
+SELECT @@global.log_ddl;
+@@global.log_ddl
+0
+SET @@global.log_ddl = -1;
+ERROR 42000: Variable 'log_ddl' can't be set to the value of '-1'
+SELECT @@global.log_ddl;
+@@global.log_ddl
+0
+SET @@global.log_ddl = 100;
+ERROR 42000: Variable 'log_ddl' can't be set to the value of '100'
+SELECT @@global.log_ddl;
+@@global.log_ddl
+0
+SET @@session.log_ddl = 10;
+ERROR HY000: Variable 'log_ddl' is a GLOBAL variable and should be set with SET GLOBAL
+SELECT @@session.log_ddl;
+ERROR HY000: Variable 'log_ddl' is a GLOBAL variable
+SET @@global.log_ddl = @start_log_ddl;
+SELECT @@global.log_ddl;
+@@global.log_ddl
+0

--- a/mysql-test/suite/sys_vars/r/log_throttle_ddl_basic.result
+++ b/mysql-test/suite/sys_vars/r/log_throttle_ddl_basic.result
@@ -1,0 +1,36 @@
+SET @start_value= @@global.log_throttle_ddl;
+SET @@global.log_throttle_ddl= DEFAULT;
+SELECT @@global.log_throttle_ddl;
+@@global.log_throttle_ddl
+0
+SET @@global.log_throttle_ddl= 1000;
+SELECT @@global.log_throttle_ddl;
+@@global.log_throttle_ddl
+1000
+SET @@global.log_throttle_ddl= -1;
+Warnings:
+Warning	1292	Truncated incorrect log_throttle_ddl value: '-1'
+SELECT @@global.log_throttle_ddl;
+@@global.log_throttle_ddl
+0
+SET @@global.log_throttle_ddl= 5;
+SELECT @@global.log_throttle_ddl;
+@@global.log_throttle_ddl
+5
+SET @@global.log_throttle_ddl= OFF;
+ERROR 42000: Incorrect argument type to variable 'log_throttle_ddl'
+SELECT @@global.log_throttle_ddl;
+@@global.log_throttle_ddl
+5
+SET @@global.log_throttle_ddl= ON;
+ERROR 42000: Incorrect argument type to variable 'log_throttle_ddl'
+SELECT @@global.log_throttle_ddl;
+@@global.log_throttle_ddl
+5
+SET GLOBAL log_throttle_ddl= 0.01;
+ERROR 42000: Incorrect argument type to variable 'log_throttle_ddl'
+SET SESSION log_throttle_ddl= 0;
+ERROR HY000: Variable 'log_throttle_ddl' is a GLOBAL variable and should be set with SET GLOBAL
+SET LOCAL log_throttle_ddl= 0;
+ERROR HY000: Variable 'log_throttle_ddl' is a GLOBAL variable and should be set with SET GLOBAL
+SET @@global.log_throttle_ddl= @start_value;

--- a/mysql-test/suite/sys_vars/t/log_ddl_basic.test
+++ b/mysql-test/suite/sys_vars/t/log_ddl_basic.test
@@ -1,0 +1,32 @@
+SET @start_log_ddl = @@global.log_ddl;
+SELECT @start_log_ddl;
+
+SET @@global.log_ddl = DEFAULT;
+SELECT @@global.log_ddl;
+
+SET @@global.log_ddl = false;
+SELECT @@global.log_ddl;
+
+SET @@global.log_ddl = true;
+SELECT @@global.log_ddl;
+
+SET @@global.log_ddl = 1;
+SELECT @@global.log_ddl;
+
+SET @@global.log_ddl = 0;
+SELECT @@global.log_ddl;
+
+--Error ER_WRONG_VALUE_FOR_VAR
+SET @@global.log_ddl = -1;
+SELECT @@global.log_ddl;
+--Error ER_WRONG_VALUE_FOR_VAR
+SET @@global.log_ddl = 100;
+SELECT @@global.log_ddl;
+
+--ERROR ER_GLOBAL_VARIABLE
+SET @@session.log_ddl = 10;
+--ERROR ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.log_ddl;
+
+SET @@global.log_ddl = @start_log_ddl;
+SELECT @@global.log_ddl;

--- a/mysql-test/suite/sys_vars/t/log_throttle_ddl_basic.test
+++ b/mysql-test/suite/sys_vars/t/log_throttle_ddl_basic.test
@@ -1,0 +1,33 @@
+SET @start_value= @@global.log_throttle_ddl;
+
+SET @@global.log_throttle_ddl= DEFAULT;
+SELECT @@global.log_throttle_ddl;
+
+SET @@global.log_throttle_ddl= 1000;
+SELECT @@global.log_throttle_ddl;
+
+# should throw a clipping warning
+SET @@global.log_throttle_ddl= -1;
+SELECT @@global.log_throttle_ddl;
+
+SET @@global.log_throttle_ddl= 5;
+SELECT @@global.log_throttle_ddl;
+
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@global.log_throttle_ddl= OFF;
+SELECT @@global.log_throttle_ddl;
+
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@global.log_throttle_ddl= ON;
+SELECT @@global.log_throttle_ddl;
+
+--error ER_WRONG_TYPE_FOR_VAR
+SET GLOBAL log_throttle_ddl= 0.01;
+
+--error ER_GLOBAL_VARIABLE
+SET SESSION log_throttle_ddl= 0;
+
+--error ER_GLOBAL_VARIABLE
+SET LOCAL log_throttle_ddl= 0;
+
+SET @@global.log_throttle_ddl= @start_value;

--- a/mysql-test/t/slow_log_ddl.test
+++ b/mysql-test/t/slow_log_ddl.test
@@ -1,0 +1,105 @@
+#
+# Test log_ddl
+#
+
+set global log_output = 'TABLE';
+truncate mysql.slow_log;
+
+set @my_log_ddl = @@global.log_ddl;
+set global log_ddl = true;
+
+# Create table t1
+create table t1 (
+id1 int unsigned not null default '0',
+primary key (id1));
+
+# Alter table t1
+alter table t1 add id2 int unsigned;
+
+# Create index for table t1
+create index sec_key on t1(id2);
+
+# Drop index from table t1
+drop index sec_key on t1;
+
+# Truncate table t1
+truncate table t1;
+
+# Rename table t1 to t2
+rename table t1 to t2;
+
+# Drop table t2
+drop table t2;
+
+select @@global.log_throttle_ddl;
+set @my_log_throttle_ddl = @@global.log_throttle_ddl;
+
+# Throttle the logging to 1 per minute
+set global log_throttle_ddl = 1;
+
+# Create table t2
+create table t2 (
+id1 int unsigned not null default '0',
+primary key (id1));
+
+# Create table t3. It should not be logged
+create table t3 (
+id1 int unsigned not null default '0',
+primary key (id1));
+
+# Wait for 60 seconds for the next throttle window
+real_sleep 60;
+
+# Create table t4. It should be logged
+create table t4 (
+id1 int unsigned not null default '0',
+primary key (id1));
+
+# Verify the slow log has correct content
+--let $assert_text = There is one slow log entry for create table t1
+--let $assert_cond= [SELECT count(*) FROM mysql.slow_log WHERE sql_text LIKE "%CREATE_TABLE%create table t1%"] = 1
+--source include/assert.inc
+
+--let $assert_text = There is one slow log entry for alter table t1
+--let $assert_cond= [SELECT count(*) FROM mysql.slow_log WHERE sql_text LIKE "%ALTER_TABLE%alter table t1%"] = 1
+--source include/assert.inc
+
+--let $assert_text = There is one slow log entry for create index for t1
+--let $assert_cond= [SELECT count(*) FROM mysql.slow_log WHERE sql_text LIKE "%CREATE_INDEX%create index%t1%"] = 1
+--source include/assert.inc
+
+--let $assert_text = There is one slow log entry for drop index from t1
+--let $assert_cond= [SELECT count(*) FROM mysql.slow_log WHERE sql_text LIKE "%DROP_INDEX%drop index%t1%"] = 1
+--source include/assert.inc
+
+--let $assert_text = There is one slow log entry for truncate table t1
+--let $assert_cond= [SELECT count(*) FROM mysql.slow_log WHERE sql_text LIKE "%TRUNCATE_TABLE%truncate table t1%"] = 1
+--source include/assert.inc
+
+--let $assert_text = There is one slow log entry for rename table t1 to t2
+--let $assert_cond= [SELECT count(*) FROM mysql.slow_log WHERE sql_text LIKE "%RENAME_TABLE%rename table t1 to t2%"] = 1
+--source include/assert.inc
+
+--let $assert_text = There is one slow log entry for drop table t2
+--let $assert_cond= [SELECT count(*) FROM mysql.slow_log WHERE sql_text LIKE "%DROP_TABLE%drop table t2%"] = 1
+--source include/assert.inc
+
+--let $assert_text = There is one slow log entry for create table t2
+--let $assert_cond= [SELECT count(*) FROM mysql.slow_log WHERE sql_text LIKE "%CREATE_TABLE%create table t2%"] = 1
+--source include/assert.inc
+
+--let $assert_text = There is no slow log entry for create table t3
+--let $assert_cond= [SELECT count(*) FROM mysql.slow_log WHERE sql_text LIKE "%CREATE_TABLE%create table t3%"] = 0
+--source include/assert.inc
+
+--let $assert_text = There is one slow log entry for create table t4
+--let $assert_cond= [SELECT count(*) FROM mysql.slow_log WHERE sql_text LIKE "%CREATE_TABLE%create table t4%"] = 1
+--source include/assert.inc
+
+drop table t2, t3, t4;
+
+truncate mysql.slow_log;
+set global log_output = default;
+set @@global.log_ddl = @my_log_ddl;
+set @@global.log_throttle_ddl = @my_log_throttle_ddl;
+

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -2200,6 +2200,13 @@ Slow_log_throttle log_throttle_qni(&opt_log_throttle_queries_not_using_indexes,
                                    "throttle: %10lu 'index "
                                    "not used' warning(s) suppressed.");
 
+Slow_log_throttle log_throttle_ddl(&opt_log_throttle_ddl,
+                                   &LOCK_log_throttle_ddl,
+                                   Log_throttle::LOG_THROTTLE_WINDOW_SIZE,
+                                   slow_log_write,
+                                   "throttle: %10lu 'ddl' "
+                                   "warning(s) suppressed.");
+
 ////////////////////////////////////////////////////////////
 //
 // Error Log

--- a/sql/log.h
+++ b/sql/log.h
@@ -725,6 +725,7 @@ class Error_log_throttle : public Log_throttle {
 };
 
 extern Slow_log_throttle log_throttle_qni;
+extern Slow_log_throttle log_throttle_ddl;
 
 ////////////////////////////////////////////////////////////
 //

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -904,6 +904,7 @@ static PSI_mutex_key key_LOCK_password_history;
 static PSI_mutex_key key_LOCK_password_reuse_interval;
 static PSI_mutex_key key_LOCK_sql_rand;
 static PSI_mutex_key key_LOCK_log_throttle_qni;
+static PSI_mutex_key key_LOCK_log_throttle_ddl;
 static PSI_mutex_key key_LOCK_reset_gtid_table;
 static PSI_mutex_key key_LOCK_compress_gtid_table;
 static PSI_mutex_key key_LOCK_collect_instance_log;
@@ -1004,6 +1005,8 @@ bool opt_general_log, opt_slow_log, opt_general_log_raw;
 ulonglong log_output_options;
 bool opt_log_queries_not_using_indexes = 0;
 ulong opt_log_throttle_queries_not_using_indexes = 0;
+bool opt_log_ddl = false;
+ulong opt_log_throttle_ddl = 0;
 bool opt_log_slow_extra = false;
 bool opt_improved_dup_key_error = false;
 bool opt_disable_networking = 0, opt_skip_show_db = 0;
@@ -1448,6 +1451,7 @@ mysql_mutex_t LOCK_sql_slave_skip_counter;
 mysql_mutex_t LOCK_slave_net_timeout;
 mysql_mutex_t LOCK_slave_trans_dep_tracker;
 mysql_mutex_t LOCK_log_throttle_qni;
+mysql_mutex_t LOCK_log_throttle_ddl;
 mysql_rwlock_t LOCK_sys_init_connect, LOCK_sys_init_slave;
 mysql_rwlock_t LOCK_system_variables_hash;
 my_thread_handle signal_thread_id;
@@ -2450,6 +2454,7 @@ static void clean_up(bool print_message) {
 
 static void clean_up_mutexes() {
   mysql_mutex_destroy(&LOCK_log_throttle_qni);
+  mysql_mutex_destroy(&LOCK_log_throttle_ddl);
   mysql_mutex_destroy(&LOCK_status);
   mysql_mutex_destroy(&LOCK_manager);
   mysql_mutex_destroy(&LOCK_crypt);
@@ -4906,6 +4911,8 @@ static int init_thread_environment() {
                    MY_MUTEX_INIT_FAST);
   mysql_mutex_init(key_LOCK_sql_rand, &LOCK_sql_rand, MY_MUTEX_INIT_FAST);
   mysql_mutex_init(key_LOCK_log_throttle_qni, &LOCK_log_throttle_qni,
+                   MY_MUTEX_INIT_FAST);
+  mysql_mutex_init(key_LOCK_log_throttle_ddl, &LOCK_log_throttle_ddl,
                    MY_MUTEX_INIT_FAST);
   mysql_mutex_init(key_LOCK_default_password_lifetime,
                    &LOCK_default_password_lifetime, MY_MUTEX_INIT_FAST);
@@ -10915,6 +10922,7 @@ static PSI_mutex_info all_server_mutexes[]=
   { &key_TABLE_SHARE_LOCK_ha_data, "TABLE_SHARE::LOCK_ha_data", 0, 0, PSI_DOCUMENT_ME},
   { &key_LOCK_error_messages, "LOCK_error_messages", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
   { &key_LOCK_log_throttle_qni, "LOCK_log_throttle_qni", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
+  { &key_LOCK_log_throttle_ddl, "LOCK_log_throttle_ddl", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
   { &key_gtid_ensure_index_mutex, "Gtid_state", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
   { &key_LOCK_query_plan, "THD::LOCK_query_plan", 0, PSI_VOLATILITY_SESSION, PSI_DOCUMENT_ME},
   { &key_LOCK_cost_const, "Cost_constant_cache::LOCK_cost_const", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -164,6 +164,7 @@ extern bool opt_general_log, opt_slow_log, opt_general_log_raw;
 extern ulonglong log_output_options;
 extern bool opt_log_queries_not_using_indexes;
 extern ulong opt_log_throttle_queries_not_using_indexes;
+extern ulong opt_log_throttle_ddl;
 extern bool opt_log_slow_extra;
 extern bool opt_disable_networking, opt_skip_show_db;
 extern bool opt_skip_name_resolve;
@@ -364,6 +365,7 @@ enum enum_binlog_error_action {
 };
 extern const char *binlog_error_action_list[];
 
+extern bool opt_log_ddl;
 extern bool slave_high_priority_ddl;
 extern ulonglong slave_high_priority_lock_wait_timeout_nsec;
 extern double slave_high_priority_lock_wait_timeout_double;
@@ -784,6 +786,7 @@ extern mysql_mutex_t LOCK_manager;
 extern mysql_mutex_t LOCK_global_system_variables;
 extern mysql_mutex_t LOCK_user_conn;
 extern mysql_mutex_t LOCK_log_throttle_qni;
+extern mysql_mutex_t LOCK_log_throttle_ddl;
 extern mysql_mutex_t LOCK_prepared_stmt_count;
 extern mysql_mutex_t LOCK_error_messages;
 extern mysql_mutex_t LOCK_sql_slave_skip_counter;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -2303,6 +2303,20 @@ done:
     mysql_audit_notify(thd, AUDIT_EVENT(MYSQL_AUDIT_GENERAL_RESULT), 0, NULL,
                        0);
 
+  if (opt_log_ddl) {
+    // log to slow log here for a pre-defined set of ddls
+    auto it = slow_log_ddls.find(thd->lex->sql_command);
+    if (it != slow_log_ddls.end() && !log_throttle_ddl.log(thd, true)) {
+      /* log the ddl */
+      bool old_enable_slow_log = thd->enable_slow_log;
+      thd->enable_slow_log = true;
+      auto output = it->second + ": " + get_user_query_info_from_thd(thd);
+      query_logger.slow_log_write(thd, output.c_str(), output.size(),
+                                  &(thd->status_var));
+      thd->enable_slow_log = old_enable_slow_log;
+    }
+  }
+
   mysql_audit_notify(
       thd, AUDIT_EVENT(MYSQL_AUDIT_GENERAL_STATUS),
       thd->get_stmt_da()->is_error() ? thd->get_stmt_da()->mysql_errno() : 0,
@@ -7539,4 +7553,28 @@ bool merge_sp_var_charset_and_collation(const CHARSET_INFO *charset,
     return true;
   }
   return merge_charset_and_collation(charset, collation, to);
+}
+
+std::string get_user_query_info_from_thd(THD *thd) {
+  DBUG_ASSERT(thd);
+
+  std::string user_info;
+  if (thd->security_context()->user().length) {
+    // log the user
+    user_info += thd->security_context()->user().str;
+  }
+  if (thd->security_context()->host_or_ip().length) {
+    // log the hostname or ip
+    user_info += std::string("@") + thd->security_context()->host_or_ip().str;
+  }
+  if (thd->db().length) {
+    /* log the session DB */
+    user_info += std::string(" on ") + thd->db().str;
+  }
+  if (thd->query().length) {
+    /* log the query */
+    user_info += std::string(", query: ") + thd->query().str;
+  }
+
+  return user_info;
 }

--- a/sql/sql_parse.h
+++ b/sql/sql_parse.h
@@ -55,6 +55,15 @@ struct Parse_context;
 struct TABLE_LIST;
 union COM_DATA;
 
+const std::unordered_map<int, std::string> slow_log_ddls = {
+    {SQLCOM_CREATE_TABLE, "CREATE_TABLE"},
+    {SQLCOM_ALTER_TABLE, "ALTER_TABLE"},
+    {SQLCOM_DROP_TABLE, "DROP_TABLE"},
+    {SQLCOM_CREATE_INDEX, "CREATE_INDEX"},
+    {SQLCOM_DROP_INDEX, "DROP_INDEX"},
+    {SQLCOM_RENAME_TABLE, "RENAME_TABLE"},
+    {SQLCOM_TRUNCATE, "TRUNCATE_TABLE"}};
+
 extern "C" int test_if_data_home_dir(const char *dir);
 
 bool stmt_causes_implicit_commit(const THD *thd, uint mask);
@@ -314,4 +323,5 @@ bool set_db_read_only(HA_CREATE_INFO *create_info, int super_read_only, int on);
   @} (end of group GROUP_PARSER)
 */
 
+std::string get_user_query_info_from_thd(THD *thd);
 #endif /* SQL_PARSE_INCLUDED */

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -7217,6 +7217,27 @@ static Sys_var_bool Sys_improved_dup_key_error(
     "key error and log the query into a new duplicate key query log file.",
     GLOBAL_VAR(opt_improved_dup_key_error), CMD_LINE(OPT_ARG), DEFAULT(false));
 
+static Sys_var_bool Sys_log_ddl("log_ddl", "Log ddls in slow query log.",
+                                GLOBAL_VAR(opt_log_ddl), CMD_LINE(OPT_ARG),
+                                DEFAULT(false));
+
+static bool update_log_throttle_ddl(sys_var *, THD *thd, enum_var_type) {
+  // Check if we should print a summary of any suppressed lines to the slow log
+  // now since opt_log_throttle_ddl was changed.
+  log_throttle_ddl.flush(thd);
+  return false;
+}
+
+static Sys_var_ulong Sys_log_throttle_ddl(
+    "log_throttle_ddl",
+    "Log at most this many DDL entries per minute to the "
+    "slow log. Any further warnings will be condensed into a single "
+    "summary line. A value of 0 disables throttling. "
+    "Option has no effect unless --log_ddl is set.",
+    GLOBAL_VAR(opt_log_throttle_ddl), CMD_LINE(OPT_ARG),
+    VALID_RANGE(0, ULONG_MAX), DEFAULT(0), BLOCK_SIZE(1), NO_MUTEX_GUARD,
+    NOT_IN_BINLOG, ON_CHECK(0), ON_UPDATE(update_log_throttle_ddl));
+
 static Sys_var_bool Sys_high_priority_ddl(
     "high_priority_ddl",
     "Setting this flag will allow DDL commands to kill conflicting "


### PR DESCRIPTION
Summary: We want to find out what non-AOSC systems do create/alter/drop tables. This change logs the 3 ddls into slow query log. The key information includes: user, host, database and query.

Reference patch: https://github.com/facebook/mysql-5.6/commit/de0bf944997
fbshipit-source-id: d5d739a07b7

**TO DO: Please re-record `mysql-test/t/all_persisted_variables.test` with
`let $total_persistent_vars=XXX + 2;` (2 new variables).**
