### PR TITLE
PS-6969: rocksdb.index_stats_large_table is unstable

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -12101,6 +12101,7 @@ static int calculate_cardinality_table_scan(
       rows_scanned++;
     }
 
+    cardinality_collector.Reset(); /* reset m_last_key for each key definition */
     cardinality_collector.SetCardinality(&stat);
     cardinality_collector.AdjustStats(&stat);
 


### PR DESCRIPTION
Fix the following issue:
```
CURRENT_TEST: rocksdb.index_stats_large_table
--- /tmp/results/PS/mysql-test/suite/rocksdb/r/index_stats_large_table.result	2020-04-01 16:28:46.000000000 +0300
+++ /tmp/results/PS/mysql-test/var/2/log/index_stats_large_table.reject	2020-04-01 20:07:59.436914670 +0300
@@ -25,8 +25,8 @@
 t0	1	t0_2	2	i2	A	10000	NULL	NULL	YES	SE_SPECIFIC			YES	NULL
 t0	1	t0_3	1	i2	A	1111	NULL	NULL	YES	SE_SPECIFIC			YES	NULL
 t0	1	t0_3	2	i1	A	10000	NULL	NULL	YES	SE_SPECIFIC			YES	NULL
-t0	1	t0_4	1	c1	A	NULL	NULL	NULL	YES	SE_SPECIFIC			YES	NULL
-t0	1	t0_4	2	c2	A	NULL	NULL	NULL	YES	SE_SPECIFIC			YES	NULL
+t0	1	t0_4	1	c1	A	10000	NULL	NULL	YES	SE_SPECIFIC			YES	NULL
+t0	1	t0_4	2	c2	A	10000	NULL	NULL	YES	SE_SPECIFIC			YES	NULL
 t0	1	t0_5	1	c2	A	1111	NULL	NULL	YES	SE_SPECIFIC			YES	NULL
 t0	1	t0_5	2	c1	A	10000	NULL	NULL	YES	SE_SPECIFIC			YES	NULL
 select table_name, table_rows from information_schema.tables where table_schema = database() and table_name = 't0';
```