### PR TITLE
PS-7032: fix compilation errors when libstdc++-10 is installed

### DIFF
--- a/cmake/build_configurations/compiler_options.cmake
+++ b/cmake/build_configurations/compiler_options.cmake
@@ -25,7 +25,10 @@ IF(UNIX)
 
   # Default GCC flags
   IF(CMAKE_COMPILER_IS_GNUCC)
-    SET(COMMON_C_FLAGS               "-g -fabi-version=2 -fno-omit-frame-pointer -fno-strict-aliasing")
+    SET(COMMON_C_FLAGS               "-g -fno-omit-frame-pointer -fno-strict-aliasing")
+    IF(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.0)  # gcc-9 or older
+      SET(COMMON_C_FLAGS             "-fabi-version=2 ${COMMON_C_FLAGS}")
+    ENDIF()
     # Disable inline optimizations for valgrind testing to avoid false positives
     IF(WITH_VALGRIND)
       SET(COMMON_C_FLAGS             "-DHAVE_purify -fno-inline ${COMMON_C_FLAGS}")
@@ -34,7 +37,10 @@ IF(UNIX)
     SET(CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 ${COMMON_C_FLAGS}")
   ENDIF()
   IF(CMAKE_COMPILER_IS_GNUCXX)
-    SET(COMMON_CXX_FLAGS               "-g -fabi-version=2 -fno-omit-frame-pointer -fno-strict-aliasing")
+    SET(COMMON_CXX_FLAGS               "-g -fno-omit-frame-pointer -fno-strict-aliasing")
+    IF(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.0)  # gcc-9 or older
+      SET(COMMON_CXX_FLAGS             "-fabi-version=2 ${COMMON_CXX_FLAGS}")
+    ENDIF()
     # Disable inline optimizations for valgrind testing to avoid false positives
     IF(WITH_VALGRIND)
       SET(COMMON_CXX_FLAGS             "-DHAVE_purify -fno-inline ${COMMON_CXX_FLAGS}")

--- a/extra/innochecksum.cc
+++ b/extra/innochecksum.cc
@@ -40,6 +40,7 @@
 #include <welcome_copyright_notice.h> /* ORACLE_WELCOME_COPYRIGHT_NOTICE */
 #include <string.h>
 #include <dirent.h>
+#include <string>
 
 /* Only parts of these files are included from the InnoDB codebase.
 The parts not included are excluded by #ifndef UNIV_INNOCHECKSUM. */

--- a/include/native_procedure.h
+++ b/include/native_procedure.h
@@ -21,6 +21,7 @@
 #include <mysql_com.h>
 
 #include <map>
+#include <string>
 #include <vector>
 
 enum execution_status_enum {

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -139,6 +139,9 @@
 #endif
 
 #include <zstd.h>
+#ifndef ZSTD_CLEVEL_DEFAULT
+#define ZSTD_CLEVEL_DEFAULT 3
+#endif
 
 #ifdef HAVE_JEMALLOC
 #ifndef EMBEDDED_LIBRARY

--- a/sql/session_tracker.h
+++ b/sql/session_tracker.h
@@ -20,6 +20,7 @@
 #include "thr_lock.h"
 
 #include "map"
+#include <string>
 
 /* forward declarations */
 class THD;

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -75,6 +75,9 @@
 #endif /* WITH_PERFSCHEMA_STORAGE_ENGINE */
 
 #include <zstd.h>
+#ifndef ZSTD_CLEVEL_DEFAULT
+#define ZSTD_CLEVEL_DEFAULT 3
+#endif
 
 TYPELIB bool_typelib={ array_elements(bool_values)-1, "", bool_values, 0 };
 

--- a/utils/perf_counters.cc
+++ b/utils/perf_counters.cc
@@ -1,5 +1,6 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 #include <memory>
+#include <string>
 #include <cassert>
 #include "perf_counters.h"
 


### PR DESCRIPTION
This patch fixes only errors (warning are left intact) with the newest libstdc++-10 installed along with gcc-10.
The errors are triggered also when using older compilers that started to use the libstdc++-10.

The list of errors:
1.
```
In file included from /usr/include/c++/10/memory:83,
                 from /data/mysql-server/fb-5.6.35/sql/sql_class.h:26,
                 from /data/mysql-server/fb-5.6.35/storage/archive/ha_archive.cc:21:
/usr/include/c++/10/bits/unique_ptr.h: In instantiation of ‘constexpr std::unique_ptr<_Tp, _Dp>::unique_ptr(std::nullptr_t) [with _Del = std::default_delete<const std::__cxx11::basic_regex<char> >; <template-parameter-2-2> = void; _Tp = const std::__cxx11::basic_regex<char>; _Dp = std::default_delete<const std::__cxx11::basic_regex<char> >; std::nullptr_t = std::nullptr_t]’:
/data/mysql-server/fb-5.6.35/sql/handler.h:1967:22:   required from here
/usr/include/c++/10/bits/unique_ptr.h:320:9: error: no matching function for call to ‘std::__uniq_ptr_data<const std::__cxx11::basic_regex<char>, std::default_delete<const std::__cxx11::basic_regex<char> >, true, true>::__uniq_ptr_data()’
  320 |  : _M_t()
/usr/include/c++/10/bits/unique_ptr.h:209:40: note: candidate: ‘std::__uniq_ptr_data<const std::__cxx11::basic_regex<char>, std::default_delete<const std::__cxx11::basic_regex<char> >, true, true>::__uniq_ptr_data(std::__uniq_ptr_impl<const std::__cxx11::basic_regex<char>, std::default_delete<const std::__cxx11::basic_regex<char> > >::pointer) [inherited from std::__uniq_ptr_impl<const std::__cxx11::basic_regex<char>, std::default_delete<const std::__cxx11::basic_regex<char> > >]’
  209 |       using __uniq_ptr_impl<_Tp, _Dp>::__uniq_ptr_impl;
```
2.
```
In file included from /data/mysql-server/fb-5.6.35/sql/session_tracker.cc:17:
/data/mysql-server/fb-5.6.35/sql/session_tracker.h:106:44: error: ‘string’ is not a member of ‘std’
  106 |   virtual void audit_tracker(std::map<std::string, std::string>& audit_map)
```
3.
```
/data/mysql-server/fb-5.6.35/utils/perf_counters.cc: In static member function ‘static std::shared_ptr<utils::PerfCounterFactory> utils::PerfCounterFactory::getFactory(const string&)’:
/data/mysql-server/fb-5.6.35/utils/perf_counters.cc:181:20: error: no match for ‘operator==’ (operand types are ‘const string’ {aka ‘const std::__cxx11::basic_string<char>’} and ‘const char [7]’)
  181 |   if (factory_name == "simple") {
      |       ~~~~~~~~~~~~ ^~ ~~~~~~~~
      |       |               |
      |       |               const char [7]
      |       const string {aka const std::__cxx11::basic_string<char>}
```
4.
```
/data/mysql-server/fb-5.6.35/extra/innochecksum.cc:80:33: error: ‘string’ is not a member of ‘std’
   80 | typedef std::unordered_set<std::string> TOKEN_SET_TYPE;
```
5.
```
/data/mysql-server/fb-5.6.35/include/native_procedure.h:93:46: error: ‘std::string’ has not been declared
   93 |   virtual int field_val_str(uint index, std::string *out) = 0;
```
6.
```
In file included from /data/mysql-server/fb-5.6.35/libmysqld/lib_sql.cc:30:
/data/mysql-server/fb-5.6.35/libmysqld/../sql/mysqld.cc:627:35: error: use of undeclared identifier 'ZSTD_CLEVEL_DEFAULT'
long zstd_net_compression_level = ZSTD_CLEVEL_DEFAULT;
```
7.
```
/data/mysql-server/fb-5.6.35/sql/sys_vars.cc:3653:42: error: use of undeclared identifier 'ZSTD_CLEVEL_DEFAULT'
      VALID_RANGE(LONG_MIN, 22), DEFAULT(ZSTD_CLEVEL_DEFAULT), BLOCK_SIZE(1));
```
