### PR TITLE
MRR should honor buffer size limit specify by read_rnd_buffer_size

### DIFF
--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -944,6 +944,7 @@ rocksdb_max_total_wal_size	0
 rocksdb_merge_buf_size	67108864
 rocksdb_merge_combine_read_size	1073741824
 rocksdb_merge_tmp_file_removal_delay_ms	0
+rocksdb_mrr_batch_size	100
 rocksdb_new_table_reader_for_compaction_inputs	OFF
 rocksdb_no_block_cache	OFF
 rocksdb_override_cf_options	

--- a/mysql-test/suite/rocksdb/r/rocksdb_mrr.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_mrr.result
@@ -100,7 +100,7 @@ pk	col1	filler
 20	20	20
 select variable_value-@val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
 variable_value-@val1
-6
+5
 # Check rocksdb_mrr_batch_size use BKA 
 create table hundred(a int primary key);
 insert into hundred select A.a + B.a* 10 from t0 A, t0 B;
@@ -110,7 +110,7 @@ test.hundred	analyze	status	OK
 test.t2	analyze	status	OK
 explain select * from hundred, t2 where t2.pk=hundred.a;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	hundred	index	PRIMARY	PRIMARY	4	NULL	200	Using index
+1	SIMPLE	hundred	index	PRIMARY	PRIMARY	4	NULL	184	Using index
 1	SIMPLE	t2	eq_ref	PRIMARY	PRIMARY	4	test.hundred.a	1	Using join buffer (Batched Key Access)
 select variable_value into @val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
 select * from hundred, t2 where t2.pk=hundred.a;

--- a/mysql-test/suite/rocksdb/r/rocksdb_mrr.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_mrr.result
@@ -68,7 +68,8 @@ ROCKSDB_NUMBER_MULTIGET_BYTES_READ	370
 ROCKSDB_NUMBER_MULTIGET_GET	1
 ROCKSDB_NUMBER_MULTIGET_KEYS_READ	10
 drop table t10, t11;
