### PR TITLE
Fix rpl_nogtid.rpl_semi_sync_deadlock MTR test

### DIFF
--- a/mysql-test/extra/rpl_tests/rpl_semi_sync_deadlock.test
+++ b/mysql-test/extra/rpl_tests/rpl_semi_sync_deadlock.test
@@ -13,6 +13,7 @@ while ($i < $n)
 --sync_slave_with_master
 
 --connection master
+CALL mtr.add_suppression("Timeout waiting for reply of binlog");
 SET GLOBAL debug= 'd,semi_sync_3-way_deadlock';
 SET GLOBAL debug= '+d,dump_thread_before_read_event';
 SET DEBUG_SYNC= "before_process_commit_stage_queue WAIT_FOR signal.continue no_clear_event";
@@ -46,7 +47,13 @@ while ($i < $n)
 
 --connection master1
 SET DEBUG_SYNC= "before_rotate_binlog SIGNAL signal.continue";
---real_sleep 3
+--let $_saved_pos= query_get_value(SHOW MASTER STATUS, Position, 1)
+# wait for binlog event INSERT INTO t1 VALUES(2) that starts at 2186
+while ($_saved_pos < 2200)
+{
+  --let $_saved_pos= query_get_value(SHOW MASTER STATUS, Position, 1)
+}
+
 --echo # Rotate binlog file
 FLUSH LOGS;
 

--- a/mysql-test/suite/rpl_nogtid/r/rpl_semi_sync_deadlock.result
+++ b/mysql-test/suite/rpl_nogtid/r/rpl_semi_sync_deadlock.result
@@ -6,10 +6,11 @@ Note	####	Storing MySQL user name or password information in the master info rep
 include/install_semisync.inc
 # Initialization
 SET @debug_save= @@GLOBAL.DEBUG;
-SET GLOBAL rpl_semi_sync_master_timeout= 6000000;
+SET GLOBAL rpl_semi_sync_master_timeout= 30000;
 #
 # Verify no deadlock at AFTER_SYNC
 #
+CALL mtr.add_suppression("Timeout waiting for reply of binlog");
 SET GLOBAL debug= 'd,semi_sync_3-way_deadlock';
 SET GLOBAL debug= '+d,dump_thread_before_read_event';
 SET DEBUG_SYNC= "before_process_commit_stage_queue WAIT_FOR signal.continue no_clear_event";
@@ -22,6 +23,7 @@ FLUSH LOGS;
 # Verify no deadlock at AFTER_COMMIT
 #
 SET GLOBAL rpl_semi_sync_master_wait_point= AFTER_COMMIT;
+CALL mtr.add_suppression("Timeout waiting for reply of binlog");
 SET GLOBAL debug= 'd,semi_sync_3-way_deadlock';
 SET GLOBAL debug= '+d,dump_thread_before_read_event';
 SET DEBUG_SYNC= "before_process_commit_stage_queue WAIT_FOR signal.continue no_clear_event";

--- a/mysql-test/suite/rpl_nogtid/t/rpl_semi_sync_deadlock.test
+++ b/mysql-test/suite/rpl_nogtid/t/rpl_semi_sync_deadlock.test
@@ -11,7 +11,7 @@
 
 --echo # Initialization
 SET @debug_save= @@GLOBAL.DEBUG;
-SET GLOBAL rpl_semi_sync_master_timeout= 6000000;
+SET GLOBAL rpl_semi_sync_master_timeout= 30000;
 
 --echo #
 --echo # Verify no deadlock at AFTER_SYNC


### PR DESCRIPTION
https://github.com/facebook/mysql-5.6/commit/6cfc2bfba63 introduces a 5-way deadlock in `rpl_nogtid.rpl_semi_sync_deadlock`:
- Thread 1 at `Stage_manager::enroll_for(SYNC_STAGE)` acquired LOCK_log + waits for LOCK_sync
- Thread 2 at `Stage_manager::enroll_for(COMMIT_STAGE)` acquired LOCK_sync + waits for LOCK_commit
- Thread 3 at `ReplSemiSyncMaster::commitTrx` acquired LOCK_commit waits for a semi-sync ACK
- Thread 4 at `Binlog_sender::read_event` is blocked with `SET GLOBAL debug= '+d,dump_thread_before_read_event'`  so a semi-sync ACK will not be send
- Thread 5 at `MYSQL_BIN_LOG::rotate_and_purge` tries to acquire LOCK_log and unblock dump_thread_before_read_event

This patch:
- set `rpl_semi_sync_master_timeout= 30000` that is 30 seconds (it was 6000 seconds before)
- allow this test to pass even when `rpl_semi_sync_master_timeout` is reached