### PR TITLE
Adding options to do blind deletes and not to use tx api

### DIFF
--- a/mysql-test/suite/rocksdb/r/blind_delete_without_tx_api.result
+++ b/mysql-test/suite/rocksdb/r/blind_delete_without_tx_api.result
@@ -1,0 +1,95 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+[connection master]
+create table t1 (id int primary key, value int, value2 varchar(200)) engine=rocksdb;
+create table t2 (id int primary key, value int, value2 varchar(200), index(value)) engine=rocksdb;
+SET session rocksdb_blind_delete_primary_key=1;
+select variable_value into @c from performance_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
+select variable_value-@c from performance_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
+variable_value-@c
+1000
+SELECT count(*) FROM t1;
+count(*)
+9000
+include/sync_slave_sql_with_master.inc
+[connection slave]
+SELECT count(*) FROM t1;
+count(*)
+9000
+[connection master]
+select variable_value into @c from performance_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
+select variable_value-@c from performance_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
+variable_value-@c
+0
+SELECT count(*) FROM t2;
+count(*)
+9000
+SET session rocksdb_master_skip_tx_api=1;
+select variable_value into @c from performance_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
+select variable_value-@c from performance_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
+variable_value-@c
+1000
+SELECT count(*) FROM t1;
+count(*)
+8000
+SELECT count(*) FROM t2;
+count(*)
+8000
+include/sync_slave_sql_with_master.inc
+[connection slave]
+SELECT count(*) FROM t1;
+count(*)
+8000
+SELECT count(*) FROM t2;
+count(*)
+8000
+[connection master]
+select variable_value into @c from performance_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
+DELETE FROM t1 WHERE id BETWEEN 3001 AND 4000;
+DELETE FROM t2 WHERE id BETWEEN 3001 AND 4000;
+select variable_value-@c from performance_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
+variable_value-@c
+0
+SELECT count(*) FROM t1;
+count(*)
+7000
+SELECT count(*) FROM t2;
+count(*)
+7000
+include/sync_slave_sql_with_master.inc
+[connection slave]
+SELECT count(*) FROM t1;
+count(*)
+7000
+SELECT count(*) FROM t2;
+count(*)
+7000
+[connection master]
+DELETE FROM t1 WHERE id = 10;
+SELECT count(*) FROM t1;
+count(*)
+7000
+[connection slave]
+call mtr.add_suppression("Slave SQL.*Could not execute Delete_rows event on table test.t1.*Error_code.*");
+call mtr.add_suppression("Slave: Can't find record in 't1'.*");
+include/wait_for_slave_sql_error.inc [errno=1032]
+[connection slave]
+set @save_rocksdb_read_free_rpl_tables=@@global.rocksdb_read_free_rpl_tables;
+set global rocksdb_read_free_rpl_tables="t.*";
+set global sql_slave_skip_counter=1;
+include/start_slave.inc
+[connection master]
+include/sync_slave_sql_with_master.inc
+[connection slave]
+SELECT count(*) FROM t1;
+count(*)
+7000
+[connection master]
+[connection slave]
+set global rocksdb_read_free_rpl_tables=@save_rocksdb_read_free_rpl_tables;
+[connection master]
+DROP TABLE t1, t2;
+include/rpl_end.inc

--- a/mysql-test/suite/rocksdb/t/blind_delete_without_tx_api.cnf
+++ b/mysql-test/suite/rocksdb/t/blind_delete_without_tx_api.cnf
@@ -1,0 +1,11 @@
+!include suite/rpl/my.cnf
+
+[mysqld.1]
+sync_binlog=0
+binlog_format=row
+slave-exec-mode=strict
+
+[mysqld.2]
+sync_binlog=0
+binlog_format=row
+slave-exec-mode=strict

--- a/mysql-test/suite/rocksdb/t/blind_delete_without_tx_api.test
+++ b/mysql-test/suite/rocksdb/t/blind_delete_without_tx_api.test
@@ -1,15 +1,9 @@
 --source include/have_rocksdb.inc
---source include/master-slave.inc;
+
+source include/master-slave.inc;
 
 --source include/rpl_connection_master.inc
 
-eval SET SESSION TRANSACTION ISOLATION LEVEL $trx_isolation;
-set @save_rocksdb_blind_delete_primary_key=@@session.rocksdb_blind_delete_primary_key;
-set @save_rocksdb_master_skip_tx_api=@@session.rocksdb_master_skip_tx_api;
-
---disable_warnings
-DROP TABLE IF EXISTS t1,t2;
---enable_warnings
 create table t1 (id int primary key, value int, value2 varchar(200)) engine=rocksdb;
 create table t2 (id int primary key, value int, value2 varchar(200), index(value)) engine=rocksdb;
 
@@ -42,7 +36,6 @@ SELECT count(*) FROM t1;
 
 --source include/sync_slave_sql_with_master.inc
 --source include/rpl_connection_slave.inc
-eval SET SESSION TRANSACTION ISOLATION LEVEL $trx_isolation;
 SELECT count(*) FROM t1;
 --source include/rpl_connection_master.inc
 
@@ -109,9 +102,11 @@ call mtr.add_suppression("Slave: Can't find record in 't1'.*");
 --source include/wait_for_slave_sql_error.inc
 
 --source include/rpl_connection_slave.inc
-set @save_rocksdb_read_free_rpl=@@global.rocksdb_read_free_rpl;
-set global rocksdb_read_free_rpl=PK_SK;
-START SLAVE;
+set @save_rocksdb_read_free_rpl_tables=@@global.rocksdb_read_free_rpl_tables;
+set global rocksdb_read_free_rpl_tables="t.*";
+set global sql_slave_skip_counter=1;
+--source include/start_slave.inc
+
 --source include/rpl_connection_master.inc
 --source include/sync_slave_sql_with_master.inc
 --source include/rpl_connection_slave.inc
@@ -121,10 +116,8 @@ SELECT count(*) FROM t1;
 
 # cleanup
 --source include/rpl_connection_slave.inc
-set global rocksdb_read_free_rpl=@save_rocksdb_read_free_rpl;
+set global rocksdb_read_free_rpl_tables=@save_rocksdb_read_free_rpl_tables;
 --source include/rpl_connection_master.inc
-SET session rocksdb_blind_delete_primary_key=@save_rocksdb_blind_delete_primary_key;
-SET session rocksdb_master_skip_tx_api=@save_rocksdb_master_skip_tx_api;
 
 DROP TABLE t1, t2;
 --source include/rpl_end.inc


### PR DESCRIPTION
Reference Patch: https://github.com/facebook/mysql-5.6/commit/1245598bf1e

---------- https://github.com/facebook/mysql-5.6/commit/1245598bf1e ----------
Summary:
This diff adds two session variables to allow some operations faster.
- rocksdb_blind_delete_primary_key -- Executing deletes without calling
GetForUpdate(). To use this feature, target table must have primary key
only (no secondary key). No multi-table operations are allowed.
- rocksdb_master_skip_tx_api -- Not using transaction api on master.
This means no row locks are held during row modifications. It's user's
responsibility to make operations safe.

Benchmark results -- deleting 100k rows with bulk deletes (1000 row
deletes per statement).
 1) Normal -- 1.448s
 2) rocksdb_blind_delete_primary_key -- 0.671s
 3) 2) + rocksdb_master_skip_tx_api -- 0.324s

Originally Reviewed By: hermanlee

fbshipit-source-id: fa5c138862e