### PR TITLE
Set and clear thd local 'should_update_hlc' correctly.

### DIFF
--- a/mysql-test/suite/rpl_gtid/r/rpl_binlog_hlc_rollback_trx_rbr.result
+++ b/mysql-test/suite/rpl_gtid/r/rpl_binlog_hlc_rollback_trx_rbr.result
@@ -1,0 +1,135 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+FLUSH LOGS;
+PURGE BINARY LOGS TO 'binlog';
+[connection slave]
+FLUSH LOGS;
+PURGE BINARY LOGS TO 'binlog';
+[connection master]
+SET @@session.debug = "+d,allow_long_hlc_drift_for_tests";
+SET @@global.minimum_hlc_ns = 2538630000000000000;
+SET @@global.enable_binlog_hlc = true;
+[connection slave]
+SET @@global.enable_binlog_hlc = true;
+Commit some trxs to move HLC forward
+[connection master]
+CREATE TABLE t1 (a INT PRIMARY KEY, b CHAR(8)) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, 'a');
+INSERT INTO t1 VALUES (2, 'b');
+include/sync_slave_sql_with_master.inc
+Now start a trx and roll it back
+[connection master]
+BEGIN;
+INSERT INTO t1 VALUES (3, 'c');
+INSERT INTO t1 VALUES (4, 'd');
+ROLLBACK;
+SELECT * FROM t1;
+a	b
+1	a
+2	b
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000002	#	Metadata	#	#	HLC time: 2538630000000000001
+master-bin.000002	#	Query	#	#	use `test`; CREATE TABLE t1 (a INT PRIMARY KEY, b CHAR(8)) ENGINE=InnoDB
+master-bin.000002	#	Metadata	#	#	HLC time: 2538630000000000002
+master-bin.000002	#	Query	#	#	BEGIN
+master-bin.000002	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000002	#	Xid	#	#	COMMIT /* XID */
+master-bin.000002	#	Metadata	#	#	HLC time: 2538630000000000003
+master-bin.000002	#	Query	#	#	BEGIN
+master-bin.000002	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000002	#	Xid	#	#	COMMIT /* XID */
+include/sync_slave_sql_with_master.inc
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+slave-bin.000002	#	Metadata	#	#	HLC time: 2538630000000000001
+slave-bin.000002	#	Query	#	#	use `test`; CREATE TABLE t1 (a INT PRIMARY KEY, b CHAR(8)) ENGINE=InnoDB
+slave-bin.000002	#	Metadata	#	#	HLC time: 2538630000000000002
+slave-bin.000002	#	Query	#	#	BEGIN
+slave-bin.000002	#	Table_map	#	#	table_id: # (test.t1)
+slave-bin.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+slave-bin.000002	#	Xid	#	#	COMMIT /* XID */
+slave-bin.000002	#	Metadata	#	#	HLC time: 2538630000000000003
+slave-bin.000002	#	Query	#	#	BEGIN
+slave-bin.000002	#	Table_map	#	#	table_id: # (test.t1)
+slave-bin.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+slave-bin.000002	#	Xid	#	#	COMMIT /* XID */
+Now disable binlog HLC and start a new trx. The new trx should not
+generate HLC and should not corrupt binlog
+[connection master]
+SET @@global.enable_binlog_hlc = false;
+INSERT INTO t1 VALUES (5, 'e');
+INSERT INTO t1 VALUES (6, 'f');
+SELECT * FROM t1;
+a	b
+1	a
+2	b
+5	e
+6	f
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000002	#	Metadata	#	#	HLC time: 2538630000000000001
+master-bin.000002	#	Query	#	#	use `test`; CREATE TABLE t1 (a INT PRIMARY KEY, b CHAR(8)) ENGINE=InnoDB
+master-bin.000002	#	Metadata	#	#	HLC time: 2538630000000000002
+master-bin.000002	#	Query	#	#	BEGIN
+master-bin.000002	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000002	#	Xid	#	#	COMMIT /* XID */
+master-bin.000002	#	Metadata	#	#	HLC time: 2538630000000000003
+master-bin.000002	#	Query	#	#	BEGIN
+master-bin.000002	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000002	#	Xid	#	#	COMMIT /* XID */
+master-bin.000002	#	Query	#	#	BEGIN
+master-bin.000002	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000002	#	Xid	#	#	COMMIT /* XID */
+master-bin.000002	#	Query	#	#	BEGIN
+master-bin.000002	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000002	#	Xid	#	#	COMMIT /* XID */
+include/sync_slave_sql_with_master.inc
+SELECT * FROM t1;
+a	b
+1	a
+2	b
+5	e
+6	f
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+slave-bin.000002	#	Metadata	#	#	HLC time: 2538630000000000001
+slave-bin.000002	#	Query	#	#	use `test`; CREATE TABLE t1 (a INT PRIMARY KEY, b CHAR(8)) ENGINE=InnoDB
+slave-bin.000002	#	Metadata	#	#	HLC time: 2538630000000000002
+slave-bin.000002	#	Query	#	#	BEGIN
+slave-bin.000002	#	Table_map	#	#	table_id: # (test.t1)
+slave-bin.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+slave-bin.000002	#	Xid	#	#	COMMIT /* XID */
+slave-bin.000002	#	Metadata	#	#	HLC time: 2538630000000000003
+slave-bin.000002	#	Query	#	#	BEGIN
+slave-bin.000002	#	Table_map	#	#	table_id: # (test.t1)
+slave-bin.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+slave-bin.000002	#	Xid	#	#	COMMIT /* XID */
+slave-bin.000002	#	Metadata	#	#	HLC time: 0
+slave-bin.000002	#	Query	#	#	BEGIN
+slave-bin.000002	#	Table_map	#	#	table_id: # (test.t1)
+slave-bin.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+slave-bin.000002	#	Xid	#	#	COMMIT /* XID */
+slave-bin.000002	#	Metadata	#	#	HLC time: 0
+slave-bin.000002	#	Query	#	#	BEGIN
+slave-bin.000002	#	Table_map	#	#	table_id: # (test.t1)
+slave-bin.000002	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+slave-bin.000002	#	Xid	#	#	COMMIT /* XID */
+[connection master]
+DROP TABLE IF EXISTS t1;
+SET @@session.debug = "-d,allow_long_hlc_drift_for_tests";
+SET @@global.minimum_hlc_ns = 0;
+SET @@global.enable_binlog_hlc = 0;
+include/sync_slave_sql_with_master.inc
+SET @@global.minimum_hlc_ns = 0;
+SET @@global.enable_binlog_hlc = 0;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl_gtid/r/rpl_binlog_hlc_rollback_trx_sbr.result
+++ b/mysql-test/suite/rpl_gtid/r/rpl_binlog_hlc_rollback_trx_sbr.result
@@ -1,0 +1,123 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+FLUSH LOGS;
+PURGE BINARY LOGS TO 'binlog';
+[connection slave]
+FLUSH LOGS;
+PURGE BINARY LOGS TO 'binlog';
+[connection master]
+SET @@session.debug = "+d,allow_long_hlc_drift_for_tests";
+SET @@global.minimum_hlc_ns = 2538630000000000000;
+SET @@global.enable_binlog_hlc = true;
+[connection slave]
+SET @@global.enable_binlog_hlc = true;
+Commit some trxs to move HLC forward
+[connection master]
+CREATE TABLE t1 (a INT PRIMARY KEY, b CHAR(8)) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, 'a');
+INSERT INTO t1 VALUES (2, 'b');
+include/sync_slave_sql_with_master.inc
+Now start a trx and roll it back
+[connection master]
+BEGIN;
+INSERT INTO t1 VALUES (3, 'c');
+INSERT INTO t1 VALUES (4, 'd');
+ROLLBACK;
+SELECT * FROM t1;
+a	b
+1	a
+2	b
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000002	#	Metadata	#	#	HLC time: 2538630000000000001
+master-bin.000002	#	Query	#	#	use `test`; CREATE TABLE t1 (a INT PRIMARY KEY, b CHAR(8)) ENGINE=InnoDB
+master-bin.000002	#	Metadata	#	#	HLC time: 2538630000000000002
+master-bin.000002	#	Query	#	#	BEGIN
+master-bin.000002	#	Query	#	#	use `test`; INSERT INTO t1 VALUES (1, 'a')
+master-bin.000002	#	Xid	#	#	COMMIT /* XID */
+master-bin.000002	#	Metadata	#	#	HLC time: 2538630000000000003
+master-bin.000002	#	Query	#	#	BEGIN
+master-bin.000002	#	Query	#	#	use `test`; INSERT INTO t1 VALUES (2, 'b')
+master-bin.000002	#	Xid	#	#	COMMIT /* XID */
+include/sync_slave_sql_with_master.inc
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+slave-bin.000002	#	Metadata	#	#	HLC time: 2538630000000000001
+slave-bin.000002	#	Query	#	#	use `test`; CREATE TABLE t1 (a INT PRIMARY KEY, b CHAR(8)) ENGINE=InnoDB
+slave-bin.000002	#	Metadata	#	#	HLC time: 2538630000000000002
+slave-bin.000002	#	Query	#	#	BEGIN
+slave-bin.000002	#	Query	#	#	use `test`; INSERT INTO t1 VALUES (1, 'a')
+slave-bin.000002	#	Xid	#	#	COMMIT /* XID */
+slave-bin.000002	#	Metadata	#	#	HLC time: 2538630000000000003
+slave-bin.000002	#	Query	#	#	BEGIN
+slave-bin.000002	#	Query	#	#	use `test`; INSERT INTO t1 VALUES (2, 'b')
+slave-bin.000002	#	Xid	#	#	COMMIT /* XID */
+Now disable binlog HLC and start a new trx. The new trx should not
+generate HLC and should not corrupt binlog
+[connection master]
+SET @@global.enable_binlog_hlc = false;
+INSERT INTO t1 VALUES (5, 'e');
+INSERT INTO t1 VALUES (6, 'f');
+SELECT * FROM t1;
+a	b
+1	a
+2	b
+5	e
+6	f
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000002	#	Metadata	#	#	HLC time: 2538630000000000001
+master-bin.000002	#	Query	#	#	use `test`; CREATE TABLE t1 (a INT PRIMARY KEY, b CHAR(8)) ENGINE=InnoDB
+master-bin.000002	#	Metadata	#	#	HLC time: 2538630000000000002
+master-bin.000002	#	Query	#	#	BEGIN
+master-bin.000002	#	Query	#	#	use `test`; INSERT INTO t1 VALUES (1, 'a')
+master-bin.000002	#	Xid	#	#	COMMIT /* XID */
+master-bin.000002	#	Metadata	#	#	HLC time: 2538630000000000003
+master-bin.000002	#	Query	#	#	BEGIN
+master-bin.000002	#	Query	#	#	use `test`; INSERT INTO t1 VALUES (2, 'b')
+master-bin.000002	#	Xid	#	#	COMMIT /* XID */
+master-bin.000002	#	Query	#	#	BEGIN
+master-bin.000002	#	Query	#	#	use `test`; INSERT INTO t1 VALUES (5, 'e')
+master-bin.000002	#	Xid	#	#	COMMIT /* XID */
+master-bin.000002	#	Query	#	#	BEGIN
+master-bin.000002	#	Query	#	#	use `test`; INSERT INTO t1 VALUES (6, 'f')
+master-bin.000002	#	Xid	#	#	COMMIT /* XID */
+include/sync_slave_sql_with_master.inc
+SELECT * FROM t1;
+a	b
+1	a
+2	b
+5	e
+6	f
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+slave-bin.000002	#	Metadata	#	#	HLC time: 2538630000000000001
+slave-bin.000002	#	Query	#	#	use `test`; CREATE TABLE t1 (a INT PRIMARY KEY, b CHAR(8)) ENGINE=InnoDB
+slave-bin.000002	#	Metadata	#	#	HLC time: 2538630000000000002
+slave-bin.000002	#	Query	#	#	BEGIN
+slave-bin.000002	#	Query	#	#	use `test`; INSERT INTO t1 VALUES (1, 'a')
+slave-bin.000002	#	Xid	#	#	COMMIT /* XID */
+slave-bin.000002	#	Metadata	#	#	HLC time: 2538630000000000003
+slave-bin.000002	#	Query	#	#	BEGIN
+slave-bin.000002	#	Query	#	#	use `test`; INSERT INTO t1 VALUES (2, 'b')
+slave-bin.000002	#	Xid	#	#	COMMIT /* XID */
+slave-bin.000002	#	Metadata	#	#	HLC time: 0
+slave-bin.000002	#	Query	#	#	BEGIN
+slave-bin.000002	#	Query	#	#	use `test`; INSERT INTO t1 VALUES (5, 'e')
+slave-bin.000002	#	Xid	#	#	COMMIT /* XID */
+slave-bin.000002	#	Metadata	#	#	HLC time: 0
+slave-bin.000002	#	Query	#	#	BEGIN
+slave-bin.000002	#	Query	#	#	use `test`; INSERT INTO t1 VALUES (6, 'f')
+slave-bin.000002	#	Xid	#	#	COMMIT /* XID */
+[connection master]
+DROP TABLE IF EXISTS t1;
+SET @@session.debug = "-d,allow_long_hlc_drift_for_tests";
+SET @@global.minimum_hlc_ns = 0;
+SET @@global.enable_binlog_hlc = 0;
+include/sync_slave_sql_with_master.inc
+SET @@global.minimum_hlc_ns = 0;
+SET @@global.enable_binlog_hlc = 0;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl_gtid/t/rpl_binlog_hlc_rollback_trx.inc
+++ b/mysql-test/suite/rpl_gtid/t/rpl_binlog_hlc_rollback_trx.inc
@@ -1,0 +1,63 @@
+# Setup
+# Set minimum_hlc_ns to a high value. Subsequent txn's should see monotonically
+# increasing timestamp from this point
+--source include/rpl_connection_master.inc
+SET @@session.debug = "+d,allow_long_hlc_drift_for_tests";
+--let $master_saved_minimum_hlc_ns = `SELECT @@global.minimum_hlc_ns`
+SET @@global.minimum_hlc_ns = 2538630000000000000; # ~2050 AD
+
+# Enable binlog_hlc in both master and slave
+--let $master_saved_enable_binlog_hlc = `SELECT @@global.enable_binlog_hlc`
+SET @@global.enable_binlog_hlc = true;
+--source include/rpl_connection_slave.inc
+--let $slave_saved_minimum_hlc_ns = `SELECT @@global.minimum_hlc_ns`
+--let $slave_saved_enable_binlog_hlc = `SELECT @@global.enable_binlog_hlc`
+SET @@global.enable_binlog_hlc = true;
+
+--echo Commit some trxs to move HLC forward
+--source include/rpl_connection_master.inc
+CREATE TABLE t1 (a INT PRIMARY KEY, b CHAR(8)) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, 'a');
+INSERT INTO t1 VALUES (2, 'b');
+
+--source include/sync_slave_sql_with_master.inc
+
+--echo Now start a trx and roll it back
+--source include/rpl_connection_master.inc
+BEGIN;
+INSERT INTO t1 VALUES (3, 'c');
+INSERT INTO t1 VALUES (4, 'd');
+ROLLBACK;
+
+SELECT * FROM t1;
+--source include/show_binlog_events.inc
+
+--source include/sync_slave_sql_with_master.inc
+--source include/show_binlog_events.inc
+
+--echo Now disable binlog HLC and start a new trx. The new trx should not
+--echo generate HLC and should not corrupt binlog
+--source include/rpl_connection_master.inc
+SET @@global.enable_binlog_hlc = false;
+
+INSERT INTO t1 VALUES (5, 'e');
+INSERT INTO t1 VALUES (6, 'f');
+
+SELECT * FROM t1;
+--source include/show_binlog_events.inc
+
+--source include/sync_slave_sql_with_master.inc
+SELECT * FROM t1;
+--source include/show_binlog_events.inc
+
+# Cleanup
+--source include/rpl_connection_master.inc
+DROP TABLE IF EXISTS t1;
+SET @@session.debug = "-d,allow_long_hlc_drift_for_tests";
+--eval SET @@global.minimum_hlc_ns = $master_saved_minimum_hlc_ns
+--eval SET @@global.enable_binlog_hlc = $master_saved_enable_binlog_hlc
+--source include/sync_slave_sql_with_master.inc
+--eval SET @@global.minimum_hlc_ns = $slave_saved_minimum_hlc_ns
+--eval SET @@global.enable_binlog_hlc = $slave_saved_enable_binlog_hlc
+
+--source include/rpl_end.inc

