### PR TITLE
Optimize replace into to do a blind write

### DIFF
--- a/libbinlogevents/include/rows_event.h
+++ b/libbinlogevents/include/rows_event.h
@@ -929,7 +929,13 @@ class Rows_event : public Binary_log_event {
       Indicates that rows in this event are complete, that is contain
       values for all columns of the table.
     */
-    COMPLETE_ROWS_F = (1U << 3)
+    COMPLETE_ROWS_F = (1U << 3),
+    /**
+      Indicates that this event is for writing a row as part of a blind
+      'replace into' statement optimization where pk constraints are ignored.
+      Note that we are using the MSB to make this forward compatible
+    */
+    BLIND_REPLACE_INTO_F = (1U << 15)
   };
 
   /**
@@ -1069,8 +1075,10 @@ class Rows_event : public Binary_log_event {
     if (flag & NO_FOREIGN_KEY_CHECKS_F) str.append(" No foreign Key checks");
     if (flag & RELAXED_UNIQUE_CHECKS_F) str.append(" No unique key checks");
     if (flag & COMPLETE_ROWS_F) str.append(" Complete Rows");
+    if (flag & BLIND_REPLACE_INTO_F) str.append(" Blind Replace Into");
     if (flag & ~(STMT_END_F | NO_FOREIGN_KEY_CHECKS_F |
-                 RELAXED_UNIQUE_CHECKS_F | COMPLETE_ROWS_F))
+                 RELAXED_UNIQUE_CHECKS_F | COMPLETE_ROWS_F |
+                 BLIND_REPLACE_INTO_F))
       str.append("Unknown Flag");
     return str;
   }

--- a/mysql-test/collections/disabled_rocksdb.def
+++ b/mysql-test/collections/disabled_rocksdb.def
@@ -30,12 +30,6 @@ rocksdb_rpl.rpl_rocksdb_schema_change : BUG#0000 missing 031b5cec711 Use column 
 rocksdb.percona_nonflushing_analyze_debug : BUG#0000 missing dbc7c09e252 Fix bug 1704195 / 87065 / TDB-83 (Stop ANALYZE...
 rocksdb.native_procedure : BUG#0000 missing 7292a82ad28 Native procedures in MySQL
 
-# Blind replace
-rocksdb.optimize_myrocks_replace_into_base : BUG#0000 missing patch f14c64cf950 Optimize replace into to do a blind write
-rocksdb.optimize_myrocks_replace_into_lock : BUG#0000 missing patch f14c64cf950 Optimize replace into to do a blind write
-rocksdb_rpl.optimize_myrocks_replace_into : BUG#0000 missing patch f14c64cf950 Optimize replace into to do a blind write
-rocksdb.mysqlbinlog_blind_replace : BUG#0000 missing patch f14c64cf950 Optimize replace into to do a blind write
-
 # Schema Validation
 rocksdb.validate_datadic : BUG#0000 redesign the testcase around schema validation
 rocksdb.skip_validate_tmp_table : BUG#0000 redesign the testcase around schema validation

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -334,6 +334,11 @@ The following options may be given as the first argument:
  name and library is the plugin library in plugin_dir.
  --enable-binlog-hlc Enable logging HLC timestamp as part of Metadata log
  event
+ --enable-blind-replace 
+ Optimize 'replace into' statement by doing a blind
+ insert. Engine ignores primary key violations. This will
+ avoid a delete and an insert. This is supported in
+ MyRocks
  --enable-query-checksum 
  Enable query checksums for queries that have the checksum
  query attribute set. Uses a CRC32 checksum of the query
@@ -2264,6 +2269,7 @@ disconnect-on-expired-password TRUE
 disconnect-slave-event-count 0
 div-precision-increment 4
 enable-binlog-hlc FALSE
+enable-blind-replace FALSE
 enable-query-checksum FALSE
 enable-resultset-checksum FALSE
 end-markers-in-json FALSE

--- a/mysql-test/suite/rocksdb/r/mysqlbinlog_blind_replace.result
+++ b/mysql-test/suite/rocksdb/r/mysqlbinlog_blind_replace.result
@@ -1,7 +1,7 @@
 reset master;
-set GLOBAL binlog_format= 'ROW';
+SET GLOBAL binlog_format= 'ROW';
 SET GLOBAL enable_blind_replace=ON;
-set binlog_format=row;
+SET binlog_format=row;
 create table t5 (c1 int primary key, c2 int);
 insert into t5 values (1, 1);
 insert into t5 values (2, 2);
@@ -11,11 +11,11 @@ c1	c2
 1	1
 2	2
 3	3
-select variable_value into @c from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @c from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 replace into t5 values (1, 11);
 replace into t5 values (2, 22);
 replace into t5 values (3, 33);
-select case when variable_value-@c = 3 then 'true' else 'false' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select case when variable_value-@c = 3 then 'true' else 'false' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 true
 select * from t5;
@@ -25,31 +25,31 @@ c1	c2
 3	33
 include/show_binlog_events.inc
 Log_name	Pos	Event_type	Server_id	End_log_pos	Info
-master-bin.000001	#	Query	#	#	use `test`; create table t5 (c1 int primary key, c2 int)
-master-bin.000001	#	Query	#	#	BEGIN
-master-bin.000001	#	Table_map	#	#	table_id: # (test.t5)
-master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
-master-bin.000001	#	Xid	#	#	COMMIT /* XID */
-master-bin.000001	#	Query	#	#	BEGIN
-master-bin.000001	#	Table_map	#	#	table_id: # (test.t5)
-master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
-master-bin.000001	#	Xid	#	#	COMMIT /* XID */
-master-bin.000001	#	Query	#	#	BEGIN
-master-bin.000001	#	Table_map	#	#	table_id: # (test.t5)
-master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
-master-bin.000001	#	Xid	#	#	COMMIT /* XID */
-master-bin.000001	#	Query	#	#	BEGIN
-master-bin.000001	#	Table_map	#	#	table_id: # (test.t5)
-master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
-master-bin.000001	#	Xid	#	#	COMMIT /* XID */
-master-bin.000001	#	Query	#	#	BEGIN
-master-bin.000001	#	Table_map	#	#	table_id: # (test.t5)
-master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
-master-bin.000001	#	Xid	#	#	COMMIT /* XID */
-master-bin.000001	#	Query	#	#	BEGIN
-master-bin.000001	#	Table_map	#	#	table_id: # (test.t5)
-master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
-master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+binlog.000001	#	Query	#	#	use `test`; create table t5 (c1 int primary key, c2 int)
+binlog.000001	#	Query	#	#	BEGIN
+binlog.000001	#	Table_map	#	#	table_id: # (test.t5)
+binlog.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000001	#	Xid	#	#	COMMIT /* XID */
+binlog.000001	#	Query	#	#	BEGIN
+binlog.000001	#	Table_map	#	#	table_id: # (test.t5)
+binlog.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000001	#	Xid	#	#	COMMIT /* XID */
+binlog.000001	#	Query	#	#	BEGIN
+binlog.000001	#	Table_map	#	#	table_id: # (test.t5)
+binlog.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000001	#	Xid	#	#	COMMIT /* XID */
+binlog.000001	#	Query	#	#	BEGIN
+binlog.000001	#	Table_map	#	#	table_id: # (test.t5)
+binlog.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000001	#	Xid	#	#	COMMIT /* XID */
+binlog.000001	#	Query	#	#	BEGIN
+binlog.000001	#	Table_map	#	#	table_id: # (test.t5)
+binlog.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000001	#	Xid	#	#	COMMIT /* XID */
+binlog.000001	#	Query	#	#	BEGIN
+binlog.000001	#	Table_map	#	#	table_id: # (test.t5)
+binlog.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000001	#	Xid	#	#	COMMIT /* XID */
 flush logs;
 drop table t5;
 reset master;
