### PR TITLE
Remove the redundant iter->Seek() call in ha_rocksdb::check_and_lock_sk

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -9792,7 +9792,6 @@ int ha_rocksdb::check_and_lock_sk(const uint key_id,
     Also need to scan RocksDB and verify the key has not been deleted
     in the transaction.
   */
-  iter->Seek(new_slice);
   *found = !read_key_exact(kd, iter, all_parts_used, new_slice,
                            row_info.tx->m_snapshot_timestamp);
   delete iter;


### PR DESCRIPTION
read_key_exact() is called next, and it will mak iter->Seek() call itself.