### PR TITLE
Can't change ownership of the file during trim binlog

### DIFF
--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -8227,7 +8227,9 @@ int MYSQL_BIN_LOG::open_binlog(const char *opt_name) {
           // NO_LINT_DEBUG
           sql_print_error("Taking backup from %s to %s\n", log_name,
                           backup_file);
-          if (my_copy(log_name, backup_file, MYF(MY_WME))) {
+          /* MY_HOLD_ORIGINAL_MODES prevents attempts to chown the file */
+          if (my_copy(log_name, backup_file,
+                      MYF(MY_WME | MY_HOLD_ORIGINAL_MODES))) {
             // NO_LINT_DEBUG
             sql_print_error(
                 "Could not take backup of the truncated binlog file %s",


### PR DESCRIPTION
Summary:
Mysqld error log:
>
2019-10-29 21:08:57 3013526 [ERROR] Taking backup from binary-logs-3306.000003 to binlog_backup.trunc
mysqld: Can't change ownership of the file 'binary-logs-3306.000003' (Errcode: 1 - Operation not permitted)
2019-10-29 21:08:58 3013526 [ERROR] Could not take backup of the truncated binlog file binary-logs-3306.000003
2019-10-29 21:08:58 3013526 [Note] Crashed binlog file binary-logs-3306.000003 size is 189413002, but recovered up to 189412705. Binlog trimmed to 189412705 bytes.
2019-10-29 21:08:58 3013526 [Note] [rpl_wait_for_semi_sync_ack] Last ACKed pos initialized to: binary-logs-3306.000003:189418122

This issue is caused by mysqld is running under mysql user instead of root user.

We copy these files for diagnostic purpose and it should be ok to don't change ownership. :)

Originally Reviewed By: yizhang82, bhatvinay

Reference Patch: facebook/mysql-5.6@8ee8ebe

fbshipit-source-id: f62bc35c895