### PR TITLE
handle binlog trimming across file rotation

### DIFF
--- a/mysql-test/suite/binlog/r/binlog_rotate_block_on_trxs_rbr.result
+++ b/mysql-test/suite/binlog/r/binlog_rotate_block_on_trxs_rbr.result
@@ -1,0 +1,49 @@
+CALL mtr.add_suppression("Timeout waiting for reply of binlog *");
+SET @save.rpl_semi_sync_master_timeout = @@global.rpl_semi_sync_master_timeout;
+SET @save.rpl_semi_sync_master_enabled = @@global.rpl_semi_sync_master_enabled;
+[connection default]
+CREATE TABLE t1(c1 INT PRIMARY KEY);
+CREATE TABLE blackhole(c1 INT PRIMARY KEY) ENGINE=blackhole;
+INSERT INTO t1 VALUES(1);
+COMMIT;
+# Create a 20 sec semisync timeout
+SET global rpl_semi_sync_master_timeout=20000;
+SET global rpl_semi_sync_master_enabled=1;
+[connection conn1]
+INSERT INTO blackhole VALUES (1);;
+[connection conn2]
+FLUSH LOGS;
+[connection conn2]
+[connection conn1]
+[connection default]
+INSERT INTO t1 VALUES (2);
+# The first binlog file should contain the trx on blackhole table since
+# the flush was blocked by the trx. The insert (of value 2) into t1
+# should be in the rotated file (second binlog file)
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (mtr.test_suppressions)
+master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE t1(c1 INT PRIMARY KEY)
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE blackhole(c1 INT PRIMARY KEY) ENGINE=blackhole
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (test.blackhole)
+master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Query	#	#	COMMIT
+master-bin.000001	#	Rotate	#	#	master-bin.000002;pos=POS
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000002	#	Query	#	#	BEGIN
+master-bin.000002	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000002	#	Xid	#	#	COMMIT /* XID */
+DROP TABLE t1;
+DROP TABLE blackhole;
+SET @@global.rpl_semi_sync_master_timeout = @save.rpl_semi_sync_master_timeout;
+SET @@global.rpl_semi_sync_master_enabled = @save.rpl_semi_sync_master_enabled;

--- a/mysql-test/suite/binlog/r/binlog_rotate_block_on_trxs_sbr.result
+++ b/mysql-test/suite/binlog/r/binlog_rotate_block_on_trxs_sbr.result
@@ -1,0 +1,45 @@
+CALL mtr.add_suppression("Timeout waiting for reply of binlog *");
+SET @save.rpl_semi_sync_master_timeout = @@global.rpl_semi_sync_master_timeout;
+SET @save.rpl_semi_sync_master_enabled = @@global.rpl_semi_sync_master_enabled;
+[connection default]
+CREATE TABLE t1(c1 INT PRIMARY KEY);
+CREATE TABLE blackhole(c1 INT PRIMARY KEY) ENGINE=blackhole;
+INSERT INTO t1 VALUES(1);
+COMMIT;
+# Create a 20 sec semisync timeout
+SET global rpl_semi_sync_master_timeout=20000;
+SET global rpl_semi_sync_master_enabled=1;
+[connection conn1]
+INSERT INTO blackhole VALUES (1);;
+[connection conn2]
+FLUSH LOGS;
+[connection conn2]
+[connection conn1]
+[connection default]
+INSERT INTO t1 VALUES (2);
+# The first binlog file should contain the trx on blackhole table since
+# the flush was blocked by the trx. The insert (of value 2) into t1
+# should be in the rotated file (second binlog file)
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Query	#	#	use `mtr`; INSERT INTO test_suppressions (pattern) VALUES ( NAME_CONST('pattern',_utf8mb4'Timeout waiting for reply of binlog *' COLLATE 'utf8mb4_0900_ai_ci'))
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE t1(c1 INT PRIMARY KEY)
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE blackhole(c1 INT PRIMARY KEY) ENGINE=blackhole
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Query	#	#	use `test`; INSERT INTO t1 VALUES(1)
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Query	#	#	use `test`; INSERT INTO blackhole VALUES (1)
+master-bin.000001	#	Query	#	#	COMMIT
+master-bin.000001	#	Rotate	#	#	master-bin.000002;pos=POS
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000002	#	Query	#	#	BEGIN
+master-bin.000002	#	Query	#	#	use `test`; INSERT INTO t1 VALUES (2)
+master-bin.000002	#	Xid	#	#	COMMIT /* XID */
+DROP TABLE t1;
+DROP TABLE blackhole;
+SET @@global.rpl_semi_sync_master_timeout = @save.rpl_semi_sync_master_timeout;
+SET @@global.rpl_semi_sync_master_enabled = @save.rpl_semi_sync_master_enabled;

