### PR TITLE
Add read-free replication api in mysqld

### DIFF
--- a/mysql-test/collections/disabled_rocksdb.def
+++ b/mysql-test/collections/disabled_rocksdb.def
@@ -36,12 +36,6 @@ rocksdb.optimize_myrocks_replace_into_lock : BUG#0000 missing patch f14c64cf950 
 rocksdb_rpl.optimize_myrocks_replace_into : BUG#0000 missing patch f14c64cf950 Optimize replace into to do a blind write
 rocksdb.mysqlbinlog_blind_replace : BUG#0000 missing patch f14c64cf950 Optimize replace into to do a blind write
 
-# rocksdb_read_free_rpl
-rocksdb.rocksdb_read_free_rpl : BUG#0000 missing af531c246d35 Added a new variable to control read-free replication
-rocksdb.rocksdb_read_free_rpl_stress : BUG#0000 missing af531c246d35 Added a new variable to control read-free replication
-rocksdb.blind_delete_rc : BUG#0000 missing af531c246d35 Added a new variable to control read-free replication
-rocksdb.blind_delete_rr : BUG#0000 missing af531c246d35 Added a new variable to control read-free replication
-
 # i_s.table_statistics
 rocksdb.lock_wait_timeout_stats : BUG#0000 table_statistics missing
 rocksdb.deadlock_stats : BUG#0000 table_statistics missing

--- a/mysql-test/suite/rocksdb/r/blind_delete_rc.result
+++ b/mysql-test/suite/rocksdb/r/blind_delete_rc.result
@@ -10,8 +10,8 @@ DROP TABLE IF EXISTS t1,t2;
 create table t1 (id int primary key, value int, value2 varchar(200)) engine=rocksdb;
 create table t2 (id int primary key, value int, value2 varchar(200), index(value)) engine=rocksdb;
 SET session rocksdb_blind_delete_primary_key=1;
-select variable_value into @c from information_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
-select variable_value-@c from information_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
+select variable_value into @c from performance_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
+select variable_value-@c from performance_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
 variable_value-@c
 1000
 SELECT count(*) FROM t1;
@@ -22,16 +22,16 @@ SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
 SELECT count(*) FROM t1;
 count(*)
 9000
-select variable_value into @c from information_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
-select variable_value-@c from information_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
+select variable_value into @c from performance_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
+select variable_value-@c from performance_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
 variable_value-@c
 0
 SELECT count(*) FROM t2;
 count(*)
 9000
 SET session rocksdb_master_skip_tx_api=1;
-select variable_value into @c from information_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
-select variable_value-@c from information_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
+select variable_value into @c from performance_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
+select variable_value-@c from performance_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
 variable_value-@c
 1000
 SELECT count(*) FROM t1;
@@ -47,10 +47,10 @@ count(*)
 SELECT count(*) FROM t2;
 count(*)
 8000
-select variable_value into @c from information_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
+select variable_value into @c from performance_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
 DELETE FROM t1 WHERE id BETWEEN 3001 AND 4000;
 DELETE FROM t2 WHERE id BETWEEN 3001 AND 4000;
-select variable_value-@c from information_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
+select variable_value-@c from performance_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
 variable_value-@c
 0
 SELECT count(*) FROM t1;

--- a/mysql-test/suite/rocksdb/r/blind_delete_rr.result
+++ b/mysql-test/suite/rocksdb/r/blind_delete_rr.result
@@ -10,8 +10,8 @@ DROP TABLE IF EXISTS t1,t2;
 create table t1 (id int primary key, value int, value2 varchar(200)) engine=rocksdb;
 create table t2 (id int primary key, value int, value2 varchar(200), index(value)) engine=rocksdb;
 SET session rocksdb_blind_delete_primary_key=1;
-select variable_value into @c from information_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
-select variable_value-@c from information_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
+select variable_value into @c from performance_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
+select variable_value-@c from performance_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
 variable_value-@c
 1000
 SELECT count(*) FROM t1;
@@ -22,16 +22,16 @@ SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 SELECT count(*) FROM t1;
 count(*)
 9000
-select variable_value into @c from information_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
-select variable_value-@c from information_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
+select variable_value into @c from performance_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
+select variable_value-@c from performance_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
 variable_value-@c
 0
 SELECT count(*) FROM t2;
 count(*)
 9000
 SET session rocksdb_master_skip_tx_api=1;
-select variable_value into @c from information_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
-select variable_value-@c from information_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
+select variable_value into @c from performance_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
+select variable_value-@c from performance_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
 variable_value-@c
 1000
 SELECT count(*) FROM t1;
@@ -47,10 +47,10 @@ count(*)
 SELECT count(*) FROM t2;
 count(*)
 8000
-select variable_value into @c from information_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
+select variable_value into @c from performance_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
 DELETE FROM t1 WHERE id BETWEEN 3001 AND 4000;
 DELETE FROM t2 WHERE id BETWEEN 3001 AND 4000;
-select variable_value-@c from information_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
+select variable_value-@c from performance_schema.global_status where variable_name='rocksdb_rows_deleted_blind';
 variable_value-@c
 0
 SELECT count(*) FROM t1;

--- a/mysql-test/suite/rocksdb/r/rocksdb_read_free_rpl.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_read_free_rpl.result
@@ -3,14 +3,16 @@ Warnings:
 Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
 Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
 [connection master]
-drop table if exists t1;
+[connection master]
 create table t1 (id int primary key, value int);
 insert into t1 values (1,1), (2,2), (3,3), (4,4);
 include/sync_slave_sql_with_master.inc
 
 # regular update/delete. With rocks_read_free_rpl=PK_SK, rocksdb_rows_read does not increase on slaves
 
