### PR TITLE
Issue#1026: MyRocks may return "Can't find record" which is unexpected

### DIFF
--- a/mysql-test/suite/rocksdb/r/unique_check.result
+++ b/mysql-test/suite/rocksdb/r/unique_check.result
@@ -82,3 +82,81 @@ ERROR 23000: Duplicate entry '1' for key 'PRIMARY'
 insert into t3 values (1, 1), (1, 1);
 set @@session.unique_checks = @old_val;
 drop table t1, t2, t3;
+#
+#  Issue#1026: MyRocks may return "Can't find record" which is unexpected
+#
+CREATE TABLE t1 (
+id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+a varchar(36) NOT NULL ,
+b varchar(128) NOT NULL ,
+c varchar(10240) NOT NULL ,
+PRIMARY KEY (id),
+UNIQUE KEY uniq_idx (a,b)
+) ENGINE=ROCKSDB;
+insert into t1 values (1,1,1,1), (2,2,2,2);
+begin;
+set debug_sync='rocksdb.after_unique_pk_check SIGNAL trx_a_sleep WAIT_FOR trx_a_cont';
+insert into t1(a,b,c) values (10,'file_type','trx-a') on duplicate key update c=values(c);
+set debug_sync='now WAIT_FOR trx_a_sleep';
+begin;
+insert into t1(a,b,c) values (10,'file_type','trx-b') on duplicate key update c=values(c);
+commit;
+set debug_sync='now SIGNAL trx_a_cont';
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction (snapshot conflict)
+rollback;
+drop table t1;
+set debug_sync='RESET';
+#
+# Issue#1026, testcase #2 (with READ-COMMITTED).
+#
+CREATE table t1 (
+pk0 int primary key auto_increment,
+sk int,
+val int default 0,
+unique(sk)
+) engine=rocksdb;
+insert into t1 (sk) values (20), (30);
+set tx_isolation='READ-COMMITTED';
+begin;
+set debug_sync='rocksdb.after_unique_sk_check SIGNAL here WAIT_FOR go';
+insert into t1 (sk) values (1), (2) on duplicate key update val = val + 1;
+set debug_sync='now WAIT_FOR here';
+begin;
+insert into t1 (sk) values (2);
+commit;
+set debug_sync='now SIGNAL go';
+commit;
+select * from t1;
+pk0	sk	val
+1	20	0
+2	30	0
+3	1	0
+4	2	1
+drop table t1;
+set debug_sync='RESET';
+#
+# Issue#1026, testcase #3 (with READ-COMMITTED and PK).
+#
+CREATE table t1 (
+pk int primary key,
+val int default 0
+) engine=rocksdb;
+insert into t1 (pk) values (20), (30);
+set tx_isolation='READ-COMMITTED';
+begin;
+set debug_sync='rocksdb.after_unique_pk_check SIGNAL here WAIT_FOR go';
+insert into t1 (pk) values (1), (2) on duplicate key update val = val + 1;
+set debug_sync='now WAIT_FOR here';
+begin;
+insert into t1 (pk) values (2);
+commit;
+set debug_sync='now SIGNAL go';
+commit;
+select * from t1;
+pk	val
+1	0
+2	1
+20	0
+30	0
+drop table t1;
+set debug_sync='RESET';

--- a/mysql-test/suite/rocksdb/t/unique_check.test
+++ b/mysql-test/suite/rocksdb/t/unique_check.test
@@ -170,3 +170,129 @@ insert into t3 values (1, 1), (1, 1);
 set @@session.unique_checks = @old_val;
 # cleanup
 drop table t1, t2, t3;
+
+--echo #
+--echo #  Issue#1026: MyRocks may return "Can't find record" which is unexpected
+--echo #
+
+connect (con1, localhost, root,,);
+connection default;
+
+CREATE TABLE t1 (
+  id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  a varchar(36) NOT NULL ,
+  b varchar(128) NOT NULL ,
+  c varchar(10240) NOT NULL ,
+  PRIMARY KEY (id),
+  UNIQUE KEY uniq_idx (a,b)
+) ENGINE=ROCKSDB;
+
+insert into t1 values (1,1,1,1), (2,2,2,2);
+
+## TRX A:
+begin;
+set debug_sync='rocksdb.after_unique_pk_check SIGNAL trx_a_sleep WAIT_FOR trx_a_cont';
+send
+insert into t1(a,b,c) values (10,'file_type','trx-a') on duplicate key update c=values(c);
+
+connection con1;
+# TRX B:
+set debug_sync='now WAIT_FOR trx_a_sleep';
+begin;
+insert into t1(a,b,c) values (10,'file_type','trx-b') on duplicate key update c=values(c);
+commit;
+set debug_sync='now SIGNAL trx_a_cont';
+
+
+connection default;
+--error ER_LOCK_DEADLOCK
+reap;
+
+disconnect con1;
+rollback;
+drop table t1;
+
+set debug_sync='RESET';
+
+--echo #
+--echo # Issue#1026, testcase #2 (with READ-COMMITTED).
+--echo #
+
+CREATE table t1 (
+  pk0 int primary key auto_increment,
+  sk int,
+  val int default 0,
+  unique(sk)
+) engine=rocksdb;
+
+insert into t1 (sk) values (20), (30);
+
+connect (con1, localhost, root,,);
+
+connection con1;
+set tx_isolation='READ-COMMITTED';
+begin;
+set debug_sync='rocksdb.after_unique_sk_check SIGNAL here WAIT_FOR go';
+send 
+insert into t1 (sk) values (1), (2) on duplicate key update val = val + 1;
+
+connection default;
+set debug_sync='now WAIT_FOR here';
+begin;
+insert into t1 (sk) values (2);
+commit;
+set debug_sync='now SIGNAL go';
+
+connection con1;
+reap;
+commit;
+
+connection default;
+disconnect con1;
+
+select * from t1;
+
+drop table t1;
+
+set debug_sync='RESET';
+
+--echo #
+--echo # Issue#1026, testcase #3 (with READ-COMMITTED and PK).
+--echo #
+
+CREATE table t1 (
+  pk int primary key,
+  val int default 0
+) engine=rocksdb;
+
+insert into t1 (pk) values (20), (30);
+
+connect (con1, localhost, root,,);
+
+connection con1;
+set tx_isolation='READ-COMMITTED';
+begin;
+set debug_sync='rocksdb.after_unique_pk_check SIGNAL here WAIT_FOR go';
+send 
+insert into t1 (pk) values (1), (2) on duplicate key update val = val + 1;
+
+connection default;
+set debug_sync='now WAIT_FOR here';
+begin;
+insert into t1 (pk) values (2);
+commit;
+set debug_sync='now SIGNAL go';
+
+connection con1;
+reap;
+commit;
+
+connection default;
+disconnect con1;
+
+select * from t1;
+
+drop table t1;
+
+set debug_sync='RESET';
+

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -6394,7 +6394,7 @@ ha_rocksdb::ha_rocksdb(my_core::handlerton *const hton,
       m_lock_rows(RDB_LOCK_NONE),
       m_keyread_only(false),
       m_insert_with_update(false),
-      m_dup_pk_found(false),
+      m_dup_key_found(false),
       mrr_rowid_reader(nullptr),
       mrr_n_elements(0),
       mrr_enabled_keyread(false),
@@ -8494,6 +8494,23 @@ int ha_rocksdb::index_read_map_impl(uchar *const buf, const uchar *const key,
         kd.get_key_parts()) {
       using_full_key = false;
     }
+
+    if (m_insert_with_update && m_dup_key_found &&
+        active_index == m_dupp_errkey) {
+      /*
+        We are in INSERT ... ON DUPLICATE KEY UPDATE, and this is a read
+        that SQL layer does to read the duplicate key.
+        Its rowid is saved in m_last_rowkey. Get the full record and return it.
+      */
+
+      DBUG_ASSERT(m_dup_key_retrieved_record.length() >= packed_size);
+      DBUG_ASSERT(memcmp(m_dup_key_retrieved_record.ptr(), m_sk_packed_tuple,
+                         packed_size) == 0);
+
+      rc = get_row_by_rowid(buf, m_last_rowkey.ptr(), m_last_rowkey.length());
+      DBUG_RETURN(rc);
+    }
+
   } else {
     packed_size = kd.pack_index_tuple(table, m_pack_buffer, m_sk_packed_tuple,
                                       key, keypart_map);
@@ -8978,11 +8995,11 @@ int ha_rocksdb::get_row_by_rowid(uchar *const buf, const char *const rowid,
   if (m_lock_rows == RDB_LOCK_NONE) {
     tx->acquire_snapshot(true);
     s = tx->get(m_pk_descr->get_cf(), key_slice, &m_retrieved_record);
-  } else if (m_insert_with_update && m_dup_pk_found) {
-    DBUG_ASSERT(m_pk_descr->get_keyno() == m_dupp_errkey);
-    DBUG_ASSERT(m_dup_pk_retrieved_record.length() ==
+  } else if (m_insert_with_update && m_dup_key_found &&
+             m_pk_descr->get_keyno() == m_dupp_errkey) {
+    DBUG_ASSERT(m_dup_key_retrieved_record.length() ==
                 m_retrieved_record.size());
-    DBUG_ASSERT(memcmp(m_dup_pk_retrieved_record.ptr(),
+    DBUG_ASSERT(memcmp(m_dup_key_retrieved_record.ptr(),
                        m_retrieved_record.data(),
                        m_retrieved_record.size()) == 0);
 
@@ -9541,7 +9558,7 @@ int ha_rocksdb::write_row(uchar *const buf) {
   // clear cache at beginning of write for INSERT ON DUPLICATE
   // we may get multiple write->fail->read->update if there are multiple
   // values from INSERT
-  m_dup_pk_found = false;
+  m_dup_key_found = false;
 
   const int rv = update_write_row(nullptr, buf, skip_unique_check());
 
@@ -9720,12 +9737,13 @@ int ha_rocksdb::check_and_lock_unique_pk(const uint key_id,
     // In INSERT ON DUPLICATE KEY UPDATE ... case, if the insert failed
     // due to a duplicate key, remember the last key and skip the check
     // next time
-    m_dup_pk_found = true;
+    m_dup_key_found = true;
 
 #ifndef DBUG_OFF
     // save it for sanity checking later
-    m_dup_pk_retrieved_record.copy(m_retrieved_record.data(),
-                                   m_retrieved_record.size(), &my_charset_bin);
+    m_dup_key_retrieved_record.copy(m_retrieved_record.data(),
+                                    m_retrieved_record.size(),
+                                    &my_charset_bin);
 #endif
   }
 
@@ -9869,9 +9887,29 @@ int ha_rocksdb::check_and_lock_sk(const uint key_id,
   */
   *found = !read_key_exact(kd, iter, all_parts_used, new_slice,
                            row_info.tx->m_snapshot_timestamp);
-  delete iter;
 
-  return HA_EXIT_SUCCESS;
+  int rc = HA_EXIT_SUCCESS;
+
+  if (*found && m_insert_with_update) {
+    const rocksdb::Slice &rkey = iter->key();
+    uint pk_size = kd.get_primary_key_tuple(table, *m_pk_descr, &rkey,
+                                            m_pk_packed_tuple);
+    if (pk_size == RDB_INVALID_KEY_LEN) {
+      rc = HA_ERR_ROCKSDB_CORRUPT_DATA;
+    } else {
+      m_dup_key_found = true;
+      m_last_rowkey.copy((const char *)m_pk_packed_tuple, pk_size,
+                         &my_charset_bin);
+#ifndef DBUG_OFF
+      // save it for sanity checking later
+      m_dup_key_retrieved_record.copy(rkey.data(), rkey.size(),
+                                      &my_charset_bin);
+#endif
+    }
+  }
+
+  delete iter;
+  return rc;
 }
 
 /**
@@ -9902,9 +9940,11 @@ int ha_rocksdb::check_uniqueness_and_lock(
         rc = HA_EXIT_SUCCESS;
       } else {
         rc = check_and_lock_unique_pk(key_id, row_info, &found);
+        DEBUG_SYNC(ha_thd(), "rocksdb.after_unique_pk_check");
       }
     } else {
       rc = check_and_lock_sk(key_id, row_info, &found);
+      DEBUG_SYNC(ha_thd(), "rocksdb.after_unique_sk_check");
     }
 
     if (rc != HA_EXIT_SUCCESS) {

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -271,12 +271,18 @@ class ha_rocksdb : public my_core::handler {
    */
   bool m_insert_with_update;
 
-  /* TRUE if last time the insertion failed due to duplicated PK */
-  bool m_dup_pk_found;
+  /*
+    TRUE if last time the insertion failed due to duplicate key error.
+    (m_dupp_errkey holds the key# that we've had error for)
+  */
+  bool m_dup_key_found;
 
 #ifndef DBUG_OFF
-  /* Last retreived record for sanity checking */
-  String m_dup_pk_retrieved_record;
+  /*
+    Last retrieved record (for duplicate PK) or index tuple (for duplicate
+    unique SK). Used for sanity checking.
+  */
+  String m_dup_key_retrieved_record;
 #endif
 
   /**


### PR DESCRIPTION
MyRocks generally uses Snapshot Checking for transactional isolation:
read rows through snapshot, if we need to modify a row - get a lock
on it and check that it hasn't been modified after snapshot was taken.

The exception is unique secondary key check which uses "READ-COMMITED":
get a lock on the secondary key value, then scan the latest committed
data to see if there are duplicate rows.

This works, except for INSERT ... ON DUPLICATE KEY UPDATE, where
the SQL layer expects to be able to read the duplicate row if it has
got HA_ERR_FOUND_DUPP_KEY error from the storage engine.  If it
doesn't see it, the user gets a "record not found" error.

Fixed this by returning "Snapshot conflict" in the case when the
duplicate row is present but is not visible in the current
transaction's snapshot.