### PR TITLE
Fixes of innodb.mysqld_core_dump_without_buffer_pool*

### DIFF
--- a/mysql-test/include/mysqld_core_dump.inc
+++ b/mysql-test/include/mysqld_core_dump.inc
@@ -33,13 +33,7 @@ $cur_time = time;
 system("kill", "-s", "SIGSEGV", "$pid");
 print "# Perl: Sent a SIGSEGV to mysqld to dump a core.\n";
 
-# Get the core file pattern, e.g. /var/tmp/cores/%e.%p
-$core_pattern = `cat /proc/sys/kernel/core_pattern`;
-
-$last_slash = rindex($core_pattern, '/');
-
-# The core file directory, e.g. /var/tmp/cores
-$core_dir = substr($core_pattern, 0, $last_slash);
+$core_dir = $ENV{'MYSQLTEST_VARDIR'} . '/mysqld.1/data/';
 
 $found_core = 0;
 $core_size = 0;

--- a/mysql-test/suite/innodb/r/mysqld_core_dump_without_buffer_pool.result
+++ b/mysql-test/suite/innodb/r/mysqld_core_dump_without_buffer_pool.result
@@ -3,7 +3,7 @@
 # Get the full path name of the PID file
 # Expecting a "crash", but don't restart the server until it is told to
 # Expected max core size is 1300 MB
-# Perl: Sent a SIGABRT to mysqld to dump a core.
+# Perl: Sent a SIGSEGV to mysqld to dump a core.
 # Perl: OK! Found the core file and it's small!
 # Make server restart
 # Wait for server to be back online

--- a/mysql-test/suite/innodb/r/mysqld_core_dump_without_buffer_pool_dynamic.result
+++ b/mysql-test/suite/innodb/r/mysqld_core_dump_without_buffer_pool_dynamic.result
@@ -18,7 +18,7 @@ SELECT @@global.innodb_buffer_pool_in_core_file;
 # Get the full path name of the PID file
 # Expecting a "crash", but don't restart the server until it is told to
 # Expected max core size is 1300 MB
-# Perl: Sent a SIGABRT to mysqld to dump a core.
+# Perl: Sent a SIGSEGV to mysqld to dump a core.
 # Perl: OK! Found the core file and it's small!
 # Make server restart
 # Wait for server to be back online

--- a/mysql-test/suite/innodb/r/mysqld_core_dump_without_buffer_pool_with_resizing.result
+++ b/mysql-test/suite/innodb/r/mysqld_core_dump_without_buffer_pool_with_resizing.result
@@ -8,7 +8,7 @@ set global innodb_buffer_pool_size = 2048*1024*1024;
 # Get the full path name of the PID file
 # Expecting a "crash", but don't restart the server until it is told to
 # Expected max core size is 1600 MB
-# Perl: Sent a SIGABRT to mysqld to dump a core.
+# Perl: Sent a SIGSEGV to mysqld to dump a core.
 # Perl: OK! Found the core file and it's small!
 # Make server restart
 # Wait for server to be back online


### PR DESCRIPTION
Summary:
- innodb.mysqld_core_dump_without_buffer_pool* MTR test cases expect
  core pattern to be simple 'core' and core files located in the var dir
- `mysqld` is killed to dump a core using SIGSEGV