### PR TITLE
A new system variable to disable flow control between cordinator and worker threads

### DIFF
--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -1765,6 +1765,11 @@ The following options may be given as the first argument:
  --rpl-send-buffer-size=# 
  The size of output buffer for the socket used during
  sending events to a slave.
+ --rpl-slave-flow-control 
+ If this is set then underrun and overrun based flow
+ control between coordinator and worker threads in slave
+ instance will be enabled. Does not affect master instance
+ (Defaults to on; use --skip-rpl-slave-flow-control to disable.)
  --rpl-stop-slave-timeout=# 
  Timeout in seconds to wait for slave to stop before
  returning a warning.
@@ -2617,6 +2622,7 @@ rocksdb-write-policy write_committed
 rpl-read-size 8192
 rpl-receive-buffer-size 2097152
 rpl-send-buffer-size 2097152
+rpl-slave-flow-control TRUE
 rpl-stop-slave-timeout 31536000
 rpl-wait-for-semi-sync-ack FALSE
 safe-user-create FALSE

--- a/mysql-test/r/mysqld--help-win.result
+++ b/mysql-test/r/mysqld--help-win.result
@@ -1113,6 +1113,11 @@ The following options may be given as the first argument:
  must be a multiple of 4kb. Making it larger might help
  with IO stalls while reading these files when they are
  not in the OS buffer cache
+ --rpl-slave-flow-control 
+ If this is set then underrun and overrun based flow
+ control between coordinator and worker threads in slave
+ instance will be enabled. Does not affect master instance
+ (Defaults to on; use --skip-rpl-slave-flow-control to disable.)
  --rpl-stop-slave-timeout=# 
  Timeout in seconds to wait for slave to stop before
  returning a warning.
@@ -1690,6 +1695,7 @@ report-port 0
 report-user (No default value)
 require-secure-transport FALSE
 rpl-read-size 8192
+rpl-slave-flow-control TRUE
 rpl-stop-slave-timeout 31536000
 safe-user-create FALSE
 schema-definition-cache 256

--- a/mysql-test/suite/binlog_nogtid/r/binlog_persist_only_variables.result
+++ b/mysql-test/suite/binlog_nogtid/r/binlog_persist_only_variables.result
@@ -26,7 +26,7 @@ VARIABLE_NAME LIKE '%slave%') AND
 (VARIABLE_NAME NOT LIKE 'rocksdb%')
 ORDER BY VARIABLE_NAME;
 
-include/assert.inc ['Expect 99 variables in the table.']
+include/assert.inc ['Expect 100 variables in the table.']
 
 # Test SET PERSIST_ONLY
 SET PERSIST_ONLY binlog_cache_size = @@GLOBAL.binlog_cache_size;
@@ -107,6 +107,7 @@ SET PERSIST_ONLY rpl_semi_sync_master_whitelist = @@GLOBAL.rpl_semi_sync_master_
 SET PERSIST_ONLY rpl_semi_sync_slave_enabled = @@GLOBAL.rpl_semi_sync_slave_enabled;
 SET PERSIST_ONLY rpl_semi_sync_slave_trace_level = @@GLOBAL.rpl_semi_sync_slave_trace_level;
 SET PERSIST_ONLY rpl_send_buffer_size = @@GLOBAL.rpl_send_buffer_size;
+SET PERSIST_ONLY rpl_slave_flow_control = @@GLOBAL.rpl_slave_flow_control;
 SET PERSIST_ONLY rpl_stop_slave_timeout = @@GLOBAL.rpl_stop_slave_timeout;
 SET PERSIST_ONLY rpl_wait_for_semi_sync_ack = @@GLOBAL.rpl_wait_for_semi_sync_ack;
 SET PERSIST_ONLY session_track_gtids = @@GLOBAL.session_track_gtids;
@@ -143,16 +144,16 @@ SET PERSIST_ONLY sync_master_info = @@GLOBAL.sync_master_info;
 SET PERSIST_ONLY sync_relay_log = @@GLOBAL.sync_relay_log;
 SET PERSIST_ONLY sync_relay_log_info = @@GLOBAL.sync_relay_log_info;
 