-select variable_value into @up from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection slave]
+select variable_value into @up from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection master]
 update t1 set value=value+1 where id=1;
 delete from t1 where id=4;
 select * from t1;
@@ -19,7 +21,8 @@ id	value
 2	2
 3	3
 include/sync_slave_sql_with_master.inc
-select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection slave]
+select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 true
 select * from t1;
@@ -30,10 +33,12 @@ id	value
 
 # "rocks_read_free_rpl=PK_SK" makes "row not found error" not happen anymore
 
+[connection slave]
 include/stop_slave.inc
 delete from t1 where id in (2, 3);
 include/start_slave.inc
-select variable_value into @up from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @up from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection master]
 update t1 set value=value+1 where id=3;
 delete from t1 where id=2;
 select * from t1;
@@ -41,7 +46,8 @@ id	value
 1	2
 3	4
 include/sync_slave_sql_with_master.inc
-select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection slave]
+select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 true
 select * from t1;
@@ -54,15 +60,19 @@ id	value
 
 #no index
 
+[connection master]
 drop table t1;
 create table t1 (c1 int, c2 int);
 insert into t1 values (1,1), (2,2),(3,3),(4,4),(5,5);
 include/sync_slave_sql_with_master.inc
-select variable_value into @up from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection slave]
+select variable_value into @up from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection master]
 update t1 set c2=100 where c1=3;
 delete from t1 where c1 <= 2;
 include/sync_slave_sql_with_master.inc
-select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection slave]
+select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 false
 select * from t1;
@@ -73,15 +83,19 @@ c1	c2
 
 #secondary index only
 
+[connection master]
 drop table t1;
 create table t1 (c1 int, c2 int, index i(c1));
 insert into t1 values (1,1), (2,2),(3,3),(4,4),(5,5);
 include/sync_slave_sql_with_master.inc
-select variable_value into @up from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection slave]
+select variable_value into @up from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection master]
 update t1 set c2=100 where c1=3;
 delete from t1 where c1 <= 2;
 include/sync_slave_sql_with_master.inc
-select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection slave]
+select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 false
 select * from t1;
@@ -92,85 +106,113 @@ c1	c2
 
 ## large row operations -- primary key modification, secondary key modification
 
+[connection master]
 drop table t1;
 create table t1 (id1 bigint, id2 bigint, c1 bigint, c2 bigint, c3 bigint, c4 bigint, c5 bigint, c6 bigint, c7 bigint, primary key (id1, id2), index i(c1, c2));
 include/sync_slave_sql_with_master.inc
-select variable_value into @up from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection slave]
+select variable_value into @up from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection master]
 
 #updating all secondary keys by 1
 
 include/sync_slave_sql_with_master.inc
-select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection slave]
+select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 true
+[connection master]
 include/diff_tables.inc [master:t1, slave:t1]
 
 #updating all primary keys by 2
 
-select variable_value into @up from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection slave]
+select variable_value into @up from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection master]
 include/sync_slave_sql_with_master.inc
-select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection slave]
+select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 true
+[connection master]
 include/diff_tables.inc [master:t1, slave:t1]
 
 #updating secondary keys after truncating t1 on slave
 
+[connection slave]
 truncate table t1;
-select variable_value into @up from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @up from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection master]
 update t1 set c2=c2+10;
 include/sync_slave_sql_with_master.inc
-select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection slave]
+select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 true
+[connection master]
 include/diff_tables.inc [master:t1, slave:t1]
 
 #updating primary keys after truncating t1 on slave
 
+[connection slave]
 truncate table t1;
-select variable_value into @up from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+select variable_value into @up from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection master]
 update t1 set id2=id2+10;
 include/sync_slave_sql_with_master.inc
-select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection slave]
+select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 true
+[connection master]
 include/diff_tables.inc [master:t1, slave:t1]
 
 #deleting half rows
 
-select variable_value into @up from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection slave]
+select variable_value into @up from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection master]
 delete from t1 where id1 <= 5000;
 include/sync_slave_sql_with_master.inc
-select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection slave]
+select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 true
+[connection master]
 include/diff_tables.inc [master:t1, slave:t1]
 
 # rocksdb_read_free_rpl = PK_ONLY i.e. it only works on tables with only PK
 
+[connection slave]
 [on slave]
 stop slave;
 set @@global.rocksdb_read_free_rpl = PK_ONLY;
 start slave;
+[connection master]
 [on master]
 create table t2 (id int primary key, i1 int, i2 int, value int);
 create table u2 (id int primary key, i1 int, i2 int, value int, index(i1), index(i2));
 insert into t2 values (1,1,1,1),(2,2,2,2),(3,3,3,3);
 insert into u2 values (1,1,1,1),(2,2,2,2),(3,3,3,3);
 include/sync_slave_sql_with_master.inc
+[connection slave]
 [on slave]
 delete from t2 where id <= 2;
 delete from u2 where id <= 2;
+[connection master]
 [on master]
 update t2 set i2=100, value=100 where id=1;
 update u2 set i2=100, value=100 where id=1;
+[connection slave]
 [on slave]
 call mtr.add_suppression("Slave SQL.*Could not execute Update_rows event on table test.u2.*Error_code.*");
 call mtr.add_suppression("Slave: Can't find record in 'u2'.*");
 include/wait_for_slave_sql_error.inc [errno=1032]
-select count(*) from t2 force index(primary);
-count(*)
-2
+[connection slave]
+select id from t2 force index(primary);
+id
+1
+3
 select * from t2 where id=1;
 id	i1	i2	value
 1	1	100	100
@@ -180,15 +222,15 @@ i1
 select i2 from t2 where i2=100;
 i2
 100
-select count(*) from u2 force index(primary);
-count(*)
-1
-select count(*) from u2 force index(i1);
-count(*)
-1
-select count(*) from u2 force index(i2);
-count(*)
-1
+select id from u2 force index(primary);
+id
+3
+select i1 from u2 force index(i1);
+i1
+3
+select i2 from u2 force index(i2);
+i2
+3
 select * from u2 where id=1;
 id	i1	i2	value
 select i1 from u2 where i1=1;
@@ -196,6 +238,7 @@ i1
 select i2 from u2 where i2=100;
 i2
 include/wait_for_slave_sql_to_start.inc
+[connection slave]
 [on slave]
 stop slave;
 set @@global.rocksdb_read_free_rpl = PK_SK;
@@ -203,10 +246,12 @@ start slave;
 
 # some tables with read-free replication on and some with it off
 
+[connection slave]
 [on slave]
 stop slave;
 set @@global.rocksdb_read_free_rpl_tables = "t.*";
 start slave;
+[connection master]
 [on master]
 drop table if exists t2;
 drop table if exists u2;
@@ -215,19 +260,24 @@ create table u2 (id int primary key, i1 int, i2 int, value int);
 insert into t2 values (1,1,1,1),(2,2,2,2),(3,3,3,3);
 insert into u2 values (1,1,1,1),(2,2,2,2),(3,3,3,3);
 include/sync_slave_sql_with_master.inc
+[connection slave]
 [on slave]
 delete from t2 where id <= 2;
 delete from u2 where id <= 2;
+[connection master]
 [on master]
 update t2 set i2=100, value=100 where id=1;
 update u2 set i2=100, value=100 where id=1;
+[connection slave]
 [on slave]
 call mtr.add_suppression("Slave SQL.*Could not execute Update_rows event on table test.u2.*Error_code.*");
 call mtr.add_suppression("Slave: Can't find record in 'u2'.*");
 include/wait_for_slave_sql_error.inc [errno=1032]
-select count(*) from t2 force index(primary);
-count(*)
-2
+[connection slave]
+select id from t2 force index(primary);
+id
+1
+3
 select * from t2 where id=1;
 id	i1	i2	value
 1	1	100	100
@@ -237,9 +287,9 @@ i1
 select i2 from t2 where i2=100;
 i2
 100
-select count(*) from u2 force index(primary);
-count(*)
-1
+select id from u2 force index(primary);
+id
+3
 select * from u2 where id=1;
 id	i1	i2	value
 select i1 from u2 where i1=1;
@@ -247,6 +297,7 @@ i1
 select i2 from u2 where i2=100;
 i2
 include/wait_for_slave_sql_to_start.inc
+[connection slave]
 [on slave]
 stop slave;
 set @@global.rocksdb_read_free_rpl_tables = ".*";
@@ -254,25 +305,31 @@ start slave;
 
 # secondary keys lose rows
 
+[connection master]
 [on master]
 create table t3 (id int primary key, i1 int, i2 int, value int, index(i1),
 index(i2));
 insert into t3 values (1,1,1,1),(2,2,2,2),(3,3,3,3);
 include/sync_slave_sql_with_master.inc
+[connection slave]
 [on slave]
 delete from t3 where id <= 2;
+[connection master]
 [on master]
 update t3 set i2=100, value=100 where id=1;
 include/sync_slave_sql_with_master.inc
-select count(*) from t3 force index(primary);
-count(*)
-2
-select count(*) from t3 force index(i1);
-count(*)
+[connection slave]
+select id from t3 force index(primary);
+id
 1
-select count(*) from t3 force index(i2);
-count(*)
-2
+3
+select i1 from t3 force index(i1);
+i1
+3
+select i2 from t3 force index(i2);
+i2
+3
+100
 select * from t3 where id=1;
 id	i1	i2	value
 1	1	100	100
@@ -284,43 +341,55 @@ i2
 
 # secondary keys have extra rows
 
+[connection master]
 [on master]
 create table t4 (id int primary key, i1 int, i2 int, value int, index(i1), index(i2));
 insert into t4 values (1,1,1,1),(2,2,2,2),(3,3,3,3);
 include/sync_slave_sql_with_master.inc
+[connection slave]
 [on slave]
 update t4 set i1=100 where id=1;
+[connection master]
 [on master]
 delete from t4 where id=1;
 include/sync_slave_sql_with_master.inc
+[connection slave]
 [on slave]
-select count(*) from t4 force index(primary);
-count(*)
+select id from t4 force index(primary);
+id
 2
-select count(*) from t4 force index(i1);
-count(*)
 3
-select count(*) from t4 force index(i2);
-count(*)
+select i1 from t4 force index(i1);
+i1
 2
+3
+100
+select i2 from t4 force index(i2);
+i2
+2
+3
 select i1 from t4 where i1=100;
 i1
 100
 
 # inserts are also read-free
 
+[connection master]
 [on master]
 drop table if exists t2;
 drop table if exists t3;
 create table t2 (id int primary key, i1 int, i2 int);
 create table t3 (id int primary key, i1 int, i2 int, key(i1));
-select variable_value into @up from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection slave]
+select variable_value into @up from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection master]
 insert into t2 values(1, 1, 1);
 insert into t2 values(2, 2, 2);
 insert into t3 values(1, 1, 1);
 insert into t3 values(2, 2, 2);
 include/sync_slave_sql_with_master.inc
-select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from information_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
+[connection slave]
+select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 read_free
 true
 select * from t2;
@@ -331,5 +400,6 @@ select * from t3;
 id	i1	i2
 1	1	1
 2	2	2