@@ -61,31 +61,31 @@ c1	c2
 3	33
 include/show_binlog_events.inc
 Log_name	Pos	Event_type	Server_id	End_log_pos	Info
-master-bin.000001	#	Query	#	#	use `test`; create table t5 (c1 int primary key, c2 int)
-master-bin.000001	#	Query	#	#	BEGIN
-master-bin.000001	#	Table_map	#	#	table_id: # (test.t5)
-master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
-master-bin.000001	#	Xid	#	#	COMMIT /* XID */
-master-bin.000001	#	Query	#	#	BEGIN
-master-bin.000001	#	Table_map	#	#	table_id: # (test.t5)
-master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
-master-bin.000001	#	Xid	#	#	COMMIT /* XID */
-master-bin.000001	#	Query	#	#	BEGIN
-master-bin.000001	#	Table_map	#	#	table_id: # (test.t5)
-master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
-master-bin.000001	#	Xid	#	#	COMMIT /* XID */
-master-bin.000001	#	Query	#	#	BEGIN
-master-bin.000001	#	Table_map	#	#	table_id: # (test.t5)
-master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
-master-bin.000001	#	Xid	#	#	COMMIT /* XID */
-master-bin.000001	#	Query	#	#	BEGIN
-master-bin.000001	#	Table_map	#	#	table_id: # (test.t5)
-master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
-master-bin.000001	#	Xid	#	#	COMMIT /* XID */
-master-bin.000001	#	Query	#	#	BEGIN
-master-bin.000001	#	Table_map	#	#	table_id: # (test.t5)
-master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
-master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+binlog.000001	#	Query	#	#	use `test`; create table t5 (c1 int primary key, c2 int)
+binlog.000001	#	Query	#	#	BEGIN
+binlog.000001	#	Table_map	#	#	table_id: # (test.t5)
+binlog.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000001	#	Xid	#	#	COMMIT /* XID */
+binlog.000001	#	Query	#	#	BEGIN
+binlog.000001	#	Table_map	#	#	table_id: # (test.t5)
+binlog.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000001	#	Xid	#	#	COMMIT /* XID */
+binlog.000001	#	Query	#	#	BEGIN
+binlog.000001	#	Table_map	#	#	table_id: # (test.t5)
+binlog.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000001	#	Xid	#	#	COMMIT /* XID */
+binlog.000001	#	Query	#	#	BEGIN
+binlog.000001	#	Table_map	#	#	table_id: # (test.t5)
+binlog.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000001	#	Xid	#	#	COMMIT /* XID */
+binlog.000001	#	Query	#	#	BEGIN
+binlog.000001	#	Table_map	#	#	table_id: # (test.t5)
+binlog.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000001	#	Xid	#	#	COMMIT /* XID */
+binlog.000001	#	Query	#	#	BEGIN
+binlog.000001	#	Table_map	#	#	table_id: # (test.t5)
+binlog.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000001	#	Xid	#	#	COMMIT /* XID */
 drop table t5;
 reset master;
 Replaying the same binlog events with blind replace disabled should work