-include/assert.inc ['Expect 88 persisted variables in persisted_variables table.']
+include/assert.inc ['Expect 89 persisted variables in persisted_variables table.']
 
 ############################################################
 # 2. Restart server, it must preserve the persisted variable
 #    settings. Verify persisted configuration.
 # restart
 
-include/assert.inc ['Expect 88 persisted variables in persisted_variables table.']
-include/assert.inc ['Expect 88 persisted variables shown as PERSISTED in variables_info table.']
-include/assert.inc ['Expect 87 persisted variables with matching persisted and global values.']
+include/assert.inc ['Expect 89 persisted variables in persisted_variables table.']
+include/assert.inc ['Expect 89 persisted variables shown as PERSISTED in variables_info table.']
+include/assert.inc ['Expect 88 persisted variables with matching persisted and global values.']
 
 ############################################################
 # 3. Test RESET PERSIST. Verify persisted variable settings
@@ -232,6 +233,7 @@ RESET PERSIST rpl_semi_sync_master_whitelist;
 RESET PERSIST rpl_semi_sync_slave_enabled;
 RESET PERSIST rpl_semi_sync_slave_trace_level;
 RESET PERSIST rpl_send_buffer_size;
+RESET PERSIST rpl_slave_flow_control;
 RESET PERSIST rpl_stop_slave_timeout;
 RESET PERSIST rpl_wait_for_semi_sync_ack;
 RESET PERSIST session_track_gtids;

--- a/mysql-test/suite/binlog_nogtid/r/binlog_persist_variables.result
+++ b/mysql-test/suite/binlog_nogtid/r/binlog_persist_variables.result
@@ -26,7 +26,7 @@ VARIABLE_NAME LIKE '%slave%') AND
 (VARIABLE_NAME NOT LIKE 'rocksdb%')
 ORDER BY VARIABLE_NAME;
 
-include/assert.inc ['Expect 99 variables in the table.']
+include/assert.inc ['Expect 100 variables in the table.']
 
 # Test SET PERSIST
 SET PERSIST binlog_cache_size = @@GLOBAL.binlog_cache_size;
@@ -113,6 +113,7 @@ SET PERSIST rpl_semi_sync_master_whitelist = @@GLOBAL.rpl_semi_sync_master_white
 SET PERSIST rpl_semi_sync_slave_enabled = @@GLOBAL.rpl_semi_sync_slave_enabled;
 SET PERSIST rpl_semi_sync_slave_trace_level = @@GLOBAL.rpl_semi_sync_slave_trace_level;
 SET PERSIST rpl_send_buffer_size = @@GLOBAL.rpl_send_buffer_size;
+SET PERSIST rpl_slave_flow_control = @@GLOBAL.rpl_slave_flow_control;
 SET PERSIST rpl_stop_slave_timeout = @@GLOBAL.rpl_stop_slave_timeout;
 SET PERSIST rpl_wait_for_semi_sync_ack = @@GLOBAL.rpl_wait_for_semi_sync_ack;
 SET PERSIST session_track_gtids = @@GLOBAL.session_track_gtids;
@@ -150,16 +151,16 @@ SET PERSIST sync_master_info = @@GLOBAL.sync_master_info;
 SET PERSIST sync_relay_log = @@GLOBAL.sync_relay_log;
 SET PERSIST sync_relay_log_info = @@GLOBAL.sync_relay_log_info;
 
-include/assert.inc ['Expect 81 persisted variables in persisted_variables table.']
+include/assert.inc ['Expect 82 persisted variables in persisted_variables table.']
 
 ############################################################
 # 2. Restart server, it must preserve the persisted variable
 #    settings. Verify persisted configuration.
 # restart
 
-include/assert.inc ['Expect 81 persisted variables in persisted_variables table.']
-include/assert.inc ['Expect 81 persisted variables shown as PERSISTED in variables_info table.']
-include/assert.inc ['Expect 81 persisted variables with matching persisted and global values.']
+include/assert.inc ['Expect 82 persisted variables in persisted_variables table.']
+include/assert.inc ['Expect 82 persisted variables shown as PERSISTED in variables_info table.']
+include/assert.inc ['Expect 82 persisted variables with matching persisted and global values.']
 
 ############################################################
 # 3. Test RESET PERSIST IF EXISTS. Verify persisted variable
