### PR TITLE
Add lock information to lock timeout error message

### DIFF
--- a/mysql-test/suite/rocksdb/t/hermitage.inc
+++ b/mysql-test/suite/rocksdb/t/hermitage.inc
@@ -125,8 +125,6 @@ if ($trx_isolation == "READ COMMITTED")
 }
 if ($trx_isolation == "REPEATABLE READ")
 {
-  # TODO(yzha) - Update error message once following patch is ported
-  # 1e50e3fe7bf Add lock information to lock timeout error message
   --error ER_LOCK_DEADLOCK
   reap;
   select variable_value-@a from performance_schema.global_status where variable_name='rocksdb_snapshot_conflict_errors';
@@ -157,8 +155,6 @@ if ($trx_isolation == "READ COMMITTED")
 }
 if ($trx_isolation == "REPEATABLE READ")
 {
-  # TODO(yzha) - Update error message once following patch is ported
-  # 1e50e3fe7bf Add lock information to lock timeout error message
   --error ER_LOCK_DEADLOCK
   reap;
 }
@@ -211,8 +207,6 @@ if ($trx_isolation == "READ COMMITTED")
 }
 if ($trx_isolation == "REPEATABLE READ")
 {
-  # TODO(yzha) - Update error message once following patch is ported
-  # 1e50e3fe7bf Add lock information to lock timeout error message
   --error ER_LOCK_DEADLOCK
   delete from test where value = 20;
 }

--- a/mysql-test/suite/rocksdb/t/issue111.test
+++ b/mysql-test/suite/rocksdb/t/issue111.test
@@ -31,8 +31,6 @@ commit;
 
 connection default;
 
-# TODO(yzha) - Update error message once following patch is ported
-# 1e50e3fe7bf Add lock information to lock timeout error message
 --error ER_LOCK_DEADLOCK
 update t1 set col2=col2+1 where col1 < 10 limit 5;
 

--- a/mysql-test/suite/rocksdb/t/rocksdb_concurrent_delete.inc
+++ b/mysql-test/suite/rocksdb/t/rocksdb_concurrent_delete.inc
@@ -68,8 +68,6 @@ SET debug_sync='now SIGNAL go';
 connection con;
 if ($isolation_level == "REPEATABLE READ")
 {
-  # TODO(yzha) - Update error message once following patch is ported
-  # 1e50e3fe7bf Add lock information to lock timeout error message
   --error ER_LOCK_DEADLOCK
   reap;
 }
@@ -91,8 +89,6 @@ SET debug_sync='now SIGNAL go';
 connection con;
 if ($isolation_level == "REPEATABLE READ")
 {
-  # TODO(yzha) - Update error message once following patch is ported
-  # 1e50e3fe7bf Add lock information to lock timeout error message
   --error ER_LOCK_DEADLOCK
   reap;
 }

--- a/mysql-test/suite/rocksdb/t/rocksdb_concurrent_delete_range.inc
+++ b/mysql-test/suite/rocksdb/t/rocksdb_concurrent_delete_range.inc
@@ -45,8 +45,6 @@ set debug_sync='now SIGNAL go';
 connection con;
 if ($isolation_level == "REPEATABLE READ")
 {
-  # TODO(yzha) - Update error message once following patch is ported
-  # 1e50e3fe7bf Add lock information to lock timeout error message
   --error ER_LOCK_DEADLOCK
   reap;
 }
@@ -70,8 +68,6 @@ set debug_sync='now SIGNAL go';
 connection con;
 if ($isolation_level == "REPEATABLE READ")
 {
-  # TODO(yzha) - Update error message once following patch is ported
-  # 1e50e3fe7bf Add lock information to lock timeout error message
   --error ER_LOCK_DEADLOCK
   reap;
 }

--- a/mysql-test/suite/rocksdb/t/rocksdb_concurrent_delete_sk.inc
+++ b/mysql-test/suite/rocksdb/t/rocksdb_concurrent_delete_sk.inc
@@ -45,8 +45,6 @@ SET debug_sync='now SIGNAL go';
 connection con;
 if ($isolation_level == "REPEATABLE READ")
 {
-  # TODO(yzha) - Update error message once following patch is ported
-  # 1e50e3fe7bf Add lock information to lock timeout error message
   --error ER_LOCK_DEADLOCK
   reap;
 }
@@ -68,8 +66,6 @@ SET debug_sync='now SIGNAL go';
 connection con;
 if ($isolation_level == "REPEATABLE READ")
 {
-  # TODO(yzha) - Update error message once following patch is ported
-  # 1e50e3fe7bf Add lock information to lock timeout error message
   --error ER_LOCK_DEADLOCK
   reap;
 }

--- a/mysql-test/suite/rocksdb/t/rocksdb_locks.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_locks.test
@@ -85,8 +85,6 @@ UPDATE t1 SET value=30 WHERE id=3;
 COMMIT;
 
 --connection con1
-# TODO(yzha) - Update error message once following patch is ported
-# 1e50e3fe7bf Add lock information to lock timeout error message
 --error ER_LOCK_DEADLOCK
 SELECT * FROM t1 WHERE id=3 FOR UPDATE;
 


### PR DESCRIPTION
Reference Patch: https://github.com/facebook/mysql-5.6/commit/1e50e3fe7bf

Notice: Only outdated TODOs were removed in this commit

---------- https://github.com/facebook/mysql-5.6/commit/1e50e3fe7bf ----------
Summary:
Currently, on lock timeout, we only give
  ERROR 1205 (HY000): Lock wait timeout exceeded; try restarting transaction
 which has no information on what type of lock timed out.

This change augments the message with the lock type to say something like
  ERROR 1205 (HY000): Lock wait timeout exceeded; try restarting transaction: Timeout on index: test/t1.GEN_CLUST_INDEX
which shows which type of lock timed out as well as the associated object.

There two cases to handle here. For error messages coming from the storage engine, the error is stored onto the transaction, which will get forwarded to the SQL layer for display through `handler::get_error_message`.. For MDL locks in the SQL layer, we are directly using the information in the MDL lock to display the error message.

I didn't touch NDB because I didn't bother getting that to build.

Originally Reviewed By: jtolmer

fbshipit-source-id: 014f0bc407f