### PR TITLE
reserve additional raft plugin related types in metadata event

### DIFF
--- a/libbinlogevents/include/control_events.h
+++ b/libbinlogevents/include/control_events.h
@@ -733,6 +733,8 @@ class Metadata_event : public Binary_log_event {
     PREV_HLC_TYPE = 1,
     /* Raft term and index added by raft consensus plugin */
     RAFT_TERM_INDEX_TYPE = 2,
+    /* Config added by raft consensus plugin */
+    RAFT_CONFIG_TYPE = 3,
     METADATA_EVENT_TYPE_MAX,
   };
 


### PR DESCRIPTION
Summary:
Additional types in raft plugin. Term and index is represented as one type.
config is another type. Got rid of raft_metadata type.

Originally Reviewed By: anirbanr-fb

fbshipit-source-id: 0f173450372