### PR TITLE
initialize mrr_iter for RANGE_SEQ_IF::skip_record scenario

### DIFF
--- a/mysql-test/suite/rocksdb/r/rocksdb_mrr.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_mrr.result
@@ -652,6 +652,20 @@ select * from t0 left join t3 on t3.col1=t0.a where t3.pk1 is null;
 a	pk1	pk2	col1	filler
 3	NULL	NULL	NULL	NULL
 5	NULL	NULL	NULL	NULL
+explain 
+select * from t0 left join t4 using (a) where t4.a is null;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t0	ALL	NULL	NULL	NULL	NULL	10	NULL
+1	SIMPLE	t4	eq_ref	PRIMARY	PRIMARY	4	test.t0.a	1	Using where; Not exists; Using index; Using join buffer (Batched Key Access)
+select * from t0 left join t4 using (a) where t4.a is null;
+a
+0
+1
+2
+3
+5
+7
+9
 set optimizer_switch='mrr=off';
 select * from t0 left join t3 on t3.col1=t0.a where t3.pk1 is null;
 a	pk1	pk2	col1	filler

--- a/mysql-test/suite/rocksdb/t/rocksdb_mrr.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_mrr.test
@@ -352,6 +352,11 @@ delete from t3 where col1 in (3,5);
 explain
 select * from t0 left join t3 on t3.col1=t0.a where t3.pk1 is null;
 select * from t0 left join t3 on t3.col1=t0.a where t3.pk1 is null;
+
+explain 
+select * from t0 left join t4 using (a) where t4.a is null;
+select * from t0 left join t4 using (a) where t4.a is null;
+
 set optimizer_switch='mrr=off';
 select * from t0 left join t3 on t3.col1=t0.a where t3.pk1 is null;
 set optimizer_switch='mrr=on';

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -15428,6 +15428,7 @@ int ha_rocksdb::multi_range_read_init(RANGE_SEQ_IF *seq, void *seq_init_param,
   mrr_enabled_keyread = false;
   mrr_rowid_reader = nullptr;
 
+  mrr_iter = seq->init(seq_init_param, n_ranges, mode);
   mrr_funcs = *seq;
   mrr_buf = *buf;
 


### PR DESCRIPTION
Summary:
mrr_iter must be initialized before using in skip_record scenario. otherwise, mysqld will crash during [bka_range_seq_skip_record](https://github.com/facebook/mysql-5.6/blob/42a5444d52f264682c7805bf8117dd884095c476/sql/sql_join_buffer.cc#L2278)(rseq point to a null)
```
call stack:
#0 bka_range_seq_skip_record
#1 myrocks::ha_rocksdb::multi_range_read_next(https://github.com/facebook/mysql-5.6/blob/fb-mysql-5.6.35/storage/rocksdb/ha_rocksdb.cc#L15675)
#2 JOIN_CACHE_BKA::join_matching_records
#3 JOIN_CACHE::join_records 
```
Test Plan:
MTR

Reviewers:

Subscribers:

Tasks:

Tags: