### PR TITLE
Add rocksdb_mrr_batch_size_basic testcase

### DIFF
--- a/mysql-test/r/mysqld--help-notwin-profiling.result
+++ b/mysql-test/r/mysqld--help-notwin-profiling.result
@@ -1486,6 +1486,8 @@ The following options may be given as the first argument:
  sleep (in milliseconds) between calling chsize() to
  truncate the file in chunks.  The chunk size is  the same
  as merge_buf_size.
+ --rocksdb-mrr-batch-size=# 
+ maximum number of keys to fetch during each MRR
  --rocksdb-new-table-reader-for-compaction-inputs 
  DBOptions::new_table_reader_for_compaction_inputs for
  RocksDB
@@ -2487,6 +2489,7 @@ rocksdb-max-total-wal-size 0
 rocksdb-merge-buf-size 67108864
 rocksdb-merge-combine-read-size 1073741824
 rocksdb-merge-tmp-file-removal-delay-ms 0
+rocksdb-mrr-batch-size 100
 rocksdb-new-table-reader-for-compaction-inputs FALSE
 rocksdb-no-block-cache FALSE
 rocksdb-override-cf-options 

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -1484,6 +1484,8 @@ The following options may be given as the first argument:
  sleep (in milliseconds) between calling chsize() to
  truncate the file in chunks.  The chunk size is  the same
  as merge_buf_size.
+ --rocksdb-mrr-batch-size=# 
+ maximum number of keys to fetch during each MRR
  --rocksdb-new-table-reader-for-compaction-inputs 
  DBOptions::new_table_reader_for_compaction_inputs for
  RocksDB
@@ -2484,6 +2486,7 @@ rocksdb-max-total-wal-size 0
 rocksdb-merge-buf-size 67108864
 rocksdb-merge-combine-read-size 1073741824
 rocksdb-merge-tmp-file-removal-delay-ms 0
+rocksdb-mrr-batch-size 100
 rocksdb-new-table-reader-for-compaction-inputs FALSE
 rocksdb-no-block-cache FALSE
 rocksdb-override-cf-options 

--- a/mysql-test/suite/rocksdb_sys_vars/r/all_vars.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/all_vars.result
@@ -9,7 +9,5 @@ There should be *no* long test name listed below:
 select variable_name as `There should be *no* variables listed below:` from t2
 left join t1 on variable_name=test_name where test_name is null ORDER BY variable_name;
 There should be *no* variables listed below:
-ROCKSDB_MRR_BATCH_SIZE
-ROCKSDB_MRR_BATCH_SIZE
 drop table t1;
 drop table t2;