--- a/mysql-test/suite/rpl_gtid/t/rpl_binlog_hlc_rollback_trx_rbr-master.opt
+++ b/mysql-test/suite/rpl_gtid/t/rpl_binlog_hlc_rollback_trx_rbr-master.opt
@@ -1,0 +1,1 @@
+--force-restart

--- a/mysql-test/suite/rpl_gtid/t/rpl_binlog_hlc_rollback_trx_rbr.test
+++ b/mysql-test/suite/rpl_gtid/t/rpl_binlog_hlc_rollback_trx_rbr.test
@@ -1,0 +1,19 @@
+--source include/have_debug.inc
+--source include/have_binlog_format_row.inc
+--source include/master-slave.inc
+
+# Cleanup old binlogs; note, that default connection after 'master-slave.inc'
+# execution is 'master'
+FLUSH LOGS;
+--let $binlog=query_get_value(SHOW MASTER STATUS, File, 1)
+--replace_result $binlog binlog
+--eval PURGE BINARY LOGS TO '$binlog'
+
+--source include/rpl_connection_slave.inc
+FLUSH LOGS;
+--let $binlog=query_get_value(SHOW MASTER STATUS, File, 1)
+--replace_result $binlog binlog
+--eval PURGE BINARY LOGS TO '$binlog'
+
+# Include the tests
+--source rpl_binlog_hlc_rollback_trx.inc