@@ -98,31 +98,31 @@ c1	c2
 3	33
 include/show_binlog_events.inc
 Log_name	Pos	Event_type	Server_id	End_log_pos	Info
-master-bin.000001	#	Query	#	#	use `test`; create table t5 (c1 int primary key, c2 int)
-master-bin.000001	#	Query	#	#	BEGIN
-master-bin.000001	#	Table_map	#	#	table_id: # (test.t5)
-master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
-master-bin.000001	#	Xid	#	#	COMMIT /* XID */
-master-bin.000001	#	Query	#	#	BEGIN
-master-bin.000001	#	Table_map	#	#	table_id: # (test.t5)
-master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
-master-bin.000001	#	Xid	#	#	COMMIT /* XID */
-master-bin.000001	#	Query	#	#	BEGIN
-master-bin.000001	#	Table_map	#	#	table_id: # (test.t5)
-master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
-master-bin.000001	#	Xid	#	#	COMMIT /* XID */
-master-bin.000001	#	Query	#	#	BEGIN
-master-bin.000001	#	Table_map	#	#	table_id: # (test.t5)
-master-bin.000001	#	Update_rows	#	#	table_id: # flags: STMT_END_F
-master-bin.000001	#	Xid	#	#	COMMIT /* XID */
-master-bin.000001	#	Query	#	#	BEGIN
-master-bin.000001	#	Table_map	#	#	table_id: # (test.t5)
-master-bin.000001	#	Update_rows	#	#	table_id: # flags: STMT_END_F
-master-bin.000001	#	Xid	#	#	COMMIT /* XID */
-master-bin.000001	#	Query	#	#	BEGIN
-master-bin.000001	#	Table_map	#	#	table_id: # (test.t5)
-master-bin.000001	#	Update_rows	#	#	table_id: # flags: STMT_END_F
-master-bin.000001	#	Xid	#	#	COMMIT /* XID */
-set GLOBAL binlog_format=DEFAULT;
+binlog.000001	#	Query	#	#	use `test`; create table t5 (c1 int primary key, c2 int)
+binlog.000001	#	Query	#	#	BEGIN
+binlog.000001	#	Table_map	#	#	table_id: # (test.t5)
+binlog.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000001	#	Xid	#	#	COMMIT /* XID */
+binlog.000001	#	Query	#	#	BEGIN
+binlog.000001	#	Table_map	#	#	table_id: # (test.t5)
+binlog.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000001	#	Xid	#	#	COMMIT /* XID */
+binlog.000001	#	Query	#	#	BEGIN
+binlog.000001	#	Table_map	#	#	table_id: # (test.t5)
+binlog.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000001	#	Xid	#	#	COMMIT /* XID */
+binlog.000001	#	Query	#	#	BEGIN
+binlog.000001	#	Table_map	#	#	table_id: # (test.t5)
+binlog.000001	#	Update_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000001	#	Xid	#	#	COMMIT /* XID */
+binlog.000001	#	Query	#	#	BEGIN
+binlog.000001	#	Table_map	#	#	table_id: # (test.t5)
+binlog.000001	#	Update_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000001	#	Xid	#	#	COMMIT /* XID */
+binlog.000001	#	Query	#	#	BEGIN
+binlog.000001	#	Table_map	#	#	table_id: # (test.t5)
+binlog.000001	#	Update_rows	#	#	table_id: # flags: STMT_END_F
+binlog.000001	#	Xid	#	#	COMMIT /* XID */
+SET GLOBAL binlog_format=DEFAULT;
 SET GLOBAL enable_blind_replace=DEFAULT;
 drop table t5;

--- a/mysql-test/suite/rocksdb/r/optimize_myrocks_replace_into_base.result
+++ b/mysql-test/suite/rocksdb/r/optimize_myrocks_replace_into_base.result
@@ -8,9 +8,9 @@ c1	c2
 1	1
 2	2
 3	3
-select variable_value into @c from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @c from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 replace into t1 values(1,11);
-select case when variable_value-@c > 1 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select case when variable_value-@c > 1 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 true
 drop table t1;
@@ -22,9 +22,9 @@ c1	c2
 1	1
 2	2
 3	3
-select variable_value into @c from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @c from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 replace into t1 values(1,11);
-select case when variable_value-@c > 1 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select case when variable_value-@c > 1 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 false
 drop table t1;
@@ -35,9 +35,9 @@ c1	c2
 1	1
 2	2
 3	3
-select variable_value into @c from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @c from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 replace into t1 values(1,11);
-select case when variable_value-@c > 1 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select case when variable_value-@c > 1 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 true
 drop table t1;
@@ -48,9 +48,9 @@ c1	c2
 1	1
 2	2
 3	3