@@ -261,6 +262,7 @@ RESET PERSIST IF EXISTS rpl_semi_sync_master_whitelist;
 RESET PERSIST IF EXISTS rpl_semi_sync_slave_enabled;
 RESET PERSIST IF EXISTS rpl_semi_sync_slave_trace_level;
 RESET PERSIST IF EXISTS rpl_send_buffer_size;
+RESET PERSIST IF EXISTS rpl_slave_flow_control;
 RESET PERSIST IF EXISTS rpl_stop_slave_timeout;
 RESET PERSIST IF EXISTS rpl_wait_for_semi_sync_ack;
 RESET PERSIST IF EXISTS session_track_gtids;

--- a/mysql-test/suite/binlog_nogtid/t/binlog_persist_only_variables.test
+++ b/mysql-test/suite/binlog_nogtid/t/binlog_persist_only_variables.test
@@ -61,7 +61,7 @@ INSERT INTO rplvars (varname, varvalue)
 # If this count differs, it means a variable has been added or removed.
 # In that case, this testcase needs to be updated accordingly.
 --echo
---let $expected=99
+--let $expected=100
 --let $assert_text= 'Expect $expected variables in the table.'
 --let $assert_cond= [SELECT COUNT(*) as count FROM rplvars, count, 1] = $expected
 --source include/assert.inc
@@ -81,7 +81,7 @@ while ( $varid <= $countvars )
   --eval SET PERSIST_ONLY $varnames = @@GLOBAL.$varnames
 
   #  TODO: Remove/update this once Bug#27322592 is FIXED.
-  if (`SELECT '$varnames' IN ('binlog_direct_non_transactional_updates', 'binlog_order_commits', 'binlog_rows_query_log_events', 'log_bin_trust_function_creators', 'log_slow_slave_statements', 'log_statements_unsafe_for_binlog', 'master_verify_checksum', 'slave_allow_batching', 'slave_compressed_protocol', 'slave_preserve_commit_order', 'slave_sql_verify_checksum', 'relay_log_purge', 'rpl_semi_sync_master_enabled', 'rpl_semi_sync_master_wait_no_slave', 'rpl_semi_sync_slave_enabled', 'binlog_gtid_simple_recovery', 'log_slave_updates', 'relay_log_recovery', 'binlog_rotate_encryption_master_key_at_startup', 'binlog_trx_meta_data', 'sql_log_bin_triggers', 'slave_high_priority_ddl', 'enable_binlog_hlc', 'rpl_wait_for_semi_sync_ack')`)
+  if (`SELECT '$varnames' IN ('binlog_direct_non_transactional_updates', 'binlog_order_commits', 'binlog_rows_query_log_events', 'log_bin_trust_function_creators', 'log_slow_slave_statements', 'log_statements_unsafe_for_binlog', 'master_verify_checksum', 'slave_allow_batching', 'slave_compressed_protocol', 'slave_preserve_commit_order', 'slave_sql_verify_checksum', 'relay_log_purge', 'rpl_semi_sync_master_enabled', 'rpl_semi_sync_master_wait_no_slave', 'rpl_semi_sync_slave_enabled', 'binlog_gtid_simple_recovery', 'log_slave_updates', 'relay_log_recovery', 'binlog_rotate_encryption_master_key_at_startup', 'binlog_trx_meta_data', 'sql_log_bin_triggers', 'slave_high_priority_ddl', 'enable_binlog_hlc', 'rpl_wait_for_semi_sync_ack', 'rpl_slave_flow_control')`)
   {
     --disable_query_log
       --eval SELECT varvalue INTO @varvalues FROM rplvars WHERE id=$varid
@@ -93,7 +93,7 @@ while ( $varid <= $countvars )
 }
 
 --echo