--- a/mysql-test/suite/rpl_gtid/t/rpl_binlog_hlc_rollback_trx_sbr-master.opt
+++ b/mysql-test/suite/rpl_gtid/t/rpl_binlog_hlc_rollback_trx_sbr-master.opt
@@ -1,0 +1,1 @@
+--force-restart

--- a/mysql-test/suite/rpl_gtid/t/rpl_binlog_hlc_rollback_trx_sbr.test
+++ b/mysql-test/suite/rpl_gtid/t/rpl_binlog_hlc_rollback_trx_sbr.test
@@ -1,0 +1,19 @@
+--source include/have_debug.inc
+--source include/have_binlog_format_mixed_or_statement.inc
+--source include/master-slave.inc
+
+# Cleanup old binlogs; note, that default connection after 'master-slave.inc'
+# execution is 'master'
+FLUSH LOGS;
+--let $binlog=query_get_value(SHOW MASTER STATUS, File, 1)
+--replace_result $binlog binlog
+--eval PURGE BINARY LOGS TO '$binlog'
+
+--source include/rpl_connection_slave.inc
+FLUSH LOGS;
+--let $binlog=query_get_value(SHOW MASTER STATUS, File, 1)
+--replace_result $binlog binlog
+--eval PURGE BINARY LOGS TO '$binlog'
+
+# Include the tests
+--source rpl_binlog_hlc_rollback_trx.inc

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -5200,7 +5200,7 @@ bool MYSQL_BIN_LOG::open_binlog(
      * function (open_binlog()) should be called during server restart only
      * after initializing the local instance's HLC clock (by reading the
      * previous binlog file) */
-    if (enable_binlog_hlc) {
+    if (enable_binlog_hlc && !is_relay_log) {
       uint64_t current_hlc = mysql_bin_log.get_current_hlc();
       Metadata_log_event metadata_ev(current_hlc);
       if (write_event_to_binlog(&metadata_ev)) goto err;


### PR DESCRIPTION
Summary:
Enabling and disabling of HLC is controlled by a system variable
'enable_binlog_hlc'. To prevent ongoing trxs from corrupting binlogs, this
variable is captured in a thread local when the first event of the trx is
written to the trx binlog cache and cleared during the commit time of the trx.
However, the thd local was not cleared during the trx 'rollback' path. This
causes problems when the same thread gets used for a subsequent trx - the begin
of a trx will not write a dummy metadata event in the cache, but the commit of
the trx (which relies on thread local to figure out if hlc is enabled) writes
metadata event in the trx cache (effectively corrupting one trx in the binlog).

This fix correctly unsets the thread local when we write the first event for the
trx.

Reference Patch: facebook/mysql-5.6@8cd3411

Originally Reviewed By: abhinav04sharma

fbshipit-source-id: f070e22