### PR TITLE
Log a error line in flush stage

### DIFF
--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -8666,7 +8666,13 @@ int MYSQL_BIN_LOG::process_flush_stage_queue(my_off_t *total_bytes_var,
   for (THD *head = first_seen; head; head = head->next_to_commit) {
     std::pair<int, my_off_t> result = flush_thread_caches(head);
     total_bytes += result.second;
-    if (flush_error == 1) flush_error = result.first;
+    if (flush_error == 1)
+      flush_error = result.first;
+    else if (result.first) {
+      // NO_LINT_DEBUG
+      sql_print_error(
+          "flush stage hides errors of follower threads in the group");
+    }
 #ifndef DBUG_OFF
     no_flushes++;
 #endif


### PR DESCRIPTION
Summary:
It seems like flush stage of ordered commit eats up the error which makes
ordered_commit to skip handling flush stage failures.

process_flush_stage_queue thinks that if the first thread in the group is able
to flush its trx successfully, then all subsequent threads can also successfully
flush their transactions. Intution and code reading indicates that this is
not right. This would need multiple things to happen at the same time to fail:
1. Multiple threads enter flush stage with leader thread handling the flush for
all threads
2. Leader thread should successfully flush its own trx into log_file (binlog)
3. Leader thread should fail to flush the trx of any subsequent threads in the
group.

When 1, 2 and 3 happens the flush stage error gets dropped by
process_flush_stage_queue. ordered_commit() will skip invoking
binlog_error_action (which could be set to abort_server to avoid
inconsistencies) and commit all the trxs into engine. This will lead to a
situation where master will commit extra transaction into the engine which the
slave will never get (since it was not written to binlog) leading to a silent
data inconsistency. gtid_executed will not indicate the problem since it will
not have any holes (as the trxs were never flushed to master's binlog)

Adding a error line to see if this happens in prod and needs to be fixed.

Reference Patch: https://github.com/facebook/mysql-5.6/commit/7bdd211c8eb

Originally Reviewed By: iRitwik

fbshipit-source-id: cbcc735cf51