### PR TITLE
Fix rpl_recovery.rpl_slave_recovery_with_binlog_checksum

### DIFF
--- a/mysql-test/suite/rpl_recovery/r/rpl_slave_recovery_with_binlog_checksum.result
+++ b/mysql-test/suite/rpl_recovery/r/rpl_slave_recovery_with_binlog_checksum.result
@@ -1,0 +1,31 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+CALL mtr.add_suppression("Error in Log_event::read_log_event()");
+CALL mtr.add_suppression("Recovery from master pos");
+[connection master]
+CREATE TABLE t1(a INT primary key) ENGINE = InnoDB;
+include/sync_slave_sql_with_master.inc
+[connection slave]
+FLUSH LOGS;
+[connection master]
+INSERT INTO t1 VALUES(1);
+INSERT INTO t1 VALUES(2);
+INSERT INTO t1 VALUES(3);
+INSERT INTO t1 VALUES(4);
+INSERT INTO t1 VALUES(5);
+include/sync_slave_sql_with_master.inc
+[connection slave]
+include/rpl_restart_server.inc [server_number=2 gtids=on]
+[connection slave]
+CHANGE MASTER TO master_auto_position=1, master_heartbeat_period=0.25;
+include/start_slave.inc
+[connection master]
+include/sync_slave_sql_with_master.inc
+0
+[connection master]
+DROP TABLE t1;
+include/sync_slave_sql_with_master.inc
+include/rpl_end.inc

--- a/mysql-test/suite/rpl_recovery/t/rpl_slave_recovery_with_binlog_checksum-master.opt
+++ b/mysql-test/suite/rpl_recovery/t/rpl_slave_recovery_with_binlog_checksum-master.opt
@@ -1,0 +1,2 @@
+--gtid_mode=ON --enforce_gtid_consistency --log_slave_updates
+--binlog_rows_query_log_events=ON --binlog_checksum=CRC32

--- a/mysql-test/suite/rpl_recovery/t/rpl_slave_recovery_with_binlog_checksum-slave.opt
+++ b/mysql-test/suite/rpl_recovery/t/rpl_slave_recovery_with_binlog_checksum-slave.opt
@@ -1,0 +1,3 @@
+--gtid_mode=ON --enforce_gtid_consistency --log_slave_updates
+--binlog_rows_query_log_events=ON --binlog_checksum=CRC32 --relay-log-recovery=1
+--sync_binlog=1000 --slave_parallel_workers=10

--- a/mysql-test/suite/rpl_recovery/t/rpl_slave_recovery_with_binlog_checksum.test
+++ b/mysql-test/suite/rpl_recovery/t/rpl_slave_recovery_with_binlog_checksum.test
@@ -1,0 +1,56 @@
+--source include/assert_gtid_mode_on.inc
+--source include/have_slave_use_idempotent_for_recovery.inc
+--source include/have_grep.inc
+--source include/master-slave.inc
+
+CALL mtr.add_suppression("Error in Log_event::read_log_event()");
+CALL mtr.add_suppression("Recovery from master pos");
+
+--source include/rpl_connection_master.inc
+CREATE TABLE t1(a INT primary key) ENGINE = InnoDB;
+--source include/sync_slave_sql_with_master.inc
+
+--source include/rpl_connection_slave.inc
+FLUSH LOGS;
+
+--source include/rpl_connection_master.inc
+INSERT INTO t1 VALUES(1);
+INSERT INTO t1 VALUES(2);
+INSERT INTO t1 VALUES(3);
+INSERT INTO t1 VALUES(4);
+INSERT INTO t1 VALUES(5);
+--source include/sync_slave_sql_with_master.inc
+
+--source include/rpl_connection_slave.inc
+--let $MYSQLD_DATADIR = `select @@datadir`
+--let $slave_binlog_file = query_get_value("SHOW MASTER STATUS", "File", 1)
+--let $slave_binlog_size = query_get_value("SHOW MASTER STATUS", "Position", 1)
+
+# Truncate the binlog
+--let $half = `select ROUND($slave_binlog_size / 2)`
+--exec truncate -s $half $MYSQLD_DATADIR/$slave_binlog_file
+
+--let $rpl_server_number = 2
+--let $rpl_start_with_gtids = 1
+--let $rpl_force_stop = 1
+--source include/rpl_restart_server.inc
+
+--source include/rpl_connection_slave.inc
+CHANGE MASTER TO master_auto_position=1, master_heartbeat_period=0.25;
+--source include/start_slave.inc
+
+--source include/rpl_connection_master.inc
+--let $use_gtids=1
+--source include/sync_slave_sql_with_master.inc
+
+# Check if the binlogs have corrupted events
+--exec $MYSQL_BINLOG -v -v $MYSQLD_DATADIR/slave-bin.0* > $MYSQLTEST_VARDIR/tmp/fulldump.sql
+--exec grep -c "**Corrupt" $MYSQLTEST_VARDIR/tmp/fulldump.sql || true
+--remove_file $MYSQLTEST_VARDIR/tmp/fulldump.sql
+
+--source include/rpl_connection_master.inc
+DROP TABLE t1;
+--source include/sync_slave_sql_with_master.inc
+
+--let $use_gtids=0
+--source include/rpl_end.inc


### PR DESCRIPTION
Summary:
This change (https://github.com/facebook/mysql-5.6/commit/fb2c08e) started enforcing the presence of primary keys when row idempotent recovery is used. However, the rpl_recovery.rpl_slave_recovery_with_binlog_checksum test currently did not have primary keys. Fix by adding primary keys.

Squash with: D4113718

Originally Reviewed By: abhinav04sharma

fbshipit-source-id: 4e7bc52997c

Reference Patch: https://github.com/facebook/mysql-5.6/commit/d6201cb2147

Porting notes: `rpl_slave_recovery_with_binlog_checksum` was ported from https://github.com/facebook/mysql-5.6/commit/63eb24e9a06c