### PR TITLE
Big files slow removal

### DIFF
--- a/mysql-test/suite/innodb/r/big_file_slow_removal.result
+++ b/mysql-test/suite/innodb/r/big_file_slow_removal.result
@@ -1,0 +1,12 @@
+SET GLOBAL local_infile = ON;
+SET GLOBAL innodb_big_file_slow_removal_speed = 100;
+SET GLOBAL debug = '+d,ib_os_big_file_slow_removal';
+CREATE TABLE t1 (x VARCHAR(100)) ENGINE=InnoDB;
+LOAD DATA LOCAL INFILE 'INPUT_FILE' INTO TABLE t1;
+t1.ibd
+DROP TABLE t1;
+SET debug_sync = 'now WAIT_FOR big_file_removed';
+SET GLOBAL debug = '-d,ib_os_big_file_slow_removal';
+CREATE TABLE t1 (x VARCHAR(100)) ENGINE=InnoDB;
+DROP TABLE t1;
+# restart

--- a/mysql-test/suite/innodb/t/big_file_slow_removal.test
+++ b/mysql-test/suite/innodb/t/big_file_slow_removal.test
@@ -1,0 +1,68 @@
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+--source include/big_test.inc
+
+#
+# This test drops big innodb table
+# which store in big file
+# which SSD usually very slow deletes
+#
+
+# no need to save/restore the var as the server is restarted
+SET GLOBAL local_infile = ON;
+
+--let $MYSQLD_DATADIR = `SELECT @@datadir`
+--let $tmp_dir = `SELECT @@global.secure_file_priv`
+--let $input_file = $tmp_dir/t1.txt
+--let $slowrmdir = $MYSQLD_DATADIR/.slowrm
+
+# set removal speed 100 Mbps
+# no need to save/restore the var as the server is restarted
+SET GLOBAL innodb_big_file_slow_removal_speed = 100;
+
+# activate debug synchronization point in the special background
+# thread intended for slow removal
+SET GLOBAL debug = '+d,ib_os_big_file_slow_removal';
+
+# create second big table 100MB
+CREATE TABLE t1 (x VARCHAR(100)) ENGINE=InnoDB;
+--exec dd bs=102400 count=1024 if=/dev/urandom | base64 -w 80 > $input_file
+--replace_result $input_file INPUT_FILE
+--eval LOAD DATA LOCAL INFILE '$input_file' INTO TABLE t1
+
+# check that file exists
+--list_files $MYSQLD_DATADIR/test
+
+# delete table file
+DROP TABLE t1;
+
+# check that file was deleted
+--list_files $MYSQLD_DATADIR/test
+
+# if $slowrmdir exists then slowrm create hardlink
+--file_exists $slowrmdir
+
+# file is slowly removed with speed 100 Mbps
+# wait till file get removed
+SET debug_sync = 'now WAIT_FOR big_file_removed';
+
+# $slowrmdir should be empty
+--rmdir $slowrmdir
+
+# deactivate debug synchronization point
+SET GLOBAL debug = '-d,ib_os_big_file_slow_removal';
+
+# test small table size
+CREATE TABLE t1 (x VARCHAR(100)) ENGINE=InnoDB;
+DROP TABLE t1;
+
+# $slowrmdir should not be created
+--error 1
+--file_exists $slowrmdir
+
+# Check that bg thread does not prevent server shutdown
+# Restart the server
+--source include/restart_mysqld.inc
+
+# cleanup
+--remove_file $input_file

--- a/mysql-test/suite/perfschema/r/threads_innodb.result
+++ b/mysql-test/suite/perfschema/r/threads_innodb.result
@@ -27,4 +27,5 @@ thread/innodb/srv_lock_timeout_thread	BACKGROUND	NULL	NULL	NULL	NULL	NULL	NULL	N
 thread/innodb/srv_master_thread	BACKGROUND	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	YES
 thread/innodb/srv_monitor_thread	BACKGROUND	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	YES
 thread/innodb/srv_purge_thread	BACKGROUND	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	YES