-select variable_value into @c from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @c from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 replace into t1 values(1,11);
-select case when variable_value-@c > 1 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select case when variable_value-@c > 1 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 false
 drop table t1;
@@ -61,9 +61,9 @@ c1	c2
 1	1
 2	2
 3	3
-select variable_value into @c from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @c from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 replace into t1 values(1,11);
-select case when variable_value-@c > 1 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select case when variable_value-@c > 1 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 false
 drop table t1;
@@ -74,9 +74,9 @@ c1	c2
 1	1
 2	2
 3	3
-select variable_value into @c from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @c from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 replace into t1 values(1,11);
-select case when variable_value-@c > 1 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select case when variable_value-@c > 1 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 false
 drop table t1;
@@ -88,9 +88,9 @@ c1	c2
 1	1
 2	2
 3	3
-select variable_value into @c from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @c from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 replace into t1 values(1,11);
-select case when variable_value-@c > 1 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select case when variable_value-@c > 1 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 false
 drop table t1;

--- a/mysql-test/suite/rocksdb/t/mysqlbinlog_blind_replace.test
+++ b/mysql-test/suite/rocksdb/t/mysqlbinlog_blind_replace.test
@@ -9,9 +9,9 @@
 --source include/have_debug.inc
 
 reset master;
-set GLOBAL binlog_format= 'ROW';
+SET GLOBAL binlog_format= 'ROW';
 SET GLOBAL enable_blind_replace=ON;
-set binlog_format=row;
+SET binlog_format=row;
 
 create table t5 (c1 int primary key, c2 int);
 insert into t5 values (1, 1);
@@ -57,6 +57,7 @@ select * from t5;
 
 --source include/show_binlog_events.inc
 
-set GLOBAL binlog_format=DEFAULT;
+--remove_file $MYSQLTEST_VARDIR/tmp/mysqlbinlog-output
+SET GLOBAL binlog_format=DEFAULT;
 SET GLOBAL enable_blind_replace=DEFAULT;
 drop table t5;

--- a/mysql-test/suite/rocksdb_rpl/r/optimize_myrocks_replace_into.result
+++ b/mysql-test/suite/rocksdb_rpl/r/optimize_myrocks_replace_into.result
@@ -3,6 +3,7 @@ Warnings:
 Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
 Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
 [connection master]
+[connection master]
 SET @prior_rocksdb_perf_context_level = @@rocksdb_perf_context_level;
 SET GLOBAL rocksdb_perf_context_level=3;
 SET GLOBAL enable_blind_replace=ON;
@@ -27,18 +28,23 @@ c1	c2
 1	1
 2	2
 3	3
+include/sync_slave_sql_with_master.inc
+[connection slave]
 SET GLOBAL enable_blind_replace=ON;
 create trigger trg before insert on t2 for each row set @a:=1;
 alter table t3 add constraint slave_unique_key unique (c2);
+[connection master]
+include/sync_slave_sql_with_master.inc
 connect slave
-select variable_value into @d from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @d from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 Case 1
+[connection master]
 connect master
-select variable_value into @d from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @d from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 replace into t1 values(1,11);
 replace into t1 values(2,22);
 replace into t1 values(3,33);
-select case when variable_value-@d > 3 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select case when variable_value-@d > 3 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 true
 select * from t1;
@@ -46,8 +52,9 @@ c1	c2
 1	11
 2	22
 3	33
+include/sync_slave_sql_with_master.inc
 connect slave
-select case when variable_value-@d > 3 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select case when variable_value-@d > 3 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 true
 select * from t1;
@@ -55,12 +62,13 @@ c1	c2
 1	11
 2	22
 3	33
-select variable_value into @d from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @d from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection master]
 Case 2
 connect master
-select variable_value into @d from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @d from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 replace into t1 values(2,44),(3,55);
-select case when variable_value-@d > 2 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select case when variable_value-@d > 2 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 true
 select * from t1;
@@ -68,8 +76,9 @@ c1	c2
 1	11
 2	44
 3	55
+include/sync_slave_sql_with_master.inc
 connect slave
-select case when variable_value-@d > 2 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select case when variable_value-@d > 2 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 true
 select * from t1;
@@ -77,8 +86,9 @@ c1	c2
 1	11
 2	44
 3	55
-select variable_value into @d from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @d from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 Case 3
+[connection master]
 connect master
 update t1 set c2=66 where c1=3;
 select * from t1;
@@ -86,20 +96,22 @@ c1	c2
 1	11
 2	44
 3	66
+include/sync_slave_sql_with_master.inc
 connect slave
 select * from t1;
 c1	c2
 1	11
 2	44
 3	66
-select variable_value into @d from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @d from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 Case 4
+[connection master]
 connect master
-select variable_value into @d from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @d from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 replace into t2 values(1,111);
 replace into t2 values(2,222);
 replace into t2 values(3,333);
-select case when variable_value-@d > 3 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select case when variable_value-@d > 3 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 true
 select * from t2;
@@ -107,8 +119,9 @@ c1	c2
 1	111
 2	222
 3	333
+include/sync_slave_sql_with_master.inc
 connect slave
-select case when variable_value-@d > 3 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select case when variable_value-@d > 3 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 false
 select * from t2;