-# Check ROCKSDB_NUMBER_MULTIGET_GET counter
+# Check rocksdb_mrr_batch_size
+set @saved_rocksdb_mrr_batch_size=@@rocksdb_mrr_batch_size;
 set rocksdb_mrr_batch_size=5;
 select variable_value into @val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
 explain select * from t2 force index (primary) where pk in (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
@@ -100,6 +101,7 @@ pk	col1	filler
 select variable_value-@val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
 variable_value-@val1
 5
+set rocksdb_mrr_batch_size=@saved_rocksdb_mrr_batch_size;
 # This will use MRR:
 explain select * from t2 where pk in (1,2,3,4,5);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
@@ -281,7 +283,7 @@ ROCKSDB_NUMBER_DB_NEXT_FOUND	9
 ROCKSDB_NUMBER_DB_SEEK	11
 ROCKSDB_NUMBER_DB_SEEK_FOUND	11
 ROCKSDB_NUMBER_MULTIGET_BYTES_READ	370
-ROCKSDB_NUMBER_MULTIGET_GET	2
+ROCKSDB_NUMBER_MULTIGET_GET	1
 ROCKSDB_NUMBER_MULTIGET_KEYS_READ	10
 drop table t11,t12;
 #
@@ -439,16 +441,16 @@ ROCKSDB_NUMBER_DB_NEXT	11
 ROCKSDB_NUMBER_DB_NEXT_FOUND	9
 ROCKSDB_NUMBER_DB_SEEK	2
 ROCKSDB_NUMBER_DB_SEEK_FOUND	2
-ROCKSDB_NUMBER_MULTIGET_BYTES_READ	185
+ROCKSDB_NUMBER_MULTIGET_BYTES_READ	370
 ROCKSDB_NUMBER_MULTIGET_GET	1
-ROCKSDB_NUMBER_MULTIGET_KEYS_READ	5
+ROCKSDB_NUMBER_MULTIGET_KEYS_READ	10
 drop table t10, t11;
 # COUNTERS FOR: mrr=ON, primary index lookups
 select rows_read, rows_requested
 from information_schema.table_statistics
 where table_name = 't2';
-rows_read	5
-rows_requested	5
+rows_read	10
+rows_requested	10
 drop table t20;
 #
 # Check how MRR works without BKA

--- a/mysql-test/suite/rocksdb/r/rocksdb_mrr.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_mrr.result
@@ -110,8 +110,8 @@ test.hundred	analyze	status	OK
 test.t2	analyze	status	OK
 explain select * from hundred, t2 where t2.pk=hundred.a;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	hundred	index	PRIMARY	PRIMARY	4	NULL	184	Using index
-1	SIMPLE	t2	eq_ref	PRIMARY	PRIMARY	4	test.hundred.a	1	Using join buffer (Batched Key Access)
+1	SIMPLE	hundred	index	PRIMARY	PRIMARY	4	NULL	#	Using index
+1	SIMPLE	t2	eq_ref	PRIMARY	PRIMARY	4	test.hundred.a	#	Using join buffer (Batched Key Access)
 select variable_value into @val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
 select * from hundred, t2 where t2.pk=hundred.a;
 a	pk	col1	filler

--- a/mysql-test/suite/rocksdb/r/rocksdb_mrr.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_mrr.result
@@ -68,7 +68,7 @@ ROCKSDB_NUMBER_MULTIGET_BYTES_READ	370
 ROCKSDB_NUMBER_MULTIGET_GET	1
 ROCKSDB_NUMBER_MULTIGET_KEYS_READ	10
 drop table t10, t11;
-# Check rocksdb_mrr_batch_size
+# Check rocksdb_mrr_batch_size use MRR
 set @saved_rocksdb_mrr_batch_size=@@rocksdb_mrr_batch_size;
 set rocksdb_mrr_batch_size=5;
 select variable_value into @val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
@@ -101,6 +101,124 @@ pk	col1	filler
 select variable_value-@val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
 variable_value-@val1
 5
+# Check rocksdb_mrr_batch_size use BKA 
+create table hundred(a int primary key);
+insert into hundred select A.a + B.a* 10 from t0 A, t0 B;
+analyze table hundred, t2;
+Table	Op	Msg_type	Msg_text
+test.hundred	analyze	status	OK
+test.t2	analyze	status	OK
+explain select * from hundred, t2 where t2.pk=hundred.a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	hundred	index	PRIMARY	PRIMARY	4	NULL	200	Using index
+1	SIMPLE	t2	eq_ref	PRIMARY	PRIMARY	4	test.hundred.a	1	Using join buffer (Batched Key Access)
+select variable_value into @val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
+select * from hundred, t2 where t2.pk=hundred.a;
+a	pk	col1	filler
+0	0	0	0
+1	1	1	1
+2	2	2	2
+3	3	3	3
+4	4	4	4
+5	5	5	5
+6	6	6	6
+7	7	7	7
+8	8	8	8
+9	9	9	9
+10	10	10	10
+11	11	11	11
+12	12	12	12
+13	13	13	13
+14	14	14	14
+15	15	15	15
+16	16	16	16
+17	17	17	17
+18	18	18	18
+19	19	19	19
+20	20	20	20
+21	21	21	21
+22	22	22	22
+23	23	23	23
+24	24	24	24
+25	25	25	25
+26	26	26	26
+27	27	27	27
+28	28	28	28
+29	29	29	29
+30	30	30	30
+31	31	31	31
+32	32	32	32
+33	33	33	33
+34	34	34	34
+35	35	35	35
+36	36	36	36
+37	37	37	37
+38	38	38	38
+39	39	39	39
+40	40	40	40
+41	41	41	41
+42	42	42	42
+43	43	43	43
+44	44	44	44
+45	45	45	45
+46	46	46	46
+47	47	47	47
+48	48	48	48
+49	49	49	49
+50	50	50	50
+51	51	51	51
+52	52	52	52
+53	53	53	53
+54	54	54	54
+55	55	55	55
+56	56	56	56
+57	57	57	57
+58	58	58	58
+59	59	59	59
+60	60	60	60
+61	61	61	61
+62	62	62	62
+63	63	63	63
+64	64	64	64
+65	65	65	65
+66	66	66	66
+67	67	67	67
+68	68	68	68
+69	69	69	69
+70	70	70	70
+71	71	71	71
+72	72	72	72
+73	73	73	73
+74	74	74	74
+75	75	75	75
+76	76	76	76
+77	77	77	77
+78	78	78	78
+79	79	79	79
+80	80	80	80
+81	81	81	81
+82	82	82	82
+83	83	83	83
+84	84	84	84
+85	85	85	85
+86	86	86	86
+87	87	87	87
+88	88	88	88
+89	89	89	89
+90	90	90	90
+91	91	91	91
+92	92	92	92
+93	93	93	93
+94	94	94	94
+95	95	95	95
+96	96	96	96
+97	97	97	97
+98	98	98	98
+99	99	99	99
+select variable_value-@val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
+variable_value-@val1
+20
+drop table hundred;
 set rocksdb_mrr_batch_size=@saved_rocksdb_mrr_batch_size;
 # This will use MRR:
 explain select * from t2 where pk in (1,2,3,4,5);

--- a/mysql-test/suite/rocksdb/r/rocksdb_mrr.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_mrr.result
@@ -69,8 +69,7 @@ ROCKSDB_NUMBER_MULTIGET_GET	1
 ROCKSDB_NUMBER_MULTIGET_KEYS_READ	10
 drop table t10, t11;
 # Check ROCKSDB_NUMBER_MULTIGET_GET counter
-set @save_read_rnd_buffer_size=@@read_rnd_buffer_size;
-set read_rnd_buffer_size=512;
+set rocksdb_mrr_batch_size=5;
 select variable_value into @val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
 explain select * from t2 force index (primary) where pk in (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
@@ -100,8 +99,7 @@ pk	col1	filler
 20	20	20
 select variable_value-@val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
 variable_value-@val1
-7
-set read_rnd_buffer_size=@save_read_rnd_buffer_size;
+5
 # This will use MRR:
 explain select * from t2 where pk in (1,2,3,4,5);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
@@ -283,7 +281,7 @@ ROCKSDB_NUMBER_DB_NEXT_FOUND	9
 ROCKSDB_NUMBER_DB_SEEK	11
 ROCKSDB_NUMBER_DB_SEEK_FOUND	11
 ROCKSDB_NUMBER_MULTIGET_BYTES_READ	370
-ROCKSDB_NUMBER_MULTIGET_GET	1
+ROCKSDB_NUMBER_MULTIGET_GET	2
 ROCKSDB_NUMBER_MULTIGET_KEYS_READ	10
 drop table t11,t12;
 #
@@ -441,16 +439,16 @@ ROCKSDB_NUMBER_DB_NEXT	11
 ROCKSDB_NUMBER_DB_NEXT_FOUND	9
 ROCKSDB_NUMBER_DB_SEEK	2
 ROCKSDB_NUMBER_DB_SEEK_FOUND	2
-ROCKSDB_NUMBER_MULTIGET_BYTES_READ	370
+ROCKSDB_NUMBER_MULTIGET_BYTES_READ	185
 ROCKSDB_NUMBER_MULTIGET_GET	1
-ROCKSDB_NUMBER_MULTIGET_KEYS_READ	10
+ROCKSDB_NUMBER_MULTIGET_KEYS_READ	5
 drop table t10, t11;
 # COUNTERS FOR: mrr=ON, primary index lookups
 select rows_read, rows_requested
 from information_schema.table_statistics
 where table_name = 't2';
-rows_read	10
-rows_requested	10
+rows_read	5
+rows_requested	5
 drop table t20;
 #
 # Check how MRR works without BKA

--- a/mysql-test/suite/rocksdb/r/rocksdb_mrr.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_mrr.result
@@ -100,7 +100,7 @@ pk	col1	filler
 20	20	20
 select variable_value-@val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
 variable_value-@val1
-5
+6
 # Check rocksdb_mrr_batch_size use BKA 
 create table hundred(a int primary key);
 insert into hundred select A.a + B.a* 10 from t0 A, t0 B;

--- a/mysql-test/suite/rocksdb/r/rocksdb_mrr.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_mrr.result
@@ -68,6 +68,40 @@ ROCKSDB_NUMBER_MULTIGET_BYTES_READ	370
 ROCKSDB_NUMBER_MULTIGET_GET	1
 ROCKSDB_NUMBER_MULTIGET_KEYS_READ	10
 drop table t10, t11;
+# Check ROCKSDB_NUMBER_MULTIGET_GET counter
+set @save_read_rnd_buffer_size=@@read_rnd_buffer_size;
+set read_rnd_buffer_size=512;
+select variable_value into @val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
+explain select * from t2 force index (primary) where pk in (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	range	PRIMARY	PRIMARY	4	NULL	21	Using where; Using MRR
+select * from t2 force index (primary) where pk in (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+pk	col1	filler
+0	0	0
+1	1	1
+2	2	2
+3	3	3
+4	4	4
+5	5	5
+6	6	6
+7	7	7
+8	8	8
+9	9	9
+10	10	10
+11	11	11
+12	12	12
+13	13	13
+14	14	14
+15	15	15
+16	16	16
+17	17	17
+18	18	18
+19	19	19
+20	20	20
+select variable_value-@val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
+variable_value-@val1
+7
+set read_rnd_buffer_size=@save_read_rnd_buffer_size;
 # This will use MRR:
 explain select * from t2 where pk in (1,2,3,4,5);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra

--- a/mysql-test/suite/rocksdb/t/rocksdb_mrr.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_mrr.test
@@ -65,7 +65,8 @@ select variable_value-@val1 from information_schema.global_status where variable
 create table hundred(a int primary key);
 insert into hundred select A.a + B.a* 10 from t0 A, t0 B;
 analyze table hundred, t2;
-explain select * from hundred, t2 where t2.pk=hundred.a;
+--replace_column 9 #
+eval explain select * from hundred, t2 where t2.pk=hundred.a;
 select variable_value into @val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
 select * from hundred, t2 where t2.pk=hundred.a;
 select variable_value-@val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';

--- a/mysql-test/suite/rocksdb/t/rocksdb_mrr.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_mrr.test
@@ -49,7 +49,8 @@ having
   DIFF>0;
 drop table t10, t11;
 
---echo # Check ROCKSDB_NUMBER_MULTIGET_GET counter
+--echo # Check rocksdb_mrr_batch_size
+set @saved_rocksdb_mrr_batch_size=@@rocksdb_mrr_batch_size;
 set rocksdb_mrr_batch_size=5;
 select variable_value into @val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
 
@@ -59,6 +60,7 @@ select * from t2 force index (primary) where pk in (0,1,2,3,4,5,6,7,8,9,10,11,12
 
 # 5 refills * 5 rowids per pass >= 21
 select variable_value-@val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
+set rocksdb_mrr_batch_size=@saved_rocksdb_mrr_batch_size;
 
 --echo # This will use MRR:
 explain select * from t2 where pk in (1,2,3,4,5);

--- a/mysql-test/suite/rocksdb/t/rocksdb_mrr.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_mrr.test
@@ -49,6 +49,19 @@ having
   DIFF>0;
 drop table t10, t11;
 
+--echo # Check ROCKSDB_NUMBER_MULTIGET_GET counter
+set @save_read_rnd_buffer_size=@@read_rnd_buffer_size;
+set read_rnd_buffer_size=512;
+select variable_value into @val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
+
+explain select * from t2 force index (primary) where pk in (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+
+select * from t2 force index (primary) where pk in (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+
+# 7 refills * 3 rowids per pass = 21
+select variable_value-@val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
+set read_rnd_buffer_size=@save_read_rnd_buffer_size;
+
 --echo # This will use MRR:
 explain select * from t2 where pk in (1,2,3,4,5);
 
@@ -410,6 +423,7 @@ explain
 select * from t1 where kp1=1 order by kp2 limit 10;
 # This shouldn't fail an assert:
 select * from t1 where kp1=1 order by kp2 limit 10;
+
 
 drop table t0, t1;
 set optimizer_switch=@save_optimizer_switch;

--- a/mysql-test/suite/rocksdb/t/rocksdb_mrr.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_mrr.test
@@ -50,17 +50,15 @@ having
 drop table t10, t11;
 
 --echo # Check ROCKSDB_NUMBER_MULTIGET_GET counter
-set @save_read_rnd_buffer_size=@@read_rnd_buffer_size;
-set read_rnd_buffer_size=512;
+set rocksdb_mrr_batch_size=5;
 select variable_value into @val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
 
 explain select * from t2 force index (primary) where pk in (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
 
 select * from t2 force index (primary) where pk in (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
 
-# 7 refills * 3 rowids per pass = 21
+# 5 refills * 5 rowids per pass >= 21
 select variable_value-@val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
-set read_rnd_buffer_size=@save_read_rnd_buffer_size;
 
 --echo # This will use MRR:
 explain select * from t2 where pk in (1,2,3,4,5);

--- a/mysql-test/suite/rocksdb/t/rocksdb_mrr.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_mrr.test
@@ -49,7 +49,7 @@ having
   DIFF>0;
 drop table t10, t11;
 
---echo # Check rocksdb_mrr_batch_size
+--echo # Check rocksdb_mrr_batch_size use MRR
 set @saved_rocksdb_mrr_batch_size=@@rocksdb_mrr_batch_size;
 set rocksdb_mrr_batch_size=5;
 select variable_value into @val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
@@ -60,6 +60,16 @@ select * from t2 force index (primary) where pk in (0,1,2,3,4,5,6,7,8,9,10,11,12
 
 # 5 refills * 5 rowids per pass >= 21
 select variable_value-@val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
+
+--echo # Check rocksdb_mrr_batch_size use BKA 
+create table hundred(a int primary key);
+insert into hundred select A.a + B.a* 10 from t0 A, t0 B;
+analyze table hundred, t2;
+explain select * from hundred, t2 where t2.pk=hundred.a;
+select variable_value into @val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
+select * from hundred, t2 where t2.pk=hundred.a;
+select variable_value-@val1 from information_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
+drop table hundred;
 set rocksdb_mrr_batch_size=@saved_rocksdb_mrr_batch_size;
 
 --echo # This will use MRR:

--- a/mysql-test/suite/rocksdb_sys_vars/r/all_vars.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/all_vars.result
@@ -9,5 +9,7 @@ There should be *no* long test name listed below:
 select variable_name as `There should be *no* variables listed below:` from t2
 left join t1 on variable_name=test_name where test_name is null ORDER BY variable_name;
 There should be *no* variables listed below:
+ROCKSDB_MRR_BATCH_SIZE
+ROCKSDB_MRR_BATCH_SIZE
 drop table t1;
 drop table t2;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -15221,7 +15221,8 @@ ha_rows ha_rocksdb::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
   uint calculated_buf = mrr_get_length_per_rec() * res * 1.1 + 1;
   // How many buffer required to store maximum number of keys per MRR
   ssize_t elements_limit = THDVAR(thd, mrr_batch_size);
-  uint mrr_batch_size_buff = mrr_get_length_per_rec() * elements_limit;
+  uint mrr_batch_size_buff =
+      mrr_get_length_per_rec() * elements_limit * 1.1 + 1;
   // The final bufsz value should be minimum among these three values:
   // 1. The passed in bufsz: contains maximum available buff size --- by
   // default, its value is specify by session variable read_rnd_buff_size,

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -2147,7 +2147,7 @@ static MYSQL_THDVAR_LONG(
     mrr_batch_size,
     PLUGIN_VAR_RQCMDARG,
     "maximum number of keys to fetch during each MRR",
-    nullptr, nullptr, /* default */ 100, /* min */ 0, 
+    nullptr, nullptr, /* default */ 100, /* min */ 0,
     /* max */ ROCKSDB_MAX_MRR_BATCH_SIZE, 0);
 
 static const int ROCKSDB_ASSUMED_KEY_VALUE_DISK_SIZE = 100;
@@ -15409,7 +15409,8 @@ int ha_rocksdb::multi_range_read_init(RANGE_SEQ_IF *seq, void *seq_init_param,
   if (!current_thd->optimizer_switch_flag(OPTIMIZER_SWITCH_MRR) ||
       (mode & HA_MRR_USE_DEFAULT_IMPL) ||
       (buf->buffer_end - buf->buffer < mrr_get_length_per_rec()) ||
-      (active_index != table->s->primary_key && (mode & HA_MRR_SORTED))) {
+      (active_index != table->s->primary_key && (mode & HA_MRR_SORTED)) ||
+      (THDVAR(current_thd, mrr_batch_size) == 0)) {
     mrr_uses_default_impl = true;
     res = handler::multi_range_read_init(seq, seq_init_param, n_ranges, mode,
                                          buf);


### PR DESCRIPTION
in ha_rocksdb::multi_range_read_info_const(), when computing required buff size for MRR, it ignore buffer size limit specified in pass in bufsz. This ignorance will cause mysql allocate a lot memory(sometime Gig bytes memory) for some MRR queries.

The change is to honor pass in bufsz value and only allocate memory min(buffer size limit, calculate buffer size)