+[connection master]
 drop table t1, t2, t3, t4, u2;
 include/rpl_end.inc

--- a/mysql-test/suite/rocksdb/t/rocksdb_read_free_rpl.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_read_free_rpl.test
@@ -1,15 +1,9 @@
+source include/have_debug.inc;
 source include/have_rocksdb.inc;
 source include/master-slave.inc;
-source include/have_debug.inc;
-
-
-connection master;
---disable_warnings
-drop table if exists t1;
---enable_warnings
 
 # initialization/insert
-connection master;
+--source include/rpl_connection_master.inc
 create table t1 (id int primary key, value int);
 insert into t1 values (1,1), (2,2), (3,3), (4,4);
 --source include/sync_slave_sql_with_master.inc
@@ -19,14 +13,14 @@ insert into t1 values (1,1), (2,2), (3,3), (4,4);
 --echo
 --echo # regular update/delete. With rocks_read_free_rpl=PK_SK, rocksdb_rows_read does not increase on slaves
 --echo
-connection slave;
+--source include/rpl_connection_slave.inc
 select variable_value into @up from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
-connection master;
+--source include/rpl_connection_master.inc
 update t1 set value=value+1 where id=1;
 delete from t1 where id=4;
 select * from t1;
 --source include/sync_slave_sql_with_master.inc
-connection slave;
+--source include/rpl_connection_slave.inc
 select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 select * from t1;
 
@@ -34,18 +28,18 @@ select * from t1;
 --echo
 --echo # "rocks_read_free_rpl=PK_SK" makes "row not found error" not happen anymore
 --echo
-connection slave;
+--source include/rpl_connection_slave.inc
 --source include/stop_slave.inc
 delete from t1 where id in (2, 3);
 --source include/start_slave.inc
 select variable_value into @up from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 
-connection master;
+--source include/rpl_connection_master.inc
 update t1 set value=value+1 where id=3;
 delete from t1 where id=2;
 select * from t1;
 --source include/sync_slave_sql_with_master.inc
-connection slave;
+--source include/rpl_connection_slave.inc
 select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 select * from t1;
 
@@ -56,36 +50,36 @@ select * from t1;
 --echo
 --echo #no index
 --echo
-connection master;
+--source include/rpl_connection_master.inc
 drop table t1;
 create table t1 (c1 int, c2 int);
 insert into t1 values (1,1), (2,2),(3,3),(4,4),(5,5);
 --source include/sync_slave_sql_with_master.inc
-connection slave;
+--source include/rpl_connection_slave.inc
 select variable_value into @up from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
-connection master;
+--source include/rpl_connection_master.inc
 update t1 set c2=100 where c1=3;
 delete from t1 where c1 <= 2;
 --source include/sync_slave_sql_with_master.inc
-connection slave;
+--source include/rpl_connection_slave.inc
 select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 select * from t1;
 
 --echo
 --echo #secondary index only
 --echo
-connection master;
+--source include/rpl_connection_master.inc
 drop table t1;
 create table t1 (c1 int, c2 int, index i(c1));
 insert into t1 values (1,1), (2,2),(3,3),(4,4),(5,5);
 --source include/sync_slave_sql_with_master.inc
-connection slave;
+--source include/rpl_connection_slave.inc
 select variable_value into @up from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
-connection master;
+--source include/rpl_connection_master.inc
 update t1 set c2=100 where c1=3;
 delete from t1 where c1 <= 2;
 --source include/sync_slave_sql_with_master.inc
-connection slave;
+--source include/rpl_connection_slave.inc
 select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 select * from t1;
 
@@ -94,7 +88,7 @@ select * from t1;
 --echo
 --echo ## large row operations -- primary key modification, secondary key modification
 --echo
-connection master;
+--source include/rpl_connection_master.inc
 drop table t1;
 create table t1 (id1 bigint, id2 bigint, c1 bigint, c2 bigint, c3 bigint, c4 bigint, c5 bigint, c6 bigint, c7 bigint, primary key (id1, id2), index i(c1, c2));
 
@@ -109,9 +103,9 @@ while ($i<=10000)
 --enable_query_log
 
 --source include/sync_slave_sql_with_master.inc
-connection slave;
+--source include/rpl_connection_slave.inc
 select variable_value into @up from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
-connection master;
+--source include/rpl_connection_master.inc
 
 --echo
 --echo #updating all secondary keys by 1
@@ -125,17 +119,17 @@ while ($i<=10000)
 }
 --enable_query_log
 --source include/sync_slave_sql_with_master.inc
-connection slave;
+--source include/rpl_connection_slave.inc
 select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
-connection master;
+--source include/rpl_connection_master.inc
 --source include/diff_tables.inc
 
 --echo
 --echo #updating all primary keys by 2
 --echo
-connection slave;
+--source include/rpl_connection_slave.inc
 select variable_value into @up from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
-connection master;
+--source include/rpl_connection_master.inc
 --disable_query_log
 let $i=1;
 while ($i<=10000)
@@ -145,61 +139,61 @@ while ($i<=10000)
 }
 --enable_query_log
 --source include/sync_slave_sql_with_master.inc
-connection slave;
+--source include/rpl_connection_slave.inc
 select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
-connection master;
+--source include/rpl_connection_master.inc
 --source include/diff_tables.inc
 
 --echo
 --echo #updating secondary keys after truncating t1 on slave
 --echo
-connection slave;
+--source include/rpl_connection_slave.inc
 truncate table t1;
 select variable_value into @up from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
-connection master;
+--source include/rpl_connection_master.inc
 update t1 set c2=c2+10;
 --source include/sync_slave_sql_with_master.inc