---let $expected=88
+--let $expected=89
 --let $assert_text= 'Expect $expected persisted variables in persisted_variables table.'
 --let $assert_cond= [SELECT COUNT(*) as count FROM performance_schema.persisted_variables, count, 1] = $expected
 --source include/assert.inc

--- a/mysql-test/suite/binlog_nogtid/t/binlog_persist_variables.test
+++ b/mysql-test/suite/binlog_nogtid/t/binlog_persist_variables.test
@@ -62,7 +62,7 @@ INSERT INTO rplvars (varname, varvalue)
 # If this count differs, it means a variable has been added or removed.
 # In that case, this testcase needs to be updated accordingly.
 --echo
---let $expected=99
+--let $expected=100
 --let $assert_text= 'Expect $expected variables in the table.'
 --let $assert_cond= [SELECT COUNT(*) as count FROM rplvars, count, 1] = $expected
 --source include/assert.inc
@@ -85,7 +85,7 @@ while ( $varid <= $countvars )
 }
 
 --echo
---let $expected=81
+--let $expected=82
 --let $assert_text= 'Expect $expected persisted variables in persisted_variables table.'
 --let $assert_cond= [SELECT COUNT(*) as count FROM performance_schema.persisted_variables, count, 1] = $expected
 --source include/assert.inc

--- a/mysql-test/suite/sys_vars/r/rpl_slave_flow_control_basic.result
+++ b/mysql-test/suite/sys_vars/r/rpl_slave_flow_control_basic.result
@@ -1,0 +1,48 @@
+SELECT COUNT(@@GLOBAL.rpl_slave_flow_control);
+COUNT(@@GLOBAL.rpl_slave_flow_control)
+1
+SELECT COUNT(@@SESSION.rpl_slave_flow_control);
+ERROR HY000: Variable 'rpl_slave_flow_control' is a GLOBAL variable
+SELECT VARIABLE_NAME FROM performance_schema.global_variables WHERE VARIABLE_NAME='rpl_slave_flow_control';
+VARIABLE_NAME
+rpl_slave_flow_control
+SELECT VARIABLE_NAME FROM performance_schema.session_variables WHERE VARIABLE_NAME='rpl_slave_flow_control';
+VARIABLE_NAME
+rpl_slave_flow_control
+SET GLOBAL rpl_slave_flow_control= ON;
+include/assert.inc ['rpl_slave_flow_control is a dynamic variable']
+SET GLOBAL rpl_slave_flow_control= OFF;
+include/assert.inc ['rpl_slave_flow_control should be OFF']
+SET GLOBAL rpl_slave_flow_control= ON;
+include/assert.inc ['rpl_slave_flow_control should be ON']
+SET GLOBAL rpl_slave_flow_control= 0;
+include/assert.inc ['rpl_slave_flow_control should be OFF']
+SET GLOBAL rpl_slave_flow_control= 1;
+include/assert.inc ['rpl_slave_flow_control should be ON']
+SET GLOBAL rpl_slave_flow_control= DEFAULT;
+include/assert.inc ['rpl_slave_flow_control should be ON']
+SET GLOBAL rpl_slave_flow_control= NULL;
+ERROR 42000: Variable 'rpl_slave_flow_control' can't be set to the value of 'NULL'
+SET GLOBAL rpl_slave_flow_control= '';
+ERROR 42000: Variable 'rpl_slave_flow_control' can't be set to the value of ''
+SET GLOBAL rpl_slave_flow_control= -1;
+ERROR 42000: Variable 'rpl_slave_flow_control' can't be set to the value of '-1'
+SET GLOBAL rpl_slave_flow_control= 1.0;
+ERROR 42000: Incorrect argument type to variable 'rpl_slave_flow_control'
+SET GLOBAL rpl_slave_flow_control= 'GARBAGE';
+ERROR 42000: Variable 'rpl_slave_flow_control' can't be set to the value of 'GARBAGE'
+SET GLOBAL rpl_slave_flow_control= 2;
+ERROR 42000: Variable 'rpl_slave_flow_control' can't be set to the value of '2'
+Expect value still set to "ON"
+SELECT @@global.rpl_slave_flow_control;
+@@global.rpl_slave_flow_control
+1
+CREATE USER user1;
+SET GLOBAL rpl_slave_flow_control=ON;
+ERROR 42000: Access denied; you need (at least one of) the SUPER or SYSTEM_VARIABLES_ADMIN privilege(s) for this operation
+GRANT SYSTEM_VARIABLES_ADMIN ON *.* TO user1@'%';
+SET GLOBAL rpl_slave_flow_control=ON;
+REVOKE SYSTEM_VARIABLES_ADMIN ON *.* FROM user1@'%';
+SET GLOBAL rpl_slave_flow_control=OFF;
+ERROR 42000: Access denied; you need (at least one of) the SUPER or SYSTEM_VARIABLES_ADMIN privilege(s) for this operation
+DROP USER user1;

