### PR TITLE
FB8-246 main.implicit_commit fails in debug compilation

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -3505,17 +3505,26 @@ int mysql_execute_command(THD *thd, bool first_level, ulonglong *last_timer) {
     }
     case SQLCOM_SHOW_ENGINE_STATUS: {
       if (check_global_access(thd, PROCESS_ACL)) goto error;
-      res = ha_show_status(thd, lex->create_info->db_type, HA_ENGINE_STATUS);
+      if (ha_show_status(thd, lex->create_info->db_type, HA_ENGINE_STATUS)) {
+        my_error(ER_UNKNOWN_ERROR, MYF(0), "SHOW ENGINE STATUS");
+        goto error;
+      }
       break;
     }
     case SQLCOM_SHOW_ENGINE_MUTEX: {
       if (check_global_access(thd, PROCESS_ACL)) goto error;
-      res = ha_show_status(thd, lex->create_info->db_type, HA_ENGINE_MUTEX);
+      if (ha_show_status(thd, lex->create_info->db_type, HA_ENGINE_MUTEX)) {
+        my_error(ER_UNKNOWN_ERROR, MYF(0), "SHOW ENGINE MUTEX");
+        goto error;
+      }
       break;
     }
     case SQLCOM_SHOW_ENGINE_TRX: {
       if (check_global_access(thd, PROCESS_ACL)) goto error;
-      res = ha_show_status(thd, lex->create_info->db_type, HA_ENGINE_TRX);
+      if (ha_show_status(thd, lex->create_info->db_type, HA_ENGINE_TRX)) {
+        my_error(ER_UNKNOWN_ERROR, MYF(0), "SHOW ENGINE TRX");
+        goto error;
+      }
       break;
     }
     case SQLCOM_SHOW_MEMORY_STATUS: {
@@ -3833,7 +3842,10 @@ int mysql_execute_command(THD *thd, bool first_level, ulonglong *last_timer) {
       break;
     case SQLCOM_SHOW_ENGINE_LOGS: {
       if (check_access(thd, FILE_ACL, any_db, NULL, NULL, 0, 0)) goto error;
-      res = ha_show_status(thd, lex->create_info->db_type, HA_ENGINE_LOGS);
+      if (ha_show_status(thd, lex->create_info->db_type, HA_ENGINE_LOGS)) {
+        my_error(ER_UNKNOWN_ERROR, MYF(0), "SHOW ENGINE LOGS");
+        goto error;
+      }
       break;
     }
     case SQLCOM_CHANGE_DB: {

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -4912,7 +4912,9 @@ static bool rocksdb_show_status(handlerton *const hton, THD *const thd,
     std::vector<rocksdb::ThreadStatus> thread_list;
     rocksdb::Status s = rdb->GetEnv()->GetThreadList(&thread_list);
 
-    if (!s.ok()) {
+    // GetThreadList() may return Status::NotSupported when
+    // ROCKSDB_USING_THREAD_STATUS is not defined
+    if (!s.ok() && !s.IsNotSupported()) {
       // NO_LINT_DEBUG
       sql_print_error("RocksDB: Returned error (%s) from GetThreadList.\n",
                       s.ToString().c_str());


### PR DESCRIPTION
Summary:
`main.implicit_commit` crashes in debug build

Crashes due to the fact that `Diagnostics_area::m_status` is not set to other
than the default value (`DA_EMPTY`) on error. The error occurs due to the lack
of implementation of `Env::GetThreadList()` for rockdb.
Any `Diagnostics_area::m_status` must be set in `mysql_execute_command()` after
executing sql commands. In case of any error `Diagnostics_area::m_status` should
be set to `DA_ERROR` using `my_error()`.