-connection slave;
+--source include/rpl_connection_slave.inc
 select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
-connection master;
+--source include/rpl_connection_master.inc
 --source include/diff_tables.inc
 
 --echo
 --echo #updating primary keys after truncating t1 on slave
 --echo
-connection slave;
+--source include/rpl_connection_slave.inc
 truncate table t1;
 select variable_value into @up from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
-connection master;
+--source include/rpl_connection_master.inc
 update t1 set id2=id2+10;
 --source include/sync_slave_sql_with_master.inc
-connection slave;
+--source include/rpl_connection_slave.inc
 select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
-connection master;
+--source include/rpl_connection_master.inc
 --source include/diff_tables.inc
 
 --echo
 --echo #deleting half rows
 --echo
-connection slave;
+--source include/rpl_connection_slave.inc
 select variable_value into @up from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
-connection master;
+--source include/rpl_connection_master.inc
 delete from t1 where id1 <= 5000;
 --source include/sync_slave_sql_with_master.inc
-connection slave;
+--source include/rpl_connection_slave.inc
 select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
-connection master;
+--source include/rpl_connection_master.inc
 --source include/diff_tables.inc
 
 --echo
 --echo # rocksdb_read_free_rpl = PK_ONLY i.e. it only works on tables with only PK
 --echo
-connection slave;
+--source include/rpl_connection_slave.inc
 --echo [on slave]
 stop slave;
 set @@global.rocksdb_read_free_rpl = PK_ONLY;
 start slave;
-connection master;
+--source include/rpl_connection_master.inc
 --echo [on master]
 create table t2 (id int primary key, i1 int, i2 int, value int);
 create table u2 (id int primary key, i1 int, i2 int, value int, index(i1), index(i2));
@@ -208,18 +202,18 @@ insert into u2 values (1,1,1,1),(2,2,2,2),(3,3,3,3);
 --source include/sync_slave_sql_with_master.inc
 
 # make a mismatch between the slave and the master
-connection slave;
+--source include/rpl_connection_slave.inc
 --echo [on slave]
 delete from t2 where id <= 2;
 delete from u2 where id <= 2;
 
 # make changes on the master
-connection master;
+--source include/rpl_connection_master.inc
 --echo [on master]
 update t2 set i2=100, value=100 where id=1;
 update u2 set i2=100, value=100 where id=1;
 
-connection slave;
+--source include/rpl_connection_slave.inc
 --echo [on slave]
 call mtr.add_suppression("Slave SQL.*Could not execute Update_rows event on table test.u2.*Error_code.*");
 call mtr.add_suppression("Slave: Can't find record in 'u2'.*");
@@ -228,16 +222,16 @@ call mtr.add_suppression("Slave: Can't find record in 'u2'.*");
 --source include/wait_for_slave_sql_error.inc
 
 # query the t2 table on the slave
-connection slave;
-select count(*) from t2 force index(primary);
+--source include/rpl_connection_slave.inc
+select id from t2 force index(primary);
 select * from t2 where id=1;
 select i1 from t2 where i1=1;
 select i2 from t2 where i2=100;
 
 # query the u2 table on the slave
-select count(*) from u2 force index(primary);
-select count(*) from u2 force index(i1);
-select count(*) from u2 force index(i2);
+select id from u2 force index(primary);
+select i1 from u2 force index(i1);
+select i2 from u2 force index(i2);
 select * from u2 where id=1;
 select i1 from u2 where i1=1;
 select i2 from u2 where i2=100;
@@ -250,7 +244,7 @@ start slave sql_thread;
 --source include/wait_for_slave_sql_to_start.inc
 --enable_query_log
 
-connection slave;
+--source include/rpl_connection_slave.inc
 --echo [on slave]
 stop slave;
 set @@global.rocksdb_read_free_rpl = PK_SK;
@@ -260,12 +254,12 @@ start slave;
 --echo # some tables with read-free replication on and some with it off
 --echo
 # We'll set the table filter to all tables starting with 't'
-connection slave;
+--source include/rpl_connection_slave.inc
 --echo [on slave]
 stop slave;
 set @@global.rocksdb_read_free_rpl_tables = "t.*";
 start slave;
-connection master;
+--source include/rpl_connection_master.inc
 --echo [on master]
 drop table if exists t2;
 drop table if exists u2;
@@ -276,18 +270,18 @@ insert into u2 values (1,1,1,1),(2,2,2,2),(3,3,3,3);
 --source include/sync_slave_sql_with_master.inc
 
 # make a mismatch between the slave and the master
-connection slave;
+--source include/rpl_connection_slave.inc
 --echo [on slave]
 delete from t2 where id <= 2;
 delete from u2 where id <= 2;
 
 # make changes on the master
-connection master;
+--source include/rpl_connection_master.inc
 --echo [on master]
 update t2 set i2=100, value=100 where id=1;
 update u2 set i2=100, value=100 where id=1;
 
-connection slave;
+--source include/rpl_connection_slave.inc
 --echo [on slave]
 call mtr.add_suppression("Slave SQL.*Could not execute Update_rows event on table test.u2.*Error_code.*");
 call mtr.add_suppression("Slave: Can't find record in 'u2'.*");
@@ -296,14 +290,14 @@ call mtr.add_suppression("Slave: Can't find record in 'u2'.*");
 --source include/wait_for_slave_sql_error.inc
 
 # query the t2 table on the slave
-connection slave;
-select count(*) from t2 force index(primary);
+--source include/rpl_connection_slave.inc
+select id from t2 force index(primary);
 select * from t2 where id=1;
 select i1 from t2 where i1=1;
 select i2 from t2 where i2=100;
 
 # query the u2 table on the slave