--- a/mysql-test/suite/binlog/r/binlog_truncate_across_flush_rbr.result
+++ b/mysql-test/suite/binlog/r/binlog_truncate_across_flush_rbr.result
@@ -1,0 +1,91 @@
+CALL mtr.add_suppression("Taking backup from .*");
+CREATE TABLE t1(c1 INT);
+CREATE TABLE blackhole (c1 INT PRIMARY KEY) ENGINE=BLACKHOLE;
+INSERT INTO t1 VALUES(1);
+INSERT INTO blackhole VALUES(1);
+COMMIT;
+INSERT INTO t1 VALUES(2);
+COMMIT;
+FLUSH LOGS;
+# Crash right after flushing binary log
+SET SESSION DEBUG="+d,crash_after_flush_binlog";
+BEGIN;
+INSERT INTO t1 VALUES(3);
+COMMIT;
+ERROR HY000: Lost connection to MySQL server during query
+# Restart the master server
+#
+# Verify that a transaction cannot be recovered during server
+# recovery from a crash, which happened after flushing it
+# to binary log. This is because the transaction is still marked
+# as prepared in engine and will be rollbacked when
+# trim-binlog-to-recover is set
+#
+include/assert.inc [There should be 2 rows in table t1]
+INSERT INTO t1 VALUES(4);
+COMMIT;
+FLUSH ENGINE LOGS;
+#
+# verify that the latest binlog file is trimmed to the starting position
+# of the first gtid event
+#
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (mtr.test_suppressions)
+master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE t1(c1 INT)
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE blackhole (c1 INT PRIMARY KEY) ENGINE=BLACKHOLE
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (test.blackhole)
+master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Query	#	#	COMMIT
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Rotate	#	#	master-bin.000002;pos=POS
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000003	#	Query	#	#	BEGIN
+master-bin.000003	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000003	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000003	#	Xid	#	#	COMMIT /* XID */
+master-bin.000003	#	Query	#	#	use `test`; FLUSH ENGINE LOGS
+# Crash right after flushing binary log
+SET SESSION DEBUG="+d,crash_after_flush_binlog";
+BEGIN;
+INSERT INTO blackhole VALUES(2);
+COMMIT;
+ERROR HY000: Lost connection to MySQL server during query
+# Restart the master server
+INSERT INTO t1 VALUES(5);
+COMMIT;
+FLUSH ENGINE LOGS;
+include/assert.inc [There should be 4 rows in table t1]
+#
+# verify that the latest binlog file is trimmed to the starting position
+# of the first gtid event
+#
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000003	#	Query	#	#	BEGIN
+master-bin.000003	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000003	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000003	#	Xid	#	#	COMMIT /* XID */
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000004	#	Query	#	#	BEGIN
+master-bin.000004	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000004	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000004	#	Xid	#	#	COMMIT /* XID */
+master-bin.000004	#	Query	#	#	use `test`; FLUSH ENGINE LOGS
+DROP TABLE t1;
+DROP TABLE blackhole;

--- a/mysql-test/suite/binlog/r/binlog_truncate_across_flush_sbr.result
+++ b/mysql-test/suite/binlog/r/binlog_truncate_across_flush_sbr.result
@@ -1,0 +1,84 @@
+CALL mtr.add_suppression("Taking backup from .*");
+CREATE TABLE t1(c1 INT);
+CREATE TABLE blackhole (c1 INT PRIMARY KEY) ENGINE=BLACKHOLE;
+INSERT INTO t1 VALUES(1);
+INSERT INTO blackhole VALUES(1);
+COMMIT;
+INSERT INTO t1 VALUES(2);
+COMMIT;
+FLUSH LOGS;
+# Crash right after flushing binary log
+SET SESSION DEBUG="+d,crash_after_flush_binlog";
+BEGIN;
+INSERT INTO t1 VALUES(3);
+COMMIT;
+ERROR HY000: Lost connection to MySQL server during query
+# Restart the master server
+#
+# Verify that a transaction cannot be recovered during server
+# recovery from a crash, which happened after flushing it
+# to binary log. This is because the transaction is still marked
+# as prepared in engine and will be rollbacked when
+# trim-binlog-to-recover is set
+#
+include/assert.inc [There should be 2 rows in table t1]
+INSERT INTO t1 VALUES(4);
+COMMIT;
+FLUSH ENGINE LOGS;
+#
+# verify that the latest binlog file is trimmed to the starting position
+# of the first gtid event
+#
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Query	#	#	use `mtr`; INSERT INTO test_suppressions (pattern) VALUES ( NAME_CONST('pattern',_utf8mb4'Taking backup from .*' COLLATE 'utf8mb4_0900_ai_ci'))
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE t1(c1 INT)
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE blackhole (c1 INT PRIMARY KEY) ENGINE=BLACKHOLE
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Query	#	#	use `test`; INSERT INTO t1 VALUES(1)
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Query	#	#	use `test`; INSERT INTO blackhole VALUES(1)
+master-bin.000001	#	Query	#	#	COMMIT
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Query	#	#	use `test`; INSERT INTO t1 VALUES(2)
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Rotate	#	#	master-bin.000002;pos=POS
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000003	#	Query	#	#	BEGIN
+master-bin.000003	#	Query	#	#	use `test`; INSERT INTO t1 VALUES(4)
+master-bin.000003	#	Xid	#	#	COMMIT /* XID */
+master-bin.000003	#	Query	#	#	use `test`; FLUSH ENGINE LOGS
+# Crash right after flushing binary log
+SET SESSION DEBUG="+d,crash_after_flush_binlog";
+BEGIN;
+INSERT INTO blackhole VALUES(2);
+COMMIT;
+ERROR HY000: Lost connection to MySQL server during query
+# Restart the master server
+INSERT INTO t1 VALUES(5);
+COMMIT;
+FLUSH ENGINE LOGS;
+include/assert.inc [There should be 4 rows in table t1]
+#
+# verify that the latest binlog file is trimmed to the starting position
+# of the first gtid event
+#
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000003	#	Query	#	#	BEGIN
+master-bin.000003	#	Query	#	#	use `test`; INSERT INTO t1 VALUES(4)
+master-bin.000003	#	Xid	#	#	COMMIT /* XID */
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000004	#	Query	#	#	BEGIN
+master-bin.000004	#	Query	#	#	use `test`; INSERT INTO t1 VALUES(5)
+master-bin.000004	#	Xid	#	#	COMMIT /* XID */
+master-bin.000004	#	Query	#	#	use `test`; FLUSH ENGINE LOGS
+DROP TABLE t1;
+DROP TABLE blackhole;

--- a/mysql-test/suite/binlog/t/binlog_rotate_block_on_trxs.inc
+++ b/mysql-test/suite/binlog/t/binlog_rotate_block_on_trxs.inc
@@ -1,0 +1,71 @@
+--source include/count_sessions.inc
+
+CALL mtr.add_suppression("Timeout waiting for reply of binlog *");
+
+SET @save.rpl_semi_sync_master_timeout = @@global.rpl_semi_sync_master_timeout;
+SET @save.rpl_semi_sync_master_enabled = @@global.rpl_semi_sync_master_enabled;
+
+--connect(conn1,localhost,root,,test)
+--connect(conn2,localhost,root,,test)
+
+--let $rpl_connection_name= default
+--source include/rpl_connection.inc
+CREATE TABLE t1(c1 INT PRIMARY KEY);
+CREATE TABLE blackhole(c1 INT PRIMARY KEY) ENGINE=blackhole;
+
+INSERT INTO t1 VALUES(1);
+COMMIT;
+
+
+--let $first_binlog_file= query_get_value(SHOW MASTER STATUS, File, 1)
+
+-- echo # Create a 20 sec semisync timeout
+SET global rpl_semi_sync_master_timeout=20000;
+SET global rpl_semi_sync_master_enabled=1;
+
+--let $rpl_connection_name= conn1
+--source include/rpl_connection.inc
+--send INSERT INTO blackhole VALUES (1);
+
+--let $rpl_connection_name= conn2
+--source include/rpl_connection.inc
+
+# Rotate the binary log
+--send FLUSH LOGS
+
+# Wait until the server reaches the debug sync point while rotating the
+# binary log
+--let $rpl_connection_name= conn2
+--source include/rpl_connection.inc
+--reap
+
+--let $rpl_connection_name= conn1
+--source include/rpl_connection.inc
+--reap
+
+--let $rpl_connection_name= default
+--source include/rpl_connection.inc
+INSERT INTO t1 VALUES (2);
+
+--let $second_binlog_file= query_get_value(SHOW MASTER STATUS, File, 1)
+
+--echo # The first binlog file should contain the trx on blackhole table since
+--echo # the flush was blocked by the trx. The insert (of value 2) into t1
+--echo # should be in the rotated file (second binlog file)
+--let $binlog_file= $first_binlog_file
+--source include/show_binlog_events.inc
+
+--let $binlog_file= $second_binlog_file
+--source include/show_binlog_events.inc
+
+# Cleanup
+DROP TABLE t1;
+DROP TABLE blackhole;
+
+SET @@global.rpl_semi_sync_master_timeout = @save.rpl_semi_sync_master_timeout;
+SET @@global.rpl_semi_sync_master_enabled = @save.rpl_semi_sync_master_enabled;
+
+# Disconnect the additional connections
+--disconnect conn1
+--disconnect conn2
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/binlog/t/binlog_rotate_block_on_trxs_rbr-master.opt
+++ b/mysql-test/suite/binlog/t/binlog_rotate_block_on_trxs_rbr-master.opt
@@ -1,0 +1,3 @@
+$SEMISYNC_MASTER_PLUGIN_OPT $SEMISYNC_MASTER_PLUGIN_LOAD
+--trim-binlog-to-recover --gtid_mode=ON --enforce_gtid_consistency --log_bin=master-bin
+--log_slave_updates

