### PR TITLE
Dump core for mysqld without large memory buffer

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -5891,6 +5891,7 @@ sub mysqld_arguments ($$$) {
   my $found_skip_core  = 0;
   my $found_no_console = 0;
   my $found_log_error  = 0;
+  my $innodb_dump_core_without_large_mem_buf = 0;
 
   # Check if the option 'log-error' is found in the .cnf file
   # In the group defined for the server
@@ -5920,6 +5921,9 @@ sub mysqld_arguments ($$$) {
       # Allow --skip-core-file to be set in <testname>-[master|slave].opt file
       $found_skip_core = 1;
       next;
+    } elsif ($arg eq "--innodb-dump-core-without-large-mem-buf") {
+      $innodb_dump_core_without_large_mem_buf = 1;
+      next;
     } elsif ($arg eq "--no-console") {
       $found_no_console = 1;
       next;
@@ -5946,6 +5950,11 @@ sub mysqld_arguments ($$$) {
 
   if (!$found_skip_core && !$opt_user_args) {
     mtr_add_arg($args, "%s", "--core-file");
+  }
+
+  # Set the default value to false so that the full core will be dumped
+  if ( !$innodb_dump_core_without_large_mem_buf) {
+      mtr_add_arg($args, "--skip-innodb-dump-core-without-large-mem-buf");
   }
 
   return $args;

--- a/mysql-test/suite/innodb/r/mysqld_core_dump_without_large_mem_buf.result
+++ b/mysql-test/suite/innodb/r/mysqld_core_dump_without_large_mem_buf.result
@@ -1,0 +1,7 @@
+# Get the full path name of the PID file
+# Expecting a "crash", but don't restart the server until it is told to
+# Expected max core size is 3584 MB
+# Perl: Sent a SIGSEGV to mysqld to dump a core.
+# Perl: OK! Found the core file and it's small!
+# Make server restart
+# Wait for server to be back online

--- a/mysql-test/suite/innodb/r/mysqld_core_dump_without_large_mem_buf_with_resizing.result
+++ b/mysql-test/suite/innodb/r/mysqld_core_dump_without_large_mem_buf_with_resizing.result
@@ -1,0 +1,17 @@
+set global innodb_adaptive_hash_index=ON;
+set global innodb_buffer_pool_size = 21474836480;
+select @@innodb_buffer_pool_size;
+@@innodb_buffer_pool_size
+21474836480
+set global innodb_adaptive_hash_index=OFF;
+set global innodb_buffer_pool_size = 64424509440;
+select @@innodb_buffer_pool_size;
+@@innodb_buffer_pool_size
+64424509440
+# Get the full path name of the PID file
+# Expecting a "crash", but don't restart the server until it is told to
+# Expected max core size is 5632 MB
+# Perl: Sent a SIGSEGV to mysqld to dump a core.
+# Perl: OK! Found the core file and it's small!
+# Make server restart
+# Wait for server to be back online

--- a/mysql-test/suite/innodb/t/mysqld_core_dump_without_large_mem_buf-master.opt
+++ b/mysql-test/suite/innodb/t/mysqld_core_dump_without_large_mem_buf-master.opt
@@ -1,0 +1,2 @@
+--innodb-dump-core-without-large-mem-buf
+--innodb-buffer-pool-size=60G

--- a/mysql-test/suite/innodb/t/mysqld_core_dump_without_large_mem_buf.test
+++ b/mysql-test/suite/innodb/t/mysqld_core_dump_without_large_mem_buf.test
@@ -1,0 +1,18 @@
+################################################################################
+# This test is to test if mysqld can dump a core without large memory buffers.
+# See opt file for the config:
+#   (1) --innodb-dump-core-without-large-mem-buf is set
+#   (2) the buffer pool is set to be large so that without dropping the large
+#       memory buffers the core size will be much greater than 3.5GB (the actual
+#       core size is less than 3GB now but set the limit to 3.5GB here in case
+#       the memory footprint increases in the future)
+
+--source include/big_test.inc
+--source include/not_valgrind.inc
+--source include/linux_core_pattern.inc
+
+--let $restart_parameters = restart:--log-error=$MYSQLTEST_VARDIR/log/core_dump.err
+--source include/restart_mysqld_no_echo.inc
+
+--let $expected_max_core_size = 3584
+--source include/mysqld_core_dump.inc

--- a/mysql-test/suite/innodb/t/mysqld_core_dump_without_large_mem_buf_with_resizing-master.opt
+++ b/mysql-test/suite/innodb/t/mysqld_core_dump_without_large_mem_buf_with_resizing-master.opt
@@ -1,0 +1,2 @@
+--innodb-dump-core-without-large-mem-buf
+--innodb-buffer-pool-size=60G

--- a/mysql-test/suite/innodb/t/mysqld_core_dump_without_large_mem_buf_with_resizing.test
+++ b/mysql-test/suite/innodb/t/mysqld_core_dump_without_large_mem_buf_with_resizing.test
@@ -1,0 +1,51 @@
+################################################################################
+# This test is to test if mysqld can dump a core without large memory buffers.
+# See opt file for the config:
+#   (1) --innodb-dump-core-without-large-mem-buf is set
+#   (2) the buffer pool is set to be large initially, shrink it, then expand
+#       it back to the original large size, without dropping the large memory
+#       buffers the core size will be much greater than 5.5GB (the actual
+#       core size is less than 5GB now but set the limit to 5.5GB here in case
+#       the memory footprint increases in the future)
+
+--source include/big_test.inc
+--source include/not_valgrind.inc
+--source include/linux_core_pattern.inc
+
+--let $restart_parameters = restart:--log-error=$MYSQLTEST_VARDIR/log/core_dump.err
+--source include/restart_mysqld_no_echo.inc
+
+let $wait_timeout = 600;
+let $wait_condition =
+  SELECT SUBSTR(variable_value, 1, 34) = 'Completed resizing buffer pool at '
+  FROM performance_schema.global_status
+  WHERE LOWER(variable_name) = 'innodb_buffer_pool_resize_status';
+
+--disable_query_log
+set @old_innodb_buffer_pool_size = @@innodb_buffer_pool_size;
+set @old_innodb_adaptive_hash_index = @@innodb_adaptive_hash_index;
+--enable_query_log
+
+set global innodb_adaptive_hash_index=ON;
+
+# Shrink buffer pool to 20GB
+set global innodb_buffer_pool_size = 21474836480;
+--source include/wait_condition.inc
+
+select @@innodb_buffer_pool_size;
+
+set global innodb_adaptive_hash_index=OFF;
+
+# Expand buffer pool back to 60GB
+set global innodb_buffer_pool_size = 64424509440;
+--source include/wait_condition.inc
+
+select @@innodb_buffer_pool_size;
+
+--disable_query_log
+set global innodb_buffer_pool_size = @old_innodb_buffer_pool_size;
+set global innodb_adaptive_hash_index = @old_innodb_adaptive_hash_index;
+--enable_query_log
+
+--let $expected_max_core_size = 5632
+--source include/mysqld_core_dump.inc

--- a/mysql-test/suite/sys_vars/r/core_file_basic.result
+++ b/mysql-test/suite/sys_vars/r/core_file_basic.result
@@ -1,22 +1,23 @@
-SET @old_val = @@global.core_file;
-SET GLOBAL core_file = FALSE;
-SELECT @@core_file;
-@@core_file
-0
-SHOW GLOBAL VARIABLES LIKE 'core_file';
-Variable_name	Value
-core_file	OFF
-SELECT * FROM performance_schema.global_variables WHERE VARIABLE_NAME = 'core_file';
-VARIABLE_NAME	VARIABLE_VALUE
-core_file	OFF
-SET GLOBAL core_file = TRUE;
-SELECT @@core_file;
-@@core_file
+select @@global.core_file;
+@@global.core_file
 1
-SHOW GLOBAL VARIABLES LIKE 'core_file';
+select @@session.core_file;
+ERROR HY000: Variable 'core_file' is a GLOBAL variable
+show global variables like 'core_file';
 Variable_name	Value
 core_file	ON
-SELECT * FROM performance_schema.global_variables WHERE VARIABLE_NAME = 'core_file';
+show session variables like 'core_file';
+Variable_name	Value
+core_file	ON
+select * from performance_schema.global_variables where variable_name='core_file';
 VARIABLE_NAME	VARIABLE_VALUE
 core_file	ON
-SET @@global.core_file = @old_val;
+select * from performance_schema.session_variables where variable_name='core_file';
+VARIABLE_NAME	VARIABLE_VALUE
+core_file	ON
+set global core_file = default;
+ERROR HY000: Variable 'core_file' is a read only variable
+Expected error 'Read only variable'
+set global core_file = true;
+ERROR HY000: Variable 'core_file' is a read only variable
+Expected error 'Read only variable'

--- a/mysql-test/suite/sys_vars/r/innodb_dump_core_without_large_mem_buf_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_dump_core_without_large_mem_buf_basic.result
@@ -1,0 +1,23 @@
+select @@global.innodb_dump_core_without_large_mem_buf;
+@@global.innodb_dump_core_without_large_mem_buf
+0
+select @@session.innodb_dump_core_without_large_mem_buf;
+ERROR HY000: Variable 'innodb_dump_core_without_large_mem_buf' is a GLOBAL variable
+show global variables like 'innodb_dump_core_without_large_mem_buf';
+Variable_name	Value
+innodb_dump_core_without_large_mem_buf	OFF
+show session variables like 'innodb_dump_core_without_large_mem_buf';
+Variable_name	Value
+innodb_dump_core_without_large_mem_buf	OFF
+select * from performance_schema.global_variables where variable_name='innodb_dump_core_without_large_mem_buf';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_dump_core_without_large_mem_buf	OFF
+select * from performance_schema.session_variables where variable_name='innodb_dump_core_without_large_mem_buf';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_dump_core_without_large_mem_buf	OFF
+set global innodb_dump_core_without_large_mem_buf = default;
+ERROR HY000: Variable 'innodb_dump_core_without_large_mem_buf' is a read only variable
+Expected error 'Read only variable'
+set global innodb_dump_core_without_large_mem_buf = true;
+ERROR HY000: Variable 'innodb_dump_core_without_large_mem_buf' is a read only variable
+Expected error 'Read only variable'

--- a/mysql-test/suite/sys_vars/t/core_file_basic.test
+++ b/mysql-test/suite/sys_vars/t/core_file_basic.test
@@ -1,15 +1,20 @@
-SET @old_val = @@global.core_file;
+--source include/load_sysvars.inc
 
-SET GLOBAL core_file = FALSE;
+select @@global.core_file;
 
-SELECT @@core_file;
-SHOW GLOBAL VARIABLES LIKE 'core_file';
-SELECT * FROM performance_schema.global_variables WHERE VARIABLE_NAME = 'core_file';
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+select @@session.core_file;
 
-SET GLOBAL core_file = TRUE;
+show global variables like 'core_file';
+show session variables like 'core_file';
 
-SELECT @@core_file;
-SHOW GLOBAL VARIABLES LIKE 'core_file';
-SELECT * FROM performance_schema.global_variables WHERE VARIABLE_NAME = 'core_file';
+select * from performance_schema.global_variables where variable_name='core_file';
+select * from performance_schema.session_variables where variable_name='core_file';
 
-SET @@global.core_file = @old_val;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+set global core_file = default;
+--echo Expected error 'Read only variable'
+
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+set global core_file = true;
+--echo Expected error 'Read only variable'

--- a/mysql-test/suite/sys_vars/t/innodb_dump_core_without_large_mem_buf_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_dump_core_without_large_mem_buf_basic.test
@@ -1,0 +1,20 @@
+--source include/load_sysvars.inc
+
+select @@global.innodb_dump_core_without_large_mem_buf;
+
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+select @@session.innodb_dump_core_without_large_mem_buf;
+
+show global variables like 'innodb_dump_core_without_large_mem_buf';
+show session variables like 'innodb_dump_core_without_large_mem_buf';
+
+select * from performance_schema.global_variables where variable_name='innodb_dump_core_without_large_mem_buf';
+select * from performance_schema.session_variables where variable_name='innodb_dump_core_without_large_mem_buf';
+
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+set global innodb_dump_core_without_large_mem_buf = default;
+--echo Expected error 'Read only variable'
+
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+set global innodb_dump_core_without_large_mem_buf = true;
+--echo Expected error 'Read only variable'

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -1274,7 +1274,7 @@ static bool prevent_global_rbr_exec_mode_idempotent(sys_var *self, THD *thd,
 }
 
 static Sys_var_bool Sys_core_file("core_file", "write a core-file on crashes",
-                                  GLOBAL_VAR(opt_core_file), NO_CMD_LINE,
+                                  READ_ONLY GLOBAL_VAR(opt_core_file), NO_CMD_LINE,
                                   DEFAULT(false));
 
 static Sys_var_bool Sys_skip_core_dump_on_error(

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -240,6 +240,10 @@ bool srv_buffer_pool_in_core_file = TRUE;
 
 extern thread_local ulint ut_rnd_ulint_counter;
 
+/* Boolean config knobs that tell Linux kernel whether to dump core without
+large memory buffer, e.g. InnoDB buffer pool, when core-file is enabled. */
+bool srv_dump_core_without_large_mem_buf = TRUE;
+
 /** Percentage of the buffer pool to reserve for 'old' blocks.
 Connected to buf_LRU_old_ratio. */
 static uint innobase_old_blocks_pct;
@@ -21678,6 +21682,13 @@ static MYSQL_SYSVAR_ULONG(
     "Dump only the hottest N% of each buffer pool, defaults to 25", NULL, NULL,
     25, 1, 100, 0);
 
+static MYSQL_SYSVAR_BOOL(
+    dump_core_without_large_mem_buf, srv_dump_core_without_large_mem_buf,
+    PLUGIN_VAR_NOCMDARG | PLUGIN_VAR_READONLY,
+    "Dump core without large memory buffer. Default value is TRUE. "
+    "Disable with --skip-innodb-dump-core-without-large-mem-buf.",
+    NULL, NULL, TRUE);
+
 #ifdef UNIV_DEBUG
 static MYSQL_SYSVAR_STR(buffer_pool_evict, srv_buffer_pool_evict,
                         PLUGIN_VAR_RQCMDARG, "Evict pages from the buffer pool",
@@ -22466,6 +22477,7 @@ static SYS_VAR *innobase_system_variables[] = {
     MYSQL_SYSVAR(buffer_pool_filename),
     MYSQL_SYSVAR(buffer_pool_dump_now),
     MYSQL_SYSVAR(buffer_pool_dump_at_shutdown),
+    MYSQL_SYSVAR(dump_core_without_large_mem_buf),
     MYSQL_SYSVAR(buffer_pool_in_core_file),
     MYSQL_SYSVAR(buffer_pool_dump_pct),
 #ifdef UNIV_DEBUG


### PR DESCRIPTION
Reference Patch: https://github.com/facebook/mysql-5.6/commit/e31a21144b8

---------- https://github.com/facebook/mysql-5.6/commit/e31a21144b8 ----------
Summary:
Core files can be very helpful for debugging production crashes but core dump has been disabled on production due to multiple reasons. One of the reasons is that the core file can be huge due to the huge InnoDB buffer pool within the process. This diff introduces a new command line argument '--innodb-dump-core-without-large-mem-buf', when it is set, all the large memory allocation by function os_mem_alloc_large() in InnoDB won't be dumped in the core file by calling Linux API madvise() with argument MADV_DONTDUMP. It can be disabled by '--skip-innodb-dump-core-without-large-mem-buf'. os_mem_alloc_large() is used to allocate large memory chunk for InnoDB buffer pool, file data merge, row log buffer, etc. Buffer pool is the main one. With this feature, the core size will be less than 3GB when the buffer pool size is 60GB so it won't impact production.
-- This sys var only take effect when core dump is enabled by setting 'core-file' in my.cnf.
-- By default '--innodb-dump-core-without-large-mem-buf' is set in prod to dump smaller cores, but it is not set by default in MTR so that full core file can be dumped.
-- This diff also makes sys var core_file readonly.
-- There are other bugs that prevent mysqld from dumping cores, e.g. when mysqld switching user from root to a non-root user, etc. Those will be addressed in separated diffs.

Originally Reviewed By: jtolmer

fbshipit-source-id: 119924337ab