-select count(*) from u2 force index(primary);
+select id from u2 force index(primary);
 select * from u2 where id=1;
 select i1 from u2 where i1=1;
 select i2 from u2 where i2=100;
@@ -316,7 +310,7 @@ start slave sql_thread;
 --source include/wait_for_slave_sql_to_start.inc
 --enable_query_log
 
-connection slave;
+--source include/rpl_connection_slave.inc
 --echo [on slave]
 stop slave;
 set @@global.rocksdb_read_free_rpl_tables = ".*";
@@ -325,7 +319,7 @@ start slave;
 --echo
 --echo # secondary keys lose rows
 --echo
-connection master;
+--source include/rpl_connection_master.inc
 --echo [on master]
 create table t3 (id int primary key, i1 int, i2 int, value int, index(i1),
 index(i2));
@@ -333,12 +327,12 @@ insert into t3 values (1,1,1,1),(2,2,2,2),(3,3,3,3);
 --source include/sync_slave_sql_with_master.inc
 
 # make a mismatch between the slave and the master
-connection slave;
+--source include/rpl_connection_slave.inc
 --echo [on slave]
 delete from t3 where id <= 2;
 
 # make changes on the master
-connection master;
+--source include/rpl_connection_master.inc
 --echo [on master]
 update t3 set i2=100, value=100 where id=1;
 
@@ -346,10 +340,10 @@ update t3 set i2=100, value=100 where id=1;
 --source include/sync_slave_sql_with_master.inc
 
 # query the t3 table on the slave
-connection slave;
-select count(*) from t3 force index(primary);
-select count(*) from t3 force index(i1);
-select count(*) from t3 force index(i2);
+--source include/rpl_connection_slave.inc
+select id from t3 force index(primary);
+select i1 from t3 force index(i1);
+select i2 from t3 force index(i2);
 select * from t3 where id=1;
 select i1 from t3 where i1=1;
 select i2 from t3 where i2=100;
@@ -357,19 +351,19 @@ select i2 from t3 where i2=100;
 --echo
 --echo # secondary keys have extra rows
 --echo
-connection master;
+--source include/rpl_connection_master.inc
 --echo [on master]
 create table t4 (id int primary key, i1 int, i2 int, value int, index(i1), index(i2));
 insert into t4 values (1,1,1,1),(2,2,2,2),(3,3,3,3);
 --source include/sync_slave_sql_with_master.inc
 
 # make a mismatch between the slave and the master
-connection slave;
+--source include/rpl_connection_slave.inc
 --echo [on slave]
 update t4 set i1=100 where id=1;
 
 # make changes on the master
-connection master;
+--source include/rpl_connection_master.inc
 --echo [on master]
 delete from t4 where id=1;
 
@@ -377,37 +371,37 @@ delete from t4 where id=1;
 --source include/sync_slave_sql_with_master.inc
 
 # query the t4 table on the slave
-connection slave;
+--source include/rpl_connection_slave.inc
 --echo [on slave]
-select count(*) from t4 force index(primary);
-select count(*) from t4 force index(i1);
-select count(*) from t4 force index(i2);
+select id from t4 force index(primary);
+select i1 from t4 force index(i1);
+select i2 from t4 force index(i2);
 select i1 from t4 where i1=100;
 
 --echo
 --echo # inserts are also read-free
 --echo
-connection master;
+--source include/rpl_connection_master.inc
 --echo [on master]
 drop table if exists t2;
 drop table if exists t3;
 create table t2 (id int primary key, i1 int, i2 int);
 create table t3 (id int primary key, i1 int, i2 int, key(i1));
-connection slave;
+--source include/rpl_connection_slave.inc
 select variable_value into @up from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
-connection master;
+--source include/rpl_connection_master.inc
 insert into t2 values(1, 1, 1);
 insert into t2 values(2, 2, 2);
 insert into t3 values(1, 1, 1);
 insert into t3 values(2, 2, 2);
 --source include/sync_slave_sql_with_master.inc
-connection slave;
+--source include/rpl_connection_slave.inc
 select case when variable_value-@up > 0 then 'false' else 'true' end as read_free from performance_schema.global_status where variable_name='rocksdb_num_get_for_update_calls';
 select * from t2;
 select * from t3;
 
 # cleanup