--- a/mysql-test/suite/sys_vars/t/rpl_slave_flow_control_basic.test
+++ b/mysql-test/suite/sys_vars/t/rpl_slave_flow_control_basic.test
@@ -1,0 +1,125 @@
+###############################################################################
+# Variable Name: rpl_slave_flow_control
+# Scope: global
+# Access Type: dynamic
+# Data Type: boolean
+#
+# Description: Test case for checking the behavior of dynamic system variable
+#              "fast_integer_to_string", specifically regarding:
+#              - Scope & access type
+#              - Valid & default value
+#              - Invalid values
+#              - Required privileges
+#
+###############################################################################
+
+--source include/count_sessions.inc
+
+# Save initial value
+--let $saved_rpl_slave_flow_control= `SELECT @@global.rpl_slave_flow_control`
+
+#
+# Scope: Global only
+#
+SELECT COUNT(@@GLOBAL.rpl_slave_flow_control);
+
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT COUNT(@@SESSION.rpl_slave_flow_control);
+
+--disable_warnings
+SELECT VARIABLE_NAME FROM performance_schema.global_variables WHERE VARIABLE_NAME='rpl_slave_flow_control';
+SELECT VARIABLE_NAME FROM performance_schema.session_variables WHERE VARIABLE_NAME='rpl_slave_flow_control';
+--enable_warnings
+
+#
+# Access Type: Dynamic
+#
+SET GLOBAL rpl_slave_flow_control= ON;
+--let $assert_text= 'rpl_slave_flow_control is a dynamic variable'
+--let $assert_cond= "[SELECT @@GLOBAL.rpl_slave_flow_control]" = "1"
+--source include/assert.inc
+
+#
+# Valid values and Default value
+#
+SET GLOBAL rpl_slave_flow_control= OFF;
+--let $assert_text= 'rpl_slave_flow_control should be OFF'
+--let $assert_cond= "[SELECT @@GLOBAL.rpl_slave_flow_control]" = "0"
+--source include/assert.inc
+
+SET GLOBAL rpl_slave_flow_control= ON;
+--let $assert_text= 'rpl_slave_flow_control should be ON'
+--let $assert_cond= "[SELECT @@GLOBAL.rpl_slave_flow_control]" = "1"
+--source include/assert.inc
+
+SET GLOBAL rpl_slave_flow_control= 0;
+--let $assert_text= 'rpl_slave_flow_control should be OFF'
+--let $assert_cond= "[SELECT @@GLOBAL.rpl_slave_flow_control]" = "0"
+--source include/assert.inc
+
+SET GLOBAL rpl_slave_flow_control= 1;
+--let $assert_text= 'rpl_slave_flow_control should be ON'
+--let $assert_cond= "[SELECT @@GLOBAL.rpl_slave_flow_control]" = "1"
+--source include/assert.inc
+
+SET GLOBAL rpl_slave_flow_control= DEFAULT;
+--let $assert_text= 'rpl_slave_flow_control should be ON'
+--let $assert_cond= "[SELECT @@GLOBAL.rpl_slave_flow_control]" = "1"
+--source include/assert.inc
+
+#
+# Invalid values
+#
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL rpl_slave_flow_control= NULL;
+
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL rpl_slave_flow_control= '';
+
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL rpl_slave_flow_control= -1;
+
+--error ER_WRONG_TYPE_FOR_VAR
+SET GLOBAL rpl_slave_flow_control= 1.0;
+
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL rpl_slave_flow_control= 'GARBAGE';
+
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL rpl_slave_flow_control= 2;
+
+--echo Expect value still set to "ON"
+SELECT @@global.rpl_slave_flow_control;
+
+#
+# Privileges
+#
+
+CREATE USER user1;
+--connect(conn_user1,localhost,user1,,)
+
+--Error ER_SPECIFIC_ACCESS_DENIED_ERROR
+SET GLOBAL rpl_slave_flow_control=ON;
+
+--connection default
+GRANT SYSTEM_VARIABLES_ADMIN ON *.* TO user1@'%';
+--connection conn_user1
+SET GLOBAL rpl_slave_flow_control=ON;
+
+--connection default
+REVOKE SYSTEM_VARIABLES_ADMIN ON *.* FROM user1@'%';
+--connection conn_user1
+# FAST_INTEGER_TO_STRING_ADMIN is not enough
+--Error ER_SPECIFIC_ACCESS_DENIED_ERROR
+SET GLOBAL rpl_slave_flow_control=OFF;
+
+--connection default
+--disconnect conn_user1
+DROP USER user1;
+
+# Clean up
+--disable_query_log
+--eval SET GLOBAL rpl_slave_flow_control= $saved_rpl_slave_flow_control
+--enable_query_log
+
+--source include/wait_until_count_sessions.inc

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1256,6 +1256,7 @@ ulong max_connections, max_connect_errors;
 ulong max_nonsuper_connections = 0, nonsuper_connections = 0;
 ulong opt_max_running_queries, opt_max_waiting_queries;
 ulong rpl_stop_slave_timeout = LONG_TIMEOUT;
+bool rpl_slave_flow_control = true;
 bool log_bin_use_v1_row_events = 0;
 bool thread_cache_size_specified = false;
 bool host_cache_size_specified = false;

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -153,6 +153,7 @@ enum enum_server_operational_state {
 enum_server_operational_state get_server_state();
 
 extern const char *mysql_compression_lib_names[5];
+extern bool rpl_slave_flow_control;
 extern bool opt_improved_dup_key_error;
 extern bool opt_large_files, server_id_supplied;
 extern bool opt_bin_log, opt_trim_binlog;

--- a/sql/rpl_rli_pdb.cc
+++ b/sql/rpl_rli_pdb.cc
@@ -2338,8 +2338,12 @@ bool append_item_to_jobs(slave_job_item *job_item, Slave_worker *worker,
        the precision of wake-up through @c select() may be greater or
        equal 1 ms. So don't expect the nap last a prescribed fraction of 1 ms
        in such case.
+       Sleep only if this flow control is enabled through system variable
+       rpl_slave_flow_control
     */
-    my_sleep(min<ulong>(1000, nap_weight * rli->mts_coordinator_basic_nap));
+    if (rpl_slave_flow_control) {
+      my_sleep(min<ulong>(1000, nap_weight * rli->mts_coordinator_basic_nap));
+    }
     rli->mts_wq_no_underrun_cnt++;
   }
 

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -7472,3 +7472,10 @@ static Sys_var_bool Sys_high_precision_processlist(
     "high_precision_processlist",
     "If set, MySQL will display the time in 1/1000000 of a second precision",
     SESSION_VAR(high_precision_processlist), CMD_LINE(OPT_ARG), DEFAULT(false));
+
+static Sys_var_bool Sys_rpl_slave_flow_control(
+    "rpl_slave_flow_control",
+    "If this is set then underrun and "
+    "overrun based flow control between coordinator and worker threads in "
+    "slave instance will be enabled. Does not affect master instance",
+    GLOBAL_VAR(rpl_slave_flow_control), CMD_LINE(OPT_ARG), DEFAULT(true));


### PR DESCRIPTION
Summary:
The diff adds a new system variable to disable flow control between cordinator and worker replication threads in slave instance.
The default value of the system variable is false, hence the feature will not effect anything unless this variable is set explicitly.

Originally Reviewed By: anirbanr-fb

fbshipit-source-id: 4c87b6ea2bf