### PR TITLE
Fix innodb_stats_on_metadata corrupting index stats on partitioned tables

### DIFF
--- a/mysql-test/suite/innodb/r/innodb_stats_on_metadata_partitions.result
+++ b/mysql-test/suite/innodb/r/innodb_stats_on_metadata_partitions.result
@@ -1,0 +1,22 @@
+CREATE TABLE t (a INT NOT NULL AUTO_INCREMENT,
+b INT NOT NULL,
+c INT DEFAULT NULL,
+PRIMARY KEY (a, b),
+KEY b (b, c)) ENGINE=InnoDB
+PARTITION BY RANGE (b)
+(PARTITION p0 VALUES LESS THAN (100),
+PARTITION p1 VALUES LESS THAN (200),
+PARTITION p2 VALUES LESS THAN (300),
+PARTITION p3 VALUES LESS THAN (MAXVALUE));
+INSERT INTO t VALUES (NULL, 0, 0);
+INSERT INTO t SELECT NULL, 0, 0 FROM t;
+INSERT INTO t SELECT NULL, 0, 0 FROM t a, t b, t c, t d, t e, t f, t g;
+ANALYZE TABLE t;
+Table	Op	Msg_type	Msg_text
+test.t	analyze	status	OK
+SET innodb_stats_on_metadata = OFF;
+include/assert.inc ["Index 'b' cardinality is expected be 1 (when innodb_stats_on_metadata = OFF)"]
+SET innodb_stats_on_metadata = ON;
+include/assert.inc ["Index 'b' cardinality is expected be 1 (when innodb_stats_on_metadata = ON)"]
+SET innodb_stats_on_metadata = DEFAULT;
+DROP TABLE t;

--- a/mysql-test/suite/innodb/t/innodb_stats_on_metadata_partitions.test
+++ b/mysql-test/suite/innodb/t/innodb_stats_on_metadata_partitions.test
@@ -1,0 +1,34 @@
+CREATE TABLE t (a INT NOT NULL AUTO_INCREMENT,
+                b INT NOT NULL,
+                c INT DEFAULT NULL,
+                PRIMARY KEY (a, b),
+                KEY b (b, c)) ENGINE=InnoDB
+PARTITION BY RANGE (b)
+  (PARTITION p0 VALUES LESS THAN (100),
+   PARTITION p1 VALUES LESS THAN (200),
+   PARTITION p2 VALUES LESS THAN (300),
+   PARTITION p3 VALUES LESS THAN (MAXVALUE));
+
+INSERT INTO t VALUES (NULL, 0, 0);
+INSERT INTO t SELECT NULL, 0, 0 FROM t;
+INSERT INTO t SELECT NULL, 0, 0 FROM t a, t b, t c, t d, t e, t f, t g;
+
+ANALYZE TABLE t;
+
+SET innodb_stats_on_metadata = OFF;
+
+--let $cardinality = query_get_value(SELECT GROUP_CONCAT(Cardinality) AS c FROM information_schema.statistics WHERE Table_name='t' and Index_name='b', c, 1)
+--let $assert_cond = "$cardinality" = "1,1"
+--let $assert_text="Index 'b' cardinality is expected be 1 (when innodb_stats_on_metadata = OFF)"
+--source include/assert.inc
+
+SET innodb_stats_on_metadata = ON;
+
+--let $cardinality = query_get_value(SELECT GROUP_CONCAT(Cardinality) AS c FROM information_schema.statistics WHERE Table_name='t' and Index_name='b', c, 1)
+--let $assert_cond = "$cardinality" = "1,1"
+--let $assert_text="Index 'b' cardinality is expected be 1 (when innodb_stats_on_metadata = ON)"
+--source include/assert.inc
+
+SET innodb_stats_on_metadata = DEFAULT;
+
+DROP TABLE t;


### PR DESCRIPTION
Summary:
The innodb_stats_on_metadata is not correct for partitioned tables.

For partitioned tables, the `info(HA_STATUS_CONST)` call is only done on the largest partition while for most other flags including `HA_STATUS_VARIABLE`, the call is done for all partitions in a loop.

The issue is that `innodb_stats_on_metadata` implicitly converts `info(HA_STATUS_VARIABLE)` calls into `info(HA_STATUS_VARIABLE | HA_STATUS_CONST)` calls. Since this is done in a loop, it means that we're calculating index stats for just the last partition, giving inaccurate statistics.

There's no good way to fix it, because we either need InnoDB to understand partitions, or ther other way around. The latter approach was chosen, so `innodb_stats_on_metadata` is made a server session variable, and ha_partition will do the correct thing if it detects the variable is on, and InnoDB tables are used.

Because MySQL 8 has native partitions, this is a not an issue there, as the native partition code has access to both the innodb_stats_on_metadata variable, and the algorithm for processing info for partitioned tables.

Originally Reviewed By: luqun

fbshipit-source-id: cfdeefcf9ae

8.0 porting notes:
As said earlier in the original description, InnoDB in 8.0 has native
partitions. As only the largest partition is used for the rec_per_key
calculation, the issue is already resolved in the 8.0 branch.