-connection master;
+--source include/rpl_connection_master.inc
 drop table t1, t2, t3, t4, u2;
 
 --source include/rpl_end.inc

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -6598,6 +6598,27 @@ class handler {
   */
   bool filter_dup_records();
 
+ public:
+  /* Read-free replication interface */
+
+  /**
+    Determine whether the storage engine asks for row-based replication that
+    may skip the lookup of the old row image.
+    @return true if old rows should not be read
+            false if old rows should be read (the default)
+   */
+  virtual bool use_read_free_rpl() const { return false; }
+  /*
+    Storage engine hooks to be called before and after row write, delete, and
+    update events
+  */
+  virtual void rpl_before_write_rows() { }
+  virtual void rpl_after_write_rows() { }
+  virtual void rpl_before_delete_rows() { }
+  virtual void rpl_after_delete_rows() { }
+  virtual void rpl_before_update_rows() { }
+  virtual void rpl_after_update_rows() { }
+
  protected:
   Handler_share *get_ha_share_ptr();
   void set_ha_share_ptr(Handler_share *arg_ha_share);

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -8335,7 +8335,11 @@ void Rows_log_event::decide_row_lookup_algorithm_and_key(table_def *tabledef) {
   this->m_key_index = MAX_KEY;
   this->m_key_info = nullptr;
 
-  if (event_type == binary_log::WRITE_ROWS_EVENT)  // row lookup not needed
+  // row lookup not needed
+  if (event_type == binary_log::WRITE_ROWS_EVENT ||
+     ((event_type == binary_log::DELETE_ROWS_EVENT ||
+       event_type == binary_log::UPDATE_ROWS_EVENT) &&
+      get_flags(COMPLETE_ROWS_F) && m_table->file->use_read_free_rpl()))
     DBUG_VOID_RETURN;
 
   if (!(slave_rows_search_algorithms_options & SLAVE_ROWS_INDEX_SCAN))
@@ -10241,7 +10245,10 @@ int Rows_log_event::do_apply_event(Relay_log_info const *rli) {
         break;
 
       case ROW_LOOKUP_NOT_NEEDED:
-        DBUG_ASSERT(get_general_type_code() == binary_log::WRITE_ROWS_EVENT);
+        DBUG_ASSERT(get_general_type_code() == binary_log::WRITE_ROWS_EVENT ||
+                    ((get_general_type_code() == binary_log::DELETE_ROWS_EVENT ||
+                    get_general_type_code() == binary_log::UPDATE_ROWS_EVENT) &&
+                    m_table->file->use_read_free_rpl()));
 
         /* No need to scan for rows, just apply it */
         do_apply_row_ptr = &Rows_log_event::do_apply_row;
@@ -12197,6 +12204,8 @@ int Write_rows_log_event::do_before_row_operations(
     const Slave_reporting_capability *const, table_def *tabledef) {
   int error = 0;
 
+  m_table->file->rpl_before_write_rows();
+
   /*
     Increment the global status insert count variable
   */
@@ -12322,6 +12331,7 @@ int Write_rows_log_event::do_after_row_operations(
   }
 
   m_rows_lookup_algorithm = ROW_LOOKUP_UNDEFINED;
+  m_table->file->rpl_after_write_rows();
 
   return error ? error : local_error;
 }
@@ -12718,6 +12728,7 @@ int Delete_rows_log_event::do_before_row_operations(
     const Slave_reporting_capability *const, table_def *tabledef) {
   int error = 0;
   DBUG_ENTER("Delete_rows_log_event::do_before_row_operations");
+  m_table->file->rpl_before_delete_rows();
   /*
     Increment the global status delete count variable
    */
@@ -12744,14 +12755,21 @@ int Delete_rows_log_event::do_after_row_operations(
     const Slave_reporting_capability *const, int error) {
   DBUG_ENTER("Delete_rows_log_event::do_after_row_operations");
   error = row_operations_scan_and_key_teardown(error);
+  m_table->file->rpl_after_delete_rows();
   DBUG_RETURN(error);
 }
 
-int Delete_rows_log_event::do_exec_row(const Relay_log_info *const) {
+int Delete_rows_log_event::do_exec_row(const Relay_log_info *const rli) {
   int error = 0;
   DBUG_ASSERT(m_table != nullptr);
   const bool invoke_triggers =
       slave_run_triggers_for_rbr && !master_had_triggers && m_table->triggers;
+
+  if (m_rows_lookup_algorithm == ROW_LOOKUP_NOT_NEEDED) {
+    error = unpack_current_row(rli, &m_cols, false /*not AI*/);
+    if (error)
+      return error;
+  }
 
   /* m_table->record[0] contains the BI */
   m_table->mark_columns_per_binlog_row_image(thd);
@@ -12869,6 +12887,7 @@ int Update_rows_log_event::do_before_row_operations(
     const Slave_reporting_capability *const, table_def *tabledef) {
   int error = 0;
   DBUG_ENTER("Update_rows_log_event::do_before_row_operations");
+  m_table->file->rpl_before_update_rows();
   /*
     Increment the global status update count variable
   */
@@ -12895,6 +12914,7 @@ int Update_rows_log_event::do_after_row_operations(
     const Slave_reporting_capability *const, int error) {
   DBUG_ENTER("Update_rows_log_event::do_after_row_operations");
   error = row_operations_scan_and_key_teardown(error);
+  m_table->file->rpl_after_update_rows();
   DBUG_RETURN(error);
 }
 
@@ -13004,6 +13024,12 @@ int Update_rows_log_event::do_exec_row(const Relay_log_info *const rli) {
   int error = 0;
   const bool invoke_triggers =
       slave_run_triggers_for_rbr && !master_had_triggers && m_table->triggers;
+
+  if (m_rows_lookup_algorithm == ROW_LOOKUP_NOT_NEEDED) {
+    error = unpack_current_row(rli, &m_cols, false /*not AI*/);
+    if (error)
+      return error;
+  }
 
   const uchar *const saved_curr_row = m_curr_row;
 

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -9572,9 +9572,7 @@ bool ha_rocksdb::skip_unique_check() const {
          (my_core::thd_test_options(table->in_use,
                                     OPTION_RELAXED_UNIQUE_CHECKS) &&
           m_tbl_def->m_key_count == 1)
-      /* TODO(yzha) - af531c246d35 (New variable to control read free
-      replication)
-      || use_read_free_rpl() */
+      || use_read_free_rpl()
       ;
 }
 
@@ -9800,14 +9798,12 @@ void ha_rocksdb::dec_table_n_rows() {
 */
 void ha_rocksdb::set_last_rowkey(
     const uchar *const old_data MY_ATTRIBUTE((__unused__))) {
-  /* TODO(yzha) - af531c246d35 (New variable to control read free replication)
   if (old_data && use_read_free_rpl()) {
     const int old_pk_size = m_pk_descr->pack_record(
         table, m_pack_buffer, old_data, m_pk_packed_tuple, nullptr, false);
     m_last_rowkey.copy((const char *)m_pk_packed_tuple, old_pk_size,
                        &my_charset_bin);
   }
-  */
 }
 
 /**
@@ -14595,9 +14591,7 @@ bool ha_rocksdb::should_recreate_snapshot(const int rc,
  * using TX API and skipping row locking.
  */
 bool ha_rocksdb::can_assume_tracked(THD *thd) {
-  /* TODO(yzha) - af531c246d35 (New variable to control read free replication)
-   */
-  if (/*use_read_free_rpl() || */ (THDVAR(thd, blind_delete_primary_key))) {
+  if (use_read_free_rpl() || (THDVAR(thd, blind_delete_primary_key))) {
     return false;
   }
   return true;
@@ -15407,7 +15401,6 @@ static void rocksdb_set_update_cf_options(THD *const /* unused */,
 
 void rdb_queue_save_stats_request() { rdb_bg_thread.request_save_stats(); }
 
-/* TODO(yzha) - c0e6859bffd (Read free replication)
 void ha_rocksdb::rpl_before_delete_rows() {
   DBUG_ENTER_FUNC();
 
@@ -15439,9 +15432,7 @@ void ha_rocksdb::rpl_after_update_rows() {
 
   DBUG_VOID_RETURN;
 }
-*/
 
-/* TODO(yzha) - af531c246d35 (New variable to control read free replication) */
 bool ha_rocksdb::is_read_free_rpl_table() const {
   return table->s && m_tbl_def->m_is_read_free_rpl_table;
 }
@@ -15451,7 +15442,6 @@ bool ha_rocksdb::is_read_free_rpl_table() const {
   Read Free Replication can be used or not. Returning true means
   Read Free Replication can be used.
 */
-/* TODO(yzha) - af531c246d35 (New variable to control read free replication)
 bool ha_rocksdb::use_read_free_rpl() const {
   DBUG_ENTER_FUNC();
 
@@ -15471,7 +15461,6 @@ bool ha_rocksdb::use_read_free_rpl() const {
   DBUG_ASSERT(false);
   DBUG_RETURN(false);
 }
-*/
 
 /**
   @brief

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -952,16 +952,12 @@ class ha_rocksdb : public my_core::handler {
   int adjust_handler_stats_table_scan();
 
  public:
-  /* TODO(yzha) - 019a9fcd7f6 Add Tokutek's read-free replication api in mysqld
   virtual void rpl_before_delete_rows() override;
   virtual void rpl_after_delete_rows() override;
   virtual void rpl_before_update_rows() override;
   virtual void rpl_after_update_rows() override;
-   */
 
-  /* TODO(yzha) - af531c246d35 New variable to control read free replication
   virtual bool use_read_free_rpl() const override;
-   */
 
   virtual bool has_ttl_column() const override;
 


### PR DESCRIPTION
Reference Patch: https://github.com/facebook/mysql-5.6/commit/019a9fcd7f6
Reference Patch: https://github.com/facebook/mysql-5.6/commit/19e810f960c
Reference Patch: https://github.com/facebook/mysql-5.6/commit/af531c246d35

---------- https://github.com/facebook/mysql-5.6/commit/019a9fcd7f6 ----------
Add Tokutek's read-free replication api in mysqld

Summary:
This diff was taken from
percona/percona-server@ecc04b1,
which added Read Free replication support(API) for Percona Server 5.6.
Original implementation was done by Tokutek.

This diff adds new handler methods -- rpl_lookup_rows for determing whether the old
row image should be looked up before update or delete, and hooks to be
called before and after row write, delete, and update events. Allow
skipping reads in Rows_log_event::decide_row_lookup_algorithm and in
Rows_log_event::do_apply_event. Call the event before/after hooks at
the right places. For update and delete, construct a dummy before
image if no row lookup was done.

Test Plan: mtr

Reviewers: hermanlee4, spetrunia, jkedgar, santoshb

Originally Reviewed By: santoshb

Subscribers: webscalesql-eng

---------- https://github.com/facebook/mysql-5.6/commit/19e810f960c ----------
Replace rocksdb_rpl_lookup_rows with rocksdb_read_free_rpl_tables

Summary: The rocksdb_rpl_lookup_rows variable is a binary setting - either all tables use read-free replication or none do.  Replace it with a new variable that allows specific tables to use read-free replication (using a regex).  The new variable - rocksdb_read_free_rpl_tables - is a list of tables (separated by ',' or '|' and allowing regular expressions - i.e. "a.*") that will be enabled for read-free replication

Test Plan: MTR with new tests in rocksdb.rpl_read_free

Reviewers: yoshinorim, hermanlee4

Originally Reviewed By: hermanlee4

Subscribers: webscalesql-eng, vasilep

---------- https://github.com/facebook/mysql-5.6/commit/af531c246d35 ----------
[MyRocks] Added a new variable to control read-free replication

Summary:
Added a new variable rocksdb_read_free_rpl to control read-free repl more
globally (i.e. without relying on table name regex). It takes three values: ON,
OFF, PK_ONLY. PK_ONLY enables read free rpl on tables which have only primary
key (i.e. no secondary keys). Read free replication will be enabled only when
values in both rocksdb_read_free_rpl and rocksdb_read_free_rpl_tables are
satisfied. Also changed the default value of rocksdb_read_free_rpl_tables to
'.*' because we expect users to use the other variable.

Test Plan: MTR

Reviewers: herman, mung, yoshinori

Originally Reviewed By: herman

Subscribers: butterflybot, vinaybhat, webscalesql-eng@fb.com

Tasks: T32641123

Signature: 13382889:1553284649:c32410a248975c0b9e758512b553d80a9083160c