### PR TITLE
Return hlc timestamp for a write txn

### DIFF
--- a/mysql-test/include/have_gtid.inc
+++ b/mysql-test/include/have_gtid.inc
@@ -1,0 +1,14 @@
+# ==== Purpose ====
+#
+# Ensure that the server is running with GTID support on.
+#
+# ==== Usage ====
+#
+# --source include/have_gtid.inc
+
+--source include/have_log_bin.inc
+
+if ( `SELECT @@GLOBAL.GTID_MODE = "OFF"` )
+{
+  --skip Test requires GTID_MODE=ON.
+}

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -1280,6 +1280,13 @@ The following options may be given as the first argument:
  between 0 and the real lag when the IO thread is the
  bottleneck.
  (Defaults to on; use --skip-reset-seconds-behind-master to disable.)
+ --response-attrs-contain-hlc 
+ If this is enabled, then the HLC timestamp of a RW
+ transaction is sent back to clients as part of OK packet
+ in session response attribute. HLC is sent as a key-value
+ pair - 'hlc_ts' is the key and the value is the
+ stringified HLC timestamp. Note that HLC should be
+ enabled by setting enable_binlog_hlc
  --rocksdb[=name]    Enable or disable ROCKSDB plugin. Possible values are ON,
  OFF, FORCE (don't start if the plugin fails to load).
  --rocksdb-access-hint-on-compaction-start=# 
@@ -2455,6 +2462,7 @@ report-port 0
 report-user (No default value)
 require-secure-transport FALSE
 reset-seconds-behind-master TRUE
+response-attrs-contain-hlc FALSE
 rocksdb ON
 rocksdb-access-hint-on-compaction-start 1
 rocksdb-advise-random-on-open TRUE

--- a/mysql-test/r/mysqld--help-win.result
+++ b/mysql-test/r/mysqld--help-win.result
@@ -1109,6 +1109,13 @@ The following options may be given as the first argument:
  When this option is enabled, connections attempted using
  insecure transport will be rejected.  Secure transports
  are SSL/TLS, Unix socket or Shared Memory (on Windows).
+ --response-attrs-contain-hlc 
+ If this is enabled, then the HLC timestamp of a RW
+ transaction is sent back to clients as part of OK packet
+ in session response attribute. HLC is sent as a key-value
+ pair - 'hlc_ts' is the key and the value is the
+ stringified HLC timestamp. Note that HLC should be
+ enabled by setting enable_binlog_hlc
  --rpl-read-size=#   The size for reads done from the binlog and relay log. It
  must be a multiple of 4kb. Making it larger might help
  with IO stalls while reading these files when they are
@@ -1689,6 +1696,7 @@ report-password (No default value)
 report-port 0
 report-user (No default value)
 require-secure-transport FALSE
+response-attrs-contain-hlc FALSE
 rpl-read-size 8192
 rpl-stop-slave-timeout 31536000
 safe-user-create FALSE

--- a/mysql-test/suite/binlog_gtid/r/session_attrs_contain_hlc.result
+++ b/mysql-test/suite/binlog_gtid/r/session_attrs_contain_hlc.result
@@ -1,0 +1,155 @@
+flush logs;
+purge binary logs to 'binlog';
+SET SESSION DEBUG="+d,allow_long_hlc_drift_for_tests";
+SET @@global.minimum_hlc_ns = 2538630000000000000;
+SET @@session.session_track_response_attributes = on;
+SET @@global.enable_binlog_hlc = true;
+SET @@session.response_attrs_contain_hlc = true;
+Case 1: Single statement txn. Commit ts needs to be updated at commit time
+USE test;
+-- Tracker : SESSION_TRACK_SCHEMA
+-- test
+
+-- Tracker : SESSION_TRACK_RESP_ATTR
+-- change_db
+-- test
+
+CREATE TABLE t1 (a INT PRIMARY KEY, b CHAR(8));
+-- Tracker : SESSION_TRACK_RESP_ATTR
+-- hlc_ts
+-- 2538630000000000001
+
+INSERT INTO t1 VALUES(1, 'a');
+-- Tracker : SESSION_TRACK_RESP_ATTR
+-- hlc_ts
+-- 2538630000000000002
+
+INSERT INTO t1 VALUES(2, 'b');
+-- Tracker : SESSION_TRACK_RESP_ATTR
+-- hlc_ts
+-- 2538630000000000003
+
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+binlog.000002	#	Metadata	#	#	HLC time: 2538630000000000001
+binlog.000002	#	Query	#	#	use `test`; CREATE TABLE t1 (a INT PRIMARY KEY, b CHAR(8))
+binlog.000002	#	Metadata	#	#	HLC time: 2538630000000000002
+binlog.000002	#	Query	#	#	BEGIN
+binlog.000002	#	Table_map	#	#	table_id: # (test.t1)
+binlog.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000002	#	Xid	#	#	COMMIT /* XID */
+binlog.000002	#	Metadata	#	#	HLC time: 2538630000000000003
+binlog.000002	#	Query	#	#	BEGIN
+binlog.000002	#	Table_map	#	#	table_id: # (test.t1)
+binlog.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000002	#	Xid	#	#	COMMIT /* XID */
+Case 2: Multi statement txn. Commit ts needs to be updated at commit time
+BEGIN;
+INSERT INTO t1 VALUES(3, 'c');
+INSERT INTO t1 VALUES(4, 'd');
+COMMIT;
+-- Tracker : SESSION_TRACK_RESP_ATTR
+-- hlc_ts
+-- 2538630000000000004
+
+SELECT * FROM t1;
+a	b
+1	a
+2	b
+3	c
+4	d
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+binlog.000002	#	Metadata	#	#	HLC time: 2538630000000000001
+binlog.000002	#	Query	#	#	use `test`; CREATE TABLE t1 (a INT PRIMARY KEY, b CHAR(8))
+binlog.000002	#	Metadata	#	#	HLC time: 2538630000000000002
+binlog.000002	#	Query	#	#	BEGIN
+binlog.000002	#	Table_map	#	#	table_id: # (test.t1)
+binlog.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000002	#	Xid	#	#	COMMIT /* XID */
+binlog.000002	#	Metadata	#	#	HLC time: 2538630000000000003
+binlog.000002	#	Query	#	#	BEGIN
+binlog.000002	#	Table_map	#	#	table_id: # (test.t1)
+binlog.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000002	#	Xid	#	#	COMMIT /* XID */
+binlog.000002	#	Metadata	#	#	HLC time: 2538630000000000004
+binlog.000002	#	Query	#	#	BEGIN
+binlog.000002	#	Table_map	#	#	table_id: # (test.t1)
+binlog.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000002	#	Table_map	#	#	table_id: # (test.t1)
+binlog.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000002	#	Xid	#	#	COMMIT /* XID */
+Case 3: Turning off binlog_hlc should stop sending hlc in ok packets
+SET @@global.enable_binlog_hlc = false;
+SET @@session.response_attrs_contain_hlc = true;
+INSERT INTO t1 VALUES(5, 'e');
+COMMIT;
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+binlog.000002	#	Metadata	#	#	HLC time: 2538630000000000001
+binlog.000002	#	Query	#	#	use `test`; CREATE TABLE t1 (a INT PRIMARY KEY, b CHAR(8))
+binlog.000002	#	Metadata	#	#	HLC time: 2538630000000000002
+binlog.000002	#	Query	#	#	BEGIN
+binlog.000002	#	Table_map	#	#	table_id: # (test.t1)
+binlog.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000002	#	Xid	#	#	COMMIT /* XID */
+binlog.000002	#	Metadata	#	#	HLC time: 2538630000000000003
+binlog.000002	#	Query	#	#	BEGIN
+binlog.000002	#	Table_map	#	#	table_id: # (test.t1)
+binlog.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000002	#	Xid	#	#	COMMIT /* XID */
+binlog.000002	#	Metadata	#	#	HLC time: 2538630000000000004
+binlog.000002	#	Query	#	#	BEGIN
+binlog.000002	#	Table_map	#	#	table_id: # (test.t1)
+binlog.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000002	#	Table_map	#	#	table_id: # (test.t1)
+binlog.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000002	#	Xid	#	#	COMMIT /* XID */
+binlog.000002	#	Query	#	#	BEGIN
+binlog.000002	#	Table_map	#	#	table_id: # (test.t1)
+binlog.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000002	#	Xid	#	#	COMMIT /* XID */
+Case 4: Turning off response_attrs_contain_hlc should stop sending hlc in ok packets
+SET @@global.enable_binlog_hlc = true;
+SET @@session.response_attrs_contain_hlc = false;
+INSERT INTO t1 VALUES(6, 'f');
+COMMIT;
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+binlog.000002	#	Metadata	#	#	HLC time: 2538630000000000001
+binlog.000002	#	Query	#	#	use `test`; CREATE TABLE t1 (a INT PRIMARY KEY, b CHAR(8))
+binlog.000002	#	Metadata	#	#	HLC time: 2538630000000000002
+binlog.000002	#	Query	#	#	BEGIN
+binlog.000002	#	Table_map	#	#	table_id: # (test.t1)
+binlog.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000002	#	Xid	#	#	COMMIT /* XID */
+binlog.000002	#	Metadata	#	#	HLC time: 2538630000000000003
+binlog.000002	#	Query	#	#	BEGIN
+binlog.000002	#	Table_map	#	#	table_id: # (test.t1)
+binlog.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000002	#	Xid	#	#	COMMIT /* XID */
+binlog.000002	#	Metadata	#	#	HLC time: 2538630000000000004
+binlog.000002	#	Query	#	#	BEGIN
+binlog.000002	#	Table_map	#	#	table_id: # (test.t1)
+binlog.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000002	#	Table_map	#	#	table_id: # (test.t1)
+binlog.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000002	#	Xid	#	#	COMMIT /* XID */
+binlog.000002	#	Query	#	#	BEGIN
+binlog.000002	#	Table_map	#	#	table_id: # (test.t1)
+binlog.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000002	#	Xid	#	#	COMMIT /* XID */
+binlog.000002	#	Metadata	#	#	HLC time: 2538630000000000005
+binlog.000002	#	Query	#	#	BEGIN
+binlog.000002	#	Table_map	#	#	table_id: # (test.t1)
+binlog.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000002	#	Xid	#	#	COMMIT /* XID */
+USE test;
+-- Tracker : SESSION_TRACK_SCHEMA
+-- test
+
+-- Tracker : SESSION_TRACK_RESP_ATTR
+-- change_db
+-- test
+
+DROP TABLE t1;

--- a/mysql-test/suite/binlog_gtid/t/session_attrs_contain_hlc-master.opt
+++ b/mysql-test/suite/binlog_gtid/t/session_attrs_contain_hlc-master.opt
@@ -1,0 +1,1 @@
+--force-restart

--- a/mysql-test/suite/binlog_gtid/t/session_attrs_contain_hlc.test
+++ b/mysql-test/suite/binlog_gtid/t/session_attrs_contain_hlc.test
@@ -1,0 +1,81 @@
+--source include/have_binlog_format_row.inc
+--source include/have_debug.inc
+--source include/have_gtid.inc
+
+--enable_session_track_info
+
+--let $saved_minimum_hlc_ns= `SELECT @@global.minimum_hlc_ns`
+--let $saved_enable_binlog_hlc= `SELECT @@global.enable_binlog_hlc`
+--let $saved_response_attrs_contain_hlc= `SELECT @@session.response_attrs_contain_hlc`
+
+# Cleanup old binlog
+flush logs;
+let $binlog= query_get_value(SHOW MASTER STATUS, File, 1);
+replace_result $binlog binlog;
+eval purge binary logs to '$binlog';
+
+# Setup
+# Set minimum_hlc_ns to a high value. Subsequent txn's should see monotonically
+# increasing timestamp from this point
+SET SESSION DEBUG="+d,allow_long_hlc_drift_for_tests";
+SET @@global.minimum_hlc_ns = 2538630000000000000; # ~2050 AD
+
+# Enable tracking response attribute
+SET @@session.session_track_response_attributes = on;
+
+# Enable binlog_hlc
+SET @@global.enable_binlog_hlc = true;
+
+# Enable session to track HLC
+SET @@session.response_attrs_contain_hlc = true;
+
+# Case 1: Enable binlog HLC and run a single statement txn
+--echo Case 1: Single statement txn. Commit ts needs to be updated at commit time
+USE test;
+
+CREATE TABLE t1 (a INT PRIMARY KEY, b CHAR(8));
+INSERT INTO t1 VALUES(1, 'a');
+INSERT INTO t1 VALUES(2, 'b');
+--source include/show_binlog_events.inc
+
+# Case 2: Enable binlog HLC and run multi statement txn
+--echo Case 2: Multi statement txn. Commit ts needs to be updated at commit time
+BEGIN;
+  INSERT INTO t1 VALUES(3, 'c');
+  INSERT INTO t1 VALUES(4, 'd');
+COMMIT;
+
+SELECT * FROM t1;
+
+--source include/show_binlog_events.inc
+
+# Case 3: Turning off binlog_hlc should stop sending hlc in ok packets
+--echo Case 3: Turning off binlog_hlc should stop sending hlc in ok packets
+# Disable binlog_hlc
+SET @@global.enable_binlog_hlc = false;
+
+# Enable session to track HLC
+SET @@session.response_attrs_contain_hlc = true;
+INSERT INTO t1 VALUES(5, 'e');
+COMMIT;
+
+--source include/show_binlog_events.inc
+
+# Case 4: Turning off response_attrs_contain_hlc should stop sending hlc in ok packets even though binlog_hlc is enabled
+--echo Case 4: Turning off response_attrs_contain_hlc should stop sending hlc in ok packets
+SET @@global.enable_binlog_hlc = true;
+SET @@session.response_attrs_contain_hlc = false;
+INSERT INTO t1 VALUES(6, 'f');
+COMMIT;
+
+--source include/show_binlog_events.inc
+
+# Cleanup
+USE test;
+DROP TABLE t1;
+--disable_query_log
+--eval SET GLOBAL minimum_hlc_ns = $saved_minimum_hlc_ns
+--eval SET GLOBAL enable_binlog_hlc = $saved_enable_binlog_hlc
+--eval SET SESSION response_attrs_contain_hlc = $saved_response_attrs_contain_hlc
+--eval SET SESSION DEBUG="-d,allow_long_hlc_drift_for_tests"
+--enable_query_log

--- a/mysql-test/suite/sys_vars/r/response_attrs_contain_hlc_basic.result
+++ b/mysql-test/suite/sys_vars/r/response_attrs_contain_hlc_basic.result
@@ -1,0 +1,135 @@
+#
+# Variable name : response_attrs_contain_hlc
+# Scope         : Global & Session
+#
+# Global - default
+SELECT @@global.response_attrs_contain_hlc;
+@@global.response_attrs_contain_hlc
+0
+# Session - default
+SELECT @@session.response_attrs_contain_hlc;
+@@session.response_attrs_contain_hlc
+0
+
+SET @global_saved_tmp =  @@global.response_attrs_contain_hlc;
+
+# Altering global variable's value
+SET @@global.response_attrs_contain_hlc = 0;
+SELECT @@global.response_attrs_contain_hlc;
+@@global.response_attrs_contain_hlc
+0
+SELECT @@session.response_attrs_contain_hlc;
+@@session.response_attrs_contain_hlc
+0
+SET @@global.response_attrs_contain_hlc = TrUe;
+SELECT @@global.response_attrs_contain_hlc;
+@@global.response_attrs_contain_hlc
+1
+SELECT @@session.response_attrs_contain_hlc;
+@@session.response_attrs_contain_hlc
+0
+SET @@global.response_attrs_contain_hlc = FaLsE;
+SELECT @@global.response_attrs_contain_hlc;
+@@global.response_attrs_contain_hlc
+0
+SELECT @@session.response_attrs_contain_hlc;
+@@session.response_attrs_contain_hlc
+0
+
+# Altering session variable's value
+SET @@session.response_attrs_contain_hlc = 0;
+SELECT @@global.response_attrs_contain_hlc;
+@@global.response_attrs_contain_hlc
+0
+SELECT @@session.response_attrs_contain_hlc;
+@@session.response_attrs_contain_hlc
+0
+
+SET @@session.response_attrs_contain_hlc = TrUe;
+SELECT @@global.response_attrs_contain_hlc;
+@@global.response_attrs_contain_hlc
+0
+SELECT @@session.response_attrs_contain_hlc;
+@@session.response_attrs_contain_hlc
+1
+
+SET @@session.response_attrs_contain_hlc = FaLsE;
+SELECT @@global.response_attrs_contain_hlc;
+@@global.response_attrs_contain_hlc
+0
+SELECT @@session.response_attrs_contain_hlc;
+@@session.response_attrs_contain_hlc
+0
+
+SET @@session.response_attrs_contain_hlc = TrUe;
+SELECT @@global.response_attrs_contain_hlc;
+@@global.response_attrs_contain_hlc
+0
+SELECT @@session.response_attrs_contain_hlc;
+@@session.response_attrs_contain_hlc
+1
+
+# Variables' values in a new session.
+# Global - expect 0
+SELECT @@global.response_attrs_contain_hlc;
+@@global.response_attrs_contain_hlc
+0
+
+# Session - expect 0
+SELECT @@session.response_attrs_contain_hlc;
+@@session.response_attrs_contain_hlc
+0
+
+# Switching to the default connection.
+SELECT @@global.response_attrs_contain_hlc;
+@@global.response_attrs_contain_hlc
+0
+SELECT @@session.response_attrs_contain_hlc;
+@@session.response_attrs_contain_hlc
+1
+
+# Test if DEFAULT is working as expected.
+SET @@global.response_attrs_contain_hlc = DEFAULT;
+SET @@session.response_attrs_contain_hlc = DEFAULT;
+
+# Global - expect 0
+SELECT @@global.response_attrs_contain_hlc;
+@@global.response_attrs_contain_hlc
+0
+# Session - expect 0
+SELECT @@session.response_attrs_contain_hlc;
+@@session.response_attrs_contain_hlc
+0
+
+# Variables' values in a new session (con2).
+SELECT @@global.response_attrs_contain_hlc;
+@@global.response_attrs_contain_hlc
+0
+SELECT @@session.response_attrs_contain_hlc;
+@@session.response_attrs_contain_hlc
+0
+
+# Altering session should not affect global.
+SET @@session.response_attrs_contain_hlc = TRUE;
+SELECT @@global.response_attrs_contain_hlc;
+@@global.response_attrs_contain_hlc
+0
+SELECT @@session.response_attrs_contain_hlc;
+@@session.response_attrs_contain_hlc
+1
+
+# Variables' values in a new session (con3).
+# Altering global should not affect session.
+SET @@global.response_attrs_contain_hlc = ON;
+SELECT @@global.response_attrs_contain_hlc;
+@@global.response_attrs_contain_hlc
+1
+SELECT @@session.response_attrs_contain_hlc;
+@@session.response_attrs_contain_hlc
+0
+
+# Switching to the default connection.
+# Restoring the original values.
+SET @@global.response_attrs_contain_hlc = DEFAULT;
+SET @@session.response_attrs_contain_hlc = DEFAULT;
+# End of tests.

--- a/mysql-test/suite/sys_vars/t/response_attrs_contain_hlc_basic.test
+++ b/mysql-test/suite/sys_vars/t/response_attrs_contain_hlc_basic.test
@@ -1,0 +1,109 @@
+--echo #
+--echo # Variable name : response_attrs_contain_hlc
+--echo # Scope         : Global & Session
+--echo #
+
+--echo # Global - default
+SELECT @@global.response_attrs_contain_hlc;
+--echo # Session - default
+SELECT @@session.response_attrs_contain_hlc;
+--echo
+
+# Save the global value to be used to restore the original value.
+SET @global_saved_tmp =  @@global.response_attrs_contain_hlc;
+--echo
+
+--echo # Altering global variable's value
+SET @@global.response_attrs_contain_hlc = 0;
+SELECT @@global.response_attrs_contain_hlc;
+SELECT @@session.response_attrs_contain_hlc;
+
+SET @@global.response_attrs_contain_hlc = TrUe;
+SELECT @@global.response_attrs_contain_hlc;
+SELECT @@session.response_attrs_contain_hlc;
+
+SET @@global.response_attrs_contain_hlc = FaLsE;
+SELECT @@global.response_attrs_contain_hlc;
+SELECT @@session.response_attrs_contain_hlc;
+--echo
+
+--echo # Altering session variable's value
+SET @@session.response_attrs_contain_hlc = 0;
+SELECT @@global.response_attrs_contain_hlc;
+SELECT @@session.response_attrs_contain_hlc;
+--echo
+
+SET @@session.response_attrs_contain_hlc = TrUe;
+SELECT @@global.response_attrs_contain_hlc;
+SELECT @@session.response_attrs_contain_hlc;
+--echo
+
+SET @@session.response_attrs_contain_hlc = FaLsE;
+SELECT @@global.response_attrs_contain_hlc;
+SELECT @@session.response_attrs_contain_hlc;
+--echo
+
+SET @@session.response_attrs_contain_hlc = TrUe;
+SELECT @@global.response_attrs_contain_hlc;
+SELECT @@session.response_attrs_contain_hlc;
+--echo
+
+--echo # Variables' values in a new session.
+connect (con1,"127.0.0.1",root,,test,$MASTER_MYPORT,);
+
+--echo # Global - expect 0
+SELECT @@global.response_attrs_contain_hlc;
+--echo
+--echo # Session - expect 0
+SELECT @@session.response_attrs_contain_hlc;
+--echo
+
+--echo # Switching to the default connection.
+connection default;
+
+SELECT @@global.response_attrs_contain_hlc;
+SELECT @@session.response_attrs_contain_hlc;
+--echo
+
+--echo # Test if DEFAULT is working as expected.
+SET @@global.response_attrs_contain_hlc = DEFAULT;
+SET @@session.response_attrs_contain_hlc = DEFAULT;
+--echo
+
+--echo # Global - expect 0
+SELECT @@global.response_attrs_contain_hlc;
+--echo # Session - expect 0
+SELECT @@session.response_attrs_contain_hlc;
+--echo
+
+--echo # Variables' values in a new session (con2).
+connect (con2,"127.0.0.1",root,,test,$MASTER_MYPORT,);
+
+SELECT @@global.response_attrs_contain_hlc;
+SELECT @@session.response_attrs_contain_hlc;
+--echo
+
+--echo # Altering session should not affect global.
+SET @@session.response_attrs_contain_hlc = TRUE;
+SELECT @@global.response_attrs_contain_hlc;
+SELECT @@session.response_attrs_contain_hlc;
+--echo
+
+--echo # Variables' values in a new session (con3).
+connect (con3,"127.0.0.1",root,,test,$MASTER_MYPORT,);
+
+--echo # Altering global should not affect session.
+SET @@global.response_attrs_contain_hlc = ON;
+SELECT @@global.response_attrs_contain_hlc;
+SELECT @@session.response_attrs_contain_hlc;
+--echo
+
+--echo # Switching to the default connection.
+connection default;
+
+--echo # Restoring the original values.
+SET @@global.response_attrs_contain_hlc = DEFAULT;
+SET @@session.response_attrs_contain_hlc = DEFAULT;
+
+--echo # End of tests.
+

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -1479,7 +1479,19 @@ bool MYSQL_BIN_LOG::write_hlc(THD *thd, binlog_cache_data *cache_data,
 
   Metadata_log_event metadata_ev(thd, cache_data->is_trx_cache(),
                                  thd->hlc_time_ns_next);
-  return metadata_ev.write(writer);
+  bool result = metadata_ev.write(writer);
+
+  /* Update session tracker with hlc timestamp of this trx */
+  auto tracker = thd->session_tracker.get_tracker(SESSION_RESP_ATTR_TRACKER);
+  if (!result && thd->variables.response_attrs_contain_hlc &&
+      tracker->is_enabled()) {
+    LEX_CSTRING key = {STRING_WITH_LEN("hlc_ts")};
+    std::string value_str = std::to_string(thd->hlc_time_ns_next);
+    const LEX_CSTRING value = {value_str.c_str(), value_str.length()};
+    tracker->mark_as_changed(thd, &key, &value);
+  }
+
+  return result;
 }
 
 bool MYSQL_BIN_LOG::assign_automatic_gtids_to_flush_group(THD *first_seen) {

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -5065,6 +5065,26 @@ static Sys_var_transaction_read_only Sys_transaction_read_only(
     DEFAULT(0), NO_MUTEX_GUARD, NOT_IN_BINLOG,
     ON_CHECK(check_transaction_read_only));
 
+static bool check_outside_transaction(sys_var *, THD *thd, set_var *var) {
+  if (thd->in_active_multi_stmt_transaction()) {
+    my_error(ER_VARIABLE_NOT_SETTABLE_IN_TRANSACTION, MYF(0),
+             var->var->name.str);
+    return true;
+  }
+  return false;
+}
+
+static Sys_var_bool Sys_response_attrs_contain_hlc(
+    "response_attrs_contain_hlc",
+    "If this is enabled, then the HLC timestamp of a RW transaction is sent "
+    "back to clients as part of OK packet in session response attribute. HLC "
+    "is sent as a key-value pair - 'hlc_ts' is the key and the value is the "
+    "stringified HLC timestamp. Note that HLC should be enabled by setting "
+    "enable_binlog_hlc",
+    SESSION_VAR(response_attrs_contain_hlc), CMD_LINE(OPT_ARG), DEFAULT(false),
+    NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(check_outside_transaction),
+    ON_UPDATE(nullptr));
+
 static Sys_var_ulonglong Sys_tmp_table_size(
     "tmp_table_size",
     "If an internal in-memory temporary table in the MEMORY storage engine "

--- a/sql/system_variables.h
+++ b/sql/system_variables.h
@@ -341,6 +341,12 @@ struct System_variables {
   Gtid_set_or_null gtid_next_list;
   ulong session_track_gtids;  // see enum_session_track_gtids
 
+  /*
+    Should we set the HLC timestamp of a read write transaction in response
+    attribute?
+   */
+  bool response_attrs_contain_hlc;
+
   ulong max_execution_time;
 
   char *track_sysvars_ptr;


### PR DESCRIPTION
Summary:
The HLC timestamp associated with a GTID of a txn is returned as part of OK
packets. The HLC timestamp is stored in session response attributes tracker
field of the OK packet. The HLC is stored as a key-value pair in session
response attribute - the key is 'hlc_ts' and the value is the HLC timestamp.
Setting the HLC timestamp in OK packets is gated by a sysvar
'session_track_hlc'.

Only a RW transaction (i.e a transaction that genarates a GTID) will have a HLC
timestamp retuned in its OK packet.

Reference Patch: facebook/mysql-5.6@7bfac75

Originally Reviewed By: jrahman