### PR TITLE
add skip master info for read_only_msg_extra

### DIFF
--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -1818,6 +1818,9 @@ The following options may be given as the first argument:
  --skip-grant-tables Start without grant tables. This gives all users FULL
  ACCESS to all tables.
  --skip-host-cache   Don't cache host names.
+ --skip-master-info-check-for-read-only-error-msg-extra 
+ Skip master info validaton check for read only error
+ messages
  --skip-name-resolve Don't resolve hostnames. All hostnames are IP's or
  'localhost'.
  --skip-networking   Don't allow connection with TCP/IP
@@ -2605,6 +2608,7 @@ show-old-temporals FALSE
 show-slave-auth-info FALSE
 skip-flush-master-info FALSE
 skip-grant-tables TRUE
+skip-master-info-check-for-read-only-error-msg-extra FALSE
 skip-name-resolve FALSE
 skip-networking FALSE
 skip-show-database FALSE

--- a/mysql-test/r/skip_master_info_check_for_read_only_msg_extra.result
+++ b/mysql-test/r/skip_master_info_check_for_read_only_msg_extra.result
@@ -1,0 +1,45 @@
+set @save.read_only = @@global.read_only;
+set @save.skip_master_info_check_for_read_only_error_msg_extra = @@global.skip_master_info_check_for_read_only_error_msg_extra;
+set @save.read_only_error_msg_extra = @@global.read_only_error_msg_extra;
+set global read_only = 1;
+select @@global.read_only;
+@@global.read_only
+1
+select @@global.skip_master_info_check_for_read_only_error_msg_extra;
+@@global.skip_master_info_check_for_read_only_error_msg_extra
+0
+create table tbl (id int primary key);
+set global skip_master_info_check_for_read_only_error_msg_extra = 1;
+# create normal user
+create user normal_user;
+# test empty error msg when skip_master_info_check_for_read_only_error_msg_extra turned on
+insert into tbl values(1);
+ERROR HY000: The MySQL server is running with the --read-only option so it cannot execute this statement
+set global skip_master_info_check_for_read_only_error_msg_extra = 0;
+set global read_only_error_msg_extra='{"new_master": "new_master:1234", "timestamp": 1567019679.2644575}';
+change master to master_host='127.0.0.1', master_user='root';
+Warnings:
+Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	1760	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+# connecting conn with 'normal_user', master info should be displayed
+insert into tbl values(1);
+ERROR HY000: The MySQL server is running with the --read-only option so it cannot execute this statement. Current master_host: 127.0.0.1, master_port: 3306. {"new_master": "new_master:1234", "timestamp": 1567019679.2644575}
+set global skip_master_info_check_for_read_only_error_msg_extra = 1;
+# now skip_master_info_check_for_read_only_error_msg_extra is on, we should display the same read_only_error_msg_extra as previous
+insert into tbl values(1);
+ERROR HY000: The MySQL server is running with the --read-only option so it cannot execute this statement. Current master_host: 127.0.0.1, master_port: 3306. {"new_master": "new_master:1234", "timestamp": 1567019679.2644575}
+# reset master_info
+reset slave all;
+set global skip_master_info_check_for_read_only_error_msg_extra = 0;
+# master_info is empty, we shouldn't display any read_only_error_msg_extra
+insert into tbl values(1);
+ERROR HY000: The MySQL server is running with the --read-only option so it cannot execute this statement
+set global skip_master_info_check_for_read_only_error_msg_extra = 1;
+# now skip_master_info_check_for_read_only_error_msg_extra is on, we should display any read_only_error_msg_extra
+insert into tbl values(1);
+ERROR HY000: The MySQL server is running with the --read-only option so it cannot execute this statement. {"new_master": "new_master:1234", "timestamp": 1567019679.2644575}
+drop user normal_user;
+drop table tbl;
+set global read_only = @save.read_only;
+set global skip_master_info_check_for_read_only_error_msg_extra = @save.skip_master_info_check_for_read_only_error_msg_extra;
+set global read_only_error_msg_extra = @save.read_only_error_msg_extra;

