### PR TITLE
PS-7000: Add "rocksdb.type_varchar_packing" to validate padding of [VAR]CHAR collations

### DIFF
--- a/mysql-test/suite/rocksdb/r/type_varchar_packing.result
+++ b/mysql-test/suite/rocksdb/r/type_varchar_packing.result
@@ -1,0 +1,4557 @@
+CREATE TABLE collations AS SELECT * FROM information_schema.COLLATION_CHARACTER_SET_APPLICABILITY WHERE COLLATION_NAME NOT IN ("latin2_czech_cs", "cp1250_czech_cs");
+# Testing character set "big5" collation "big5_chinese_ci"
+CREATE TABLE t_big5 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET big5 COLLATE big5_chinese_ci;
+INSERT INTO t_big5 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_big5 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_big5 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_big5 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_big5 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_big5 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_big5 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_big5 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_big5;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_big5;
+# Testing character set "big5" collation "big5_bin"
+CREATE TABLE t_big5 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET big5 COLLATE big5_bin;
+INSERT INTO t_big5 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_big5 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_big5 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_big5 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_big5 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_big5 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_big5 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_big5 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_big5;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_big5;
+# Testing character set "dec8" collation "dec8_swedish_ci"
+CREATE TABLE t_dec8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET dec8 COLLATE dec8_swedish_ci;
+INSERT INTO t_dec8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_dec8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_dec8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_dec8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_dec8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_dec8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_dec8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_dec8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_dec8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_dec8;
+# Testing character set "dec8" collation "dec8_bin"
+CREATE TABLE t_dec8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET dec8 COLLATE dec8_bin;
+INSERT INTO t_dec8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_dec8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_dec8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_dec8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_dec8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_dec8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_dec8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_dec8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_dec8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_dec8;
+# Testing character set "cp850" collation "cp850_general_ci"
+CREATE TABLE t_cp850 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp850 COLLATE cp850_general_ci;
+INSERT INTO t_cp850 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp850 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp850 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp850 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp850 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp850 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp850 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp850 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp850;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp850;
+# Testing character set "cp850" collation "cp850_bin"
+CREATE TABLE t_cp850 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp850 COLLATE cp850_bin;
+INSERT INTO t_cp850 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp850 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp850 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp850 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp850 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp850 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp850 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp850 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp850;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp850;
+# Testing character set "hp8" collation "hp8_english_ci"
+CREATE TABLE t_hp8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET hp8 COLLATE hp8_english_ci;
+INSERT INTO t_hp8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_hp8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_hp8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_hp8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_hp8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_hp8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_hp8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_hp8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_hp8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_hp8;
+# Testing character set "hp8" collation "hp8_bin"
+CREATE TABLE t_hp8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET hp8 COLLATE hp8_bin;
+INSERT INTO t_hp8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_hp8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_hp8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_hp8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_hp8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_hp8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_hp8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_hp8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_hp8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_hp8;
+# Testing character set "koi8r" collation "koi8r_general_ci"
+CREATE TABLE t_koi8r (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET koi8r COLLATE koi8r_general_ci;
+INSERT INTO t_koi8r VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_koi8r VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_koi8r VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_koi8r VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_koi8r VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_koi8r VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_koi8r VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_koi8r VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_koi8r;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_koi8r;
+# Testing character set "koi8r" collation "koi8r_bin"
+CREATE TABLE t_koi8r (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET koi8r COLLATE koi8r_bin;
+INSERT INTO t_koi8r VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_koi8r VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_koi8r VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_koi8r VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_koi8r VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_koi8r VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_koi8r VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_koi8r VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_koi8r;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_koi8r;
+# Testing character set "latin1" collation "latin1_german1_ci"
+CREATE TABLE t_latin1 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin1 COLLATE latin1_german1_ci;
+INSERT INTO t_latin1 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin1 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin1 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin1 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin1 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin1;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin1;
+# Testing character set "latin1" collation "latin1_swedish_ci"
+CREATE TABLE t_latin1 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin1 COLLATE latin1_swedish_ci;
+INSERT INTO t_latin1 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin1 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin1 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin1 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin1 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin1;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin1;
+# Testing character set "latin1" collation "latin1_danish_ci"
+CREATE TABLE t_latin1 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin1 COLLATE latin1_danish_ci;
+INSERT INTO t_latin1 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin1 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin1 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin1 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin1 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin1;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin1;
+# Testing character set "latin1" collation "latin1_german2_ci"
+CREATE TABLE t_latin1 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin1 COLLATE latin1_german2_ci;
+INSERT INTO t_latin1 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin1 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin1 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin1 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin1 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin1;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin1;
+# Testing character set "latin1" collation "latin1_bin"
+CREATE TABLE t_latin1 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin1 COLLATE latin1_bin;
+INSERT INTO t_latin1 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin1 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin1 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin1 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin1 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin1;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin1;
+# Testing character set "latin1" collation "latin1_general_ci"
+CREATE TABLE t_latin1 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin1 COLLATE latin1_general_ci;
+INSERT INTO t_latin1 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin1 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin1 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin1 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin1 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin1;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin1;
+# Testing character set "latin1" collation "latin1_general_cs"
+CREATE TABLE t_latin1 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin1 COLLATE latin1_general_cs;
+INSERT INTO t_latin1 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin1 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin1 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin1 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin1 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin1;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin1;
+# Testing character set "latin1" collation "latin1_spanish_ci"
+CREATE TABLE t_latin1 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin1 COLLATE latin1_spanish_ci;
+INSERT INTO t_latin1 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin1 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin1 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin1 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin1 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin1;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin1;
+# Testing character set "latin2" collation "latin2_general_ci"
+CREATE TABLE t_latin2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin2 COLLATE latin2_general_ci;
+INSERT INTO t_latin2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin2;
+# Testing character set "latin2" collation "latin2_hungarian_ci"
+CREATE TABLE t_latin2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin2 COLLATE latin2_hungarian_ci;
+INSERT INTO t_latin2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin2;
+# Testing character set "latin2" collation "latin2_croatian_ci"
+CREATE TABLE t_latin2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin2 COLLATE latin2_croatian_ci;
+INSERT INTO t_latin2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin2;
+# Testing character set "latin2" collation "latin2_bin"
+CREATE TABLE t_latin2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin2 COLLATE latin2_bin;
+INSERT INTO t_latin2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin2;
+# Testing character set "swe7" collation "swe7_swedish_ci"
+CREATE TABLE t_swe7 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET swe7 COLLATE swe7_swedish_ci;
+INSERT INTO t_swe7 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_swe7 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_swe7 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_swe7 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_swe7 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_swe7 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_swe7 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_swe7 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_swe7;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_swe7;
+# Testing character set "swe7" collation "swe7_bin"
+CREATE TABLE t_swe7 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET swe7 COLLATE swe7_bin;
+INSERT INTO t_swe7 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_swe7 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_swe7 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_swe7 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_swe7 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_swe7 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_swe7 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_swe7 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_swe7;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_swe7;
+# Testing character set "ascii" collation "ascii_general_ci"
+CREATE TABLE t_ascii (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ascii COLLATE ascii_general_ci;
+INSERT INTO t_ascii VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ascii VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ascii VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ascii VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ascii VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ascii VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ascii VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ascii VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ascii;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_ascii;
+# Testing character set "ascii" collation "ascii_bin"
+CREATE TABLE t_ascii (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ascii COLLATE ascii_bin;
+INSERT INTO t_ascii VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ascii VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ascii VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ascii VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ascii VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ascii VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ascii VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ascii VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ascii;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_ascii;
+# Testing character set "ujis" collation "ujis_japanese_ci"
+CREATE TABLE t_ujis (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ujis COLLATE ujis_japanese_ci;
+INSERT INTO t_ujis VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ujis VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ujis VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ujis VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ujis VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ujis VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ujis VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ujis VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ujis;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_ujis;
+# Testing character set "ujis" collation "ujis_bin"
+CREATE TABLE t_ujis (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ujis COLLATE ujis_bin;
+INSERT INTO t_ujis VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ujis VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ujis VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ujis VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ujis VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ujis VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ujis VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ujis VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ujis;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_ujis;
+# Testing character set "sjis" collation "sjis_japanese_ci"
+CREATE TABLE t_sjis (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET sjis COLLATE sjis_japanese_ci;
+INSERT INTO t_sjis VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_sjis VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_sjis VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_sjis VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_sjis VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_sjis VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_sjis VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_sjis VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_sjis;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_sjis;
+# Testing character set "sjis" collation "sjis_bin"
+CREATE TABLE t_sjis (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET sjis COLLATE sjis_bin;
+INSERT INTO t_sjis VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_sjis VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_sjis VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_sjis VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_sjis VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_sjis VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_sjis VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_sjis VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_sjis;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_sjis;
+# Testing character set "hebrew" collation "hebrew_general_ci"
+CREATE TABLE t_hebrew (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET hebrew COLLATE hebrew_general_ci;
+INSERT INTO t_hebrew VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_hebrew VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_hebrew VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_hebrew VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_hebrew VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_hebrew VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_hebrew VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_hebrew VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_hebrew;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_hebrew;
+# Testing character set "hebrew" collation "hebrew_bin"
+CREATE TABLE t_hebrew (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET hebrew COLLATE hebrew_bin;
+INSERT INTO t_hebrew VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_hebrew VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_hebrew VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_hebrew VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_hebrew VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_hebrew VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_hebrew VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_hebrew VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_hebrew;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_hebrew;
+# Testing character set "tis620" collation "tis620_thai_ci"
+CREATE TABLE t_tis620 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET tis620 COLLATE tis620_thai_ci;
+INSERT INTO t_tis620 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_tis620 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_tis620 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_tis620 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_tis620 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_tis620 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_tis620 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_tis620 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_tis620;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_tis620;
+# Testing character set "tis620" collation "tis620_bin"
+CREATE TABLE t_tis620 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET tis620 COLLATE tis620_bin;
+INSERT INTO t_tis620 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_tis620 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_tis620 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_tis620 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_tis620 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_tis620 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_tis620 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_tis620 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_tis620;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_tis620;
+# Testing character set "euckr" collation "euckr_korean_ci"
+CREATE TABLE t_euckr (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET euckr COLLATE euckr_korean_ci;
+INSERT INTO t_euckr VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_euckr VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_euckr VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_euckr VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_euckr VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_euckr VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_euckr VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_euckr VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_euckr;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_euckr;
+# Testing character set "euckr" collation "euckr_bin"
+CREATE TABLE t_euckr (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET euckr COLLATE euckr_bin;
+INSERT INTO t_euckr VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_euckr VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_euckr VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_euckr VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_euckr VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_euckr VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_euckr VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_euckr VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_euckr;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_euckr;
+# Testing character set "koi8u" collation "koi8u_general_ci"
+CREATE TABLE t_koi8u (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET koi8u COLLATE koi8u_general_ci;
+INSERT INTO t_koi8u VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_koi8u VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_koi8u VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_koi8u VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_koi8u VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_koi8u VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_koi8u VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_koi8u VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_koi8u;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	C       `	9	432020202020202060	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_koi8u;
+# Testing character set "koi8u" collation "koi8u_bin"
+CREATE TABLE t_koi8u (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET koi8u COLLATE koi8u_bin;
+INSERT INTO t_koi8u VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_koi8u VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_koi8u VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_koi8u VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_koi8u VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_koi8u VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_koi8u VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_koi8u VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_koi8u;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_koi8u;
+# Testing character set "gb2312" collation "gb2312_chinese_ci"
+CREATE TABLE t_gb2312 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET gb2312 COLLATE gb2312_chinese_ci;
+INSERT INTO t_gb2312 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_gb2312 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_gb2312 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_gb2312 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_gb2312 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_gb2312 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_gb2312 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_gb2312 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_gb2312;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_gb2312;
+# Testing character set "gb2312" collation "gb2312_bin"
+CREATE TABLE t_gb2312 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET gb2312 COLLATE gb2312_bin;
+INSERT INTO t_gb2312 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_gb2312 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_gb2312 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_gb2312 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_gb2312 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_gb2312 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_gb2312 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_gb2312 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_gb2312;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_gb2312;
+# Testing character set "greek" collation "greek_general_ci"
+CREATE TABLE t_greek (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET greek COLLATE greek_general_ci;
+INSERT INTO t_greek VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_greek VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_greek VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_greek VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_greek VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_greek VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_greek VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_greek VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_greek;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_greek;
+# Testing character set "greek" collation "greek_bin"
+CREATE TABLE t_greek (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET greek COLLATE greek_bin;
+INSERT INTO t_greek VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_greek VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_greek VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_greek VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_greek VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_greek VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_greek VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_greek VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_greek;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_greek;
+# Testing character set "cp1250" collation "cp1250_general_ci"
+CREATE TABLE t_cp1250 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1250 COLLATE cp1250_general_ci;
+INSERT INTO t_cp1250 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1250 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1250 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1250 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1250 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1250 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1250 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1250 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1250;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1250;
+# Testing character set "cp1250" collation "cp1250_croatian_ci"
+CREATE TABLE t_cp1250 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1250 COLLATE cp1250_croatian_ci;
+INSERT INTO t_cp1250 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1250 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1250 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1250 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1250 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1250 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1250 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1250 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1250;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1250;
+# Testing character set "cp1250" collation "cp1250_bin"
+CREATE TABLE t_cp1250 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1250 COLLATE cp1250_bin;
+INSERT INTO t_cp1250 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1250 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1250 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1250 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1250 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1250 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1250 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1250 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1250;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1250;
+# Testing character set "cp1250" collation "cp1250_polish_ci"
+CREATE TABLE t_cp1250 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1250 COLLATE cp1250_polish_ci;
+INSERT INTO t_cp1250 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1250 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1250 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1250 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1250 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1250 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1250 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1250 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1250;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1250;
+# Testing character set "gbk" collation "gbk_chinese_ci"
+CREATE TABLE t_gbk (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET gbk COLLATE gbk_chinese_ci;
+INSERT INTO t_gbk VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_gbk VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_gbk VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_gbk VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_gbk VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_gbk VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_gbk VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_gbk VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_gbk;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_gbk;
+# Testing character set "gbk" collation "gbk_bin"
+CREATE TABLE t_gbk (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET gbk COLLATE gbk_bin;
+INSERT INTO t_gbk VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_gbk VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_gbk VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_gbk VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_gbk VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_gbk VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_gbk VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_gbk VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_gbk;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_gbk;
+# Testing character set "latin5" collation "latin5_turkish_ci"
+CREATE TABLE t_latin5 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin5 COLLATE latin5_turkish_ci;
+INSERT INTO t_latin5 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin5 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin5 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin5 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin5 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin5 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin5 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin5 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin5;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin5;
+# Testing character set "latin5" collation "latin5_bin"
+CREATE TABLE t_latin5 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin5 COLLATE latin5_bin;
+INSERT INTO t_latin5 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin5 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin5 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin5 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin5 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin5 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin5 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin5 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin5;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin5;
+# Testing character set "armscii8" collation "armscii8_general_ci"
+CREATE TABLE t_armscii8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET armscii8 COLLATE armscii8_general_ci;
+INSERT INTO t_armscii8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_armscii8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_armscii8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_armscii8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_armscii8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_armscii8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_armscii8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_armscii8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_armscii8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_armscii8;
+# Testing character set "armscii8" collation "armscii8_bin"
+CREATE TABLE t_armscii8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET armscii8 COLLATE armscii8_bin;
+INSERT INTO t_armscii8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_armscii8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_armscii8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_armscii8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_armscii8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_armscii8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_armscii8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_armscii8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_armscii8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_armscii8;
+# Testing character set "utf8" collation "utf8_general_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_general_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_bin"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_bin;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_unicode_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_unicode_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_icelandic_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_icelandic_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_latvian_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_latvian_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_romanian_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_romanian_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_slovenian_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_slovenian_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_polish_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_polish_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_estonian_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_estonian_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_spanish_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_spanish_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_swedish_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_swedish_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_turkish_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_turkish_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_czech_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_czech_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_danish_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_danish_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_lithuanian_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_lithuanian_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_slovak_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_slovak_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_spanish2_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_spanish2_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_roman_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_roman_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_persian_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_persian_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_esperanto_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_esperanto_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_hungarian_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_hungarian_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_sinhala_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_sinhala_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_german2_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_german2_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_croatian_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_croatian_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_unicode_520_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_unicode_520_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_vietnamese_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_vietnamese_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_general_mysql500_ci"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_general_mysql500_ci;
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "ucs2" collation "ucs2_general_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_general_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_bin"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_bin;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_unicode_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_unicode_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_icelandic_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_icelandic_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_latvian_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_latvian_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_romanian_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_romanian_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_slovenian_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_slovenian_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_polish_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_polish_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_estonian_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_estonian_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_spanish_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_spanish_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_swedish_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_swedish_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_turkish_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_turkish_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_czech_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_czech_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_danish_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_danish_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_lithuanian_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_lithuanian_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_slovak_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_slovak_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_spanish2_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_spanish2_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_roman_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_roman_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_persian_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_persian_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_esperanto_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_esperanto_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_hungarian_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_hungarian_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_sinhala_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_sinhala_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_german2_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_german2_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_croatian_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_croatian_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_unicode_520_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_unicode_520_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_vietnamese_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_vietnamese_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_general_mysql500_ci"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_general_mysql500_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "cp866" collation "cp866_general_ci"
+CREATE TABLE t_cp866 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp866 COLLATE cp866_general_ci;
+INSERT INTO t_cp866 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp866 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp866 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp866 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp866 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp866 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp866 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp866 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp866;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp866;
+# Testing character set "cp866" collation "cp866_bin"
+CREATE TABLE t_cp866 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp866 COLLATE cp866_bin;
+INSERT INTO t_cp866 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp866 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp866 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp866 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp866 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp866 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp866 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp866 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp866;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp866;
+# Testing character set "keybcs2" collation "keybcs2_general_ci"
+CREATE TABLE t_keybcs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET keybcs2 COLLATE keybcs2_general_ci;
+INSERT INTO t_keybcs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_keybcs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_keybcs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_keybcs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_keybcs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_keybcs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_keybcs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_keybcs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_keybcs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_keybcs2;
+# Testing character set "keybcs2" collation "keybcs2_bin"
+CREATE TABLE t_keybcs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET keybcs2 COLLATE keybcs2_bin;
+INSERT INTO t_keybcs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_keybcs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_keybcs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_keybcs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_keybcs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_keybcs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_keybcs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_keybcs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_keybcs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_keybcs2;
+# Testing character set "macce" collation "macce_general_ci"
+CREATE TABLE t_macce (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET macce COLLATE macce_general_ci;
+INSERT INTO t_macce VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_macce VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_macce VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_macce VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_macce VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_macce VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_macce VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_macce VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_macce;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_macce;
+# Testing character set "macce" collation "macce_bin"
+CREATE TABLE t_macce (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET macce COLLATE macce_bin;
+INSERT INTO t_macce VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_macce VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_macce VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_macce VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_macce VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_macce VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_macce VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_macce VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_macce;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_macce;
+# Testing character set "macroman" collation "macroman_general_ci"
+CREATE TABLE t_macroman (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET macroman COLLATE macroman_general_ci;
+INSERT INTO t_macroman VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_macroman VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_macroman VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_macroman VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_macroman VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_macroman VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_macroman VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_macroman VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_macroman;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_macroman;
+# Testing character set "macroman" collation "macroman_bin"
+CREATE TABLE t_macroman (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET macroman COLLATE macroman_bin;
+INSERT INTO t_macroman VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_macroman VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_macroman VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_macroman VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_macroman VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_macroman VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_macroman VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_macroman VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_macroman;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_macroman;
+# Testing character set "cp852" collation "cp852_general_ci"
+CREATE TABLE t_cp852 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp852 COLLATE cp852_general_ci;
+INSERT INTO t_cp852 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp852 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp852 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp852 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp852 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp852 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp852 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp852 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp852;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp852;
+# Testing character set "cp852" collation "cp852_bin"
+CREATE TABLE t_cp852 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp852 COLLATE cp852_bin;
+INSERT INTO t_cp852 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp852 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp852 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp852 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp852 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp852 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp852 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp852 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp852;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp852;
+# Testing character set "latin7" collation "latin7_estonian_cs"
+CREATE TABLE t_latin7 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin7 COLLATE latin7_estonian_cs;
+INSERT INTO t_latin7 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin7 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin7 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin7 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin7 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin7 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin7 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin7 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin7;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin7;
+# Testing character set "latin7" collation "latin7_general_ci"
+CREATE TABLE t_latin7 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin7 COLLATE latin7_general_ci;
+INSERT INTO t_latin7 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin7 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin7 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin7 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin7 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin7 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin7 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin7 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin7;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin7;
+# Testing character set "latin7" collation "latin7_general_cs"
+CREATE TABLE t_latin7 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin7 COLLATE latin7_general_cs;
+INSERT INTO t_latin7 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin7 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin7 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin7 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin7 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin7 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin7 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin7 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin7;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin7;
+# Testing character set "latin7" collation "latin7_bin"
+CREATE TABLE t_latin7 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin7 COLLATE latin7_bin;
+INSERT INTO t_latin7 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin7 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin7 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin7 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin7 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin7 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin7 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin7 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin7;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin7;
+# Testing character set "utf8mb4" collation "utf8mb4_general_ci"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_general_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_bin"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_bin;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_unicode_ci"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_unicode_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_icelandic_ci"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_icelandic_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_latvian_ci"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_latvian_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_romanian_ci"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_romanian_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_slovenian_ci"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_slovenian_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_polish_ci"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_polish_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_estonian_ci"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_estonian_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_spanish_ci"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_spanish_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_swedish_ci"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_swedish_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_turkish_ci"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_turkish_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_czech_ci"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_czech_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_danish_ci"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_danish_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_lithuanian_ci"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_lithuanian_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_slovak_ci"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_slovak_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_spanish2_ci"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_spanish2_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_roman_ci"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_roman_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_persian_ci"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_persian_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_esperanto_ci"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_esperanto_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_hungarian_ci"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_hungarian_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_sinhala_ci"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_sinhala_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_german2_ci"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_german2_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_croatian_ci"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_croatian_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_unicode_520_ci"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_unicode_520_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_vietnamese_ci"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_vietnamese_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "cp1251" collation "cp1251_bulgarian_ci"
+CREATE TABLE t_cp1251 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1251 COLLATE cp1251_bulgarian_ci;
+INSERT INTO t_cp1251 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1251 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1251 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1251 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1251 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1251;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1251;
+# Testing character set "cp1251" collation "cp1251_ukrainian_ci"
+CREATE TABLE t_cp1251 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1251 COLLATE cp1251_ukrainian_ci;
+INSERT INTO t_cp1251 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1251 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1251 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1251 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1251 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1251;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	C       `	9	432020202020202060	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1251;
+# Testing character set "cp1251" collation "cp1251_bin"
+CREATE TABLE t_cp1251 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1251 COLLATE cp1251_bin;
+INSERT INTO t_cp1251 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1251 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1251 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1251 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1251 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1251;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1251;
+# Testing character set "cp1251" collation "cp1251_general_ci"
+CREATE TABLE t_cp1251 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1251 COLLATE cp1251_general_ci;
+INSERT INTO t_cp1251 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1251 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1251 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1251 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1251 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1251;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1251;
+# Testing character set "cp1251" collation "cp1251_general_cs"
+CREATE TABLE t_cp1251 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1251 COLLATE cp1251_general_cs;
+INSERT INTO t_cp1251 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1251 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1251 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1251 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1251 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1251;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1251;
+# Testing character set "utf16" collation "utf16_general_ci"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_general_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_bin"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_bin;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_unicode_ci"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_unicode_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_icelandic_ci"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_icelandic_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_latvian_ci"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_latvian_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_romanian_ci"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_romanian_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_slovenian_ci"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_slovenian_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_polish_ci"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_polish_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_estonian_ci"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_estonian_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_spanish_ci"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_spanish_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_swedish_ci"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_swedish_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_turkish_ci"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_turkish_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_czech_ci"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_czech_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_danish_ci"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_danish_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_lithuanian_ci"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_lithuanian_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_slovak_ci"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_slovak_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_spanish2_ci"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_spanish2_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_roman_ci"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_roman_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_persian_ci"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_persian_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_esperanto_ci"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_esperanto_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_hungarian_ci"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_hungarian_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_sinhala_ci"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_sinhala_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_german2_ci"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_german2_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_croatian_ci"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_croatian_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_unicode_520_ci"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_unicode_520_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_vietnamese_ci"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_vietnamese_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16le" collation "utf16le_general_ci"
+CREATE TABLE t_utf16le (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16le COLLATE utf16le_general_ci;
+INSERT INTO t_utf16le VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16le VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16le VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16le VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16le VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16le VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16le VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16le VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16le;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	61000900	a		4	61000900	a		4	61000900	a		4	61000900
+a 		6	610020000900	a 		6	610020000900	a 		6	610020000900	a 		6	610020000900
+a 	4	61002000	a	2	6100	a 	4	61002000	a	2	6100
+b  	6	620020002000	b	2	6200	b  	6	620020002000	b	2	6200
+c          	22	63002000200020002000200020002000200020002000	c	2	6300	c          	22	63002000200020002000200020002000200020002000	c	2	6300
+DROP TABLE t_utf16le;
+# Testing character set "utf16le" collation "utf16le_bin"
+CREATE TABLE t_utf16le (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16le COLLATE utf16le_bin;
+INSERT INTO t_utf16le VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16le VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16le VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16le VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16le VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16le VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16le VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16le VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16le;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	61000900	a		4	61000900	a		4	61000900	a		4	61000900
+a 		6	610020000900	a 		6	610020000900	a 		6	610020000900	a 		6	610020000900
+a 	4	61002000	a	2	6100	a 	4	61002000	a	2	6100
+b  	6	620020002000	b	2	6200	b  	6	620020002000	b	2	6200
+c          	22	63002000200020002000200020002000200020002000	c	2	6300	c          	22	63002000200020002000200020002000200020002000	c	2	6300
+DROP TABLE t_utf16le;
+# Testing character set "cp1256" collation "cp1256_general_ci"
+CREATE TABLE t_cp1256 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1256 COLLATE cp1256_general_ci;
+INSERT INTO t_cp1256 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1256 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1256 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1256 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1256 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1256 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1256 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1256 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1256;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1256;
+# Testing character set "cp1256" collation "cp1256_bin"
+CREATE TABLE t_cp1256 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1256 COLLATE cp1256_bin;
+INSERT INTO t_cp1256 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1256 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1256 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1256 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1256 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1256 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1256 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1256 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1256;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1256;
+# Testing character set "cp1257" collation "cp1257_lithuanian_ci"
+CREATE TABLE t_cp1257 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1257 COLLATE cp1257_lithuanian_ci;
+INSERT INTO t_cp1257 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1257 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1257 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1257 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1257 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1257 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1257 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1257 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1257;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1257;
+# Testing character set "cp1257" collation "cp1257_bin"
+CREATE TABLE t_cp1257 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1257 COLLATE cp1257_bin;
+INSERT INTO t_cp1257 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1257 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1257 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1257 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1257 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1257 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1257 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1257 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1257;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1257;
+# Testing character set "cp1257" collation "cp1257_general_ci"
+CREATE TABLE t_cp1257 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1257 COLLATE cp1257_general_ci;
+INSERT INTO t_cp1257 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1257 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1257 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1257 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1257 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1257 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1257 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1257 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1257;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1257;
+# Testing character set "utf32" collation "utf32_general_ci"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_general_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_bin"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_bin;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_unicode_ci"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_unicode_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_icelandic_ci"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_icelandic_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_latvian_ci"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_latvian_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_romanian_ci"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_romanian_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_slovenian_ci"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_slovenian_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_polish_ci"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_polish_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_estonian_ci"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_estonian_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_spanish_ci"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_spanish_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_swedish_ci"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_swedish_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_turkish_ci"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_turkish_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_czech_ci"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_czech_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_danish_ci"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_danish_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_lithuanian_ci"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_lithuanian_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_slovak_ci"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_slovak_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_spanish2_ci"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_spanish2_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_roman_ci"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_roman_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_persian_ci"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_persian_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_esperanto_ci"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_esperanto_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_hungarian_ci"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_hungarian_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_sinhala_ci"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_sinhala_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_german2_ci"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_german2_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_croatian_ci"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_croatian_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_unicode_520_ci"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_unicode_520_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_vietnamese_ci"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_vietnamese_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "binary" collation "binary"
+CREATE TABLE t_binary (pk_varchar VARBINARY(64), pk_char BINARY(64), d_varchar VARBINARY(64), d_char BINARY(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB;
+INSERT INTO t_binary VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_binary VALUES ('a', 'a', 'a', 'a');
+INSERT INTO t_binary VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_binary VALUES('b', 'b', 'b', 'b');
+INSERT INTO t_binary VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_binary VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_binary VALUES('a          ', 'a          ', 'a          ', 'a          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_binary;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a	1	61	a                                                               	64	61000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000	a	1	61	a                                                               	64	61000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+a		2	6109	a	                                                              	64	61090000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000	a		2	6109	a	                                                              	64	61090000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+a 	2	6120	a                                                               	64	61200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000	a 	2	6120	a                                                               	64	61200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+a 		3	612009	a 	                                                             	64	61200900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000	a 		3	612009	a 	                                                             	64	61200900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+a          	11	6120202020202020202020	a                                                               	64	61202020202020202020200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000	a          	11	6120202020202020202020	a                                                               	64	61202020202020202020200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+b	1	62	b                                                               	64	62000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000	b	1	62	b                                                               	64	62000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+b  	3	622020	b                                                               	64	62202000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000	b  	3	622020	b                                                               	64	62202000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+DROP TABLE t_binary;
+# Testing character set "geostd8" collation "geostd8_general_ci"
+CREATE TABLE t_geostd8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET geostd8 COLLATE geostd8_general_ci;
+INSERT INTO t_geostd8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_geostd8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_geostd8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_geostd8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_geostd8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_geostd8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_geostd8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_geostd8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_geostd8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_geostd8;
+# Testing character set "geostd8" collation "geostd8_bin"
+CREATE TABLE t_geostd8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET geostd8 COLLATE geostd8_bin;
+INSERT INTO t_geostd8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_geostd8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_geostd8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_geostd8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_geostd8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_geostd8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_geostd8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_geostd8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_geostd8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_geostd8;
+# Testing character set "cp932" collation "cp932_japanese_ci"
+CREATE TABLE t_cp932 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp932 COLLATE cp932_japanese_ci;
+INSERT INTO t_cp932 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp932 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp932 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp932 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp932 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp932 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp932 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp932 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp932;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp932;
+# Testing character set "cp932" collation "cp932_bin"
+CREATE TABLE t_cp932 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp932 COLLATE cp932_bin;
+INSERT INTO t_cp932 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp932 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp932 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp932 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp932 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp932 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp932 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp932 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp932;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp932;
+# Testing character set "eucjpms" collation "eucjpms_japanese_ci"
+CREATE TABLE t_eucjpms (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET eucjpms COLLATE eucjpms_japanese_ci;
+INSERT INTO t_eucjpms VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_eucjpms VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_eucjpms VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_eucjpms VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_eucjpms VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_eucjpms VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_eucjpms VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_eucjpms VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_eucjpms;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_eucjpms;
+# Testing character set "eucjpms" collation "eucjpms_bin"
+CREATE TABLE t_eucjpms (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET eucjpms COLLATE eucjpms_bin;
+INSERT INTO t_eucjpms VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_eucjpms VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_eucjpms VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_eucjpms VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_eucjpms VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_eucjpms VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_eucjpms VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_eucjpms VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_eucjpms;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_eucjpms;
+DROP TABLE collations;

--- a/mysql-test/suite/rocksdb/t/type_varchar_packing.test
+++ b/mysql-test/suite/rocksdb/t/type_varchar_packing.test
@@ -1,0 +1,47 @@
+--source include/have_rocksdb.inc
+
+CREATE TABLE collations AS SELECT * FROM information_schema.COLLATION_CHARACTER_SET_APPLICABILITY WHERE COLLATION_NAME NOT IN ("latin2_czech_cs", "cp1250_czech_cs");
+
+--let $i=1
+--let $charset=query_get_value(select * from collations, CHARACTER_SET_NAME, $i)
+--let $collate=query_get_value(select * from collations, COLLATION_NAME, $i)
+while ($charset != 'No such row')
+{
+  --echo # Testing character set "$charset" collation "$collate"
+  --let table_name=t_$charset
+  if ($charset == "binary")
+  {
+    --eval CREATE TABLE $table_name (pk_varchar VARBINARY(64), pk_char BINARY(64), d_varchar VARBINARY(64), d_char BINARY(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB
+    --eval INSERT INTO $table_name VALUES('a ', 'a ', 'a ', 'a ')
+    --eval INSERT INTO $table_name VALUES ('a', 'a', 'a', 'a')
+    --eval INSERT INTO $table_name VALUES('b  ', 'b  ', 'b  ', 'b  ');
+    --eval INSERT INTO $table_name VALUES('b', 'b', 'b', 'b')
+    --eval INSERT INTO $table_name VALUES('a\t', 'a\t', 'a\t', 'a\t')
+    --eval INSERT INTO $table_name VALUES('a \t', 'a \t', 'a \t', 'a \t')
+    --eval INSERT INTO $table_name VALUES('a          ', 'a          ', 'a          ', 'a          ')
+  }
+  if ($charset != "binary")
+  {
+    --eval CREATE TABLE $table_name (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET $charset COLLATE $collate
+    --eval INSERT INTO $table_name VALUES('a ', 'a ', 'a ', 'a ')
+    --error ER_DUP_ENTRY
+    --eval INSERT INTO $table_name VALUES ('a', 'a', 'a', 'a')
+    --eval INSERT INTO $table_name VALUES('b  ', 'b  ', 'b  ', 'b  ');
+    --error ER_DUP_ENTRY
+    --eval INSERT INTO $table_name VALUES('b', 'b', 'b', 'b')
+    --eval INSERT INTO $table_name VALUES('a\t', 'a\t', 'a\t', 'a\t')
+    --eval INSERT INTO $table_name VALUES('a \t', 'a \t', 'a \t', 'a \t')
+    --error ER_DUP_ENTRY
+    --eval INSERT INTO $table_name VALUES('a          ', 'a          ', 'a          ', 'a          ')
+    --eval INSERT INTO $table_name VALUES('c          ', 'c          ', 'c          ', 'c          ')
+  }
+
+  --eval SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM $table_name
+  --eval DROP TABLE $table_name
+
+  --inc $i
+  --let $charset=query_get_value(select * from collations, CHARACTER_SET_NAME, $i)
+  --let $collate=query_get_value(select * from collations, COLLATION_NAME, $i)
+}
+
+DROP TABLE collations;


### PR DESCRIPTION
Add `rocksdb.type_varchar_packing` to validate padding of `CHAR` and `VARCHAR` collations.
Only multi-level collations (`latin2_czech_cs` and `cp1250_czech_cs`) are not supported.