+thread/innodb/srv_slowrm_thread	BACKGROUND	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	YES
 thread/innodb/srv_worker_thread	BACKGROUND	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	YES

--- a/mysql-test/suite/sys_vars/r/innodb_big_file_slow_removal_speed_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_big_file_slow_removal_speed_basic.result
@@ -1,0 +1,32 @@
+SET @old_val = @@global.innodb_big_file_slow_removal_speed;
+SELECT @old_val;
+@old_val
+100
+SET @@global.innodb_big_file_slow_removal_speed = 10;
+SELECT @@global.innodb_big_file_slow_removal_speed;
+@@global.innodb_big_file_slow_removal_speed
+10
+SET @@global.innodb_big_file_slow_removal_speed = 100000;
+SELECT @@global.innodb_big_file_slow_removal_speed;
+@@global.innodb_big_file_slow_removal_speed
+100000
+SET @@global.innodb_big_file_slow_removal_speed = DEFAULT;
+SELECT @@global.innodb_big_file_slow_removal_speed;
+@@global.innodb_big_file_slow_removal_speed
+100
+SET @@global.innodb_big_file_slow_removal_speed = -1;
+Warnings:
+Warning	1292	Truncated incorrect innodb_big_file_slow_removal_spe value: '-1'
+SELECT @@global.innodb_big_file_slow_removal_speed;
+@@global.innodb_big_file_slow_removal_speed
+0
+SET @@global.innodb_big_file_slow_removal_speed = 1000000;
+Warnings:
+Warning	1292	Truncated incorrect innodb_big_file_slow_removal_spe value: '1000000'
+SELECT @@global.innodb_big_file_slow_removal_speed;
+@@global.innodb_big_file_slow_removal_speed
+100000
+SET @@global.innodb_big_file_slow_removal_speed = @old_val;
+SELECT @@global.innodb_big_file_slow_removal_speed;
+@@global.innodb_big_file_slow_removal_speed
+100

--- a/mysql-test/suite/sys_vars/t/innodb_big_file_slow_removal_speed_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_big_file_slow_removal_speed_basic.test
@@ -1,0 +1,24 @@
+--source include/load_sysvars.inc
+
+SET @old_val = @@global.innodb_big_file_slow_removal_speed;
+SELECT @old_val;
+
+SET @@global.innodb_big_file_slow_removal_speed = 10;
+SELECT @@global.innodb_big_file_slow_removal_speed;
+
+SET @@global.innodb_big_file_slow_removal_speed = 100000;
+SELECT @@global.innodb_big_file_slow_removal_speed;
+
+SET @@global.innodb_big_file_slow_removal_speed = DEFAULT;
+SELECT @@global.innodb_big_file_slow_removal_speed;
+
+#--warning 1292
+SET @@global.innodb_big_file_slow_removal_speed = -1;
+SELECT @@global.innodb_big_file_slow_removal_speed;
+
+#--warning 1292
+SET @@global.innodb_big_file_slow_removal_speed = 1000000;
+SELECT @@global.innodb_big_file_slow_removal_speed;
+
+SET @@global.innodb_big_file_slow_removal_speed = @old_val;
+SELECT @@global.innodb_big_file_slow_removal_speed;

--- a/share/errmsg-utf8.txt
+++ b/share/errmsg-utf8.txt
@@ -19628,6 +19628,15 @@ ER_LOG_CANNOT_WRITE_EXTENDED
 ER_UPGRADE_WITH_PARTITIONED_TABLES_REJECTED
   eng "Upgrading from server version %d with partitioned tables and lower_case_table_names == 1 on a case sensitive file system may cause issues, and is therefore prohibited. To upgrade anyway, restart the new server version with the command line option 'upgrade=FORCE'. When upgrade is completed, please execute 'RENAME TABLE <part_table_name> TO <new_table_name>; RENAME TABLE <new_table_name> TO <part_table_name>;' for each of the partitioned tables. Please see the documentation for further information."
 