--- a/mysql-test/suite/binlog_nogtid/r/binlog_persist_only_variables.result
+++ b/mysql-test/suite/binlog_nogtid/r/binlog_persist_only_variables.result
@@ -22,6 +22,7 @@ VARIABLE_NAME LIKE '%slave%') AND
 'innodb_master_thread_disabled_debug',
 'binlog_file_basedir', 'binlog_index_basedir',
 'read_only_slave', 'rpl_semi_sync_master_crash_if_active_trxs',
+'skip_master_info_check_for_read_only_error_msg_extra',
 'reset_seconds_behind_master', 'skip_flush_master_info')) AND
 (VARIABLE_NAME NOT LIKE 'rocksdb%')
 ORDER BY VARIABLE_NAME;

--- a/mysql-test/suite/binlog_nogtid/r/binlog_persist_variables.result
+++ b/mysql-test/suite/binlog_nogtid/r/binlog_persist_variables.result
@@ -26,7 +26,7 @@ VARIABLE_NAME LIKE '%slave%') AND
 (VARIABLE_NAME NOT LIKE 'rocksdb%')
 ORDER BY VARIABLE_NAME;
 
-include/assert.inc ['Expect 98 variables in the table.']
+include/assert.inc ['Expect 99 variables in the table.']
 
 # Test SET PERSIST
 SET PERSIST binlog_cache_size = @@GLOBAL.binlog_cache_size;
@@ -116,6 +116,7 @@ SET PERSIST rpl_send_buffer_size = @@GLOBAL.rpl_send_buffer_size;
 SET PERSIST rpl_stop_slave_timeout = @@GLOBAL.rpl_stop_slave_timeout;
 SET PERSIST rpl_wait_for_semi_sync_ack = @@GLOBAL.rpl_wait_for_semi_sync_ack;
 SET PERSIST session_track_gtids = @@GLOBAL.session_track_gtids;
+SET PERSIST skip_master_info_check_for_read_only_error_msg_extra = @@GLOBAL.skip_master_info_check_for_read_only_error_msg_extra;
 SET PERSIST slave_allow_batching = @@GLOBAL.slave_allow_batching;
 SET PERSIST slave_check_before_image_consistency = @@GLOBAL.slave_check_before_image_consistency;
 SET PERSIST slave_checkpoint_group = @@GLOBAL.slave_checkpoint_group;
@@ -149,16 +150,16 @@ SET PERSIST sync_master_info = @@GLOBAL.sync_master_info;
 SET PERSIST sync_relay_log = @@GLOBAL.sync_relay_log;
 SET PERSIST sync_relay_log_info = @@GLOBAL.sync_relay_log_info;
 
-include/assert.inc ['Expect 80 persisted variables in persisted_variables table.']
+include/assert.inc ['Expect 81 persisted variables in persisted_variables table.']
 
 ############################################################
 # 2. Restart server, it must preserve the persisted variable
 #    settings. Verify persisted configuration.
 # restart
 
-include/assert.inc ['Expect 80 persisted variables in persisted_variables table.']
-include/assert.inc ['Expect 80 persisted variables shown as PERSISTED in variables_info table.']
-include/assert.inc ['Expect 80 persisted variables with matching persisted and global values.']
+include/assert.inc ['Expect 81 persisted variables in persisted_variables table.']
+include/assert.inc ['Expect 81 persisted variables shown as PERSISTED in variables_info table.']
+include/assert.inc ['Expect 81 persisted variables with matching persisted and global values.']
 
 ############################################################
 # 3. Test RESET PERSIST IF EXISTS. Verify persisted variable
@@ -263,6 +264,7 @@ RESET PERSIST IF EXISTS rpl_send_buffer_size;
 RESET PERSIST IF EXISTS rpl_stop_slave_timeout;
 RESET PERSIST IF EXISTS rpl_wait_for_semi_sync_ack;
 RESET PERSIST IF EXISTS session_track_gtids;
