### PR TITLE
Appended snapshot conflict error message

### DIFF
--- a/mysql-test/suite/rocksdb/r/hermitage.result
+++ b/mysql-test/suite/rocksdb/r/hermitage.result
@@ -483,7 +483,7 @@ delete from test where value = 20;
 connection con1;
 commit;
 connection con2;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction (snapshot conflict)
 select variable_value-@a from performance_schema.global_status where variable_name='rocksdb_snapshot_conflict_errors';
 variable_value-@a
 1
@@ -511,7 +511,7 @@ update test set value = 12 where id = 1;
 connection con1;
 commit;
 connection con2;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction (snapshot conflict)
 commit;
 connection con1;
 truncate table test;
@@ -582,7 +582,7 @@ update test set value = 18 where id = 2;
 commit;
 connection con1;
 delete from test where value = 20;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction (snapshot conflict)
 commit;
 connection con1;
 truncate table test;

--- a/mysql-test/suite/rocksdb/r/issue111.result
+++ b/mysql-test/suite/rocksdb/r/issue111.result
@@ -28,5 +28,5 @@ begin;
 update t1 set col2=123456 where pk=0;
 commit;
 update t1 set col2=col2+1 where col1 < 10 limit 5;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction (snapshot conflict)
 drop table t1, ten, one_k;

--- a/mysql-test/suite/rocksdb/r/rocksdb_locks.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_locks.result
@@ -57,7 +57,7 @@ UPDATE t1 SET value=30 WHERE id=3;
 COMMIT;
 connection con1;
 SELECT * FROM t1 WHERE id=3 FOR UPDATE;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction (snapshot conflict)
 ROLLBACK;
 disconnect con1;
 connection default;

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -4219,9 +4219,13 @@ void handler::print_error(int error, myf errflag) {
     case HA_ERR_LOCK_TABLE_FULL:
       textno = ER_LOCK_TABLE_FULL;
       break;
-    case HA_ERR_LOCK_DEADLOCK:
-      textno = ER_LOCK_DEADLOCK;
-      break;
+    case HA_ERR_LOCK_DEADLOCK: {
+      String str, full_err_msg(ER_DEFAULT(ER_LOCK_DEADLOCK), system_charset_info);
+      get_error_message(error, &str);
+      full_err_msg.append(str);
+      my_printf_error(ER_LOCK_DEADLOCK, "%s", errflag, full_err_msg.c_ptr_safe());
+      DBUG_VOID_RETURN;
+    }
     case HA_ERR_READ_ONLY_TRANSACTION:
       textno = ER_READ_ONLY_TRANSACTION;
       break;


### PR DESCRIPTION
Reference Patch: https://github.com/facebook/mysql-5.6/commit/db54adc81d9

---------- https://github.com/facebook/mysql-5.6/commit/db54adc81d9 ----------
appended snapshot conflict error message (#647)

Changes:
* changed the m_detailed_error string for the snapshot conflict case
* called my_printf_error in handler::print_error to propagate the detailed error string
* updated rocksdb's hermitage, issue111, and locks test cases to reflect snapshot conflict error message
Closes https://github.com/facebook/mysql-5.6/pull/647

Originally Reviewed By: gunnarku

fbshipit-source-id: ab48f298be8