### PR TITLE
make insert_duplicate_key_update_race test more stable

### DIFF
--- a/mysql-test/suite/innodb/r/insert_duplicate_key_update_race.result
+++ b/mysql-test/suite/innodb/r/insert_duplicate_key_update_race.result
@@ -1,0 +1,29 @@
+SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
+SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
+create table temp1 (a varchar(36) NOT NULL, b varchar(128) NOT NULL, c varchar(10240) NOT NULL);
+insert into temp1 values  (1, 'b1', 'c1'), (2,'b2','c2'),(3,'b3','c3'),(4,'b4','c4'),(5,'b5','c5');
+create table temp2 (a varchar(36) NOT NULL, b varchar(128) NOT NULL, c varchar(10240) NOT NULL);
+insert into temp2 values (2,'b2','c2'),(3,'b3','c3'),(4,'b4','c4'),(5,'b5','c5');
+CREATE TABLE extra (
+id bigint unsigned NOT NULL AUTO_INCREMENT,
+a varchar(36) NOT NULL,
+b varchar(128) NOT NULL,
+c varchar(10240) NOT NULL,
+PRIMARY KEY (id),
+UNIQUE KEY uniq_idx (a,b)
+) engine = innodb;
+set DEBUG_SYNC = "ha_write_row_end WAIT_FOR flushed";
+insert into extra(a, b, c) select * from temp1 on duplicate key update c=values(c);
+insert into extra(a, b, c) select * from temp2 on duplicate key update c=values(c);
+set DEBUG_SYNC = "now SIGNAL flushed";
+select a, b, c from extra order by a;
+a	b	c
+1	b1	c1
+2	b2	c2
+3	b3	c3
+4	b4	c4
+5	b5	c5
+set DEBUG_SYNC = "RESET";
+drop table extra;
+drop table temp2;
+drop table temp1;

--- a/mysql-test/suite/innodb/t/insert_duplicate_key_update_race.test
+++ b/mysql-test/suite/innodb/t/insert_duplicate_key_update_race.test
@@ -1,0 +1,39 @@
+--source include/count_sessions.inc
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+
+SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
+--connect (con1, localhost, root,,)
+SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
+--connection default
+
+create table temp1 (a varchar(36) NOT NULL, b varchar(128) NOT NULL, c varchar(10240) NOT NULL);
+insert into temp1 values  (1, 'b1', 'c1'), (2,'b2','c2'),(3,'b3','c3'),(4,'b4','c4'),(5,'b5','c5');
+create table temp2 (a varchar(36) NOT NULL, b varchar(128) NOT NULL, c varchar(10240) NOT NULL);
+insert into temp2 values (2,'b2','c2'),(3,'b3','c3'),(4,'b4','c4'),(5,'b5','c5');
+
+CREATE TABLE extra (
+  id bigint unsigned NOT NULL AUTO_INCREMENT,
+  a varchar(36) NOT NULL,
+  b varchar(128) NOT NULL,
+  c varchar(10240) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uniq_idx (a,b)
+) engine = innodb;
+set DEBUG_SYNC = "ha_write_row_end WAIT_FOR flushed";
+--send insert into extra(a, b, c) select * from temp1 on duplicate key update c=values(c)
+
+--connection con1
+insert into extra(a, b, c) select * from temp2 on duplicate key update c=values(c); 
+set DEBUG_SYNC = "now SIGNAL flushed";
+
+--connection default
+--reap
+select a, b, c from extra order by a;
+
+set DEBUG_SYNC = "RESET";
+drop table extra;
+drop table temp2;
+drop table temp1;
+--disconnect con1
+--source include/wait_until_count_sessions.inc


### PR DESCRIPTION
Summary: Valgrind run may let id generated in different order. Let's only verify the content, but without id

Originally Reviewed By: abhinav04sharma

fbshipit-source-id: 38f02037be3

Reference Patch: https://github.com/facebook/mysql-5.6/commit/03919677cb5

-----------------------------------------------------------------

make innodb.insert_duplicate_key_update_race more stable

Summary: insert_duplicate_key_update_race can generate data in none deterministic order. Add oder by to make it has an consist data output order

Originally Reviewed By: yizhang82

fbshipit-source-id: 3b4deab

Reference Patch: https://github.com/facebook/mysql-5.6/commit/2c2afd33a50