### PR TITLE
Fix bug 1704195 / 87065 / TDB-83 (Stop ANALYZE TABLE from flushing ta…

### DIFF
--- a/mysql-test/collections/disabled_rocksdb.def
+++ b/mysql-test/collections/disabled_rocksdb.def
@@ -27,7 +27,6 @@ rocksdb.autoinc_crash_safe_partition : BUG#888001 partition feature is missing i
 rocksdb.explicit_snapshot : BUG#0000 missing patch 0b671a35cc7 SQL to create and manage explicit snapshots
 rocksdb.innodb_i_s_tables_disabled : BUG#0000 missing patch
 rocksdb_rpl.rpl_rocksdb_schema_change : BUG#0000 missing 031b5cec711 Use column names while applying row changes on slave
-rocksdb.percona_nonflushing_analyze_debug : BUG#0000 missing dbc7c09e252 Fix bug 1704195 / 87065 / TDB-83 (Stop ANALYZE...
 rocksdb.native_procedure : BUG#0000 missing 7292a82ad28 Native procedures in MySQL
 
 # Blind replace

--- a/mysql-test/r/percona_nonflushing_analyze_debug.result
+++ b/mysql-test/r/percona_nonflushing_analyze_debug.result
@@ -1,0 +1,19 @@
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1), (2), (3);
+SET DEBUG_SYNC="handler_ha_index_next_end SIGNAL idx_scan_in_progress WAIT_FOR finish_scan";
+SELECT * FROM t1;
+SET DEBUG_SYNC="now WAIT_FOR idx_scan_in_progress";
+ANALYZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
+SELECT * FROM t1;
+a
+1
+2
+3
+SET DEBUG_SYNC="now SIGNAL finish_scan";
+a
+1
+2
+3
+DROP TABLE t1;

--- a/mysql-test/suite/parts/r/percona_nonflushing_analyze_debug.result
+++ b/mysql-test/suite/parts/r/percona_nonflushing_analyze_debug.result
@@ -1,0 +1,50 @@
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB
+PARTITION BY RANGE (a) (
+PARTITION p0 VALUES LESS THAN (3),
+PARTITION p1 VALUES LESS THAN (10));
+INSERT INTO t1 VALUES (1), (2), (3), (4);
+SET DEBUG_SYNC="handler_ha_index_next_end SIGNAL idx_scan_in_progress WAIT_FOR finish_scan";
+SELECT * FROM t1;
+SET DEBUG_SYNC="now WAIT_FOR idx_scan_in_progress";
+ANALYZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
+SELECT * FROM t1;
+a
+1
+2
+3
+4
+SET DEBUG_SYNC="now SIGNAL finish_scan";
+a
+1
+2
+3
+4
+DROP TABLE t1;
+CREATE TABLE t2 (a INT PRIMARY KEY) ENGINE=InnoDB
+PARTITION BY RANGE (a)
+SUBPARTITION BY HASH (A)
+SUBPARTITIONS 2 (
+PARTITION p0 VALUES LESS THAN (3),
+PARTITION p1 VALUES LESS THAN (10));
+INSERT INTO t2 VALUES (1), (2), (3), (4);
+SET DEBUG_SYNC="handler_ha_index_next_end SIGNAL idx_scan_in_progress WAIT_FOR finish_scan";
+SELECT * FROM t2;
+SET DEBUG_SYNC="now WAIT_FOR idx_scan_in_progress";
+ANALYZE TABLE t2;
+Table	Op	Msg_type	Msg_text
+test.t2	analyze	status	OK
+SELECT * FROM t2;
+a
+2
+1
+4
+3
+SET DEBUG_SYNC="now SIGNAL finish_scan";
+a
+2
+1
+4
+3
+DROP TABLE t2;

--- a/mysql-test/suite/parts/t/percona_nonflushing_analyze_debug.test
+++ b/mysql-test/suite/parts/t/percona_nonflushing_analyze_debug.test
@@ -1,0 +1,27 @@
+--source include/have_debug_sync.inc
+
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB
+       PARTITION BY RANGE (a) (
+                 PARTITION p0 VALUES LESS THAN (3),
+                 PARTITION p1 VALUES LESS THAN (10));
+
+INSERT INTO t1 VALUES (1), (2), (3), (4);
+
+--let $percona_nonflushing_analyze_table= t1
+--source include/percona_nonflushing_analyze_debug.inc
+
+DROP TABLE t1;
+
+CREATE TABLE t2 (a INT PRIMARY KEY) ENGINE=InnoDB
+       PARTITION BY RANGE (a)
+       SUBPARTITION BY HASH (A)
+       SUBPARTITIONS 2 (
+                 PARTITION p0 VALUES LESS THAN (3),
+                 PARTITION p1 VALUES LESS THAN (10));
+
+INSERT INTO t2 VALUES (1), (2), (3), (4);
+
+--let $percona_nonflushing_analyze_table= t2
+--source include/percona_nonflushing_analyze_debug.inc
+
+DROP TABLE t2;

--- a/mysql-test/t/percona_nonflushing_analyze_debug.test
+++ b/mysql-test/t/percona_nonflushing_analyze_debug.test
@@ -1,0 +1,9 @@
+--source include/have_debug_sync.inc
+
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1), (2), (3);
+
+--let $percona_nonflushing_analyze_table= t1
+--source include/percona_nonflushing_analyze_debug.inc
+
+DROP TABLE t1;

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -3238,6 +3238,7 @@ int handler::ha_index_next(uchar *buf) {
     m_update_generated_read_fields = false;
   }
   table->set_row_status_from_handler(result);
+  DEBUG_SYNC(ha_thd(), "handler_ha_index_next_end");
   DBUG_RETURN(result);
 }
 

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -522,6 +522,12 @@ enum enum_alter_inplace_result {
 */
 #define HA_MULTI_VALUED_KEY_SUPPORT (1LL << 55)
 
+/**
+  There is no need to evict the table from the table definition cache having
+  run ANALYZE TABLE on it
+ */
+#define HA_ONLINE_ANALYZE (1LL << 56)
+
 /*
   Bits in index_flags(index_number) for what you can do with index.
   If you do not implement indexes, just return zero here.

--- a/sql/sql_admin.cc
+++ b/sql/sql_admin.cc
@@ -1255,6 +1255,9 @@ static bool mysql_admin_table(
       }
     }
     if (table->table) {
+      const bool skip_flush =
+        (operator_func == &handler::ha_analyze)
+        && (table->table->file->ha_table_flags() & HA_ONLINE_ANALYZE);
       if (table->table->s->tmp_table) {
         /*
           If the table was not opened successfully, do not try to get
@@ -1262,7 +1265,7 @@ static bool mysql_admin_table(
         */
         if (open_for_modify && !open_error)
           table->table->file->info(HA_STATUS_CONST);
-      } else if (open_for_modify || fatal_error) {
+      } else if ((!skip_flush && open_for_modify) || fatal_error) {
         tdc_remove_table(thd, TDC_RT_REMOVE_UNUSED, table->db,
                          table->table_name, false);
       } else {

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -2813,7 +2813,7 @@ ha_innobase::ha_innobase(handlerton *hton, TABLE_SHARE *table_arg)
           HA_ATTACHABLE_TRX_COMPATIBLE | HA_CAN_INDEX_VIRTUAL_GENERATED_COLUMN |
           HA_DESCENDING_INDEX | HA_MULTI_VALUED_KEY_SUPPORT |
           HA_BLOB_PARTIAL_UPDATE | HA_SUPPORTS_GEOGRAPHIC_GEOMETRY_COLUMN |
-          HA_SUPPORTS_DEFAULT_EXPRESSION),
+          HA_SUPPORTS_DEFAULT_EXPRESSION | HA_ONLINE_ANALYZE),
       m_start_of_scan(),
       m_stored_select_lock_type(LOCK_NONE_UNSET),
       m_mysql_has_locked() {}

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -440,12 +440,12 @@ class ha_rocksdb : public my_core::handler {
         If we don't set it, filesort crashes, because it assumes rowids are
         1..8 byte numbers
     */
-    /* TODO(yzha) - HA_REC_NOT_IN_SEQ & HA_ONLINE_ANALYZE is gone in 8.0 */
+    /* TODO(yzha) - HA_REC_NOT_IN_SEQ is gone in 8.0 */
     DBUG_RETURN(HA_BINLOG_ROW_CAPABLE | HA_BINLOG_STMT_CAPABLE |
                 /* HA_REC_NOT_IN_SEQ | */ HA_CAN_INDEX_BLOBS |
                 (m_pk_can_be_decoded ? HA_PRIMARY_KEY_IN_READ_INDEX : 0) |
                 HA_PRIMARY_KEY_REQUIRED_FOR_POSITION | HA_NULL_IN_KEY |
-                HA_PARTIAL_COLUMN_READ /* | HA_ONLINE_ANALYZE */);
+                HA_PARTIAL_COLUMN_READ | HA_ONLINE_ANALYZE);
   }
 
   bool init_with_fields() override;


### PR DESCRIPTION
…ble definition cache)

Reference Patch: https://github.com/facebook/mysql-5.6/commit/dbc7c09e252

---------- https://github.com/facebook/mysql-5.6/commit/dbc7c09e252 ----------

Summary:
This is adapted from https://github.com/percona/percona-server/pull/1977

  Make ANALYZE TABLE stop flushing affected tables from the table
  definition cache, which has the effect of not blocking any subsequent
  new queries involving the table if there's a parallel long-running
  query:

  - new table flag HA_ONLINE_ANALYZE, return it for InnoDB and TokuDB
    tables;
  - in mysql_admin_table, if we are performing ANALYZE TABLE, and the
    table flag is set, do not remove the table from the table
    definition cache, do not invalidate query cache;
  - in partitioning handler, refresh the query optimizer statistics
    after ANALYZE if the underlying handler supports HA_ONLINE_ANALYZE;
  - new testcases main.percona_nonflushing_analyze_debug,
    parts.percona_nonflushing_abalyze_debug and a supporting debug sync
    point.

  For TokuDB, this change exposes bug TDB-83 (Index cardinality stats
  updated for handler::info(HA_STATUS_CONST), not often enough for
  tokudb_cardinality_scale_percent). TokuDB may return different
  rec_per_key values depending on dynamic variable
  tokudb_cardinality_scale_percent value. The server does not have a way
  of knowing that changing this variable invalidates the previous
  rec_per_key values in any opened table shares, and so does not call
  info(HA_STATUS_CONST) again. Fix by updating rec_per_key for both
  HA_STATUS_CONST and HA_STATUS_VARIABLE. This also forces a re-record
  of tokudb.bugs.db756_card_part_hash_1_pick, with the new output
  seeming to be more correct.

Originally Reviewed By: hermanlee

fbshipit-source-id: 659933a3408