### PR TITLE
Fixed githash.pl call parameters after introducing RocksDB

### DIFF
--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -1069,7 +1069,9 @@ IF(DEFINED MYSQL_GITHASH)
   # the perl script
   SET(GITHASH_PERL_OPTS ${GITHASH_PERL_OPTS}
                         --mysql_githash=${MYSQL_GITHASH}
-                        --mysql_gitdate=${MYSQL_GITDATE})
+                        --mysql_gitdate=${MYSQL_GITDATE}
+                        --rocksdb_githash=${ROCKSDB_GITHASH}
+                        --rocksdb_gitdate=${ROCKSDB_GITDATE})
 ELSE()
   # Otherwise we want to add the .git/logs/HEAD file to the list of
   # dependencies


### PR DESCRIPTION
In cases when Facebook MySQL Server is compiled from a source tree that was not
retrieved from git (or just does not have the '.git' directory) MYSQL_GITHASH and
MYSQL_GITDATE CMake options can be defined to skip some calls to git
executable that identifies current revision.
This used to work fine until RocksDB storage engine code was merged. Now git
executable is unconditionally executed to determine revision of the rocksdb
submodule.
Fixed by passing "--rocksdb_githash=${ROCKSDB_GITHASH}" and
"--rocksdb_gitdate=${ROCKSDB_GITDATE})" to "githash.pl" script as in 5.6.35.

Reference patch: facebook/mysql-5.6@38c5ced