+RESET PERSIST IF EXISTS skip_master_info_check_for_read_only_error_msg_extra;
 RESET PERSIST IF EXISTS slave_allow_batching;
 RESET PERSIST IF EXISTS slave_check_before_image_consistency;
 RESET PERSIST IF EXISTS slave_checkpoint_group;

--- a/mysql-test/suite/binlog_nogtid/t/binlog_persist_only_variables.test
+++ b/mysql-test/suite/binlog_nogtid/t/binlog_persist_only_variables.test
@@ -52,6 +52,7 @@ INSERT INTO rplvars (varname, varvalue)
         'innodb_master_thread_disabled_debug',
         'binlog_file_basedir', 'binlog_index_basedir',
         'read_only_slave', 'rpl_semi_sync_master_crash_if_active_trxs',
+        'skip_master_info_check_for_read_only_error_msg_extra',
         'reset_seconds_behind_master', 'skip_flush_master_info')) AND
        (VARIABLE_NAME NOT LIKE 'rocksdb%')
        ORDER BY VARIABLE_NAME;

--- a/mysql-test/suite/binlog_nogtid/t/binlog_persist_variables.test
+++ b/mysql-test/suite/binlog_nogtid/t/binlog_persist_variables.test
@@ -62,7 +62,7 @@ INSERT INTO rplvars (varname, varvalue)
 # If this count differs, it means a variable has been added or removed.
 # In that case, this testcase needs to be updated accordingly.
 --echo
---let $expected=98
+--let $expected=99
 --let $assert_text= 'Expect $expected variables in the table.'
 --let $assert_cond= [SELECT COUNT(*) as count FROM rplvars, count, 1] = $expected
 --source include/assert.inc
@@ -85,7 +85,7 @@ while ( $varid <= $countvars )
 }
 
 --echo
---let $expected=80
+--let $expected=81
 --let $assert_text= 'Expect $expected persisted variables in persisted_variables table.'
 --let $assert_cond= [SELECT COUNT(*) as count FROM performance_schema.persisted_variables, count, 1] = $expected
 --source include/assert.inc

--- a/mysql-test/suite/sys_vars/r/all_vars.result
+++ b/mysql-test/suite/sys_vars/r/all_vars.result
@@ -11,6 +11,8 @@ update t2 set variable_name= replace(variable_name, "lock_order_", "lo_");
 select variable_name as `There should be *no* long test name listed below:` from t2
 where length(variable_name) > 50;
 There should be *no* long test name listed below:
+skip_master_info_check_for_read_only_error_msg_extra
+skip_master_info_check_for_read_only_error_msg_extra
 select variable_name as `There should be *no* variables listed below:` from t2
 left join t1 on variable_name=test_name where test_name is null ORDER BY variable_name;
 There should be *no* variables listed below:
@@ -51,6 +53,8 @@ regexp_stack_limit
 regexp_time_limit
 regexp_time_limit
 resultset_metadata
+skip_master_info_check_for_read_only_error_msg_extra
+skip_master_info_check_for_read_only_error_msg_extra
 slave_high_priority_ddl
 slave_high_priority_ddl
 sql_require_primary_key

--- a/mysql-test/suite/sys_vars/r/skip_master_info_check_for_read_only_msg_extra_basic.result
+++ b/mysql-test/suite/sys_vars/r/skip_master_info_check_for_read_only_msg_extra_basic.result
@@ -1,0 +1,15 @@
+Default value of skip_master_info_check_for_read_only_error_msg_extra is 0
+SELECT @@global.skip_master_info_check_for_read_only_error_msg_extra;
+@@global.skip_master_info_check_for_read_only_error_msg_extra
+0
+skip_master_info_check_for_read_only_error_msg_extra is global varialbe
+SELECT @@session.skip_master_info_check_for_read_only_error_msg_extra;
+ERROR HY000: Variable 'skip_master_info_check_for_read_only_error_msg_extra' is a GLOBAL variable
+set @@global.skip_master_info_check_for_read_only_error_msg_extra = 1;
+SELECT @@global.skip_master_info_check_for_read_only_error_msg_extra;
+@@global.skip_master_info_check_for_read_only_error_msg_extra
+1
+SET @@global.skip_master_info_check_for_read_only_error_msg_extra = 0;
+SELECT @@global.skip_master_info_check_for_read_only_error_msg_extra;
+@@global.skip_master_info_check_for_read_only_error_msg_extra
+0

--- a/mysql-test/suite/sys_vars/t/skip_master_info_check_for_read_only_msg_extra_basic.test
+++ b/mysql-test/suite/sys_vars/t/skip_master_info_check_for_read_only_msg_extra_basic.test
@@ -1,0 +1,14 @@
+-- source include/load_sysvars.inc
+
+--echo Default value of skip_master_info_check_for_read_only_error_msg_extra is 0
+SELECT @@global.skip_master_info_check_for_read_only_error_msg_extra;
+
+--echo skip_master_info_check_for_read_only_error_msg_extra is global varialbe
+--Error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.skip_master_info_check_for_read_only_error_msg_extra;
+
+set @@global.skip_master_info_check_for_read_only_error_msg_extra = 1;
+SELECT @@global.skip_master_info_check_for_read_only_error_msg_extra;
+
+SET @@global.skip_master_info_check_for_read_only_error_msg_extra = 0;
+SELECT @@global.skip_master_info_check_for_read_only_error_msg_extra;

--- a/mysql-test/t/skip_master_info_check_for_read_only_msg_extra.test
+++ b/mysql-test/t/skip_master_info_check_for_read_only_msg_extra.test
@@ -1,0 +1,68 @@
+--source include/count_sessions.inc
+
+set @save.read_only = @@global.read_only;
+set @save.skip_master_info_check_for_read_only_error_msg_extra = @@global.skip_master_info_check_for_read_only_error_msg_extra;
+set @save.read_only_error_msg_extra = @@global.read_only_error_msg_extra;
+
+set global read_only = 1;
+
+select @@global.read_only;
+select @@global.skip_master_info_check_for_read_only_error_msg_extra;
+
+create table tbl (id int primary key);
+
+set global skip_master_info_check_for_read_only_error_msg_extra = 1;
+--echo # create normal user
+create user normal_user;
+--connect (conn,localhost,normal_user,,)
+
+--echo # test empty error msg when skip_master_info_check_for_read_only_error_msg_extra turned on
+--Error ER_OPTION_PREVENTS_STATEMENT
+insert into tbl values(1);
+
+--connection default
+set global skip_master_info_check_for_read_only_error_msg_extra = 0;
+set global read_only_error_msg_extra='{"new_master": "new_master:1234", "timestamp": 1567019679.2644575}';
+change master to master_host='127.0.0.1', master_user='root';
+
+--echo # connecting conn with 'normal_user', master info should be displayed
+--connection conn
+--Error ER_OPTION_PREVENTS_STATEMENT
+insert into tbl values(1);
+
+--connection default
+set global skip_master_info_check_for_read_only_error_msg_extra = 1;
+
+--connection conn
+--echo # now skip_master_info_check_for_read_only_error_msg_extra is on, we should display the same read_only_error_msg_extra as previous
+--Error ER_OPTION_PREVENTS_STATEMENT
+insert into tbl values(1);
+
+
+--connection default
+--echo # reset master_info
+reset slave all;
+set global skip_master_info_check_for_read_only_error_msg_extra = 0;
+
+--connection conn
+--echo # master_info is empty, we shouldn't display any read_only_error_msg_extra
+--Error ER_OPTION_PREVENTS_STATEMENT
+insert into tbl values(1);
+
+--connection default
+set global skip_master_info_check_for_read_only_error_msg_extra = 1;
+
+--connection conn
+--echo # now skip_master_info_check_for_read_only_error_msg_extra is on, we should display any read_only_error_msg_extra
+--Error ER_OPTION_PREVENTS_STATEMENT
+insert into tbl values(1);
+
+--connection default
+--disconnect conn
+drop user normal_user;
+drop table tbl;
+set global read_only = @save.read_only;
+set global skip_master_info_check_for_read_only_error_msg_extra = @save.skip_master_info_check_for_read_only_error_msg_extra;
+set global read_only_error_msg_extra = @save.read_only_error_msg_extra;
+
+--source include/wait_until_count_sessions.inc

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1079,6 +1079,7 @@ uint opt_server_id_bits = 0;
 ulong opt_server_id_mask = 0;
 bool read_only = 0, opt_readonly = 0;
 bool super_read_only = 0, opt_super_readonly = 0;
+bool skip_master_info_check_for_read_only_error_msg_extra;
 bool send_error_before_closing_timed_out_connection = 0;
 char *opt_read_only_error_msg_extra;
 bool opt_require_secure_transport = 0;

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -205,6 +205,7 @@ extern char *opt_rbr_column_type_mismatch_whitelist;
 
 extern bool read_only, opt_readonly;
 extern bool super_read_only, opt_super_readonly;
+extern bool skip_master_info_check_for_read_only_error_msg_extra;
 extern bool send_error_before_closing_timed_out_connection;
 extern char *opt_read_only_error_msg_extra;
 extern bool lower_case_file_system;

--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -10160,10 +10160,13 @@ std::string get_active_master_info() {
     str_ptr += mi->host;
     str_ptr += ", master_port: ";
     str_ptr += std::to_string(mi->port);
-    if (opt_read_only_error_msg_extra && opt_read_only_error_msg_extra[0]) {
-      str_ptr += ". ";
-      str_ptr += opt_read_only_error_msg_extra;
-    }
+  }
+
+  if ((Master_info::is_configured(mi) ||
+       skip_master_info_check_for_read_only_error_msg_extra) &&
+      opt_read_only_error_msg_extra && opt_read_only_error_msg_extra[0]) {
+    str_ptr += ". ";
+    str_ptr += opt_read_only_error_msg_extra;
   }
 
   channel_map.unlock();

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -7230,6 +7230,12 @@ static Sys_var_charptr Sys_read_only_error_msg_extra(
     GLOBAL_VAR(opt_read_only_error_msg_extra), CMD_LINE(OPT_ARG),
     IN_SYSTEM_CHARSET, DEFAULT(""), NO_MUTEX_GUARD, NOT_IN_BINLOG);
 
+static Sys_var_bool Sys_skip_master_info_check_for_read_only_error_msg_extra(
+    "skip_master_info_check_for_read_only_error_msg_extra",
+    "Skip master info validaton check for read only error messages",
+    GLOBAL_VAR(skip_master_info_check_for_read_only_error_msg_extra),
+    CMD_LINE(OPT_ARG), DEFAULT(false));
+
 #ifdef HAVE_JEMALLOC
 ulong enable_jemalloc_hpp;
 


### PR DESCRIPTION
Summary: Since it may take some time for smc for propagate new master info, people use read_only_msg_extra to get new master info from old master. However we still have a check for active master info in mysqld. And update active master info may take a few seconds. This might cause a downtime even a new master is kind of ready. Current promote_master command can specifically set new master info during the promotion. It's actually fine to skip the active master info check. For compatibility, let's add a new sys var to pass the active master info check now

Reference Patch: https://github.com/facebook/mysql-5.6/commit/80239b6c7b0

Originally Reviewed By: yoshinorim

fbshipit-source-id: 52b8364284e

**TO DO: Please re-record `mysql-test/t/all_persisted_variables.test` with
`let $total_persistent_vars=XXX + 1;` (a new variable).**