@@ -116,10 +129,11 @@ c1	c2
 1	111
 2	222
 3	333
-select variable_value into @d from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @d from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 Case 5
+[connection master]
 connect master
-select variable_value into @d from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @d from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 replace into t3 values(1,1111);
 replace into t3 values(2,2222);
 replace into t3 values(3,3333);
@@ -128,11 +142,12 @@ c1	c2
 1	1111
 2	2222
 3	3333
-select case when variable_value-@d > 3 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select case when variable_value-@d > 3 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 true
+include/sync_slave_sql_with_master.inc
 connect slave
-select case when variable_value-@d > 3 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select case when variable_value-@d > 3 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 false
 select * from t3;
@@ -146,6 +161,7 @@ c1	c2
 2	2222
 3	3333
 Case 6
+[connection master]
 include/show_binlog_events.inc
 Log_name	Pos	Event_type	Server_id	End_log_pos	Info
 master-bin.000001	#	Query	#	#	use `test`; create table t1(c1 int,c2 int, primary key (c1)) engine=rocksdb
@@ -207,6 +223,7 @@ master-bin.000001	#	Query	#	#	BEGIN
 master-bin.000001	#	Table_map	#	#	table_id: # (test.t3)
 master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
 master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+[connection slave]
 include/show_binlog_events.inc
 Log_name	Pos	Event_type	Server_id	End_log_pos	Info
 slave-bin.000001	#	Query	#	#	use `test`; create table t1(c1 int,c2 int, primary key (c1)) engine=rocksdb
@@ -273,10 +290,12 @@ slave-bin.000001	#	Table_map	#	#	table_id: # (test.t3)
 slave-bin.000001	#	Delete_rows	#	#	table_id: #
 slave-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
 slave-bin.000001	#	Xid	#	#	COMMIT /* XID */
+[connection master]
 drop table t1;
 drop table t2;
 drop table t3;
 SET GLOBAL rocksdb_perf_context_level = @prior_rocksdb_perf_context_level;
 SET GLOBAL enable_blind_replace=DEFAULT;
+[connection slave]
 SET GLOBAL enable_blind_replace=DEFAULT;
 include/rpl_end.inc

--- a/mysql-test/suite/rocksdb_rpl/t/optimize_myrocks_replace_into.test
+++ b/mysql-test/suite/rocksdb_rpl/t/optimize_myrocks_replace_into.test
@@ -1,8 +1,8 @@
+--source include/have_debug.inc
 --source include/have_rocksdb.inc
 --source include/master-slave.inc
---source include/have_debug.inc
 
-connection master;
+--source include/rpl_connection_master.inc
 SET @prior_rocksdb_perf_context_level = @@rocksdb_perf_context_level;
 SET GLOBAL rocksdb_perf_context_level=3;
 SET GLOBAL enable_blind_replace=ON;
@@ -22,106 +22,106 @@ create table t3(c1 int,c2 int, primary key (c1)) engine=rocksdb;
 insert into t3 values(1,1),(2,2),(3,3);
 select * from t3;
 
-sync_slave_with_master;
+--source include/sync_slave_sql_with_master.inc
 
 # Enable blind replace in both slave and master
-connection slave;
+--source include/rpl_connection_slave.inc
 SET GLOBAL enable_blind_replace=ON;
 create trigger trg before insert on t2 for each row set @a:=1;
 alter table t3 add constraint slave_unique_key unique (c2);
 
-connection master;
+--source include/rpl_connection_master.inc
 
-sync_slave_with_master;
+--source include/sync_slave_sql_with_master.inc
 --echo connect slave
-select variable_value into @d from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @d from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 
 # Case 1 -  'replace into' on a table with no triggers or secondary keys. Blind replace optimization should kick in both in master and slave
 --echo Case 1
-connection master;
+--source include/rpl_connection_master.inc
 --echo connect master
-select variable_value into @d from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @d from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 
 replace into t1 values(1,11);
 replace into t1 values(2,22);
 replace into t1 values(3,33);
-select case when variable_value-@d > 3 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select case when variable_value-@d > 3 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 
 select * from t1;
 
-sync_slave_with_master;
+--source include/sync_slave_sql_with_master.inc
 --echo connect slave
-select case when variable_value-@d > 3 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select case when variable_value-@d > 3 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 select * from t1;
 
-select variable_value into @d from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @d from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 
 # Case 2 - Multiple replaces in a single statement. blind replace optimization should kick in
-connection master;
+--source include/rpl_connection_master.inc
 --echo Case 2
 --echo connect master
-select variable_value into @d from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @d from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 replace into t1 values(2,44),(3,55);
-select case when variable_value-@d > 2 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select case when variable_value-@d > 2 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 select * from t1;
 
-sync_slave_with_master;
+--source include/sync_slave_sql_with_master.inc
 --echo connect slave
-select case when variable_value-@d > 2 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select case when variable_value-@d > 2 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 select * from t1;
 
-select variable_value into @d from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @d from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 
 # Case 3 - A regular update. This is not a blind replace
 --echo Case 3
-connection master;
+--source include/rpl_connection_master.inc
 --echo connect master
 update t1 set c2=66 where c1=3;
 select * from t1;
 
