### PR TITLE
Fix bug with COM_RESET_CONNECTION not respecting CLIENT_INTERACTIVE

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -236,6 +236,9 @@ static bool can_handle_expired_passwords = true;
 static bool use_async_client = false;
 static bool enable_async_client = false;
 
+// To enable sending CLIENT_INTERACTIVE in client flags
+static bool enable_client_interactive = false;
+
 // Secondary engine options
 static const char *opt_load_pool = 0;
 static const char *opt_offload_count_file;
@@ -623,6 +626,7 @@ enum enum_commands {
   Q_QUERY_ATTRS_ADD,
   Q_QUERY_ATTRS_DELETE,
   Q_QUERY_ATTRS_RESET,
+  Q_ENABLE_CLIENT_INTERACTIVE,
   Q_DUMP_TIMED_OUT_CONNECTION_SOCKET_BUFFER,
   Q_UNKNOWN, /* Unknown command.   */
   Q_COMMENT, /* Comments, ignored. */
@@ -660,7 +664,8 @@ const char *command_names[] = {
     "send_shutdown", "shutdown_server", "result_format", "move_file",
     "remove_files_wildcard", "copy_files_wildcard", "send_eval", "output",
     "reset_connection", "query_attrs_add", "query_attrs_delete",
-    "query_attrs_reset", "dump_timed_out_connection_socket_buffer",
+    "query_attrs_reset", "enable_client_interactive",
+    "dump_timed_out_connection_socket_buffer",
 
     0};
 
@@ -1091,6 +1096,7 @@ static MYSQL *mysql_real_connect_wrapper(MYSQL *mysql, const char *host,
                                          const char *db, uint port,
                                          const char *unix_socket,
                                          ulong client_flag) {
+  client_flag |= (enable_client_interactive ? CLIENT_INTERACTIVE : 0);
   if (enable_async_client)
     return async_mysql_real_connect_wrapper(mysql, host, user, passwd, db, port,
                                             unix_socket, client_flag);
@@ -10240,6 +10246,9 @@ int main(int argc, char **argv) {
           mysql_options(&cur_con->mysql, MYSQL_OPT_QUERY_ATTR_RESET, 0);
           break;
 
+        case Q_ENABLE_CLIENT_INTERACTIVE:
+          enable_client_interactive = true;
+          /* fallthrough */
         default:
           processed = 0;
           break;

--- a/mysql-test/r/reset_connection.result
+++ b/mysql-test/r/reset_connection.result
@@ -248,4 +248,18 @@ Query_ID	Duration	Query
 Warnings:
 Warning	#	'SHOW PROFILES' is deprecated and will be removed in a future release. Please use Performance Schema instead
 
+MYSQL_RESET_CONNECTION DOES NOT SET WAIT_TIMEOUT = INTERACTIVE_TIMEOUT
+
+## Setting initial value of variable to 1 ##
+SET @@global.interactive_timeout = 1;
+connection new;
+SELECT @@session.wait_timeout;
+@@session.wait_timeout
+1
+resetconnection
+SELECT @@session.wait_timeout;
+@@session.wait_timeout
+1
+SET @@global.interactive_timeout= 28800;
+
 End of tests

--- a/mysql-test/t/reset_connection.test
+++ b/mysql-test/t/reset_connection.test
@@ -220,4 +220,24 @@ SELECT 2;
 SHOW PROFILES;
 
 --echo
+--echo MYSQL_RESET_CONNECTION DOES NOT SET WAIT_TIMEOUT = INTERACTIVE_TIMEOUT
+--echo
+
+let $start_value= `SELECT @@global.interactive_timeout`;
+
+--echo ## Setting initial value of variable to 1 ##
+SET @@global.interactive_timeout = 1;
+--enable_client_interactive
+connect(new, localhost, root,,,,,);
+--echo connection new;
+connection new;
+SELECT @@session.wait_timeout;
+--reset_connection
+--echo resetconnection
+
+SELECT @@session.wait_timeout;
+
+eval SET @@global.interactive_timeout= $start_value;
+
+--echo
 --echo End of tests

--- a/sql/auth/sql_authentication.cc
+++ b/sql/auth/sql_authentication.cc
@@ -3001,8 +3001,7 @@ static void server_mpvio_initialize(THD *thd, MPVIO_EXT *mpvio,
 
 static void server_mpvio_update_thd(THD *thd, MPVIO_EXT *mpvio) {
   thd->max_client_packet_length = mpvio->max_client_packet_length;
-  if (mpvio->protocol->has_client_capability(CLIENT_INTERACTIVE))
-    thd->variables.net_wait_timeout = thd->variables.net_interactive_timeout;
+  thd->fix_capability_based_variables();
   thd->security_context()->assign_user(
       mpvio->auth_info.user_name,
       (mpvio->auth_info.user_name ? strlen(mpvio->auth_info.user_name) : 0));
@@ -3013,8 +3012,6 @@ static void server_mpvio_update_thd(THD *thd, MPVIO_EXT *mpvio) {
   LEX_CSTRING sctx_user = thd->security_context()->user();
   mpvio->auth_info.user_name = const_cast<char *>(sctx_user.str);
   mpvio->auth_info.user_name_length = sctx_user.length;
-  if (thd->get_protocol()->has_client_capability(CLIENT_IGNORE_SPACE))
-    thd->variables.sql_mode |= MODE_IGNORE_SPACE;
 }
 
 /**

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -534,7 +534,6 @@ THD::THD(bool enable_plugins)
   /* Call to init() below requires fully initialized Open_tables_state. */
   reset_open_tables_state();
 
-  init();
 #if defined(ENABLED_PROFILING)
   profiling->set_thd(this);
 #endif
@@ -549,6 +548,8 @@ THD::THD(bool enable_plugins)
   protocol_text.init(this);
   protocol_binary.init(this);
   protocol_text.set_client_capabilities(0);  // minimalistic client
+
+  init();
 
   /*
     Make sure thr_lock_info_init() is called for threads which do not get
@@ -833,6 +834,11 @@ void THD::init(void) {
     avoid temporary tables replication failure.
   */
   variables.pseudo_thread_id = m_thread_id;
+  /*
+   variables= global_system_variables also clobbers several variables set
+   based on per-connection capabilities
+   */
+  fix_capability_based_variables();
 
   /*
     NOTE: reset_connection command will reset the THD to its default state.

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -2566,6 +2566,12 @@ class THD : public MDL_context_owner,
   void init(void);
 
  public:
+  void fix_capability_based_variables() {
+    if (m_protocol->has_client_capability(CLIENT_INTERACTIVE))
+      variables.net_wait_timeout = variables.net_interactive_timeout;
+    if (m_protocol->has_client_capability(CLIENT_IGNORE_SPACE))
+      variables.sql_mode |= MODE_IGNORE_SPACE;
+  }
   /**
     Initialize memory roots necessary for query processing and (!)
     pre-allocate memory for it. We can't do that in THD constructor because


### PR DESCRIPTION
Summary:
The COM_RESET_CONNECTION command is not currently respecting
the CLIENT_INTERACTIVE flag. The CLIENT_INTERACTIVE flag is tied to the
connection, rather than the session. When COM_RESET_CONNECTION resets
session state, it's expected that wait_timeout will be set to interactive_timeout when CLIENT_INTERACTIVE is set.

Reference Patch: facebook/mysql-5.6@5de8b68

Originally Reviewed By: jkedgar

8.0 porting notes:
* The `init ()` call in the `THD` constructor is delayed until client capabilities are set