--- a/mysql-test/suite/binlog/t/binlog_rotate_block_on_trxs_rbr.test
+++ b/mysql-test/suite/binlog/t/binlog_rotate_block_on_trxs_rbr.test
@@ -1,0 +1,9 @@
+# Verifies that trxs that do not generate xid (such ad trxs on blackhole
+# engines) block rotation of binlog files until the trx finished commiting (when
+# node fenbce is enabled through rpl_semisync_timeout)
+--source include/not_valgrind.inc
+--source include/have_log_bin.inc
+--source include/have_debug.inc
+--source include/have_binlog_format_row.inc
+
+--source binlog_rotate_block_on_trxs.inc

--- a/mysql-test/suite/binlog/t/binlog_rotate_block_on_trxs_sbr-master.opt
+++ b/mysql-test/suite/binlog/t/binlog_rotate_block_on_trxs_sbr-master.opt
@@ -1,0 +1,3 @@
+$SEMISYNC_MASTER_PLUGIN_OPT $SEMISYNC_MASTER_PLUGIN_LOAD
+--trim-binlog-to-recover --gtid_mode=ON --enforce_gtid_consistency --log_bin=master-bin
+--log_slave_updates

--- a/mysql-test/suite/binlog/t/binlog_rotate_block_on_trxs_sbr.test
+++ b/mysql-test/suite/binlog/t/binlog_rotate_block_on_trxs_sbr.test
@@ -1,0 +1,9 @@
+# Verifies that trxs that do not generate xid (such ad trxs on blackhole
+# engines) block rotation of binlog files until the trx finished commiting (when
+# node fenbce is enabled through rpl_semisync_timeout)
+--source include/not_valgrind.inc
+--source include/have_log_bin.inc
+--source include/have_debug.inc
+--source include/have_binlog_format_mixed_or_statement.inc
+
+--source binlog_rotate_block_on_trxs.inc

--- a/mysql-test/suite/binlog/t/binlog_truncate_across_flush.inc
+++ b/mysql-test/suite/binlog/t/binlog_truncate_across_flush.inc
@@ -1,0 +1,123 @@
+#
+# verify that binlog truncation to match engine position works correctly across
+# binlog file rotation. On binlog file rotation which is followed by a crash
+# before committing new trx to engine, we should trim everything from the latest
+# binlog file. Without this, gtid_executed could show additional trxs that were
+# not committed to engine
+#
+# For example:
+# 1. To start with master-bin.000001 is the binlog file which gets rotated
+# 2. New trxs are started andmysqld crashes after flushing the trxs to binlog,
+# but before committing to engine
+# 3. On recovery wngine will say that the binlog file it last saw was
+# master-bin.000001. The current binlog file being recovered is
+# master-bin.000002 which should be truncated to the beginin of the first gtid
+# event in this file
+#
+--source include/not_valgrind.inc
+--source include/have_log_bin.inc
+--source include/have_debug.inc
+
+CALL mtr.add_suppression("Taking backup from .*");
+
+CREATE TABLE t1(c1 INT);
+CREATE TABLE blackhole (c1 INT PRIMARY KEY) ENGINE=BLACKHOLE;
+
+INSERT INTO t1 VALUES(1);
+INSERT INTO blackhole VALUES(1);
+COMMIT;
+
+INSERT INTO t1 VALUES(2);
+COMMIT;
+
+--let $first_binlog_file= query_get_value(SHOW MASTER STATUS, File, 1)
+
+# Flush logs to rotate binlog and make trx durable in engine
+FLUSH LOGS;
+
+--exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--echo # Crash right after flushing binary log
+
+--let $second_binlog_file= query_get_value(SHOW MASTER STATUS, File, 1)
+SET SESSION DEBUG="+d,crash_after_flush_binlog";
+BEGIN;
+INSERT INTO t1 VALUES(3);
+--error CR_SERVER_LOST
+COMMIT;
+--source include/wait_until_disconnected.inc
+
+--enable_reconnect
+--echo # Restart the master server
+--exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--source include/wait_until_connected_again.inc
+--disable_reconnect
+
+--echo #
+--echo # Verify that a transaction cannot be recovered during server
+--echo # recovery from a crash, which happened after flushing it
+--echo # to binary log. This is because the transaction is still marked
+--echo # as prepared in engine and will be rollbacked when
+--echo # trim-binlog-to-recover is set
+--echo #
+--let $assert_text= There should be 2 rows in table t1
+--let $assert_cond= [SELECT COUNT(*) FROM t1] = 2
+--source include/assert.inc
+
+--let $third_binlog_file= query_get_value(SHOW MASTER STATUS, File, 1)
+
+INSERT INTO t1 VALUES(4);
+COMMIT;
+FLUSH ENGINE LOGS;
+
+--echo #
+--echo # verify that the latest binlog file is trimmed to the starting position
+--echo # of the first gtid event
+--echo #
+--let $binlog_file= $first_binlog_file
+--source include/show_binlog_events.inc
+
+--let $binlog_file= $second_binlog_file
+--source include/show_binlog_events.inc
+
+--let $binlog_file= $third_binlog_file
+--source include/show_binlog_events.inc
+
+--exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--echo # Crash right after flushing binary log
+
+# Now write to blackhole table and simulate a crash
+SET SESSION DEBUG="+d,crash_after_flush_binlog";
+BEGIN;
+INSERT INTO blackhole VALUES(2);
+--error CR_SERVER_LOST
+COMMIT;
+--source include/wait_until_disconnected.inc
+
+--enable_reconnect
+--echo # Restart the master server
+--exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--source include/wait_until_connected_again.inc
+--disable_reconnect
+
+INSERT INTO t1 VALUES(5);
+COMMIT;
+FLUSH ENGINE LOGS;
+
+--let $assert_text= There should be 4 rows in table t1
+--let $assert_cond= [SELECT COUNT(*) FROM t1] = 4
+--source include/assert.inc
+
+--echo #
+--echo # verify that the latest binlog file is trimmed to the starting position
+--echo # of the first gtid event
+--echo #
+--let $binlog_file= $third_binlog_file
+--source include/show_binlog_events.inc
+
+--let $fourth_binlog_file= query_get_value(SHOW MASTER STATUS, File, 1)
+--let $binlog_file= $fourth_binlog_file
+--source include/show_binlog_events.inc
+
+# Cleanup
+DROP TABLE t1;
+DROP TABLE blackhole;

--- a/mysql-test/suite/binlog/t/binlog_truncate_across_flush_rbr-master.opt
+++ b/mysql-test/suite/binlog/t/binlog_truncate_across_flush_rbr-master.opt
@@ -1,0 +1,2 @@
+--trim-binlog-to-recover --gtid_mode=ON --enforce_gtid_consistency --log_bin=master-bin
+--log_slave_updates --binlog_checksum=CRC32

--- a/mysql-test/suite/binlog/t/binlog_truncate_across_flush_rbr.test
+++ b/mysql-test/suite/binlog/t/binlog_truncate_across_flush_rbr.test
@@ -1,0 +1,22 @@
+#
+# verify that binlog truncation to match engine position works correctly across
+# binlog file rotation. On binlog file rotation which is followed by a crash
+# before commiting new trx to engine, we should trim everything from the latest
+# binlog file. Without this, gtid_executed could show additional trxs that were
+# not committed to engine
+#
+# For example:
+# 1. To start with master-bin.000001 is the binlog file which gets rotated
+# 2. New trxs are started andmysqld crashes after flushing the trxs to binlog,
+# but before committing to engine
+# 3. On recovery wngine will say that the binlog file it last saw was
+# master-bin.000001. The current binlog file being recovered is
+# master-bin.000002 which should be truncated to the beginin of the first gtid
+# event in this file
+#
+--source include/not_valgrind.inc
+--source include/have_log_bin.inc
+--source include/have_debug.inc
+--source include/have_binlog_format_row.inc
+
+--source binlog_truncate_across_flush.inc

--- a/mysql-test/suite/binlog/t/binlog_truncate_across_flush_sbr-master.opt
+++ b/mysql-test/suite/binlog/t/binlog_truncate_across_flush_sbr-master.opt
@@ -1,0 +1,2 @@
+--trim-binlog-to-recover --gtid_mode=ON --enforce_gtid_consistency 
+--log_bin=master-bin --log_slave_updates --binlog_checksum=CRC32

--- a/mysql-test/suite/binlog/t/binlog_truncate_across_flush_sbr.test
+++ b/mysql-test/suite/binlog/t/binlog_truncate_across_flush_sbr.test
@@ -1,0 +1,22 @@
+#
+# verify that binlog truncation to match engine position works correctly across
+# binlog file rotation. On binlog file rotation which is followed by a crash
+# before commiting new trx to engine, we should trim everything from the latest
+# binlog file. Without this, gtid_executed could show additional trxs that were
+# not committed to engine
+#
+# For example:
+# 1. To start with master-bin.000001 is the binlog file which gets rotated
+# 2. New trxs are started andmysqld crashes after flushing the trxs to binlog,
+# but before committing to engine
+# 3. On recovery wngine will say that the binlog file it last saw was
+# master-bin.000001. The current binlog file being recovered is
+# master-bin.000002 which should be truncated to the beginin of the first gtid
+# event in this file
+#
+--source include/not_valgrind.inc
+--source include/have_log_bin.inc
+--source include/have_debug.inc
+--source include/have_binlog_format_mixed_or_statement.inc
+
+--source binlog_truncate_across_flush.inc

--- a/mysql-test/suite/perfschema/r/relaylog.result
+++ b/mysql-test/suite/perfschema/r/relaylog.result
@@ -70,6 +70,7 @@ wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_done	MANY
 wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_flush_queue	MANY
 wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_index	MANY
 wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_log	MANY
+wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_non_xid_trxs	MANY
 wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_sync	MANY
 wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_sync_queue	MANY
 wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_xids	NONE
@@ -168,6 +169,7 @@ wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_done	MANY
 wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_flush_queue	MANY
 wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_index	MANY
 wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_log	MANY
+wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_non_xid_trxs	MANY
 wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_sync	MANY
 wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_sync_queue	MANY
 wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_xids	MANY

--- a/sql/binlog.h
+++ b/sql/binlog.h
@@ -427,6 +427,7 @@ class MYSQL_BIN_LOG : public TC_LOG {
   PSI_mutex_key m_key_LOCK_sync;
   /** The instrumentation key to use for @ LOCK_xids. */
   PSI_mutex_key m_key_LOCK_xids;
+  PSI_mutex_key m_key_LOCK_non_xid_trxs;
   /** The instrumentation key to use for @ update_cond. */
   PSI_cond_key m_key_update_cond;
   /** The instrumentation key to use for @ prep_xids_cond. */
@@ -446,6 +447,7 @@ class MYSQL_BIN_LOG : public TC_LOG {
   mysql_mutex_t LOCK_sync;
   mysql_mutex_t LOCK_binlog_end_pos;
   mysql_mutex_t LOCK_xids;
+  mysql_mutex_t LOCK_non_xid_trxs;
   mysql_cond_t update_cond;
 
   std::atomic<my_off_t> atomic_binlog_end_pos;
@@ -532,6 +534,17 @@ class MYSQL_BIN_LOG : public TC_LOG {
 
   int32 get_prep_xids() { return m_atomic_prep_xids; }
 
+  uint32_t non_xid_trxs;
+  mysql_cond_t non_xid_trxs_cond;
+
+  void inc_non_xid_trxs(THD *thd);
+  void dec_non_xid_trxs(THD *thd);
+
+  int32 get_non_xid_trxs() {
+    mysql_mutex_assert_owner(&LOCK_non_xid_trxs);
+    return non_xid_trxs;
+  }
+
   inline uint get_sync_period() { return *sync_period_ptr; }
 
  public:
@@ -617,10 +630,10 @@ class MYSQL_BIN_LOG : public TC_LOG {
       PSI_mutex_key key_LOCK_flush_queue, PSI_mutex_key key_LOCK_log,
       PSI_mutex_key key_LOCK_binlog_end_pos, PSI_mutex_key key_LOCK_sync,
       PSI_mutex_key key_LOCK_sync_queue, PSI_mutex_key key_LOCK_xids,
-      PSI_cond_key key_COND_done, PSI_cond_key key_update_cond,
-      PSI_cond_key key_prep_xids_cond, PSI_file_key key_file_log,
-      PSI_file_key key_file_log_index, PSI_file_key key_file_log_cache,
-      PSI_file_key key_file_log_index_cache) {
+      PSI_mutex_key key_LOCK_non_xid_trxs, PSI_cond_key key_COND_done,
+      PSI_cond_key key_update_cond, PSI_cond_key key_prep_xids_cond,
+      PSI_file_key key_file_log, PSI_file_key key_file_log_index,
+      PSI_file_key key_file_log_cache, PSI_file_key key_file_log_index_cache) {
     m_key_COND_done = key_COND_done;
 
     m_key_LOCK_commit_queue = key_LOCK_commit_queue;
@@ -634,6 +647,7 @@ class MYSQL_BIN_LOG : public TC_LOG {
     m_key_LOCK_commit = key_LOCK_commit;
     m_key_LOCK_sync = key_LOCK_sync;
     m_key_LOCK_xids = key_LOCK_xids;
+    m_key_LOCK_non_xid_trxs = key_LOCK_non_xid_trxs;
     m_key_update_cond = key_update_cond;
     m_key_prep_xids_cond = key_prep_xids_cond;
     m_key_file_log = key_file_log;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -917,6 +917,7 @@ static PSI_mutex_key key_BINLOG_LOCK_binlog_end_pos;
 static PSI_mutex_key key_BINLOG_LOCK_sync;
 static PSI_mutex_key key_BINLOG_LOCK_sync_queue;
 static PSI_mutex_key key_BINLOG_LOCK_xids;
+static PSI_mutex_key key_BINLOG_LOCK_non_xid_trxs;
 static PSI_rwlock_key key_rwlock_global_sid_lock;
 static PSI_rwlock_key key_rwlock_gtid_mode_lock;
 static PSI_rwlock_key key_rwlock_LOCK_system_variables_hash;
@@ -4440,15 +4441,16 @@ int init_common_variables() {
     initialization, and can not be set in the MYSQL_BIN_LOG constructor (called
     before main()).
   */
-  mysql_bin_log.set_psi_keys(
-      key_BINLOG_LOCK_index, key_BINLOG_LOCK_commit,
-      key_BINLOG_LOCK_commit_queue, key_BINLOG_LOCK_done,
-      key_BINLOG_LOCK_flush_queue, key_BINLOG_LOCK_log,
-      key_BINLOG_LOCK_binlog_end_pos, key_BINLOG_LOCK_sync,
-      key_BINLOG_LOCK_sync_queue, key_BINLOG_LOCK_xids, key_BINLOG_COND_done,
-      key_BINLOG_update_cond, key_BINLOG_prep_xids_cond, key_file_binlog,
-      key_file_binlog_index, key_file_binlog_cache,
-      key_file_binlog_index_cache);
+  mysql_bin_log.set_psi_keys(key_BINLOG_LOCK_index, key_BINLOG_LOCK_commit,
+                             key_BINLOG_LOCK_commit_queue, key_BINLOG_LOCK_done,
+                             key_BINLOG_LOCK_flush_queue, key_BINLOG_LOCK_log,
+                             key_BINLOG_LOCK_binlog_end_pos,
+                             key_BINLOG_LOCK_sync, key_BINLOG_LOCK_sync_queue,
+                             key_BINLOG_LOCK_xids, key_BINLOG_LOCK_non_xid_trxs,
+                             key_BINLOG_COND_done, key_BINLOG_update_cond,
+                             key_BINLOG_prep_xids_cond, key_file_binlog,
+                             key_file_binlog_index, key_file_binlog_cache,
+                             key_file_binlog_index_cache);
 #endif
 
   /*
@@ -10879,6 +10881,7 @@ PSI_mutex_key key_RELAYLOG_LOCK_log_end_pos;
 PSI_mutex_key key_RELAYLOG_LOCK_sync;
 PSI_mutex_key key_RELAYLOG_LOCK_sync_queue;
 PSI_mutex_key key_RELAYLOG_LOCK_xids;
+PSI_mutex_key key_RELAYLOG_LOCK_non_xid_trxs;
 PSI_mutex_key key_gtid_ensure_index_mutex;
 PSI_mutex_key key_object_cache_mutex;  // TODO need to initialize
 PSI_cond_key key_object_loading_cond;  // TODO need to initialize
@@ -10902,6 +10905,7 @@ static PSI_mutex_info all_server_mutexes[]=
   { &key_BINLOG_LOCK_sync, "MYSQL_BIN_LOG::LOCK_sync", 0, 0, PSI_DOCUMENT_ME},
   { &key_BINLOG_LOCK_sync_queue, "MYSQL_BIN_LOG::LOCK_sync_queue", 0, 0, PSI_DOCUMENT_ME},
   { &key_BINLOG_LOCK_xids, "MYSQL_BIN_LOG::LOCK_xids", 0, 0, PSI_DOCUMENT_ME},
+  { &key_BINLOG_LOCK_non_xid_trxs, "MYSQL_BIN_LOG::LOCK_non_xid_trxs", 0, 0, PSI_DOCUMENT_ME},
   { &key_RELAYLOG_LOCK_commit, "MYSQL_RELAY_LOG::LOCK_commit", 0, 0, PSI_DOCUMENT_ME},
   { &key_RELAYLOG_LOCK_commit_queue, "MYSQL_RELAY_LOG::LOCK_commit_queue", 0, 0, PSI_DOCUMENT_ME},
   { &key_RELAYLOG_LOCK_done, "MYSQL_RELAY_LOG::LOCK_done", 0, 0, PSI_DOCUMENT_ME},
@@ -10912,6 +10916,7 @@ static PSI_mutex_info all_server_mutexes[]=
   { &key_RELAYLOG_LOCK_sync, "MYSQL_RELAY_LOG::LOCK_sync", 0, 0, PSI_DOCUMENT_ME},
   { &key_RELAYLOG_LOCK_sync_queue, "MYSQL_RELAY_LOG::LOCK_sync_queue", 0, 0, PSI_DOCUMENT_ME},
   { &key_RELAYLOG_LOCK_xids, "MYSQL_RELAY_LOG::LOCK_xids", 0, 0, PSI_DOCUMENT_ME},
+  { &key_RELAYLOG_LOCK_non_xid_trxs, "MYSQL_RELAY_LOG::LOCK_xids", 0, 0, PSI_DOCUMENT_ME},
   { &key_hash_filo_lock, "hash_filo::lock", 0, 0, PSI_DOCUMENT_ME},
   { &Gtid_set::key_gtid_executed_free_intervals_mutex, "Gtid_set::gtid_executed::free_intervals_mutex", 0, 0, PSI_DOCUMENT_ME},
   { &key_LOCK_crypt, "LOCK_crypt", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -554,6 +554,7 @@ extern PSI_mutex_key key_RELAYLOG_LOCK_log;
 extern PSI_mutex_key key_RELAYLOG_LOCK_log_end_pos;
 extern PSI_mutex_key key_RELAYLOG_LOCK_sync;
 extern PSI_mutex_key key_RELAYLOG_LOCK_sync_queue;
+extern PSI_mutex_key key_RELAYLOG_LOCK_non_xid_trxs;
 extern PSI_mutex_key key_RELAYLOG_LOCK_xids;
 extern PSI_mutex_key key_gtid_ensure_index_mutex;
 extern PSI_mutex_key key_mts_temp_table_LOCK;

--- a/sql/rpl_rli.cc
+++ b/sql/rpl_rli.cc
@@ -185,9 +185,10 @@ Relay_log_info::Relay_log_info(bool is_slave_recovery,
                          key_RELAYLOG_LOCK_flush_queue, key_RELAYLOG_LOCK_log,
                          key_RELAYLOG_LOCK_log_end_pos, key_RELAYLOG_LOCK_sync,
                          key_RELAYLOG_LOCK_sync_queue, key_RELAYLOG_LOCK_xids,
-                         key_RELAYLOG_COND_done, key_RELAYLOG_update_cond,
-                         key_RELAYLOG_prep_xids_cond, key_file_relaylog,
-                         key_file_relaylog_index, key_file_relaylog_cache,
+                         key_RELAYLOG_LOCK_non_xid_trxs, key_RELAYLOG_COND_done,
+                         key_RELAYLOG_update_cond, key_RELAYLOG_prep_xids_cond,
+                         key_file_relaylog, key_file_relaylog_index,
+                         key_file_relaylog_cache,
                          key_file_relaylog_index_cache);
 #endif
 

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -2455,6 +2455,7 @@ class THD : public MDL_context_owner,
   sp_cache *sp_func_cache;
 
   /** number of name_const() substitutions, see sp_head.cc:subst_spvars() */
+  bool non_xid_trx = false;
   uint query_name_consts;
 
   /*


### PR DESCRIPTION
---------- https://github.com/facebook/mysql-5.6/commit/ec039b1a46a ----------
Summary:
Fix 1:
If the following sequence of events happen, then binlog trimming will leave some
extraneous gtid in the binlog
1. Binlog file is rotated
2. A few transactions successfully flushes to binlog file, but not yet commited
to engine
3. mysqld crashes

On crash recovery, engine will point to the position in the old binlog file.
Which means extraneous trxs in the current binlog file will not be trimmed and
gtid_executed will contain these trxs. This is not an ideal scenario.

The diff fixes it by taking into account the file name stored in engine and the
current binlog file name being recovered.
1. If both file names are the same, then trimming is based solely on the
position.
2. If file names are different and the file stored in engine is older (as
noticed by the index of the file name), then we trim the current binlog file to
the begining position of the first gtid event i.e all transactions in the
current binlog file are trimmed.

Note that this does not handle the case of file names wrapping around and this
can be a rare scenario which can be fixed by instance replacements.

Fix 2:
Binlog rotation is considered a sync point for existing transactions to flush.
This is achieved by making binlog rotation block until all prepared
transactions are committed. However, the trxs that do not generate XID are not
considered 'prepared' and hence binlog rotation is not blocked by such
transactions.This could cause some extraneous GTID to be present in a
previously rotated binlog file which never got committed. This diff fixes the
problem by making binlog rotation to block on transactions without xid.

Originally Reviewed By: abhinav04sharma

fbshipit-source-id: c4d98f06025

---------- https://github.com/facebook/mysql-5.6/commit/9420260b936 ----------
    
fix failure to start
    
Summary:
Allow for recovery to proceed without special trimming if engine and recovering
binlog file prefix do not match
    
Originally Reviewed By: abhinav04sharma
    
fbshipit-source-id: fa9a466