-sync_slave_with_master;
+--source include/sync_slave_sql_with_master.inc
 --echo connect slave
 select * from t1;
 
-select variable_value into @d from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @d from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 
 # Case 4 - Slave has trigger on its table. No triggers on the table in master. 
 # Blind replace optimization should kick in on master. 
 # Slave should convert this statement into a regular update
 --echo Case 4
-connection master;
+--source include/rpl_connection_master.inc
 --echo connect master
-select variable_value into @d from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @d from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 replace into t2 values(1,111);
 replace into t2 values(2,222);
 replace into t2 values(3,333);
-select case when variable_value-@d > 3 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select case when variable_value-@d > 3 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 select * from t2;
 
-sync_slave_with_master;
+--source include/sync_slave_sql_with_master.inc
 --echo connect slave
-select case when variable_value-@d > 3 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select case when variable_value-@d > 3 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 select * from t2;
 
-select variable_value into @d from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @d from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 
 # Case 5 - Slave has secondary keys on the table. No secondary keys on the table in master
 # Blind replace optimization should kick in on master.
 # Slave should convert this statement into a regular delete_insert
 --echo Case 5
-connection master;
+--source include/rpl_connection_master.inc
 --echo connect master
-select variable_value into @d from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @d from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 replace into t3 values(1,1111);
 replace into t3 values(2,2222);
 replace into t3 values(3,3333);
 select * from t3;
 
-select case when variable_value-@d > 3 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select case when variable_value-@d > 3 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 
-sync_slave_with_master;
+--source include/sync_slave_sql_with_master.inc
 --echo connect slave
-select case when variable_value-@d > 3 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select case when variable_value-@d > 3 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 select * from t3;
 select * from t3 use index (slave_unique_key);
 
@@ -129,21 +129,21 @@ select * from t3 use index (slave_unique_key);
 # blind replace will generate a write_rows event. 
 # Or else, it will be a update_rows event or a delete_rows_write_rows event
 --echo Case 6
-connection master;
+--source include/rpl_connection_master.inc
 --source include/show_binlog_events.inc
 
-connection slave;
+--source include/rpl_connection_slave.inc
 --source include/show_binlog_events.inc
 
 # Cleanup
-connection master;
+--source include/rpl_connection_master.inc
 drop table t1;
 drop table t2;
 drop table t3;
 SET GLOBAL rocksdb_perf_context_level = @prior_rocksdb_perf_context_level;
 SET GLOBAL enable_blind_replace=DEFAULT;
 
-connection slave;
+--source include/rpl_connection_slave.inc
 SET GLOBAL enable_blind_replace=DEFAULT;
 
 --source include/rpl_end.inc

--- a/mysql-test/suite/rpl/r/optimized_replace_mixed_engine.result
+++ b/mysql-test/suite/rpl/r/optimized_replace_mixed_engine.result
@@ -1,0 +1,102 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+Create a table in master with rocskdb as storage engine
+[connection master]
+create table t1 (c1 int primary key, c2 int) engine=rocksdb;
+select table_name, engine from information_schema.tables where table_name = 't1';
+TABLE_NAME	ENGINE
+t1	ROCKSDB
+include/sync_slave_sql_with_master.inc
+Table is altered in slave to be in innodb storage engine
+[connection slave]
+alter table t1 engine=innodb;
+select table_name, engine from information_schema.tables where table_name = 't1';
+TABLE_NAME	ENGINE
+t1	InnoDB
+[connection master]
+select table_name, engine from information_schema.tables where table_name = 't1';
+TABLE_NAME	ENGINE
+t1	ROCKSDB
+insert into t1 values(1, 1);
+insert into t1 values(2, 2);
+insert into t1 values(3, 3);
+select * from t1;
+c1	c2
+1	1
+2	2
+3	3
+include/sync_slave_sql_with_master.inc
+[connection slave]
+select table_name, engine from information_schema.tables where table_name = 't1';
+TABLE_NAME	ENGINE
+t1	InnoDB
+select * from t1;
+c1	c2
+1	1
+2	2
+3	3
+replace into should be a blind replace in master and a regular replace in slave
+[connection master]
+select variable_value into @d from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+replace into t1 values (1, 11);
+select case when variable_value-@d > 1 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+read_free
+true
+select * from t1;
+c1	c2
+1	11
+2	2
+3	3
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Query	#	#	use `test`; create table t1 (c1 int primary key, c2 int) engine=rocksdb
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+include/sync_slave_sql_with_master.inc
+[connection slave]
+select * from t1;
+c1	c2
+1	11
+2	2
+3	3
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+slave-bin.000001	#	Query	#	#	use `test`; create table t1 (c1 int primary key, c2 int) engine=rocksdb
+slave-bin.000001	#	Query	#	#	use `test`; alter table t1 engine=innodb
+slave-bin.000001	#	Query	#	#	BEGIN
+slave-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+slave-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+slave-bin.000001	#	Xid	#	#	COMMIT /* XID */
+slave-bin.000001	#	Query	#	#	BEGIN
+slave-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+slave-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+slave-bin.000001	#	Xid	#	#	COMMIT /* XID */
+slave-bin.000001	#	Query	#	#	BEGIN
+slave-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+slave-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+slave-bin.000001	#	Xid	#	#	COMMIT /* XID */
+slave-bin.000001	#	Query	#	#	BEGIN
+slave-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+slave-bin.000001	#	Update_rows	#	#	table_id: # flags: STMT_END_F
+slave-bin.000001	#	Xid	#	#	COMMIT /* XID */
+[connection master]
+drop table t1;
+include/sync_slave_sql_with_master.inc
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/optimized_replace_mixed_engine-master.opt
+++ b/mysql-test/suite/rpl/t/optimized_replace_mixed_engine-master.opt
@@ -1,0 +1,1 @@
+--enable-blind-replace