--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_mrr_batch_size_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_mrr_batch_size_basic.result
@@ -1,0 +1,93 @@
+CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(100);
+INSERT INTO valid_values VALUES(1);
+INSERT INTO valid_values VALUES(0);
+CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO invalid_values VALUES('\'aaa\'');
+SET @start_global_value = @@global.ROCKSDB_MRR_BATCH_SIZE;
+SELECT @start_global_value;
+@start_global_value
+100
+SET @start_session_value = @@session.ROCKSDB_MRR_BATCH_SIZE;
+SELECT @start_session_value;
+@start_session_value
+100
+'# Setting to valid values in global scope#'
+"Trying to set variable @@global.ROCKSDB_MRR_BATCH_SIZE to 100"
+SET @@global.ROCKSDB_MRR_BATCH_SIZE   = 100;
+SELECT @@global.ROCKSDB_MRR_BATCH_SIZE;
+@@global.ROCKSDB_MRR_BATCH_SIZE
+100
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_MRR_BATCH_SIZE = DEFAULT;
+SELECT @@global.ROCKSDB_MRR_BATCH_SIZE;
+@@global.ROCKSDB_MRR_BATCH_SIZE
+100
+"Trying to set variable @@global.ROCKSDB_MRR_BATCH_SIZE to 1"
+SET @@global.ROCKSDB_MRR_BATCH_SIZE   = 1;
+SELECT @@global.ROCKSDB_MRR_BATCH_SIZE;
+@@global.ROCKSDB_MRR_BATCH_SIZE
+1
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_MRR_BATCH_SIZE = DEFAULT;
+SELECT @@global.ROCKSDB_MRR_BATCH_SIZE;
+@@global.ROCKSDB_MRR_BATCH_SIZE
+100
+"Trying to set variable @@global.ROCKSDB_MRR_BATCH_SIZE to 0"
+SET @@global.ROCKSDB_MRR_BATCH_SIZE   = 0;
+SELECT @@global.ROCKSDB_MRR_BATCH_SIZE;
+@@global.ROCKSDB_MRR_BATCH_SIZE
+0
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_MRR_BATCH_SIZE = DEFAULT;
+SELECT @@global.ROCKSDB_MRR_BATCH_SIZE;
+@@global.ROCKSDB_MRR_BATCH_SIZE
+100
+'# Setting to valid values in session scope#'
+"Trying to set variable @@session.ROCKSDB_MRR_BATCH_SIZE to 100"
+SET @@session.ROCKSDB_MRR_BATCH_SIZE   = 100;
+SELECT @@session.ROCKSDB_MRR_BATCH_SIZE;
+@@session.ROCKSDB_MRR_BATCH_SIZE
+100
+"Setting the session scope variable back to default"
+SET @@session.ROCKSDB_MRR_BATCH_SIZE = DEFAULT;
+SELECT @@session.ROCKSDB_MRR_BATCH_SIZE;
+@@session.ROCKSDB_MRR_BATCH_SIZE
+100
+"Trying to set variable @@session.ROCKSDB_MRR_BATCH_SIZE to 1"
+SET @@session.ROCKSDB_MRR_BATCH_SIZE   = 1;
+SELECT @@session.ROCKSDB_MRR_BATCH_SIZE;
+@@session.ROCKSDB_MRR_BATCH_SIZE
+1
+"Setting the session scope variable back to default"
+SET @@session.ROCKSDB_MRR_BATCH_SIZE = DEFAULT;
+SELECT @@session.ROCKSDB_MRR_BATCH_SIZE;
+@@session.ROCKSDB_MRR_BATCH_SIZE
+100
+"Trying to set variable @@session.ROCKSDB_MRR_BATCH_SIZE to 0"
+SET @@session.ROCKSDB_MRR_BATCH_SIZE   = 0;
+SELECT @@session.ROCKSDB_MRR_BATCH_SIZE;
+@@session.ROCKSDB_MRR_BATCH_SIZE
+0
+"Setting the session scope variable back to default"
+SET @@session.ROCKSDB_MRR_BATCH_SIZE = DEFAULT;
+SELECT @@session.ROCKSDB_MRR_BATCH_SIZE;
+@@session.ROCKSDB_MRR_BATCH_SIZE
+100
+'# Testing with invalid values in global scope #'
+"Trying to set variable @@global.ROCKSDB_MRR_BATCH_SIZE to 'aaa'"
+SET @@global.ROCKSDB_MRR_BATCH_SIZE   = 'aaa';
+Got one of the listed errors
+SELECT @@global.ROCKSDB_MRR_BATCH_SIZE;
+@@global.ROCKSDB_MRR_BATCH_SIZE
+100
+SET @@global.ROCKSDB_MRR_BATCH_SIZE = @start_global_value;
+SELECT @@global.ROCKSDB_MRR_BATCH_SIZE;
+@@global.ROCKSDB_MRR_BATCH_SIZE
+100
+SET @@session.ROCKSDB_MRR_BATCH_SIZE = @start_session_value;
+SELECT @@session.ROCKSDB_MRR_BATCH_SIZE;
+@@session.ROCKSDB_MRR_BATCH_SIZE
+100
+DROP TABLE valid_values;
+DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_mrr_batch_size_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_mrr_batch_size_basic.test
@@ -1,0 +1,17 @@
+--source include/have_rocksdb.inc
+
+CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(100);
+INSERT INTO valid_values VALUES(1);
+INSERT INTO valid_values VALUES(0);
+
+CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO invalid_values VALUES('\'aaa\'');
+
+--let $sys_var=ROCKSDB_MRR_BATCH_SIZE
+--let $read_only=0
+--let $session=1
+--source ../include/rocksdb_sys_var.inc
+
+DROP TABLE valid_values;
+DROP TABLE invalid_values;


### PR DESCRIPTION
Summary:
Previous PR #1078 incorrectly rebase  all_vars.results. As pointed out by sergey, the correct way is to add variable basic testcase. 

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: