### PR TITLE
copy truncated binlog file to tmp dir

### DIFF
--- a/mysql-test/suite/rocksdb/r/binlog_truncate_backup.result
+++ b/mysql-test/suite/rocksdb/r/binlog_truncate_backup.result
@@ -1,0 +1,28 @@
+CALL mtr.add_suppression("Taking backup from .*");
+CALL mtr.add_suppression("Error reading GTIDs from binary log");
+CREATE TABLE t1(c1 INT) ENGINE=rocksdb;
+INSERT INTO t1 VALUES(1);
+COMMIT;
+# Crash right after flushing binary log
+SET SESSION DEBUG="+d,crash_after_flush_binlog";
+INSERT INTO t1 VALUES(2);
+ERROR HY000: Lost connection to MySQL server during query
+# Restart the master server
+# Verify that the trx was rolled back
+include/assert.inc [t1 should have 1 row]
+
+# Verify that binlog backup was taken before truncating
+1
+INSERT INTO t1 VALUES(10);
+COMMIT;
+# Crash right after flushing binary log
+SET SESSION DEBUG="+d,crash_after_flush_binlog";
+INSERT INTO t1 VALUES(2);
+ERROR HY000: Lost connection to MySQL server during query
+# Restart the master server
+# Verify that the trx was rolled back
+include/assert.inc [t1 should have 2 rows]
+
+# Verify that binlog backup was taken before truncating
+1
+DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/t/binlog_truncate_backup-master.opt
+++ b/mysql-test/suite/rocksdb/t/binlog_truncate_backup-master.opt
@@ -1,0 +1,2 @@
+--trim-binlog-to-recover
+--binlog_format=row

--- a/mysql-test/suite/rocksdb/t/binlog_truncate_backup.test
+++ b/mysql-test/suite/rocksdb/t/binlog_truncate_backup.test
@@ -1,0 +1,75 @@
+#
+# verify that when a binlog gets truncated, a backup gets stored in the tmpdir
+#
+--source include/not_valgrind.inc
+--source include/have_log_bin.inc
+--source include/have_debug.inc
+--source include/have_rocksdb.inc
+
+CALL mtr.add_suppression("Taking backup from .*");
+CALL mtr.add_suppression("Error reading GTIDs from binary log");
+
+CREATE TABLE t1(c1 INT) ENGINE=rocksdb;
+INSERT INTO t1 VALUES(1);
+COMMIT;
+
+# Simulate after writing to binlog, but before commiting to engine
+# On restart the trx will be rolled back. binlog will be truncated and a backup
+# will be taken before truncating the binlog
+--exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--echo # Crash right after flushing binary log
+SET SESSION DEBUG="+d,crash_after_flush_binlog";
+# 2013 - CR_SERVER_LOST
+--error CR_SERVER_LOST
+INSERT INTO t1 VALUES(2);
+--source include/wait_until_disconnected.inc
+
+--enable_reconnect
+--echo # Restart the master server
+--exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--source include/wait_until_connected_again.inc
+--disable_reconnect
+
+--echo # Verify that the trx was rolled back
+--let $assert_text = t1 should have 1 row
+--let $assert_cond = [SELECT COUNT(*) from t1] = 1
+--source include/assert.inc
+
+--echo
+--echo # Verify that binlog backup was taken before truncating
+--let $MY_TMPDIR= `select @@tmpdir`
+--exec ls -l $MY_TMPDIR/binlog_backup.trunc | wc -l
+
+INSERT INTO t1 VALUES(10);
+COMMIT;
+# Simulate after writing to binlog, but before commiting to engine
+# On restart the trx will be rolled back. binlog will be truncated and a backup
+# will be taken before truncating the binlog
+# Repeat the crash again to verify that the backup file is overwritten
+--exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--echo # Crash right after flushing binary log
+SET SESSION DEBUG="+d,crash_after_flush_binlog";
+# 2013 - CR_SERVER_LOST
+--error CR_SERVER_LOST
+INSERT INTO t1 VALUES(2);
+--source include/wait_until_disconnected.inc
+
+--enable_reconnect
+--echo # Restart the master server
+--exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--source include/wait_until_connected_again.inc
+--disable_reconnect
+
+--echo # Verify that the trx was rolled back
+--let $assert_text = t1 should have 2 rows
+--let $assert_cond = [SELECT COUNT(*) from t1] = 2
+--source include/assert.inc
+
+--echo
+--echo # Verify that binlog backup was taken before truncating
+--let $MY_TMPDIR= `select @@tmpdir`
+--exec ls -l $MY_TMPDIR/binlog_backup.trunc | wc -l
+
+
+# Cleanup
+DROP TABLE t1;

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -8192,6 +8192,23 @@ int MYSQL_BIN_LOG::open_binlog(const char *opt_name) {
 
       /* Change binlog file size to valid_pos */
       if (valid_pos < binlog_size) {
+        if (opt_trim_binlog) {
+          char backup_file[FN_REFLEN];
+          myf opt = MY_REPLACE_DIR | MY_UNPACK_FILENAME | MY_APPEND_EXT;
+          fn_format(backup_file, "binlog_backup", opt_mysql_tmpdir, ".trunc",
+                    opt);
+
+          // NO_LINT_DEBUG
+          sql_print_error("Taking backup from %s to %s\n", log_name,
+                          backup_file);
+          if (my_copy(log_name, backup_file, MYF(MY_WME))) {
+            // NO_LINT_DEBUG
+            sql_print_error(
+                "Could not take backup of the truncated binlog file %s",
+                log_name);
+          }
+        }
+
         if (ofile->truncate(valid_pos)) {
           LogErr(ERROR_LEVEL, ER_BINLOG_CANT_TRIM_CRASHED_BINLOG);
           return -1;


### PR DESCRIPTION
Summary:
If opt_trim_binlog is set, then mysqld could trim the latest binlog file to
match the engine-commited position. This diff makes mysqld copy the binlog file
to tmpdir (as set in sysvar `tmpdir`) for debugging and safety purpose.

Reference Patch: https://github.com/facebook/mysql-5.6/commit/182d59c4ecc

Originally Reviewed By: yoshinorim

fbshipit-source-id: 1c8d7601174