--- a/mysql-test/suite/rpl/t/optimized_replace_mixed_engine-slave.opt
+++ b/mysql-test/suite/rpl/t/optimized_replace_mixed_engine-slave.opt
@@ -1,0 +1,1 @@
+--enable-blind-replace

--- a/mysql-test/suite/rpl/t/optimized_replace_mixed_engine.test
+++ b/mysql-test/suite/rpl/t/optimized_replace_mixed_engine.test
@@ -1,0 +1,55 @@
+--source include/have_debug.inc
+--source include/have_log_bin.inc
+--source include/have_binlog_format_row.inc
+--source include/have_rocksdb.inc
+--source include/master-slave.inc
+
+# Create a table in master with rocksdb as storage engine
+--echo Create a table in master with rocskdb as storage engine
+--source include/rpl_connection_master.inc
+create table t1 (c1 int primary key, c2 int) engine=rocksdb;
+select table_name, engine from information_schema.tables where table_name = 't1';
+--source include/sync_slave_sql_with_master.inc
+
+# Change table to have innodb as storage engine
+-- echo Table is altered in slave to be in innodb storage engine
+--source include/rpl_connection_slave.inc
+alter table t1 engine=innodb;
+select table_name, engine from information_schema.tables where table_name = 't1';
+
+--source include/rpl_connection_master.inc
+select table_name, engine from information_schema.tables where table_name = 't1';
+insert into t1 values(1, 1);
+insert into t1 values(2, 2);
+insert into t1 values(3, 3);
+select * from t1;
+--source include/sync_slave_sql_with_master.inc
+
+--source include/rpl_connection_slave.inc
+select table_name, engine from information_schema.tables where table_name = 't1';
+select * from t1;
+
+# Issue a replace into in master. This should be a blind insert
+--echo replace into should be a blind replace in master and a regular replace in slave
+--source include/rpl_connection_master.inc
+select variable_value into @d from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+replace into t1 values (1, 11);
+select case when variable_value-@d > 1 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+
+# Ensure that replace into is replayed correctly in slave. 
+# This should be a regular replace into in slave with no 'blind replace' optimization
+# binlog event should indicate a Write_rows event in master and Update_rows event in slave
+select * from t1;
+--source include/show_binlog_events.inc
+--source include/sync_slave_sql_with_master.inc
+
+--source include/rpl_connection_slave.inc
+select * from t1;
+--source include/show_binlog_events.inc
+
+# Cleanup
+--source include/rpl_connection_master.inc
+drop table t1;
+--source include/sync_slave_sql_with_master.inc
+
+--source include/rpl_end.inc

--- a/mysql-test/suite/sys_vars/r/enable_blind_replace_basic.result
+++ b/mysql-test/suite/sys_vars/r/enable_blind_replace_basic.result
@@ -1,0 +1,16 @@
+Default value of enable_blind_replace is 0
+SELECT @@global.enable_blind_replace;
+@@global.enable_blind_replace
+0
+SELECT @@session.enable_blind_replace;
+ERROR HY000: Variable 'enable_blind_replace' is a GLOBAL variable
+Expected error 'Variable is a GLOBAL variable'
+enable_blind_replace is a dynamic variable
+SET @@global.enable_blind_replace = 1;
+SELECT @@global.enable_blind_replace;
+@@global.enable_blind_replace
+1
+SET @@global.enable_blind_replace = 0;
+SELECT @@global.enable_blind_replace;
+@@global.enable_blind_replace
+0

--- a/mysql-test/suite/sys_vars/t/enable_blind_replace_basic.test
+++ b/mysql-test/suite/sys_vars/t/enable_blind_replace_basic.test
@@ -1,0 +1,24 @@
+-- source include/load_sysvars.inc
+
+####
+# Verify default value 0
+####
+--echo Default value of enable_blind_replace is 0
+SELECT @@global.enable_blind_replace;
+
+####
+# Verify that this is not a session variable
+####
+--Error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.enable_blind_replace;
+--echo Expected error 'Variable is a GLOBAL variable'
+
+####
+## Verify that the variable is dynamic
+####
+--echo enable_blind_replace is a dynamic variable
+SET @@global.enable_blind_replace = 1;
+SELECT @@global.enable_blind_replace;
+
+SET @@global.enable_blind_replace = 0;
+SELECT @@global.enable_blind_replace;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1036,6 +1036,7 @@ ulong slave_tx_isolation;
 bool enable_binlog_hlc = 0;
 bool maintain_database_hlc = false;
 char *default_collation_for_utf8mb4_init = NULL;