+ER_IB_SLOWRM_GET_TIME
+  eng "%s"
+
+ER_IB_SLOWRM_CREATE_DIR
+  eng "%s"
+
+ER_IB_SLOWRM_MOVE_FILE
+  eng "%s"
+
 # DO NOT add server-to-client messages here!
 # This range is for messages intended for the error log only.
 # See the FAQ at the end of the file for further information.

--- a/storage/innobase/CMakeLists.txt
+++ b/storage/innobase/CMakeLists.txt
@@ -153,6 +153,7 @@ SET(INNOBASE_SOURCES
 	os/os0file.cc
 	os/os0proc.cc
 	os/os0event.cc
+	os/os0slowrm.cc
 	page/page0cur.cc
 	page/page0page.cc
 	page/page0zip.cc

--- a/storage/innobase/arch/arch0arch.cc
+++ b/storage/innobase/arch/arch0arch.cc
@@ -56,7 +56,7 @@ bool arch_wake_threads() {
   return (found_alive);
 }
 
-void arch_remove_file(const char *file_path, const char *file_name) {
+bool arch_remove_file(const char *file_path, const char *file_name) {
   char path[MAX_ARCH_PAGE_FILE_NAME_LEN];
 
   ut_ad(MAX_ARCH_LOG_FILE_NAME_LEN <= MAX_ARCH_PAGE_FILE_NAME_LEN);
@@ -68,7 +68,7 @@ void arch_remove_file(const char *file_path, const char *file_name) {
       0 != strncmp(file_name, ARCH_PAGE_FILE, strlen(ARCH_PAGE_FILE)) &&
       0 != strncmp(file_name, ARCH_PAGE_GROUP_DURABLE_FILE_NAME,
                    strlen(ARCH_PAGE_GROUP_DURABLE_FILE_NAME))) {
-    return;
+    return (true);
   }
 
   snprintf(path, sizeof(path), "%s%c%s", file_path, OS_PATH_SEPARATOR,
@@ -84,6 +84,8 @@ void arch_remove_file(const char *file_path, const char *file_name) {
 #endif /* UNIV_DEBUG */
 
   os_file_delete(innodb_arch_file_key, path);
+
+  return (true);
 }
 
 void arch_remove_dir(const char *dir_path, const char *dir_name) {
@@ -109,7 +111,7 @@ void arch_remove_dir(const char *dir_path, const char *dir_name) {
   ut_a(type == OS_FILE_TYPE_DIR);
 #endif /* UNIV_DEBUG */
 
-  os_file_scan_directory(path, arch_remove_file, true);
+  os_file_scan_directory(path, arch_remove_file, true, true);
 }
 
 /** Initialize Page and Log archiver system
@@ -274,7 +276,7 @@ void Arch_File_Ctx::delete_files(lsn_t begin_lsn) {
 
   if (exists) {
     ut_ad(type == OS_FILE_TYPE_DIR);
-    os_file_scan_directory(dir_name, arch_remove_file, true);
+    os_file_scan_directory(dir_name, arch_remove_file, true, true);
   }
 }
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -725,6 +725,7 @@ static PSI_thread_info all_innodb_threads[] = {
     PSI_KEY(log_write_notifier_thread, 0, 0, PSI_DOCUMENT_ME),
     PSI_KEY(log_flush_notifier_thread, 0, 0, PSI_DOCUMENT_ME),
     PSI_KEY(recv_writer_thread, 0, 0, PSI_DOCUMENT_ME),
+    PSI_KEY(srv_slowrm_thread, 0, 0, PSI_DOCUMENT_ME),
     PSI_KEY(srv_error_monitor_thread, 0, 0, PSI_DOCUMENT_ME),
     PSI_KEY(srv_lock_timeout_thread, 0, 0, PSI_DOCUMENT_ME),
     PSI_KEY(srv_master_thread, 0, 0, PSI_DOCUMENT_ME),
@@ -22433,6 +22434,12 @@ static MYSQL_SYSVAR_ULONG(aio_outstanding_requests, srv_io_outstanding_requests,
                           "this is reached.",
                           NULL, NULL, 256, 0, 1024, 0);
 
+static MYSQL_SYSVAR_ULONG(big_file_slow_removal_speed, srv_slowrm_speed_mbps,
+                          PLUGIN_VAR_RQCMDARG,
+                          "Big files slow removal speed in megabytes per "
+                          "second.",
+                          NULL, NULL, 100, 0, 100000, 0);
+
 static SYS_VAR *innobase_system_variables[] = {
     MYSQL_SYSVAR(api_trx_level),
     MYSQL_SYSVAR(api_bk_commit_interval),
@@ -22648,6 +22655,7 @@ static SYS_VAR *innobase_system_variables[] = {
     MYSQL_SYSVAR(lra_pages_before_sleep),
     MYSQL_SYSVAR(lra_sleep),
     MYSQL_SYSVAR(lra_n_spaces),
+    MYSQL_SYSVAR(big_file_slow_removal_speed),
     NULL};
 
 mysql_declare_plugin(innobase){

--- a/storage/innobase/include/arch0arch.h
+++ b/storage/innobase/include/arch0arch.h
@@ -124,7 +124,7 @@ enum Arch_Client_State {
 /** Remove files related to page and log archiving.
 @param[in]	file_path	path to the file
 @param[in]	file_name	name of the file */
-void arch_remove_file(const char *file_path, const char *file_name);
+bool arch_remove_file(const char *file_path, const char *file_name);
 
 /** Remove group directory and the files related to page and log archiving.
 @param[in]	dir_path	path to the directory

--- a/storage/innobase/include/os0file.h
+++ b/storage/innobase/include/os0file.h
@@ -910,17 +910,20 @@ bool os_file_create_directory(const char *pathname, bool fail_if_exists);
 /** Callback function type to be implemented by caller. It is called for each
 entry in directory.
 @param[in]	path	path to the file
-@param[in]	name	name of the file */
-typedef void (*os_dir_cbk_t)(const char *path, const char *name);
+@param[in]	name	name of the file
+@return true if the callback should continue to be processed on next entry,
+        false if the processing cycle should be stopped */
+typedef bool (*os_dir_cbk_t)(const char *path, const char *name);
 
 /** This function scans the contents of a directory and invokes the callback
 for each entry.
 @param[in]	path		directory name as null-terminated string
 @param[in]	scan_cbk	use callback to be called for each entry
+@param[in]	handle_nodir	handle ENOENT error for the directory
 @param[in]	is_drop		attempt to drop the directory after scan
 @return true if call succeeds, false on error */
 bool os_file_scan_directory(const char *path, os_dir_cbk_t scan_cbk,
-                            bool is_delete);
+                            bool handle_nodir, bool is_delete);
 
 /** NOTE! Use the corresponding macro os_file_create_simple(), not directly
 this function!
@@ -953,6 +956,14 @@ null-terminated string
 pfs_os_file_t os_file_create_simple_no_error_handling_func(
     const char *name, ulint create_mode, ulint access_type, bool read_only,
     bool *success) MY_ATTRIBUTE((warn_unused_result));
+
+/** Does error handling when a file operation fails.
+@param[in]	name		name of a file or NULL
+@param[in]	operation	operation name that failed
+@param[in]	on_error_silent	if true then don't print any message to the log.
+@return true if we should retry the operation */
+bool os_file_handle_error_no_exit(const char *name, const char *operation,
+                                  bool on_error_silent);
 
 /** Tries to disable OS caching on an opened file descriptor.
 @param[in]	fd		file descriptor to alter
@@ -1879,6 +1890,13 @@ dberr_t os_get_free_space(const char *path, uint64_t &free_space);
 /** Submit buffered AIO requests on the given segment to the kernel. */
 void os_aio_linux_dispatch_read_array_submit();
 #endif /* LINUX_NATIVE_AIO */
+
+/** Move big file into special directory for subsequent slow removing
+@param[in]	filename	name of the file to move */
+int slowfileremove(const char *filename);
+
+/** A thread which slowly removes big files. */
+void srv_slowrm_thread();
 
 /** This function returns information about the specified file
 @param[in]	path		pathname of the file

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -264,6 +264,9 @@ struct Srv_threads {
   /** Thread for GTID persistence */
   IB_thread m_gtid_persister;
 
+  /** Thread for slow removal of big files. */
+  IB_thread m_slowrm;
+
 #ifdef UNIV_DEBUG
   /** Used in test scenario to delay threads' cleanup until the pre_dd_shutdown
   is ended and final plugin's shutdown is started (when plugin is DELETED).
@@ -306,6 +309,9 @@ extern bool srv_upgrade_old_undo_found;
 #endif /* INNODB_DD_TABLE */
 
 extern const char *srv_main_thread_op_info;
+
+/* The slow removal thread waits on this event. */
+extern os_event_t srv_slowrm_event;
 
 /* The monitor thread waits on this event. */
 extern os_event_t srv_monitor_event;
@@ -745,6 +751,9 @@ extern bool srv_print_ddl_logs;
 
 extern bool srv_cmp_per_index_enabled;
 
+/* big_file_slow_removal speed */
+extern ulong srv_slowrm_speed_mbps;
+
 /** Status variables to be passed to MySQL */
 extern struct export_var_t export_vars;
 
@@ -779,6 +788,7 @@ extern mysql_pfs_key_t log_flush_notifier_thread_key;
 extern mysql_pfs_key_t page_flush_coordinator_thread_key;
 extern mysql_pfs_key_t page_flush_thread_key;
 extern mysql_pfs_key_t recv_writer_thread_key;
+extern mysql_pfs_key_t srv_slowrm_thread_key;
 extern mysql_pfs_key_t srv_error_monitor_thread_key;
 extern mysql_pfs_key_t srv_lock_timeout_thread_key;
 extern mysql_pfs_key_t srv_master_thread_key;

--- a/storage/innobase/include/ut0new.h
+++ b/storage/innobase/include/ut0new.h
@@ -133,6 +133,7 @@ InnoDB:
 #include <cstring>
 #include <limits>
 #include <map>
+#include <string>      /* std::basic_string */
 #include <type_traits> /* std::is_trivially_default_constructible */
 
 #include "my_basename.h"
@@ -1268,5 +1269,21 @@ class aligned_array_pointer : public aligned_memory<T_Type, T_Align_to> {
   /** Size of the allocated array. */
   size_t m_size;
 };
+
+/** Defining a string type from the string of std::, but with custom
+allocator. */
+namespace ut {
+
+using string =
+    std::basic_string<char, std::char_traits<char>, ut_allocator<char>>;
+
+/** Specialization of basic_ostringstream which uses ut_allocator. Please note
+that it's .str() method returns std::basic_string which is not std::string, so
+it has similar API (in particular .c_str()), but you can't assign it to regular,
+std::string. */
+using ostringstream =
+    std::basic_ostringstream<char, std::char_traits<char>, ut_allocator<char>>;
+
+}  // namespace ut
 
 #endif /* ut0new_h */

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -849,16 +849,6 @@ static bool os_file_handle_error(const char *name, const char *operation);
 @return DB_SUCCESS or error code */
 dberr_t os_file_punch_hole(os_file_t fh, os_offset_t off, os_offset_t len);
 
-/**
-Does error handling when a file operation fails.
-@param[in]	name		File name or NULL
-@param[in]	operation	Name of operation e.g., "read", "write"
-@param[in]	on_error_silent	if true then don't print any message to the log.
-@return true if we should retry the operation */
-static bool os_file_handle_error_no_exit(const char *name,
-                                         const char *operation,
-                                         bool on_error_silent);
-
 /** Decompress after a read and punch a hole in the file if it was a write
 @param[in]	type		IO context
 @param[in]	fh		Open file handle
@@ -3216,24 +3206,26 @@ bool os_file_create_directory(const char *pathname, bool fail_if_exists) {
 for each entry.
 @param[in]	path		directory name as null-terminated string
 @param[in]	scan_cbk	use callback to be called for each entry
+@param[in]	handle_nodir	handle ENOENT error for the directory
 @param[in]	is_drop		attempt to drop the directory after scan
 @return true if call succeeds, false on error */
 bool os_file_scan_directory(const char *path, os_dir_cbk_t scan_cbk,
-                            bool is_drop) {
+                            bool handle_nodir, bool is_drop) {
   DIR *directory;
   dirent *entry;
 
   directory = opendir(path);
 
   if (directory == nullptr) {
-    os_file_handle_error_no_exit(path, "opendir", false);
+    if (errno != ENOENT || handle_nodir)
+      os_file_handle_error_no_exit(path, "opendir", false);
     return (false);
   }
 
   entry = readdir(directory);
 
   while (entry != nullptr) {
-    scan_cbk(path, entry->d_name);
+    if (!scan_cbk(path, entry->d_name)) break;
     entry = readdir(directory);
   }
 
@@ -3495,7 +3487,7 @@ bool os_file_delete_if_exists_func(const char *name, bool *exist) {
     *exist = true;
   }
 
-  int ret = unlink(name);
+  int ret = slowfileremove(name);
 
   if (ret != 0 && errno == ENOENT) {
     if (exist != nullptr) {
@@ -3515,7 +3507,7 @@ bool os_file_delete_if_exists_func(const char *name, bool *exist) {
 @param[in]	name		file path as a null-terminated string
 @return true if success */
 bool os_file_delete_func(const char *name) {
-  int ret = unlink(name);
+  int ret = slowfileremove(name);
 
   if (ret != 0) {
     os_file_handle_error_no_exit(name, "delete", false);
@@ -4247,7 +4239,7 @@ bool os_file_scan_directory(const char *path, os_dir_cbk_t scan_cbk,
   }
 
   do {
-    scan_cbk(path, find_data.cFileName);
+    if (!scan_cbk(path, find_data.cFileName)) break;
     file_found = FindNextFile(find_hdl, &find_data);
 
   } while (file_found);
@@ -5479,9 +5471,8 @@ static bool os_file_handle_error(const char *name, const char *operation) {
 @param[in]	operation	operation name that failed
 @param[in]	on_error_silent	if true then don't print any message to the log.
 @return true if we should retry the operation */
-static bool os_file_handle_error_no_exit(const char *name,
-                                         const char *operation,
-                                         bool on_error_silent) {
+bool os_file_handle_error_no_exit(const char *name, const char *operation,
+                                  bool on_error_silent) {
   /* Don't exit in case of unknown error */
   return (
       os_file_handle_error_cond_exit(name, operation, false, on_error_silent));

--- a/storage/innobase/os/os0slowrm.cc
+++ b/storage/innobase/os/os0slowrm.cc
@@ -1,0 +1,218 @@
+/*
+   Copyright (c) 2019, Facebook, Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+
+/*
+ * Original algorithm
+ * https://github.com/midom/slowrm
+ *
+ * Slow removal of big files
+ * 1. check file size > @@global.innodb_big_file_slow_removal_speed
+ * 2. move file to DATADIR/.slowrm/ directory
+ * 3. background thread every 10 seconds scans that directory
+ * and slowrm all files
+ */
+
+#include <algorithm> /* std::basic_string */
+
+#include "os0file.h"
+#include "sql_thd_internal_api.h"
+#include "srv0srv.h"
+#include "srv0start.h"
+
+#include "current_thd.h" /* current_thd */
+#include "debug_sync.h"  /* debug_sync_set_action */
+
+/** Event to signal the slow removal thread. */
+os_event_t srv_slowrm_event;
+
+static constexpr uint64 MICROSECS_IN_SEC = 1000000;
+
+static constexpr uint32 megabyte = 1024 * 1024;
+static constexpr uint32 thread_sleep_interval = 10000000; /* microseconds */
+static constexpr uint32 slowrm_interval = 100000;         /* microseconds */
+
+/** Directory will be created in Innodb root directory where we have database
+directories (test, mysql, ...) */
+static constexpr char slowrm_dir[] = "./.slowrm";
+
+static ut::string make_path(const ut::string &dirname,
+                            const ut::string &filename,
+                            const ut::string &extension = {}) {
+  ut::string path;
+  auto path_len = dirname.size() + filename.size() + extension.size() + 2;
+
+  path.reserve(path_len);
+  path += dirname;
+  path += OS_PATH_SEPARATOR;
+  path += filename;
+  if (!extension.empty()) {
+    path += '.';
+    path += extension;
+  }
+  return path;
+}
+
+static inline int64 chunk_size_for_slow_rm() {
+  return srv_slowrm_speed_mbps * megabyte;
+}
+
+int slowfileremove(const char *filename) {
+  uint64 usec;
+  struct timeval tv;
+  struct stat statinfo;
+  ut::string filetoremove, fname{filename};
+
+  if (!srv_slowrm_speed_mbps) goto out;
+
+  /* If file is not regular or smaller then chunk size, just delete it. */
+  if (stat(filename, &statinfo) || !S_ISREG(statinfo.st_mode) ||
+      statinfo.st_size < chunk_size_for_slow_rm())
+    goto out;
+
+  /* Files submitted for removal may contain directory name convert path to
+  file into simple filename "./test/t1.ibd" -> "__test_t1_ibd". */
+  std::replace_if(
+      fname.begin(), fname.end(), [](char c) { return c == '.' || c == '/'; },
+      '_');
+
+  if (gettimeofday(&tv, NULL)) {
+    char *reason = strerror(errno);
+    ib::error(ER_IB_SLOWRM_GET_TIME)
+        << "slowfileremove failed to execute gettimeofday: '" << reason << "'";
+    goto out;
+  }
+
+  usec = tv.tv_sec * MICROSECS_IN_SEC + tv.tv_usec;
+  {
+    ut::ostringstream oss;
+    oss << usec;
+    filetoremove = make_path(slowrm_dir, fname, oss.str());
+  }
+
+  /* Create slowrm_dir directory if it does not exist. */
+  if (os_file_create_subdirs_if_needed(filetoremove.c_str()) != DB_SUCCESS) {
+    ib::error(ER_IB_SLOWRM_CREATE_DIR) << "slowfileremove could not create "
+                                       << "directory: '" << slowrm_dir << "'";
+    goto out;
+  }
+
+  /* Move file to slowrm_dir. */
+  if (rename(filename, filetoremove.c_str())) {
+    char *reason = strerror(errno);
+    ib::error(ER_IB_SLOWRM_MOVE_FILE)
+        << "slowfileremove could not move file: '" << filename << "' to '"
+        << filetoremove << "'\nreason: '" << reason << "'";
+    goto out;
+  }
+
+  return 0;
+
+out:
+  /* If rename failed fall back to unlink. */
+  return unlink(filename);
+}
+
+static void slowrm(const ut::string &path, off_t size) {
+  int fd = open(path.c_str(), O_RDWR);
+
+  if (fd < 0) return;
+
+  while (size > chunk_size_for_slow_rm() &&
+         srv_shutdown_state == SRV_SHUTDOWN_NONE) {
+    /* Convert bytes per seconds into bytes per 0.1 second;
+    max speed 100000 (100 Gbps),
+    so (speed * 1000000 / 10) cannot produce ulonglong overflow. */
+    int64 chunk_size = chunk_size_for_slow_rm() / 10;
+
+    if (chunk_size == 0) /* srv_slowrm_speed_mbps is 0 */
+      break;
+    if (chunk_size > size)
+      size = 0;
+    else
+      size -= chunk_size;
+    if (ftruncate(fd, size) < 0) break;
+    fsync(fd);
+    usleep(slowrm_interval);
+  }
+
+  /* If we finished truncating earlier because of server shutdown
+  and file size <= chunk size, then delete it. */
+  if (size <= chunk_size_for_slow_rm()) unlink(path.c_str());
+
+  close(fd);
+
+  DBUG_EXECUTE_IF(
+      "ib_os_big_file_slow_removal",
+      ut_ad(!debug_sync_set_action(
+          current_thd, STRING_WITH_LEN("now SIGNAL big_file_removed"))););
+}
+
+static bool remove_file_cb(const char *dirname, const char *fname) {
+  ut::string path;
+  struct stat statinfo;
+  const ut::string ut_fname{fname};
+
+  ut_a(ut_fname.length() < OS_FILE_MAX_PATH);
+
+  if (srv_shutdown_state != SRV_SHUTDOWN_NONE) return false;
+
+  if (ut_fname == "." || ut_fname == "..") return true;
+
+  path = make_path(dirname, ut_fname);
+
+  /* If readdir() returned a file that does not exist, it must have been
+  deleted in the meantime. The behaviour in this case should be the same
+  as if the file was deleted before readdir(): ignore and go to the next
+  entry. */
+  if (stat(path.c_str(), &statinfo)) {
+    if (errno != ENOENT) {
+      os_file_handle_error_no_exit(path.c_str(), "stat", false);
+      return false;
+    }
+  } else if (S_ISREG(statinfo.st_mode)) {
+    slowrm(path, statinfo.st_size);
+  }
+
+  return true;
+}
+
+/** Background thread which slowly truncates files in slowrm_dir. */
+void srv_slowrm_thread() {
+  auto thd_deleter = [](THD *thd) { destroy_thd(thd); };
+  const PSI_thread_key psi_key =
+#ifdef UNIV_PFS_THREAD
+      srv_slowrm_thread_key.m_value
+#else
+      0
+#endif
+      ;
+
+  using thd_ptr = std::unique_ptr<THD, decltype(thd_deleter)>;
+  thd_ptr thd_capsule{create_thd(false, true, true, psi_key),
+                      std::move(thd_deleter)};
+  int64_t sig_count = 0;
+
+  do {
+    /* sleep thread_sleep_interval microseconds*/
+    os_event_wait_time_low(srv_slowrm_event, thread_sleep_interval, sig_count);
+    sig_count = os_event_reset(srv_slowrm_event);
+
+    if (srv_shutdown_state != SRV_SHUTDOWN_NONE) break;
+
+    os_file_scan_directory(slowrm_dir, remove_file_cb, false, false);
+
+  } while (srv_shutdown_state == SRV_SHUTDOWN_NONE);
+}

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -599,6 +599,9 @@ ib_mutex_t srv_misc_tmpfile_mutex;
 /** Temporary file for miscellanous diagnostic output */
 FILE *srv_misc_tmpfile;
 
+/* big_file_slow_removal speed */
+ulong srv_slowrm_speed_mbps = 0;
+
 #ifndef UNIV_HOTBACKUP
 static ulint srv_main_thread_process_no = 0;
 static os_thread_id_t srv_main_thread_id = 0;
@@ -1123,6 +1126,8 @@ static void srv_init(void) {
       ut_a(slot->event);
     }
 
+    srv_slowrm_event = os_event_create(nullptr);
+
     srv_error_event = os_event_create(0);
 
     srv_monitor_event = os_event_create(0);
@@ -1175,6 +1180,7 @@ void srv_free(void) {
       os_event_destroy(slot->event);
     }
 
+    os_event_destroy(srv_slowrm_event);
     os_event_destroy(srv_error_event);
     os_event_destroy(srv_monitor_event);
     os_event_destroy(srv_buf_dump_event);


### PR DESCRIPTION
Summary:
Original algorithm
https://github.com/midom/slowrm

When INNODB executes command DROP TABLE t, it deletes table and file.
If table is big, file removal may take a lot of time on SSD.
So here, first we move file to special directory MYSQLD_DATADIR/.slowrm and then slowly truncate it in background thread.

Reference Patch: https://github.com/facebook/mysql-5.6/commit/cc9b09ba97c

Originally Reviewed By: lth

fbshipit-source-id: c428c462c0b