+bool enable_blind_replace = false;
 
 #if defined(_WIN32)
 /*

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -412,6 +412,7 @@ extern bool enable_resultset_checksum;
 extern uint net_compression_level;
 extern long zstd_net_compression_level;
 extern long lz4f_net_compression_level;
+extern bool enable_blind_replace;
 
 /* SHOW STATS var: Name of current timer */
 extern const char *timer_in_use;

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -447,6 +447,7 @@ void LEX::reset() {
   keep_diagnostics = DA_KEEP_NOTHING;
   m_statement_options = 0;
   next_binlog_file_nr = 0;
+  blind_replace_into = false;
 
   name.str = NULL;
   name.length = 0;

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -3324,6 +3324,14 @@ struct LEX : public Query_tables_list {
   uint32 next_binlog_file_nr;
   ulong thread_id_opt; /* thread id option */
 
+  /*
+    If this is set, then 'replace into' will do a bind write by ignoring
+    primary key violation errors. This is an optimization which allows to
+    write the row without having to read, delete and insert the row in case
+    of 'replace into' statements.
+  */
+  bool blind_replace_into;
+
  private:
   bool m_broken;  ///< see mark_broken()
   /**

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -7647,3 +7647,11 @@ static Sys_var_charptr Sys_default_collation_for_utf8mb4_init(
     "default_collation_for_utf8mb4_init", "default collation for utf8mb4",
     READ_ONLY NON_PERSIST GLOBAL_VAR(default_collation_for_utf8mb4_init),
     NO_CMD_LINE, IN_SYSTEM_CHARSET, DEFAULT(0));
+
+static Sys_var_bool Sys_enable_blind_replace(
+    "enable_blind_replace",
+    "Optimize 'replace into' statement by doing a blind insert. Engine "
+    "ignores primary key violations. This will avoid a delete and an "
+    "insert. This is supported in MyRocks",
+    GLOBAL_VAR(enable_blind_replace),
+    CMD_LINE(OPT_ARG), DEFAULT(false));

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -9881,9 +9881,7 @@ int ha_rocksdb::check_and_lock_unique_pk(const uint key_id,
               row_info.new_pk_slice.compare(row_info.old_pk_slice) != 0);
 
   /* Ignore PK violations if this is a optimized 'replace into' */
-  const bool ignore_pk_unique_check = false;
-  /* TODO(yzha) - f14c64cf950 Optimize replace into to do a blind write
-   = ha_thd()->lex->blind_replace_into */
+  const bool ignore_pk_unique_check = ha_thd()->lex->blind_replace_into;
 
   /*
     Perform a read to determine if a duplicate entry exists. For primary

--- a/storage/rocksdb/rdb_perf_context.cc
+++ b/storage/rocksdb/rdb_perf_context.cc
@@ -108,8 +108,9 @@ std::string rdb_pc_stat_types[] = {
   } while (0)
 #define IO_STAT_RECORD(_field_)                                          \
   do {                                                                   \
-    if (rocksdb::get_iostats_context()->_field_ > 0) {                   \
-      counters->m_value[idx] += rocksdb::get_iostats_context()->_field_; \
+    auto* io_stats_context = rocksdb::get_iostats_context();             \
+    if (io_stats_context != nullptr && io_stats_context->_field_ > 0) {  \
+      counters->m_value[idx] += io_stats_context->_field_;               \
     }                                                                    \
     idx++;                                                               \
   } while (0)
@@ -205,7 +206,12 @@ bool Rdb_io_perf::start(const uint32_t perf_context_level) {
   }
 
   rocksdb::get_perf_context()->Reset();
-  rocksdb::get_iostats_context()->Reset();
+
+  auto* io_stats_context = rocksdb::get_iostats_context();
+  if (io_stats_context != nullptr) {
+    io_stats_context->Reset();
+  }
+
   return true;
 }
 


### PR DESCRIPTION
Reference Patch: https://github.com/facebook/mysql-5.6/commit/f14c64cf950

---------- https://github.com/facebook/mysql-5.6/commit/f14c64cf950 ----------

Summary:
This is a diff based of https://github.com/facebook/mysql-5.6/pull/913. The initial pull request was submitted by Zhang Yuan from Alibaba. I am trying to continue work on this.

Approach:
During sql_insert, if the statement is a 'replace into' statement, then we set a boolean in the lex to indicate that primary key violations can be ignored. This is done only for tables that have an explicitly defined primary key, does not have any triggers or secondary keys.

If the lex flag indicates that this is a blind replace into, then engine ignores duplicate primary key errors. This in turn ensures that the sql layer does not have to do a delete followed by a insert.

If the lex flag is set, then Write_rows_log_event sets a bit in its flag indicating that this was an optimized 'replace into' statement execution. This is carried over to the slave and the slave sets the lex flag (in Write_rows_log_event::write_row()) before invoking the handler's write_row methods.

On the slave, if blind replace bit is set for a write rows event and it is possible to do a blind replace, we will proceed with it.
If for some reason (such as slaves having triggers or secondary keys), we cannot do a blind replace then this will fall back to doing either an update or a delete+insert. Note that the binlog will not have a before image (since on master this is just an insert), but we can still do the regular update or delete+insert.

Originally Reviewed By: abhinav04sharma

fbshipit-source-id: be7cfcb2f70