### PR TITLE
MultiGet-MRR implementation

### DIFF
--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -1671,6 +1671,8 @@ The following options may be given as the first argument:
  sleep (in milliseconds) between calling chsize() to
  truncate the file in chunks.  The chunk size is  the same
  as merge_buf_size.
+ --rocksdb-mrr-batch-size=# 
+ maximum number of keys to fetch during each MRR
  --rocksdb-new-table-reader-for-compaction-inputs 
  DBOptions::new_table_reader_for_compaction_inputs for
  RocksDB
@@ -2680,6 +2682,7 @@ rocksdb-max-total-wal-size 0
 rocksdb-merge-buf-size 67108864
 rocksdb-merge-combine-read-size 1073741824
 rocksdb-merge-tmp-file-removal-delay-ms 0
+rocksdb-mrr-batch-size 100
 rocksdb-new-table-reader-for-compaction-inputs FALSE
 rocksdb-no-block-cache FALSE
 rocksdb-override-cf-options 

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -987,6 +987,7 @@ rocksdb_max_total_wal_size	0
 rocksdb_merge_buf_size	67108864
 rocksdb_merge_combine_read_size	1073741824
 rocksdb_merge_tmp_file_removal_delay_ms	0
+rocksdb_mrr_batch_size	100
 rocksdb_new_table_reader_for_compaction_inputs	OFF
 rocksdb_no_block_cache	OFF
 rocksdb_override_cf_options	

--- a/mysql-test/suite/rocksdb/r/rocksdb_mrr.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_mrr.result
@@ -1,0 +1,557 @@
+create table t0(a int);
+insert into t0 values (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+create table t1(a int);
+insert into t1 select A.a + B.a* 10 + C.a * 100 from t0 A, t0 B, t0 C;
+create table t2 (
+pk int primary key,
+col1 int,
+filler char(32)
+) engine=rocksdb default charset=latin1;
+insert into t2 select a,a,a from t1;
+set global rocksdb_force_flush_memtable_now=1;
+set @save_optimizer_switch=@@optimizer_switch;
+set optimizer_switch='mrr=on,mrr_cost_based=off,batched_key_access=on';
+explain 
+select * from t2,t0 where t2.pk=t0.a;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t0	NULL	ALL	NULL	NULL	NULL	NULL	10	100.00	Using where
+1	SIMPLE	t2	NULL	eq_ref	PRIMARY	PRIMARY	4	test.t0.a	1	100.00	Using join buffer (Batched Key Access)
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`pk` AS `pk`,`test`.`t2`.`col1` AS `col1`,`test`.`t2`.`filler` AS `filler`,`test`.`t0`.`a` AS `a` from `test`.`t2` join `test`.`t0` where (`test`.`t2`.`pk` = `test`.`t0`.`a`)
+select * from t2,t0 where t2.pk=t0.a;
+pk	col1	filler	a
+0	0	0	0
+1	1	1	1
+2	2	2	2
+3	3	3	3
+4	4	4	4
+5	5	5	5
+6	6	6	6
+7	7	7	7
+8	8	8	8
+9	9	9	9
+# Check the counters
+create temporary table t10 as 
+select * from performance_schema.global_status
+where variable_name in ('ROCKSDB_ROWS_READ', 'ROCKSDB_NUMBER_DB_NEXT', 'ROCKSDB_NUMBER_DB_NEXT_FOUND', 'ROCKSDB_NUMBER_DB_SEEK', 'ROCKSDB_NUMBER_DB_SEEK_FOUND', 'ROCKSDB_NUMBER_MULTIGET_BYTES_READ', 'ROCKSDB_NUMBER_MULTIGET_GET', 'ROCKSDB_NUMBER_MULTIGET_KEYS_READ');
+flush status;
+select * from t2,t0 where t2.pk=t0.a;
+pk	col1	filler	a
+0	0	0	0
+1	1	1	1
+2	2	2	2
+3	3	3	3
+4	4	4	4
+5	5	5	5
+6	6	6	6
+7	7	7	7
+8	8	8	8
+9	9	9	9
+show status like 'Handler_mrr_init';
+Variable_name	Value
+Handler_mrr_init	1
+create temporary table t11 as 
+select * from performance_schema.global_status
+where variable_name in ('ROCKSDB_ROWS_READ', 'ROCKSDB_NUMBER_DB_NEXT', 'ROCKSDB_NUMBER_DB_NEXT_FOUND', 'ROCKSDB_NUMBER_DB_SEEK', 'ROCKSDB_NUMBER_DB_SEEK_FOUND', 'ROCKSDB_NUMBER_MULTIGET_BYTES_READ', 'ROCKSDB_NUMBER_MULTIGET_GET', 'ROCKSDB_NUMBER_MULTIGET_KEYS_READ');
+select 
+variable_name, 
+t11.variable_value - t10.variable_value as DIFF 
+from 
+t10 join t11 using (VARIABLE_NAME)
+having
+DIFF>0;
+variable_name	DIFF
+rocksdb_number_db_next	10
+rocksdb_number_db_next_found	9
+rocksdb_number_db_seek	1
+rocksdb_number_db_seek_found	1
+rocksdb_number_multiget_bytes_read	370
+rocksdb_number_multiget_get	1
+rocksdb_number_multiget_keys_read	10
+rocksdb_rows_read	20
+drop table t10, t11;
+# This will use MRR:
+explain select * from t2 where pk in (1,2,3,4,5);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t2	NULL	range	PRIMARY	PRIMARY	4	NULL	5	100.00	Using where; Using MRR
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`pk` AS `pk`,`test`.`t2`.`col1` AS `col1`,`test`.`t2`.`filler` AS `filler` from `test`.`t2` where (`test`.`t2`.`pk` in (1,2,3,4,5))
+# Check how optimizer_switch flags effect it:
+set optimizer_switch='mrr_cost_based=on';
+# No MRR/BKA:
+explain select * from t2,t0 where t2.pk=t0.a;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t0	NULL	ALL	NULL	NULL	NULL	NULL	10	100.00	Using where
+1	SIMPLE	t2	NULL	eq_ref	PRIMARY	PRIMARY	4	test.t0.a	1	100.00	NULL
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`pk` AS `pk`,`test`.`t2`.`col1` AS `col1`,`test`.`t2`.`filler` AS `filler`,`test`.`t0`.`a` AS `a` from `test`.`t2` join `test`.`t0` where (`test`.`t2`.`pk` = `test`.`t0`.`a`)
+explain select * from t2 where pk in (1,2,3,4,5);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t2	NULL	range	PRIMARY	PRIMARY	4	NULL	5	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`pk` AS `pk`,`test`.`t2`.`col1` AS `col1`,`test`.`t2`.`filler` AS `filler` from `test`.`t2` where (`test`.`t2`.`pk` in (1,2,3,4,5))
+set optimizer_switch='mrr_cost_based=off,mrr=off';
+# No MRR/BKA:
+explain select * from t2,t0 where t2.pk=t0.a;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t0	NULL	ALL	NULL	NULL	NULL	NULL	10	100.00	Using where
+1	SIMPLE	t2	NULL	eq_ref	PRIMARY	PRIMARY	4	test.t0.a	1	100.00	NULL
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`pk` AS `pk`,`test`.`t2`.`col1` AS `col1`,`test`.`t2`.`filler` AS `filler`,`test`.`t0`.`a` AS `a` from `test`.`t2` join `test`.`t0` where (`test`.`t2`.`pk` = `test`.`t0`.`a`)
+explain select * from t2 where pk in (1,2,3,4,5);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t2	NULL	range	PRIMARY	PRIMARY	4	NULL	5	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`pk` AS `pk`,`test`.`t2`.`col1` AS `col1`,`test`.`t2`.`filler` AS `filler` from `test`.`t2` where (`test`.`t2`.`pk` in (1,2,3,4,5))
+set optimizer_switch='mrr_cost_based=off,mrr=on';
+# Have MRR/BKA:
+explain select * from t2,t0 where t2.pk=t0.a;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t0	NULL	ALL	NULL	NULL	NULL	NULL	10	100.00	Using where
+1	SIMPLE	t2	NULL	eq_ref	PRIMARY	PRIMARY	4	test.t0.a	1	100.00	Using join buffer (Batched Key Access)
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`pk` AS `pk`,`test`.`t2`.`col1` AS `col1`,`test`.`t2`.`filler` AS `filler`,`test`.`t0`.`a` AS `a` from `test`.`t2` join `test`.`t0` where (`test`.`t2`.`pk` = `test`.`t0`.`a`)
+explain select * from t2 where pk in (1,2,3,4,5);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t2	NULL	range	PRIMARY	PRIMARY	4	NULL	5	100.00	Using where; Using MRR
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`pk` AS `pk`,`test`.`t2`.`col1` AS `col1`,`test`.`t2`.`filler` AS `filler` from `test`.`t2` where (`test`.`t2`.`pk` in (1,2,3,4,5))
+# This will not use MRR, as one of the ranges is a non-singlepoint:
+explain select * from t2 where pk in (1,2,3,4,5) or pk between 6 and 8;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t2	NULL	range	PRIMARY	PRIMARY	4	NULL	6	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`pk` AS `pk`,`test`.`t2`.`col1` AS `col1`,`test`.`t2`.`filler` AS `filler` from `test`.`t2` where ((`test`.`t2`.`pk` in (1,2,3,4,5)) or (`test`.`t2`.`pk` between 6 and 8))
+create table t3 (
+pk1 int,
+pk2 int,
+col1 int,
+filler char(32),
+primary key(pk1, pk2),
+key(col1)
+) engine=rocksdb default charset=latin1;
+insert into t3 select a,a, a,a from t1;
+set global rocksdb_force_flush_memtable_now=1;
+# This must not use BKA as it uses key prefix:
+explain 
+select * from t3,t0 where t3.pk1=t0.a;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t0	NULL	ALL	NULL	NULL	NULL	NULL	10	100.00	Using where
+1	SIMPLE	t3	NULL	ref	PRIMARY	PRIMARY	4	test.t0.a	11	100.00	NULL
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t3`.`pk1` AS `pk1`,`test`.`t3`.`pk2` AS `pk2`,`test`.`t3`.`col1` AS `col1`,`test`.`t3`.`filler` AS `filler`,`test`.`t0`.`a` AS `a` from `test`.`t3` join `test`.`t0` where (`test`.`t3`.`pk1` = `test`.`t0`.`a`)
+# This will use BKA as it uses full key:
+explain 
+select * from t3,t0 where t3.pk1=t0.a and t3.pk2=t0.a+1;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t0	NULL	ALL	NULL	NULL	NULL	NULL	10	100.00	Using where
+1	SIMPLE	t3	NULL	eq_ref	PRIMARY	PRIMARY	8	test.t0.a,func	1	100.00	Using where; Using join buffer (Batched Key Access)
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t3`.`pk1` AS `pk1`,`test`.`t3`.`pk2` AS `pk2`,`test`.`t3`.`col1` AS `col1`,`test`.`t3`.`filler` AS `filler`,`test`.`t0`.`a` AS `a` from `test`.`t3` join `test`.`t0` where ((`test`.`t3`.`pk1` = `test`.`t0`.`a`) and (`test`.`t3`.`pk2` = (`test`.`t0`.`a` + 1)))
+# This will use MRR as it uses full key:
+explain select * from t3 where pk1 in (1,2,3,4,5) and pk2 in (3,4,5);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t3	NULL	range	PRIMARY	PRIMARY	8	NULL	15	100.00	Using where; Using MRR
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t3`.`pk1` AS `pk1`,`test`.`t3`.`pk2` AS `pk2`,`test`.`t3`.`col1` AS `col1`,`test`.`t3`.`filler` AS `filler` from `test`.`t3` where ((`test`.`t3`.`pk1` in (1,2,3,4,5)) and (`test`.`t3`.`pk2` in (3,4,5)))
+# This will not use MRR as there are non-singlepoint ranges:
+explain select * from t3 where (pk1 in (1,2,4,5) and pk2 in (4,5)) or pk1=3;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t3	NULL	range	PRIMARY	PRIMARY	8	NULL	9	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t3`.`pk1` AS `pk1`,`test`.`t3`.`pk2` AS `pk2`,`test`.`t3`.`col1` AS `col1`,`test`.`t3`.`filler` AS `filler` from `test`.`t3` where (((`test`.`t3`.`pk1` in (1,2,4,5)) and (`test`.`t3`.`pk2` in (4,5))) or (`test`.`t3`.`pk1` = 3))
+# Due to HA_MRR_SUPPORT_SORTED, the following will use MRR, and not require filesort:
+explain select * from t3 where pk1 in (1,2,3,4,5) and pk2 in (3,4,5) order by pk1, pk2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t3	NULL	range	PRIMARY	PRIMARY	8	NULL	15	100.00	Using where; Using MRR
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t3`.`pk1` AS `pk1`,`test`.`t3`.`pk2` AS `pk2`,`test`.`t3`.`col1` AS `col1`,`test`.`t3`.`filler` AS `filler` from `test`.`t3` where ((`test`.`t3`.`pk1` in (1,2,3,4,5)) and (`test`.`t3`.`pk2` in (3,4,5))) order by `test`.`t3`.`pk1`,`test`.`t3`.`pk2`
+# Test for lookups returning nothing
+delete from t2 where pk in (3,5,7,9,10) or pk between 100 and 200;
+explain
+select * from t2,t0 where t2.pk=t0.a;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t0	NULL	ALL	NULL	NULL	NULL	NULL	10	100.00	Using where
+1	SIMPLE	t2	NULL	eq_ref	PRIMARY	PRIMARY	4	test.t0.a	1	100.00	Using join buffer (Batched Key Access)
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`pk` AS `pk`,`test`.`t2`.`col1` AS `col1`,`test`.`t2`.`filler` AS `filler`,`test`.`t0`.`a` AS `a` from `test`.`t2` join `test`.`t0` where (`test`.`t2`.`pk` = `test`.`t0`.`a`)
+select * from t2,t0 where t2.pk=t0.a;
+pk	col1	filler	a
+0	0	0	0
+1	1	1	1
+2	2	2	2
+4	4	4	4
+6	6	6	6
+8	8	8	8
+# Test for a scan returning nothing at all:
+explain
+select * from t2,t0 where t2.pk=t0.a+500100;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t0	NULL	ALL	NULL	NULL	NULL	NULL	10	100.00	NULL
+1	SIMPLE	t2	NULL	eq_ref	PRIMARY	PRIMARY	4	func	1	100.00	Using where; Using join buffer (Batched Key Access)
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`pk` AS `pk`,`test`.`t2`.`col1` AS `col1`,`test`.`t2`.`filler` AS `filler`,`test`.`t0`.`a` AS `a` from `test`.`t2` join `test`.`t0` where (`test`.`t2`.`pk` = (`test`.`t0`.`a` + 500100))
+select * from t2,t0 where t2.pk=t0.a+500100;
+pk	col1	filler	a
+# Make the scan finish before it has returned all the data:
+select * from t2,t0 where t2.pk=t0.a limit 1;
+pk	col1	filler	a
+0	0	0	0
+# Re-execute MRR scan in a subquery:
+create table t4(a int primary key);
+insert into t4 values (4),(6),(8);
+explain
+select a ,
+(select concat(t0.a,'-',t2.pk) 
+from t2,t0 
+where t2.pk=t0.a and t2.col1>=t4.a
+limit 1) as SUBQ
+from t4;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t4	NULL	index	NULL	PRIMARY	4	NULL	#	#	Using index
+2	DEPENDENT SUBQUERY	t0	NULL	ALL	NULL	NULL	NULL	NULL	#	#	Using where
+2	DEPENDENT SUBQUERY	t2	NULL	eq_ref	PRIMARY	PRIMARY	4	test.t0.a	#	#	Using where; Using join buffer (Batched Key Access)
+Warnings:
+Note	1276	Field or reference 'test.t4.a' of SELECT #2 was resolved in SELECT #1
+Note	1003	/* select#1 */ select `test`.`t4`.`a` AS `a`,(/* select#2 */ select concat(`test`.`t0`.`a`,'-',`test`.`t2`.`pk`) from `test`.`t2` join `test`.`t0` where ((`test`.`t2`.`pk` = `test`.`t0`.`a`) and (`test`.`t2`.`col1` >= `test`.`t4`.`a`)) limit 1) AS `SUBQ` from `test`.`t4`
+select a ,
+(select concat(t0.a,'-',t2.pk) 
+from t2,t0 
+where t2.pk=t0.a and t2.col1>=t4.a
+limit 1) as SUBQ
+from t4;
+a	SUBQ
+4	4-4
+6	6-6
+8	8-8
+#
+# MRR/BKA on secondary keys
+#
+# This won't use BKA because it's an index-only scan:
+explain
+select t3.col1 from t3,t0 where t3.col1=t0.a;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t0	NULL	ALL	NULL	NULL	NULL	NULL	10	100.00	Using where
+1	SIMPLE	t3	NULL	ref	col1	col1	5	test.t0.a	11	100.00	Using index
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t3`.`col1` AS `col1` from `test`.`t3` join `test`.`t0` where (`test`.`t3`.`col1` = `test`.`t0`.`a`)
+# This will use BKA: 
+explain
+select * from t3,t0 where t3.col1=t0.a;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t0	NULL	ALL	NULL	NULL	NULL	NULL	10	100.00	Using where
+1	SIMPLE	t3	NULL	ref	col1	col1	5	test.t0.a	11	100.00	Using join buffer (Batched Key Access)
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t3`.`pk1` AS `pk1`,`test`.`t3`.`pk2` AS `pk2`,`test`.`t3`.`col1` AS `col1`,`test`.`t3`.`filler` AS `filler`,`test`.`t0`.`a` AS `a` from `test`.`t3` join `test`.`t0` where (`test`.`t3`.`col1` = `test`.`t0`.`a`)
+select * from t3,t0 where t3.col1=t0.a;
+pk1	pk2	col1	filler	a
+0	0	0	0	0
+1	1	1	1	1
+2	2	2	2	2
+3	3	3	3	3
+4	4	4	4	4
+5	5	5	5	5
+6	6	6	6	6
+7	7	7	7	7
+8	8	8	8	8
+9	9	9	9	9
+# Now, run the query and check the counters
+create temporary table t11 as
+select * from performance_schema.global_status
+where variable_name in ('ROCKSDB_ROWS_READ', 'ROCKSDB_NUMBER_DB_NEXT', 'ROCKSDB_NUMBER_DB_NEXT_FOUND', 'ROCKSDB_NUMBER_DB_SEEK', 'ROCKSDB_NUMBER_DB_SEEK_FOUND', 'ROCKSDB_NUMBER_MULTIGET_BYTES_READ', 'ROCKSDB_NUMBER_MULTIGET_GET', 'ROCKSDB_NUMBER_MULTIGET_KEYS_READ');
+select * from t3,t0 where t3.col1=t0.a;
+pk1	pk2	col1	filler	a
+0	0	0	0	0
+1	1	1	1	1
+2	2	2	2	2
+3	3	3	3	3
+4	4	4	4	4
+5	5	5	5	5
+6	6	6	6	6
+7	7	7	7	7
+8	8	8	8	8
+9	9	9	9	9
+create temporary table t12 as
+select * from performance_schema.global_status
+where variable_name in ('ROCKSDB_ROWS_READ', 'ROCKSDB_NUMBER_DB_NEXT', 'ROCKSDB_NUMBER_DB_NEXT_FOUND', 'ROCKSDB_NUMBER_DB_SEEK', 'ROCKSDB_NUMBER_DB_SEEK_FOUND', 'ROCKSDB_NUMBER_MULTIGET_BYTES_READ', 'ROCKSDB_NUMBER_MULTIGET_GET', 'ROCKSDB_NUMBER_MULTIGET_KEYS_READ');
+select 
+variable_name, 
+t12.variable_value - t11.variable_value as DIFF 
+from 
+t11 join t12 using (VARIABLE_NAME)
+having
+DIFF>0;
+variable_name	DIFF
+rocksdb_number_db_next	20
+rocksdb_number_db_next_found	9
+rocksdb_number_db_seek	11
+rocksdb_number_db_seek_found	11
+rocksdb_number_multiget_bytes_read	370
+rocksdb_number_multiget_get	1
+rocksdb_number_multiget_keys_read	10
+rocksdb_rows_read	20
+drop table t11,t12;
+#
+# Check how the counters are incremented when SQL
+# layer doesn't read all of the MultiGet results
+#
+create table t20 (a int);
+insert into t20 values (1);
+set global rocksdb_force_flush_memtable_now=1;
+explain
+select a, a+20 in (select t2.filler from t2,t0 where t2.pk=t0.a+20) from t20;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t20	NULL	ALL	NULL	NULL	NULL	NULL	1	100.00	NULL
+2	DEPENDENT SUBQUERY	t0	NULL	ALL	NULL	NULL	NULL	NULL	10	100.00	NULL
+2	DEPENDENT SUBQUERY	t2	NULL	eq_ref	PRIMARY	PRIMARY	4	func	1	100.00	Using where; Using join buffer (Batched Key Access)
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t20`.`a` AS `a`,<in_optimizer>((`test`.`t20`.`a` + 20),<exists>(/* select#2 */ select 1 from `test`.`t2` join `test`.`t0` where ((`test`.`t2`.`pk` = (`test`.`t0`.`a` + 20)) and <if>(outer_field_is_not_null, ((<cache>((`test`.`t20`.`a` + 20)) = `test`.`t2`.`filler`) or (`test`.`t2`.`filler` is null)), true)) having <if>(outer_field_is_not_null, <is_not_null_test>(`test`.`t2`.`filler`), true))) AS `a+20 in (select t2.filler from t2,t0 where t2.pk=t0.a+20)` from `test`.`t20`
+create temporary table t10 as 
+select * from performance_schema.global_status
+where variable_name in ('ROCKSDB_ROWS_READ', 'ROCKSDB_NUMBER_DB_NEXT', 'ROCKSDB_NUMBER_DB_NEXT_FOUND', 'ROCKSDB_NUMBER_DB_SEEK', 'ROCKSDB_NUMBER_DB_SEEK_FOUND', 'ROCKSDB_NUMBER_MULTIGET_BYTES_READ', 'ROCKSDB_NUMBER_MULTIGET_GET', 'ROCKSDB_NUMBER_MULTIGET_KEYS_READ');
+select a, a+20 in (select t2.filler from t2,t0 where t2.pk=t0.a+20) from t20;
+a	a+20 in (select t2.filler from t2,t0 where t2.pk=t0.a+20)
+1	1
+create temporary table t11 as 
+select * from performance_schema.global_status
+where variable_name in ('ROCKSDB_ROWS_READ', 'ROCKSDB_NUMBER_DB_NEXT', 'ROCKSDB_NUMBER_DB_NEXT_FOUND', 'ROCKSDB_NUMBER_DB_SEEK', 'ROCKSDB_NUMBER_DB_SEEK_FOUND', 'ROCKSDB_NUMBER_MULTIGET_BYTES_READ', 'ROCKSDB_NUMBER_MULTIGET_GET', 'ROCKSDB_NUMBER_MULTIGET_KEYS_READ');
+# The below shows ROCKSDB_ROWS_READ=13. 
+#  1 is from table t20
+# 10 are from table t0, BKA reads all its rows into buffer
+#  2 are from table t2.  BKA code reads two rows before it figures that
+#    the subquery has a match and no more rows are needed.
+#    (note that MultiGet call has read all 10 rows, but SQL layer only has read 2)
+select 
+variable_name, 
+t11.variable_value - t10.variable_value as DIFF 
+from 
+t10 join t11 using (VARIABLE_NAME)
+having
+DIFF>0;
+variable_name	DIFF
+rocksdb_number_db_next	11
+rocksdb_number_db_next_found	9
+rocksdb_number_db_seek	2
+rocksdb_number_db_seek_found	2
+rocksdb_number_multiget_bytes_read	370
+rocksdb_number_multiget_get	1
+rocksdb_number_multiget_keys_read	10
+rocksdb_rows_read	13
+drop table t10, t11;
+drop table t20;
+#
+# Check how MRR works without BKA
+#
+explain select t3.col1 from t3 where t3.col1=20 or t3.col1 between 25 and 28;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t3	NULL	range	col1	col1	5	NULL	2	100.00	Using where; Using index
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t3`.`col1` AS `col1` from `test`.`t3` where ((`test`.`t3`.`col1` = 20) or (`test`.`t3`.`col1` between 25 and 28))
+# This will use MRR:
+explain 
+select * from t3 where t3.col1=20 or t3.col1 between 25 and 28;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t3	NULL	range	col1	col1	5	NULL	2	100.00	Using index condition; Using MRR
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t3`.`pk1` AS `pk1`,`test`.`t3`.`pk2` AS `pk2`,`test`.`t3`.`col1` AS `col1`,`test`.`t3`.`filler` AS `filler` from `test`.`t3` where ((`test`.`t3`.`col1` = 20) or (`test`.`t3`.`col1` between 25 and 28))
+select * from t3 where t3.col1=20 or t3.col1 between 25 and 28;
+pk1	pk2	col1	filler
+20	20	20	20
+25	25	25	25
+26	26	26	26
+27	27	27	27
+28	28	28	28
+# Check if Index Condition Pushdown works
+explain 
+select * from t3 where (t3.col1=20 or t3.col1 between 25 and 28) and mod(t3.col1,2)=0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t3	NULL	range	col1	col1	5	NULL	2	100.00	Using index condition; Using MRR
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t3`.`pk1` AS `pk1`,`test`.`t3`.`pk2` AS `pk2`,`test`.`t3`.`col1` AS `col1`,`test`.`t3`.`filler` AS `filler` from `test`.`t3` where (((`test`.`t3`.`col1` = 20) or (`test`.`t3`.`col1` between 25 and 28)) and ((`test`.`t3`.`col1` % 2) = 0))
+select * from t3 where (t3.col1=20 or t3.col1 between 25 and 28) and mod(t3.col1,2)=0;
+pk1	pk2	col1	filler
+20	20	20	20
+26	26	26	26
+28	28	28	28
+select * from t3 use index() where (t3.col1=20 or t3.col1 between 25 and 28) and mod(t3.col1,2)=0;
+pk1	pk2	col1	filler
+20	20	20	20
+26	26	26	26
+28	28	28	28
+explain
+select pk1,pk2,col1, filler,mod(t3.col1,2) from t3
+where (t3.col1=20 or t3.col1 between 25 and 28) and mod(t3.col1,2)=0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t3	NULL	range	col1	col1	5	NULL	2	100.00	Using index condition; Using MRR
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t3`.`pk1` AS `pk1`,`test`.`t3`.`pk2` AS `pk2`,`test`.`t3`.`col1` AS `col1`,`test`.`t3`.`filler` AS `filler`,(`test`.`t3`.`col1` % 2) AS `mod(t3.col1,2)` from `test`.`t3` where (((`test`.`t3`.`col1` = 20) or (`test`.`t3`.`col1` between 25 and 28)) and ((`test`.`t3`.`col1` % 2) = 0))
+select pk1,pk2,col1, filler,mod(t3.col1,2) from t3
+where (t3.col1=20 or t3.col1 between 25 and 28) and mod(t3.col1,2)=0;
+pk1	pk2	col1	filler	mod(t3.col1,2)
+20	20	20	20	0
+26	26	26	26	0
+28	28	28	28	0
+#
+# Test for BKA's variant of Index Condition Pushdown. With BKA,
+# pushed index conditions that refer to preceding tables are 
+# handled in a special way because there's no clear concept of 
+# "current row" for the preceding table(s)
+#
+explain
+select * from t0,t3 where t3.col1=t0.a and mod(t3.pk2,2)=t0.a;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t0	NULL	ALL	NULL	NULL	NULL	NULL	10	100.00	Using where
+1	SIMPLE	t3	NULL	ref	col1	col1	5	test.t0.a	11	100.00	Using index condition; Using join buffer (Batched Key Access)
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t0`.`a` AS `a`,`test`.`t3`.`pk1` AS `pk1`,`test`.`t3`.`pk2` AS `pk2`,`test`.`t3`.`col1` AS `col1`,`test`.`t3`.`filler` AS `filler` from `test`.`t0` join `test`.`t3` where ((`test`.`t3`.`col1` = `test`.`t0`.`a`) and ((`test`.`t3`.`pk2` % 2) = `test`.`t0`.`a`))
+select * from t0,t3 where t3.col1=t0.a and mod(t3.pk2,2)=t0.a;
+a	pk1	pk2	col1	filler
+0	0	0	0	0
+1	1	1	1	1
+set optimizer_switch='mrr=off';
+select * from t0,t3 where t3.col1=t0.a and mod(t3.pk2,2)=t0.a;
+a	pk1	pk2	col1	filler
+0	0	0	0	0
+1	1	1	1	1
+set optimizer_switch='mrr=on';
+#
+# A query which has RANGE_SEQ_IF::skip_record != nullptr.
+#
+# MultiGet/MRR does not invoke skip_record() as it would not produce
+# much speedup.
+#
+insert into t3 select 10000+a, 10000+a, a, 'duplicate-match' from t1;
+delete from t3 where col1 in (3,5);
+explain
+select * from t0 left join t3 on t3.col1=t0.a where t3.pk1 is null;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t0	NULL	ALL	NULL	NULL	NULL	NULL	#	#	NULL
+1	SIMPLE	t3	NULL	ref	col1	col1	5	test.t0.a	#	#	Using where; Not exists; Using join buffer (Batched Key Access)
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t0`.`a` AS `a`,`test`.`t3`.`pk1` AS `pk1`,`test`.`t3`.`pk2` AS `pk2`,`test`.`t3`.`col1` AS `col1`,`test`.`t3`.`filler` AS `filler` from `test`.`t0` left join `test`.`t3` on((`test`.`t3`.`col1` = `test`.`t0`.`a`)) where (`test`.`t3`.`pk1` is null)
+select * from t0 left join t3 on t3.col1=t0.a where t3.pk1 is null;
+a	pk1	pk2	col1	filler
+3	NULL	NULL	NULL	NULL
+5	NULL	NULL	NULL	NULL
+set optimizer_switch='mrr=off';
+select * from t0 left join t3 on t3.col1=t0.a where t3.pk1 is null;
+a	pk1	pk2	col1	filler
+3	NULL	NULL	NULL	NULL
+5	NULL	NULL	NULL	NULL
+set optimizer_switch='mrr=on';
+explain
+select * from t0 where t0.a in (select t3.col1 from t3 where char_length(t3.filler)<30);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t0	NULL	ALL	NULL	NULL	NULL	NULL	#	#	Using where
+1	SIMPLE	t3	NULL	ref	col1	col1	5	test.t0.a	#	#	Using where; FirstMatch(t0); Using join buffer (Batched Key Access)
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t0`.`a` AS `a` from `test`.`t0` semi join (`test`.`t3`) where ((`test`.`t3`.`col1` = `test`.`t0`.`a`) and (char_length(`test`.`t3`.`filler`) < 30))
+select * from t0 where t0.a in (select t3.col1 from t3 where char_length(t3.filler)<30);
+a
+0
+1
+2
+4
+6
+7
+8
+9
+drop table t0,t1,t2,t3,t4;
+#
+# Multi-keypart testcase
+#
+create table t0(a int);
+insert into t0 values (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+CREATE TABLE t2 (
+id bigint(20) unsigned NOT NULL DEFAULT '0',
+type tinyint(3) unsigned NOT NULL DEFAULT '0',
+c1 int(10) unsigned NOT NULL DEFAULT '0',
+c2 int(10) unsigned NOT NULL DEFAULT '0',
+time_updated int(10) unsigned NOT NULL DEFAULT '0',
+id2 bigint(20) unsigned NOT NULL DEFAULT '0',
+c3 int(10) unsigned NOT NULL DEFAULT '0',
+c_id bigint(20) unsigned NOT NULL DEFAULT '0',
+a_id bigint(20) unsigned NOT NULL DEFAULT '0',
+PRIMARY KEY (id,`type`),
+KEY time_updated (time_updated),
+KEY id2 (id2),
+KEY a_idx (a_id),
+KEY c_a_idx (c_id,`a_id`)
+) ENGINE=ROCKSDB DEFAULT CHARSET=latin1;
+Warnings:
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+insert into t2 (id, type, id2, time_updated)
+select a, 1, 1, 1565888298 
+from t0;
+insert into t2 (id, type, id2, time_updated)
+select a, 2, 2, 1565888298 
+from t0;
+set optimizer_trace=1;
+# The following should have type=range, and "Using MRR":
+explain
+SELECT 
+id2, type, SUM(c1), SUM(c2) 
+FROM t2 force index (id2) 
+WHERE 
+id2 IN (1) AND 
+time_updated > 1565888297 AND 
+time_updated <= UNIX_TIMESTAMP() 
+GROUP BY id2, type;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t2	NULL	range	id2	id2	8	NULL	#	#	Using index condition; Using where; Using MRR; Using temporary
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`id2` AS `id2`,`test`.`t2`.`type` AS `type`,sum(`test`.`t2`.`c1`) AS `SUM(c1)`,sum(`test`.`t2`.`c2`) AS `SUM(c2)` from `test`.`t2` FORCE INDEX (`id2`) where ((`test`.`t2`.`id2` = 1) and (`test`.`t2`.`time_updated` > 1565888297) and (`test`.`t2`.`time_updated` <= <cache>(unix_timestamp()))) group by `test`.`t2`.`id2`,`test`.`t2`.`type`
+select 
+MID(trace, locate('access_type_changed', trace), 220)
+as TRACE_FRAGMENT
+from
+information_schema.optimizer_trace;
+TRACE_FRAGMENT
+access_type_changed": {
+              "table": "`t2` FORCE INDEX (`id2`)",
+              "index": "id2",
+              "old_type": "ref",
+              "new_type": "range",
+              "cause": "uses_mrr"
+            }
+set optimizer_trace=0;
+drop table t0, t2;
+#
+# Test for the "fallback to default MRR implementation if SQL layer
+# requests the sorted mode". 
+#
+create table t0(a int primary key);
+insert into t0 values (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+create table t1 (kp1 int, kp2 int, kp3 int, col1 int, key (kp1, kp2, kp3));
+insert into t1 select A.a, B.a, C.a, 123456 from t0 A, t0 B, t0 C;
+set global rocksdb_force_flush_memtable_now=1;
+analyze table t1;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
+explain
+select * from t1 where kp1=1 order by kp2 limit 10;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	range	kp1	kp1	5	NULL	#	#	Using index condition
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t1`.`kp1` AS `kp1`,`test`.`t1`.`kp2` AS `kp2`,`test`.`t1`.`kp3` AS `kp3`,`test`.`t1`.`col1` AS `col1` from `test`.`t1` where (`test`.`t1`.`kp1` = 1) order by `test`.`t1`.`kp2` limit 10
+select * from t1 where kp1=1 order by kp2 limit 10;
+kp1	kp2	kp3	col1
+1	0	0	123456
+1	0	1	123456
+1	0	2	123456
+1	0	3	123456
+1	0	4	123456
+1	0	5	123456
+1	0	6	123456
+1	0	7	123456
+1	0	8	123456
+1	0	9	123456
+drop table t0, t1;

--- a/mysql-test/suite/rocksdb/r/rocksdb_mrr.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_mrr.result
@@ -589,6 +589,22 @@ select * from t0 left join t3 on t3.col1=t0.a where t3.pk1 is null;
 a	pk1	pk2	col1	filler
 3	NULL	NULL	NULL	NULL
 5	NULL	NULL	NULL	NULL
+explain 
+select * from t0 left join t4 using (a) where t4.a is null;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t0	NULL	ALL	NULL	NULL	NULL	NULL	10	#	NULL
+1	SIMPLE	t4	NULL	eq_ref	PRIMARY	PRIMARY	4	test.t0.a	1	#	Using where; Not exists; Using index; Using join buffer (Batched Key Access)
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t0`.`a` AS `a` from `test`.`t0` left join `test`.`t4` on((`test`.`t4`.`a` = `test`.`t0`.`a`)) where (`test`.`t4`.`a` is null)
+select * from t0 left join t4 using (a) where t4.a is null;
+a
+0
+1
+2
+3
+5
+7
+9
 set optimizer_switch='mrr=off';
 select * from t0 left join t3 on t3.col1=t0.a where t3.pk1 is null;
 a	pk1	pk2	col1	filler

--- a/mysql-test/suite/rocksdb/r/rocksdb_mrr.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_mrr.result
@@ -70,6 +70,162 @@ rocksdb_number_multiget_get	1
 rocksdb_number_multiget_keys_read	10
 rocksdb_rows_read	20
 drop table t10, t11;
+# Check rocksdb_mrr_batch_size use MRR
+set @saved_rocksdb_mrr_batch_size=@@rocksdb_mrr_batch_size;
+set rocksdb_mrr_batch_size=5;
+select variable_value into @val1 from performance_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
+explain select * from t2 force index (primary) where pk in (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t2	NULL	range	PRIMARY	PRIMARY	4	NULL	21	#	Using where; Using MRR
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`pk` AS `pk`,`test`.`t2`.`col1` AS `col1`,`test`.`t2`.`filler` AS `filler` from `test`.`t2` FORCE INDEX (PRIMARY) where (`test`.`t2`.`pk` in (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20))
+select * from t2 force index (primary) where pk in (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+pk	col1	filler
+0	0	0
+1	1	1
+2	2	2
+3	3	3
+4	4	4
+5	5	5
+6	6	6
+7	7	7
+8	8	8
+9	9	9
+10	10	10
+11	11	11
+12	12	12
+13	13	13
+14	14	14
+15	15	15
+16	16	16
+17	17	17
+18	18	18
+19	19	19
+20	20	20
+select variable_value-@val1 from performance_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
+variable_value-@val1
+5
+# Check rocksdb_mrr_batch_size use BKA
+create table hundred(a int primary key);
+insert into hundred select A.a + B.a* 10 from t0 A, t0 B;
+analyze table hundred, t2;
+Table	Op	Msg_type	Msg_text
+test.hundred	analyze	status	OK
+test.t2	analyze	status	OK
+explain select * from hundred, t2 where t2.pk=hundred.a;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	hundred	NULL	index	PRIMARY	PRIMARY	4	NULL	#	#	Using index
+1	SIMPLE	t2	NULL	eq_ref	PRIMARY	PRIMARY	4	test.hundred.a	#	#	Using join buffer (Batched Key Access)
+Warnings:
+Note	1003	/* select#1 */ select `test`.`hundred`.`a` AS `a`,`test`.`t2`.`pk` AS `pk`,`test`.`t2`.`col1` AS `col1`,`test`.`t2`.`filler` AS `filler` from `test`.`hundred` join `test`.`t2` where (`test`.`t2`.`pk` = `test`.`hundred`.`a`)
+select variable_value into @val1 from performance_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
+select * from hundred, t2 where t2.pk=hundred.a;
+a	pk	col1	filler
+0	0	0	0
+1	1	1	1
+2	2	2	2
+3	3	3	3
+4	4	4	4
+5	5	5	5
+6	6	6	6
+7	7	7	7
+8	8	8	8
+9	9	9	9
+10	10	10	10
+11	11	11	11
+12	12	12	12
+13	13	13	13
+14	14	14	14
+15	15	15	15
+16	16	16	16
+17	17	17	17
+18	18	18	18
+19	19	19	19
+20	20	20	20
+21	21	21	21
+22	22	22	22
+23	23	23	23
+24	24	24	24
+25	25	25	25
+26	26	26	26
+27	27	27	27
+28	28	28	28
+29	29	29	29
+30	30	30	30
+31	31	31	31
+32	32	32	32
+33	33	33	33
+34	34	34	34
+35	35	35	35
+36	36	36	36
+37	37	37	37
+38	38	38	38
+39	39	39	39
+40	40	40	40
+41	41	41	41
+42	42	42	42
+43	43	43	43
+44	44	44	44
+45	45	45	45
+46	46	46	46
+47	47	47	47
+48	48	48	48
+49	49	49	49
+50	50	50	50
+51	51	51	51
+52	52	52	52
+53	53	53	53
+54	54	54	54
+55	55	55	55
+56	56	56	56
+57	57	57	57
+58	58	58	58
+59	59	59	59
+60	60	60	60
+61	61	61	61
+62	62	62	62
+63	63	63	63
+64	64	64	64
+65	65	65	65
+66	66	66	66
+67	67	67	67
+68	68	68	68
+69	69	69	69
+70	70	70	70
+71	71	71	71
+72	72	72	72
+73	73	73	73
+74	74	74	74
+75	75	75	75
+76	76	76	76
+77	77	77	77
+78	78	78	78
+79	79	79	79
+80	80	80	80
+81	81	81	81
+82	82	82	82
+83	83	83	83
+84	84	84	84
+85	85	85	85
+86	86	86	86
+87	87	87	87
+88	88	88	88
+89	89	89	89
+90	90	90	90
+91	91	91	91
+92	92	92	92
+93	93	93	93
+94	94	94	94
+95	95	95	95
+96	96	96	96
+97	97	97	97
+98	98	98	98
+99	99	99	99
+select variable_value-@val1 from performance_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
+variable_value-@val1
+20
+drop table hundred;
+set rocksdb_mrr_batch_size=@saved_rocksdb_mrr_batch_size;
 # This will use MRR:
 explain select * from t2 where pk in (1,2,3,4,5);
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra

--- a/mysql-test/suite/rocksdb/r/rocksdb_mrr2.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_mrr2.result
@@ -1,0 +1,39 @@
+show variables like 'rocksdb_block_cache_size%';
+Variable_name	Value
+rocksdb_block_cache_size	1024
+create table t0(a int);
+insert into t0 values (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+create table t1(a int);
+insert into t1 select A.a + B.a* 10 + C.a * 100  from t0 A, t0 B, t0 C;
+create table t2 (
+pk int primary key,
+col1 int,
+blob1 text,
+blob2 text
+) engine=rocksdb;
+insert into t2 select a,a,repeat(a,100), repeat(a,200) from t1;
+set global rocksdb_force_flush_memtable_now=1;
+set @save_optimizer_switch=@@optimizer_switch;
+set optimizer_switch='mrr=on,mrr_cost_based=off,batched_key_access=on';
+explain 
+select pk, col1 from t2,t0 
+where t2.pk=t0.a*90 and md5(blob1)=md5(repeat(t2.pk,100)) and md5(blob2)=md5(repeat(t2.pk,200));
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t0	NULL	ALL	NULL	NULL	NULL	NULL	10	#	NULL
+1	SIMPLE	t2	NULL	eq_ref	PRIMARY	PRIMARY	4	func	1	#	Using where; Using join buffer (Batched Key Access)
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`pk` AS `pk`,`test`.`t2`.`col1` AS `col1` from `test`.`t2` join `test`.`t0` where ((`test`.`t2`.`pk` = (`test`.`t0`.`a` * 90)) and (md5(`test`.`t2`.`blob1`) = md5(repeat(`test`.`t2`.`pk`,100))) and (md5(`test`.`t2`.`blob2`) = md5(repeat(`test`.`t2`.`pk`,200))))
+select pk, col1 from t2,t0
+where t2.pk=t0.a*90 and md5(blob1)=md5(repeat(t2.pk,100)) and md5(blob2)=md5(repeat(t2.pk,200));
+pk	col1
+0	0
+90	90
+180	180
+270	270
+360	360
+450	450
+540	540
+630	630
+720	720
+810	810
+drop table t0,t1,t2;

--- a/mysql-test/suite/rocksdb/r/rocksdb_mrr_debug.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_mrr_debug.result
@@ -1,0 +1,41 @@
+create table t0(a int);
+insert into t0 values (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+create table t1(a int);
+insert into t1 select A.a + B.a* 10 + C.a * 100 from t0 A, t0 B, t0 C;
+create table t2 (
+pk int primary key,
+col1 int,
+filler char(32)
+) engine=rocksdb;
+insert into t2 select a,a,a from t1;
+set global rocksdb_force_flush_memtable_now=1;
+set @save_optimizer_switch=@@optimizer_switch;
+set optimizer_switch='mrr=on,mrr_cost_based=off,batched_key_access=on';
+explain 
+select * from t2,t0 where t2.pk=t0.a;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t0	NULL	ALL	NULL	NULL	NULL	NULL	10	#	Using where
+1	SIMPLE	t2	NULL	eq_ref	PRIMARY	PRIMARY	4	test.t0.a	1	#	Using join buffer (Batched Key Access)
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`pk` AS `pk`,`test`.`t2`.`col1` AS `col1`,`test`.`t2`.`filler` AS `filler`,`test`.`t0`.`a` AS `a` from `test`.`t2` join `test`.`t0` where (`test`.`t2`.`pk` = `test`.`t0`.`a`)
+select variable_value into @n_multiget_orig 
+from performance_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
+set debug_sync = 'rocksdb.mrr_fill_buffer.loop SIGNAL target_ready WAIT_FOR simulate_kill';
+select * from t2,t0 where t2.pk=t0.a;
+connect  con1,localhost,root,,;
+set debug_sync = 'now WAIT_FOR target_ready';
+set @a= (select id from information_schema.processlist where state='debug sync point: rocksdb.mrr_fill_buffer.loop');
+kill query @a;
+connect  con2,localhost,root,,;
+set debug_sync = 'now SIGNAL simulate_kill';
+connection con1;
+connection default;
+ERROR 70100: Query execution was interrupted
+# Check that we didn't continue till the MultiGet() call. The following will
+# return 0:
+select variable_value into @n_multiget_new
+from performance_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
+select @n_multiget_new - @n_multiget_orig;
+@n_multiget_new - @n_multiget_orig
+0
+drop table t0,t1,t2;

--- a/mysql-test/suite/rocksdb/t/rocksdb_mrr.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_mrr.test
@@ -1,0 +1,352 @@
+#
+#  Test for MyRocks' MRR implementation based on MultiGet.
+#
+--source include/have_rocksdb.inc
+
+create table t0(a int);
+insert into t0 values (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+
+create table t1(a int);
+insert into t1 select A.a + B.a* 10 + C.a * 100 from t0 A, t0 B, t0 C;
+
+create table t2 (
+  pk int primary key,
+  col1 int,
+  filler char(32)
+) engine=rocksdb default charset=latin1;
+
+insert into t2 select a,a,a from t1;
+set global rocksdb_force_flush_memtable_now=1;
+
+set @save_optimizer_switch=@@optimizer_switch;
+set optimizer_switch='mrr=on,mrr_cost_based=off,batched_key_access=on';
+
+explain 
+select * from t2,t0 where t2.pk=t0.a;
+select * from t2,t0 where t2.pk=t0.a;
+
+--echo # Check the counters
+create temporary table t10 as 
+select * from performance_schema.global_status
+where variable_name in ('ROCKSDB_ROWS_READ', 'ROCKSDB_NUMBER_DB_NEXT', 'ROCKSDB_NUMBER_DB_NEXT_FOUND', 'ROCKSDB_NUMBER_DB_SEEK', 'ROCKSDB_NUMBER_DB_SEEK_FOUND', 'ROCKSDB_NUMBER_MULTIGET_BYTES_READ', 'ROCKSDB_NUMBER_MULTIGET_GET', 'ROCKSDB_NUMBER_MULTIGET_KEYS_READ');
+
+flush status; # for Handler_mrr_init
+
+select * from t2,t0 where t2.pk=t0.a;
+
+show status like 'Handler_mrr_init';
+
+create temporary table t11 as 
+select * from performance_schema.global_status
+where variable_name in ('ROCKSDB_ROWS_READ', 'ROCKSDB_NUMBER_DB_NEXT', 'ROCKSDB_NUMBER_DB_NEXT_FOUND', 'ROCKSDB_NUMBER_DB_SEEK', 'ROCKSDB_NUMBER_DB_SEEK_FOUND', 'ROCKSDB_NUMBER_MULTIGET_BYTES_READ', 'ROCKSDB_NUMBER_MULTIGET_GET', 'ROCKSDB_NUMBER_MULTIGET_KEYS_READ');
+
+select 
+  variable_name, 
+  t11.variable_value - t10.variable_value as DIFF 
+from 
+  t10 join t11 using (VARIABLE_NAME)
+having
+  DIFF>0;
+drop table t10, t11;
+
+--echo # This will use MRR:
+explain select * from t2 where pk in (1,2,3,4,5);
+
+--echo # Check how optimizer_switch flags effect it:
+set optimizer_switch='mrr_cost_based=on';
+
+--echo # No MRR/BKA:
+explain select * from t2,t0 where t2.pk=t0.a;
+explain select * from t2 where pk in (1,2,3,4,5);
+
+set optimizer_switch='mrr_cost_based=off,mrr=off';
+--echo # No MRR/BKA:
+explain select * from t2,t0 where t2.pk=t0.a;
+explain select * from t2 where pk in (1,2,3,4,5);
+
+set optimizer_switch='mrr_cost_based=off,mrr=on';
+--echo # Have MRR/BKA:
+explain select * from t2,t0 where t2.pk=t0.a;
+explain select * from t2 where pk in (1,2,3,4,5);
+
+--echo # This will not use MRR, as one of the ranges is a non-singlepoint:
+explain select * from t2 where pk in (1,2,3,4,5) or pk between 6 and 8;
+
+create table t3 (
+  pk1 int,
+  pk2 int,
+  col1 int,
+  filler char(32),
+  primary key(pk1, pk2),
+  key(col1)
+) engine=rocksdb default charset=latin1;
+
+insert into t3 select a,a, a,a from t1;
+set global rocksdb_force_flush_memtable_now=1;
+
+--echo # This must not use BKA as it uses key prefix:
+explain 
+select * from t3,t0 where t3.pk1=t0.a;
+
+--echo # This will use BKA as it uses full key:
+explain 
+select * from t3,t0 where t3.pk1=t0.a and t3.pk2=t0.a+1;
+
+--echo # This will use MRR as it uses full key:
+explain select * from t3 where pk1 in (1,2,3,4,5) and pk2 in (3,4,5);
+
+--echo # This will not use MRR as there are non-singlepoint ranges:
+explain select * from t3 where (pk1 in (1,2,4,5) and pk2 in (4,5)) or pk1=3;
+
+--echo # Due to HA_MRR_SUPPORT_SORTED, the following will use MRR, and not require filesort:
+explain select * from t3 where pk1 in (1,2,3,4,5) and pk2 in (3,4,5) order by pk1, pk2;
+
+#--echo #
+#--echo # More basic tests
+#--echo #
+
+--echo # Test for lookups returning nothing
+delete from t2 where pk in (3,5,7,9,10) or pk between 100 and 200;
+
+explain
+select * from t2,t0 where t2.pk=t0.a;
+select * from t2,t0 where t2.pk=t0.a;
+
+
+--echo # Test for a scan returning nothing at all:
+explain
+select * from t2,t0 where t2.pk=t0.a+500100;
+select * from t2,t0 where t2.pk=t0.a+500100;
+
+--echo # Make the scan finish before it has returned all the data:
+select * from t2,t0 where t2.pk=t0.a limit 1;
+
+--echo # Re-execute MRR scan in a subquery:
+create table t4(a int primary key);
+insert into t4 values (4),(6),(8);
+
+--replace_column 10 # 11 #
+explain
+select a ,
+       (select concat(t0.a,'-',t2.pk) 
+        from t2,t0 
+        where t2.pk=t0.a and t2.col1>=t4.a
+        limit 1) as SUBQ
+from t4;
+
+select a ,
+       (select concat(t0.a,'-',t2.pk) 
+        from t2,t0 
+        where t2.pk=t0.a and t2.col1>=t4.a
+        limit 1) as SUBQ
+from t4;
+
+--echo #
+--echo # MRR/BKA on secondary keys
+--echo #
+
+--echo # This won't use BKA because it's an index-only scan:
+explain
+select t3.col1 from t3,t0 where t3.col1=t0.a;
+
+--echo # This will use BKA: 
+explain
+select * from t3,t0 where t3.col1=t0.a;
+
+select * from t3,t0 where t3.col1=t0.a;
+
+--echo # Now, run the query and check the counters
+create temporary table t11 as
+select * from performance_schema.global_status
+where variable_name in ('ROCKSDB_ROWS_READ', 'ROCKSDB_NUMBER_DB_NEXT', 'ROCKSDB_NUMBER_DB_NEXT_FOUND', 'ROCKSDB_NUMBER_DB_SEEK', 'ROCKSDB_NUMBER_DB_SEEK_FOUND', 'ROCKSDB_NUMBER_MULTIGET_BYTES_READ', 'ROCKSDB_NUMBER_MULTIGET_GET', 'ROCKSDB_NUMBER_MULTIGET_KEYS_READ');
+
+select * from t3,t0 where t3.col1=t0.a;
+
+create temporary table t12 as
+select * from performance_schema.global_status
+where variable_name in ('ROCKSDB_ROWS_READ', 'ROCKSDB_NUMBER_DB_NEXT', 'ROCKSDB_NUMBER_DB_NEXT_FOUND', 'ROCKSDB_NUMBER_DB_SEEK', 'ROCKSDB_NUMBER_DB_SEEK_FOUND', 'ROCKSDB_NUMBER_MULTIGET_BYTES_READ', 'ROCKSDB_NUMBER_MULTIGET_GET', 'ROCKSDB_NUMBER_MULTIGET_KEYS_READ');
+
+select 
+  variable_name, 
+  t12.variable_value - t11.variable_value as DIFF 
+from 
+  t11 join t12 using (VARIABLE_NAME)
+having
+  DIFF>0;
+
+drop table t11,t12;
+
+--echo #
+--echo # Check how the counters are incremented when SQL
+--echo # layer doesn't read all of the MultiGet results
+--echo #
+create table t20 (a int);
+insert into t20 values (1);
+set global rocksdb_force_flush_memtable_now=1;
+
+explain
+select a, a+20 in (select t2.filler from t2,t0 where t2.pk=t0.a+20) from t20;
+
+create temporary table t10 as 
+select * from performance_schema.global_status
+where variable_name in ('ROCKSDB_ROWS_READ', 'ROCKSDB_NUMBER_DB_NEXT', 'ROCKSDB_NUMBER_DB_NEXT_FOUND', 'ROCKSDB_NUMBER_DB_SEEK', 'ROCKSDB_NUMBER_DB_SEEK_FOUND', 'ROCKSDB_NUMBER_MULTIGET_BYTES_READ', 'ROCKSDB_NUMBER_MULTIGET_GET', 'ROCKSDB_NUMBER_MULTIGET_KEYS_READ');
+
+select a, a+20 in (select t2.filler from t2,t0 where t2.pk=t0.a+20) from t20;
+
+create temporary table t11 as 
+select * from performance_schema.global_status
+where variable_name in ('ROCKSDB_ROWS_READ', 'ROCKSDB_NUMBER_DB_NEXT', 'ROCKSDB_NUMBER_DB_NEXT_FOUND', 'ROCKSDB_NUMBER_DB_SEEK', 'ROCKSDB_NUMBER_DB_SEEK_FOUND', 'ROCKSDB_NUMBER_MULTIGET_BYTES_READ', 'ROCKSDB_NUMBER_MULTIGET_GET', 'ROCKSDB_NUMBER_MULTIGET_KEYS_READ');
+
+--echo # The below shows ROCKSDB_ROWS_READ=13. 
+--echo #  1 is from table t20
+--echo # 10 are from table t0, BKA reads all its rows into buffer
+--echo #  2 are from table t2.  BKA code reads two rows before it figures that
+--echo #    the subquery has a match and no more rows are needed.
+--echo #    (note that MultiGet call has read all 10 rows, but SQL layer only has read 2)
+select 
+  variable_name, 
+  t11.variable_value - t10.variable_value as DIFF 
+from 
+  t10 join t11 using (VARIABLE_NAME)
+having
+  DIFF>0;
+drop table t10, t11;
+drop table t20;
+
+--echo #
+--echo # Check how MRR works without BKA
+--echo #
+explain select t3.col1 from t3 where t3.col1=20 or t3.col1 between 25 and 28;
+
+--echo # This will use MRR:
+explain 
+select * from t3 where t3.col1=20 or t3.col1 between 25 and 28;
+select * from t3 where t3.col1=20 or t3.col1 between 25 and 28;
+
+--echo # Check if Index Condition Pushdown works
+explain 
+select * from t3 where (t3.col1=20 or t3.col1 between 25 and 28) and mod(t3.col1,2)=0;
+select * from t3 where (t3.col1=20 or t3.col1 between 25 and 28) and mod(t3.col1,2)=0;
+
+select * from t3 use index() where (t3.col1=20 or t3.col1 between 25 and 28) and mod(t3.col1,2)=0;
+
+explain
+select pk1,pk2,col1, filler,mod(t3.col1,2) from t3
+where (t3.col1=20 or t3.col1 between 25 and 28) and mod(t3.col1,2)=0;
+
+select pk1,pk2,col1, filler,mod(t3.col1,2) from t3
+where (t3.col1=20 or t3.col1 between 25 and 28) and mod(t3.col1,2)=0;
+
+--echo #
+--echo # Test for BKA's variant of Index Condition Pushdown. With BKA,
+--echo # pushed index conditions that refer to preceding tables are 
+--echo # handled in a special way because there's no clear concept of 
+--echo # "current row" for the preceding table(s)
+--echo #
+
+explain
+select * from t0,t3 where t3.col1=t0.a and mod(t3.pk2,2)=t0.a;
+select * from t0,t3 where t3.col1=t0.a and mod(t3.pk2,2)=t0.a;
+
+set optimizer_switch='mrr=off';
+select * from t0,t3 where t3.col1=t0.a and mod(t3.pk2,2)=t0.a;
+set optimizer_switch='mrr=on';
+
+--echo #
+--echo # A query which has RANGE_SEQ_IF::skip_record != nullptr.
+--echo #
+--echo # MultiGet/MRR does not invoke skip_record() as it would not produce
+--echo # much speedup.
+--echo #
+insert into t3 select 10000+a, 10000+a, a, 'duplicate-match' from t1;
+delete from t3 where col1 in (3,5);
+
+--replace_column 10 # 11 #
+explain
+select * from t0 left join t3 on t3.col1=t0.a where t3.pk1 is null;
+select * from t0 left join t3 on t3.col1=t0.a where t3.pk1 is null;
+set optimizer_switch='mrr=off';
+select * from t0 left join t3 on t3.col1=t0.a where t3.pk1 is null;
+set optimizer_switch='mrr=on';
+
+--replace_column 10 # 11 #
+explain
+select * from t0 where t0.a in (select t3.col1 from t3 where char_length(t3.filler)<30);
+select * from t0 where t0.a in (select t3.col1 from t3 where char_length(t3.filler)<30);
+
+drop table t0,t1,t2,t3,t4;
+
+--echo #
+--echo # Multi-keypart testcase
+--echo #
+create table t0(a int);
+insert into t0 values (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+
+CREATE TABLE t2 (
+  id bigint(20) unsigned NOT NULL DEFAULT '0',
+  type tinyint(3) unsigned NOT NULL DEFAULT '0',
+  c1 int(10) unsigned NOT NULL DEFAULT '0',
+  c2 int(10) unsigned NOT NULL DEFAULT '0',
+  time_updated int(10) unsigned NOT NULL DEFAULT '0',
+  id2 bigint(20) unsigned NOT NULL DEFAULT '0',
+  c3 int(10) unsigned NOT NULL DEFAULT '0',
+  c_id bigint(20) unsigned NOT NULL DEFAULT '0',
+  a_id bigint(20) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (id,`type`),
+  KEY time_updated (time_updated),
+  KEY id2 (id2),
+  KEY a_idx (a_id),
+  KEY c_a_idx (c_id,`a_id`)
+) ENGINE=ROCKSDB DEFAULT CHARSET=latin1;
+
+
+insert into t2 (id, type, id2, time_updated)
+ select a, 1, 1, 1565888298 
+from t0;
+
+insert into t2 (id, type, id2, time_updated)
+ select a, 2, 2, 1565888298 
+from t0;
+
+set optimizer_trace=1;
+--echo # The following should have type=range, and "Using MRR":
+--replace_column 10 # 11 #
+explain
+SELECT 
+  id2, type, SUM(c1), SUM(c2) 
+FROM t2 force index (id2) 
+WHERE 
+  id2 IN (1) AND 
+  time_updated > 1565888297 AND 
+  time_updated <= UNIX_TIMESTAMP() 
+GROUP BY id2, type;
+
+select 
+  MID(trace, locate('access_type_changed', trace), 220)
+    as TRACE_FRAGMENT
+from
+  information_schema.optimizer_trace;
+
+set optimizer_trace=0;
+
+drop table t0, t2;
+
+--echo #
+--echo # Test for the "fallback to default MRR implementation if SQL layer
+--echo # requests the sorted mode". 
+--echo #
+create table t0(a int primary key);
+insert into t0 values (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+
+create table t1 (kp1 int, kp2 int, kp3 int, col1 int, key (kp1, kp2, kp3));
+insert into t1 select A.a, B.a, C.a, 123456 from t0 A, t0 B, t0 C;
+
+set global rocksdb_force_flush_memtable_now=1;
+analyze table t1;
+--replace_column 10 # 11 #
+explain
+select * from t1 where kp1=1 order by kp2 limit 10;
+# This shouldn't fail an assert:
+select * from t1 where kp1=1 order by kp2 limit 10;
+
+drop table t0, t1;

--- a/mysql-test/suite/rocksdb/t/rocksdb_mrr.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_mrr.test
@@ -49,6 +49,31 @@ having
   DIFF>0;
 drop table t10, t11;
 
+--echo # Check rocksdb_mrr_batch_size use MRR
+set @saved_rocksdb_mrr_batch_size=@@rocksdb_mrr_batch_size;
+set rocksdb_mrr_batch_size=5;
+select variable_value into @val1 from performance_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
+
+--replace_column 11 #
+explain select * from t2 force index (primary) where pk in (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+
+select * from t2 force index (primary) where pk in (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+
+# 5 refills * 5 rowids per pass >= 21
+select variable_value-@val1 from performance_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
+
+--echo # Check rocksdb_mrr_batch_size use BKA
+create table hundred(a int primary key);
+insert into hundred select A.a + B.a* 10 from t0 A, t0 B;
+analyze table hundred, t2;
+--replace_column 10 # 11 #
+eval explain select * from hundred, t2 where t2.pk=hundred.a;
+select variable_value into @val1 from performance_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
+select * from hundred, t2 where t2.pk=hundred.a;
+select variable_value-@val1 from performance_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
+drop table hundred;
+set rocksdb_mrr_batch_size=@saved_rocksdb_mrr_batch_size;
+
 --echo # This will use MRR:
 explain select * from t2 where pk in (1,2,3,4,5);
 

--- a/mysql-test/suite/rocksdb/t/rocksdb_mrr.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_mrr.test
@@ -290,6 +290,12 @@ delete from t3 where col1 in (3,5);
 explain
 select * from t0 left join t3 on t3.col1=t0.a where t3.pk1 is null;
 select * from t0 left join t3 on t3.col1=t0.a where t3.pk1 is null;
+
+--replace_column 11 #
+explain 
+select * from t0 left join t4 using (a) where t4.a is null;
+select * from t0 left join t4 using (a) where t4.a is null;
+
 set optimizer_switch='mrr=off';
 select * from t0 left join t3 on t3.col1=t0.a where t3.pk1 is null;
 set optimizer_switch='mrr=on';

--- a/mysql-test/suite/rocksdb/t/rocksdb_mrr2-master.opt
+++ b/mysql-test/suite/rocksdb/t/rocksdb_mrr2-master.opt
@@ -1,0 +1,1 @@
+--rocksdb-block-cache-size=1024

--- a/mysql-test/suite/rocksdb/t/rocksdb_mrr2.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_mrr2.test
@@ -1,0 +1,37 @@
+#
+# Test if MyRocks/MRR correctly releases PinnableSlice objects with value data
+# (if it doesn't, this test will produce valgrind errors: invalid memory reads
+# inside my_md5_hash)
+#
+--source include/have_rocksdb.inc
+
+show variables like 'rocksdb_block_cache_size%';
+create table t0(a int);
+insert into t0 values (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+
+create table t1(a int);
+insert into t1 select A.a + B.a* 10 + C.a * 100  from t0 A, t0 B, t0 C;
+
+create table t2 (
+  pk int primary key,
+  col1 int,
+  blob1 text,
+  blob2 text
+) engine=rocksdb;
+
+insert into t2 select a,a,repeat(a,100), repeat(a,200) from t1;
+
+set global rocksdb_force_flush_memtable_now=1;
+
+set @save_optimizer_switch=@@optimizer_switch;
+set optimizer_switch='mrr=on,mrr_cost_based=off,batched_key_access=on';
+
+--replace_column 11 #
+explain 
+select pk, col1 from t2,t0 
+where t2.pk=t0.a*90 and md5(blob1)=md5(repeat(t2.pk,100)) and md5(blob2)=md5(repeat(t2.pk,200));
+
+select pk, col1 from t2,t0
+where t2.pk=t0.a*90 and md5(blob1)=md5(repeat(t2.pk,100)) and md5(blob2)=md5(repeat(t2.pk,200));
+
+drop table t0,t1,t2;

--- a/mysql-test/suite/rocksdb/t/rocksdb_mrr_debug.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_mrr_debug.test
@@ -1,0 +1,58 @@
+--source include/have_rocksdb.inc
+--source include/have_debug_sync.inc
+
+--enable_connect_log
+
+create table t0(a int);
+insert into t0 values (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+
+create table t1(a int);
+insert into t1 select A.a + B.a* 10 + C.a * 100 from t0 A, t0 B, t0 C;
+
+create table t2 (
+  pk int primary key,
+  col1 int,
+  filler char(32)
+) engine=rocksdb;
+
+insert into t2 select a,a,a from t1;
+set global rocksdb_force_flush_memtable_now=1;
+
+set @save_optimizer_switch=@@optimizer_switch;
+set optimizer_switch='mrr=on,mrr_cost_based=off,batched_key_access=on';
+
+--replace_column 11 #
+explain 
+select * from t2,t0 where t2.pk=t0.a;
+
+select variable_value into @n_multiget_orig 
+from performance_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
+
+set debug_sync = 'rocksdb.mrr_fill_buffer.loop SIGNAL target_ready WAIT_FOR simulate_kill';
+send select * from t2,t0 where t2.pk=t0.a;
+
+connect (con1,localhost,root,,);
+set debug_sync = 'now WAIT_FOR target_ready';
+set @a= (select id from information_schema.processlist where state='debug sync point: rocksdb.mrr_fill_buffer.loop');
+send kill query @a;
+
+# Note: it seems, just KILL QUERY will already cause debug sync point wait to
+# finish.  Leave the signal anyway since it doesn't hurt
+connect (con2,localhost,root,,);
+set debug_sync = 'now SIGNAL simulate_kill';
+
+connection con1;
+reap;
+
+connection default;
+--error ER_QUERY_INTERRUPTED
+reap;
+
+--echo # Check that we didn't continue till the MultiGet() call. The following will
+--echo # return 0:
+select variable_value into @n_multiget_new
+from performance_schema.global_status where variable_name='ROCKSDB_NUMBER_MULTIGET_GET';
+
+select @n_multiget_new - @n_multiget_orig;
+
+drop table t0,t1,t2;

--- a/mysql-test/suite/rocksdb_sys_vars/r/all_vars.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/all_vars.result
@@ -9,5 +9,7 @@ There should be *no* long test name listed below:
 select variable_name as `There should be *no* variables listed below:` from t2
 left join t1 on variable_name=test_name where test_name is null ORDER BY variable_name;
 There should be *no* variables listed below:
+ROCKSDB_MRR_BATCH_SIZE
+ROCKSDB_MRR_BATCH_SIZE
 drop table t1;
 drop table t2;

--- a/mysql-test/suite/rocksdb_sys_vars/r/all_vars.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/all_vars.result
@@ -9,7 +9,5 @@ There should be *no* long test name listed below:
 select variable_name as `There should be *no* variables listed below:` from t2
 left join t1 on variable_name=test_name where test_name is null ORDER BY variable_name;
 There should be *no* variables listed below:
-ROCKSDB_MRR_BATCH_SIZE
-ROCKSDB_MRR_BATCH_SIZE
 drop table t1;
 drop table t2;

--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_mrr_batch_size_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_mrr_batch_size_basic.result
@@ -1,0 +1,93 @@
+CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(100);
+INSERT INTO valid_values VALUES(1);
+INSERT INTO valid_values VALUES(0);
+CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO invalid_values VALUES('\'aaa\'');
+SET @start_global_value = @@global.ROCKSDB_MRR_BATCH_SIZE;
+SELECT @start_global_value;
+@start_global_value
+100
+SET @start_session_value = @@session.ROCKSDB_MRR_BATCH_SIZE;
+SELECT @start_session_value;
+@start_session_value
+100
+'# Setting to valid values in global scope#'
+"Trying to set variable @@global.ROCKSDB_MRR_BATCH_SIZE to 100"
+SET @@global.ROCKSDB_MRR_BATCH_SIZE   = 100;
+SELECT @@global.ROCKSDB_MRR_BATCH_SIZE;
+@@global.ROCKSDB_MRR_BATCH_SIZE
+100
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_MRR_BATCH_SIZE = DEFAULT;
+SELECT @@global.ROCKSDB_MRR_BATCH_SIZE;
+@@global.ROCKSDB_MRR_BATCH_SIZE
+100
+"Trying to set variable @@global.ROCKSDB_MRR_BATCH_SIZE to 1"
+SET @@global.ROCKSDB_MRR_BATCH_SIZE   = 1;
+SELECT @@global.ROCKSDB_MRR_BATCH_SIZE;
+@@global.ROCKSDB_MRR_BATCH_SIZE
+1
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_MRR_BATCH_SIZE = DEFAULT;
+SELECT @@global.ROCKSDB_MRR_BATCH_SIZE;
+@@global.ROCKSDB_MRR_BATCH_SIZE
+100
+"Trying to set variable @@global.ROCKSDB_MRR_BATCH_SIZE to 0"
+SET @@global.ROCKSDB_MRR_BATCH_SIZE   = 0;
+SELECT @@global.ROCKSDB_MRR_BATCH_SIZE;
+@@global.ROCKSDB_MRR_BATCH_SIZE
+0
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_MRR_BATCH_SIZE = DEFAULT;
+SELECT @@global.ROCKSDB_MRR_BATCH_SIZE;
+@@global.ROCKSDB_MRR_BATCH_SIZE
+100
+'# Setting to valid values in session scope#'
+"Trying to set variable @@session.ROCKSDB_MRR_BATCH_SIZE to 100"
+SET @@session.ROCKSDB_MRR_BATCH_SIZE   = 100;
+SELECT @@session.ROCKSDB_MRR_BATCH_SIZE;
+@@session.ROCKSDB_MRR_BATCH_SIZE
+100
+"Setting the session scope variable back to default"
+SET @@session.ROCKSDB_MRR_BATCH_SIZE = DEFAULT;
+SELECT @@session.ROCKSDB_MRR_BATCH_SIZE;
+@@session.ROCKSDB_MRR_BATCH_SIZE
+100
+"Trying to set variable @@session.ROCKSDB_MRR_BATCH_SIZE to 1"
+SET @@session.ROCKSDB_MRR_BATCH_SIZE   = 1;
+SELECT @@session.ROCKSDB_MRR_BATCH_SIZE;
+@@session.ROCKSDB_MRR_BATCH_SIZE
+1
+"Setting the session scope variable back to default"
+SET @@session.ROCKSDB_MRR_BATCH_SIZE = DEFAULT;
+SELECT @@session.ROCKSDB_MRR_BATCH_SIZE;
+@@session.ROCKSDB_MRR_BATCH_SIZE
+100
+"Trying to set variable @@session.ROCKSDB_MRR_BATCH_SIZE to 0"
+SET @@session.ROCKSDB_MRR_BATCH_SIZE   = 0;
+SELECT @@session.ROCKSDB_MRR_BATCH_SIZE;
+@@session.ROCKSDB_MRR_BATCH_SIZE
+0
+"Setting the session scope variable back to default"
+SET @@session.ROCKSDB_MRR_BATCH_SIZE = DEFAULT;
+SELECT @@session.ROCKSDB_MRR_BATCH_SIZE;
+@@session.ROCKSDB_MRR_BATCH_SIZE
+100
+'# Testing with invalid values in global scope #'
+"Trying to set variable @@global.ROCKSDB_MRR_BATCH_SIZE to 'aaa'"
+SET @@global.ROCKSDB_MRR_BATCH_SIZE   = 'aaa';
+Got one of the listed errors
+SELECT @@global.ROCKSDB_MRR_BATCH_SIZE;
+@@global.ROCKSDB_MRR_BATCH_SIZE
+100
+SET @@global.ROCKSDB_MRR_BATCH_SIZE = @start_global_value;
+SELECT @@global.ROCKSDB_MRR_BATCH_SIZE;
+@@global.ROCKSDB_MRR_BATCH_SIZE
+100
+SET @@session.ROCKSDB_MRR_BATCH_SIZE = @start_session_value;
+SELECT @@session.ROCKSDB_MRR_BATCH_SIZE;
+@@session.ROCKSDB_MRR_BATCH_SIZE
+100
+DROP TABLE valid_values;
+DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_mrr_batch_size_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_mrr_batch_size_basic.test
@@ -1,0 +1,17 @@
+--source include/have_rocksdb.inc
+
+CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(100);
+INSERT INTO valid_values VALUES(1);
+INSERT INTO valid_values VALUES(0);
+
+CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO invalid_values VALUES('\'aaa\'');
+
+--let $sys_var=ROCKSDB_MRR_BATCH_SIZE
+--let $read_only=0
+--let $session=1
+--source ../include/rocksdb_sys_var.inc
+
+DROP TABLE valid_values;
+DROP TABLE invalid_values;

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -3490,6 +3490,21 @@ void get_sweep_read_cost(TABLE *table, ha_rows nrows, bool interrupted,
 */
 #define HA_MRR_SUPPORT_SORTED 256
 
+/*
+  SQL layer passes this as an argument to multi_range_read_info() to indicate
+  that the lookup keys are full extended keys for the index
+*/
+#define HA_MRR_FULL_EXTENDED_KEYS 512
+
+/*
+  MRR implementation returns this flag to indicate that when the optimizer has
+  a choice between
+   - ref(const) access (which doesnt use the MRR interface)
+   - range access (which does use MRR interface)
+  the latter should be preferred.
+*/
+#define HA_MRR_CONVERT_REF_TO_RANGE 1024
+
 class ha_statistics {
  public:
   ulonglong data_file_length;     /* Length off data file */

--- a/sql/sql_optimizer.cc
+++ b/sql/sql_optimizer.cc
@@ -130,9 +130,9 @@ static bool test_if_skip_sort_order(JOIN_TAB *tab, ORDER_with_src &order,
 static Item_func_match *test_if_ft_index_order(ORDER *order);
 
 static uint32 get_key_length_tmp_table(Item *item);
-static bool can_switch_from_ref_to_range(THD *thd, JOIN_TAB *tab,
-                                         enum_order ordering,
-                                         bool recheck_range);
+static const char *can_switch_from_ref_to_range(THD *thd, JOIN_TAB *tab,
+                                                enum_order ordering,
+                                                bool recheck_range);
 
 static bool has_not_null_predicate(Item *cond, Item_field *not_null_item);
 
@@ -2454,15 +2454,17 @@ bool JOIN::prune_table_partitions() {
   @param recheck_range Check possibility of range scan even if it is currently
                        unviable.
 
-  @return true   Range is better than ref
-  @return false  Ref is better or switch isn't possible
+  @return Pointer  Range is better than ref. The pointer points to a string
+                   describing why (the string is intended to be used in the
+                   optimizer trace)
+  @return nullptr  Ref is better or switch isn't possible
 
   @todo: This decision should rather be made in best_access_path()
 */
 
-static bool can_switch_from_ref_to_range(THD *thd, JOIN_TAB *tab,
-                                         enum_order ordering,
-                                         bool recheck_range) {
+static const char *can_switch_from_ref_to_range(THD *thd, JOIN_TAB *tab,
+                                                enum_order ordering,
+                                                bool recheck_range) {
   if ((tab->quick() &&                                       // 1)
        tab->position()->key->key == tab->quick()->index) ||  // 2)
       recheck_range) {
@@ -2472,7 +2474,7 @@ static bool can_switch_from_ref_to_range(THD *thd, JOIN_TAB *tab,
 
     calc_length_and_keyparts(tab->position()->key, tab,
                              tab->position()->key->key, tab->prefix_tables(),
-                             NULL, &length, &keyparts, &dep_map, &maybe_null);
+                             nullptr, &length, &keyparts, &dep_map, &maybe_null);
     if (!maybe_null &&  // 3)
         !dep_map)       // 4)
     {
@@ -2497,7 +2499,7 @@ static bool can_switch_from_ref_to_range(THD *thd, JOIN_TAB *tab,
           if (length < qck->max_used_key_length) {
             delete tab->quick();
             tab->set_quick(qck);
-            return true;
+            return "uses_more_keyparts";
           } else {
             Opt_trace_object(trace, "access_type_unchanged")
                 .add("ref_key_length", length)
@@ -2505,11 +2507,27 @@ static bool can_switch_from_ref_to_range(THD *thd, JOIN_TAB *tab,
             delete qck;
           }
         }
-      } else
-        return length < tab->quick()->max_used_key_length;  // 5)
+      } else if (length == tab->quick()->max_used_key_length &&
+                 tab->quick()->get_type() == QUICK_SELECT_I::QS_TYPE_RANGE) {
+        /*
+          If there was a quick select that
+           - was scanning the same range
+           - used MRR
+           - MRR implementation indicated that it's preferred to use MRR over
+             ref(const).
+          then switch to range access as it will read rows using the MRR interface
+        */
+        auto *qr = static_cast<QUICK_RANGE_SELECT*>(tab->quick());
+        if ((qr->mrr_flags & HA_MRR_USE_DEFAULT_IMPL) == 0 &&
+            (qr->mrr_flags & HA_MRR_CONVERT_REF_TO_RANGE) != 0) {
+          return "uses_mrr";
+        }
+      } else {
+        return length < tab->quick()->max_used_key_length ? "uses_more_keyparts" : nullptr;  // 5)
+      }
     }
   }
-  return false;
+  return nullptr;
 }
 
 /**
@@ -2559,7 +2577,8 @@ void JOIN::adjust_access_methods() {
         // From table scan to index scan, thus filter effect needs no recalc.
       }
     } else if (tab->type() == JT_REF) {
-      if (can_switch_from_ref_to_range(thd, tab, ORDER_NOT_RELEVANT, false)) {
+      const char *switch_reason = can_switch_from_ref_to_range(thd, tab, ORDER_NOT_RELEVANT, false);
+      if (switch_reason != nullptr) {
         tab->set_type(JT_RANGE);
 
         Opt_trace_context *const trace = &thd->opt_trace;
@@ -2570,7 +2589,7 @@ void JOIN::adjust_access_methods() {
                       tab->table()->key_info[tab->position()->key->key].name)
             .add_alnum("old_type", "ref")
             .add_alnum("new_type", join_type_str[tab->type()])
-            .add_alnum("cause", "uses_more_keyparts");
+            .add_alnum("cause", switch_reason);
 
         tab->use_quick = QS_RANGE;
         tab->position()->filter_effect = COND_FILTER_STALE;
@@ -3186,6 +3205,11 @@ static bool setup_join_buffering(JOIN_TAB *tab, JOIN *join,
 
       if (tab->table()->covering_keys.is_set(tab->ref().key))
         join_cache_flags |= HA_MRR_INDEX_ONLY;
+
+      if (tab->table()->key_info[tab->ref().key].actual_key_parts ==
+          tab->ref().key_parts)
+        join_cache_flags |= HA_MRR_FULL_EXTENDED_KEYS;
+
       rows = tab->table()->file->multi_range_read_info(
           tab->ref().key, 10, 20, &bufsz, &join_cache_flags, &cost);
       /*

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -15829,14 +15829,13 @@ class Mrr_rowid_source {
 // Rowid source that produces rowids by enumerating a sequence of ranges
 //
 class Mrr_pk_scan_rowid_source : public Mrr_rowid_source {
-  range_seq_t mrr_seq_it;
   bool mrr_ranges_eof;  // true means we've got eof when enumerating the ranges.
   ha_rocksdb *self;
  public:
   Mrr_pk_scan_rowid_source(ha_rocksdb *self_arg, void *seq_init_param,
                            uint n_ranges, uint mode) :
     mrr_ranges_eof(false), self(self_arg) {
-    mrr_seq_it = self->mrr_funcs.init(seq_init_param, n_ranges, mode);
+    self->mrr_iter = self->mrr_funcs.init(seq_init_param, n_ranges, mode);
   }
 
   int get_next_rowid(uchar *buf, int *size, char **range_ptr) override {
@@ -15845,7 +15844,7 @@ class Mrr_pk_scan_rowid_source : public Mrr_rowid_source {
     }
 
     KEY_MULTI_RANGE range{};
-    if ((mrr_ranges_eof = self->mrr_funcs.next(mrr_seq_it, &range))) {
+    if ((mrr_ranges_eof = self->mrr_funcs.next(self->mrr_iter, &range))) {
       return HA_ERR_END_OF_FILE; //  Got eof now
     }
 

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -3165,6 +3165,12 @@ class Rdb_transaction {
       const rocksdb::Slice &key, rocksdb::PinnableSlice *const value,
       bool exclusive, const bool do_validate) = 0;
 
+  virtual void multi_get(rocksdb::ColumnFamilyHandle *const column_family,
+                         const size_t num_keys, const rocksdb::Slice *keys,
+                         rocksdb::PinnableSlice *values,
+                         rocksdb::Status *statuses,
+                         const bool sorted_input) const = 0;
+
   rocksdb::Iterator *get_iterator(
       rocksdb::ColumnFamilyHandle *const column_family, bool skip_bloom_filter,
       bool fill_cache, const rocksdb::Slice &eq_cond_lower_bound,
@@ -3561,6 +3567,14 @@ class Rdb_transaction_impl : public Rdb_transaction {
     return m_rocksdb_tx->Get(m_read_opts, column_family, key, value);
   }
 
+  void multi_get(rocksdb::ColumnFamilyHandle *const column_family,
+                const size_t num_keys, const rocksdb::Slice *keys,
+                rocksdb::PinnableSlice *values, rocksdb::Status *statuses,
+                const bool sorted_input) const override {
+    m_rocksdb_tx->MultiGet(m_read_opts, column_family, num_keys, keys, values,
+                           statuses, sorted_input);
+  }
+
   rocksdb::Status get_for_update(
       rocksdb::ColumnFamilyHandle *const column_family,
       const rocksdb::Slice &key, rocksdb::PinnableSlice *const value,
@@ -3871,6 +3885,14 @@ class Rdb_writebatch_impl : public Rdb_transaction {
     }
 
     return get(column_family, key, value);
+  }
+
+  void multi_get(rocksdb::ColumnFamilyHandle *const column_family,
+                 const size_t num_keys, const rocksdb::Slice *keys,
+                 rocksdb::PinnableSlice *values, rocksdb::Status *statuses,
+                 const bool sorted_input) const override {
+    m_batch->MultiGetFromBatchAndDB(rdb, m_read_opts, column_family, num_keys,
+                                    keys, values, statuses, sorted_input);
   }
 
   rocksdb::Iterator *get_iterator(
@@ -6628,6 +6650,10 @@ ha_rocksdb::ha_rocksdb(my_core::handlerton *const hton,
       m_keyread_only(false),
       m_insert_with_update(false),
       m_dup_pk_found(false),
+      mrr_rowid_reader(nullptr),
+      mrr_n_elements(0),
+      mrr_enabled_keyread(false),
+      mrr_used_cpk(false),
       m_in_rpl_delete_rows(false),
       m_in_rpl_update_rows(false) {}
 
@@ -8421,8 +8447,12 @@ int ha_rocksdb::read_row_from_secondary_key(uchar *const buf,
 #ifndef DBUG_OFF
   m_keyread_only = save_keyread_only;
 #endif
+  // Due to MRR, now an index-only scan have pushed index condition.
+  // (If it does, we follow non-index only code path here, except that
+  //  we don't fetch the row).
+  bool have_icp = (pushed_idx_cond && pushed_idx_cond_keyno == active_index);
 
-  if (covered_lookup && m_lock_rows == RDB_LOCK_NONE) {
+  if (covered_lookup && m_lock_rows == RDB_LOCK_NONE && !have_icp) {
     pk_size =
         kd.get_primary_key_tuple(table, *m_pk_descr, &rkey, m_pk_packed_tuple);
     if (pk_size == RDB_INVALID_KEY_LEN) {
@@ -8443,7 +8473,9 @@ int ha_rocksdb::read_row_from_secondary_key(uchar *const buf,
       if (pk_size == RDB_INVALID_KEY_LEN) {
         rc = HA_ERR_ROCKSDB_CORRUPT_DATA;
       } else {
-        rc = get_row_by_rowid(buf, m_pk_packed_tuple, pk_size);
+        if (!covered_lookup || m_lock_rows != RDB_LOCK_NONE) {
+          rc = get_row_by_rowid(buf, m_pk_packed_tuple, pk_size);
+        }
       }
     }
   }
@@ -10995,6 +11027,10 @@ int ha_rocksdb::index_end() {
   active_index = MAX_KEY;
   in_range_check_pushed_down = false;
 
+  if (mrr_rowid_reader) {
+    mrr_free();
+  }
+
   DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
@@ -11224,6 +11260,8 @@ int ha_rocksdb::info(uint flag) {
     if (stats.records != 0) {
       stats.mean_rec_length = stats.data_file_length / stats.records;
     }
+
+    stats.mrr_length_per_rec = mrr_get_length_per_rec();
   }
 
   if (flag & HA_STATUS_CONST) {
@@ -15636,6 +15674,530 @@ void Rdb_compaction_stats::record_end(rocksdb::CompactionJobInfo info) {
   DBUG_ASSERT(record.end_timestamp != static_cast<time_t>(-1));
   record.info = std::move(info);
   m_history.emplace_back(std::move(record));
+}
+
+/****************************************************************************
+ * Multi-Range-Read implementation based on RocksDB's MultiGet() call
+ ***************************************************************************/
+
+/*
+  Check if MultiGet-MRR can be used to scan given list of ranges.
+
+  @param  seq            List of ranges to scan
+  @param  bufsz     OUT  How much buffer space will be required
+  @param  flags   INOUT  Properties of the scan to be done
+
+  @return
+     HA_POS_ERROR - The scan cannot be done at all
+     Other value  - Number of expected output rows
+*/
+ha_rows ha_rocksdb::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
+                                                void *seq_init_param,
+                                                uint n_ranges, uint *bufsz,
+                                                uint *flags,
+                                                Cost_estimate *cost) {
+  ha_rows res;
+  THD *thd = table->in_use;
+
+  // We allow MultiGet-MRR only with these settings:
+  //   optimizer_switch='mrr=on,mrr_cost_based=off'
+  // mrr_cost_based is not supported
+  bool mrr_enabled =
+      thd->optimizer_switch_flag(OPTIMIZER_SWITCH_MRR) &&
+      !thd->optimizer_switch_flag(OPTIMIZER_SWITCH_MRR_COST_BASED);
+
+  res = handler::multi_range_read_info_const(keyno, seq, seq_init_param,
+                                             n_ranges, bufsz, flags, cost);
+
+  if (res == HA_POS_ERROR) {
+    return res; // Not possible to do the scan
+  }
+
+  // Use the default MRR implementation if @@optimizer_switch value tells us
+  // to, or if the query needs to do a locking read.
+  if (!mrr_enabled || m_lock_rows != RDB_LOCK_NONE) {
+    return res;
+  }
+
+  if (keyno == table->s->primary_key) {
+    // We need all ranges to be single-point lookups using full PK values.
+    // (Range scans, like "pk BETWEEN 10 and 20" or restrictions on PK prefix
+    //  cannot be used)
+    bool all_eq_ranges = true;
+    KEY_MULTI_RANGE range{};
+    range_seq_t seq_it;
+    seq_it = seq->init(seq_init_param, n_ranges, *flags);
+    while (!seq->next(seq_it, &range)) {
+      if ((range.range_flag & UNIQUE_RANGE) == 0) {
+        all_eq_ranges = false;
+        break;
+      }
+      if (table->in_use->killed) {
+        return HA_POS_ERROR;
+      }
+    }
+
+    if (all_eq_ranges) {
+      // Indicate that we will use MultiGet MRR
+      *flags &= ~HA_MRR_USE_DEFAULT_IMPL;
+      *flags |= HA_MRR_SUPPORT_SORTED;
+      *bufsz = mrr_get_length_per_rec() * res * 1.1 + 1;
+    }
+  } else {
+    // For scans on secondary keys, we use MultiGet when we read the PK values.
+    // We only need PK values when the scan is non-index-only.
+    if ((*flags & HA_MRR_INDEX_ONLY) == 0) {
+      *flags &= ~HA_MRR_SUPPORT_SORTED; //  Non-sorted mode
+      *flags &= ~HA_MRR_USE_DEFAULT_IMPL;
+      *flags |= HA_MRR_CONVERT_REF_TO_RANGE;
+      *bufsz = mrr_get_length_per_rec() * res * 1.1 + 1;
+    }
+  }
+
+  return res;
+}
+
+ha_rows ha_rocksdb::multi_range_read_info(uint keyno, uint n_ranges, uint keys,
+                                          uint *bufsz, uint *flags,
+                                          Cost_estimate *cost) {
+  ha_rows res;
+  THD *thd = table->in_use;
+  bool mrr_enabled =
+      thd->optimizer_switch_flag(OPTIMIZER_SWITCH_MRR) &&
+      !thd->optimizer_switch_flag(OPTIMIZER_SWITCH_MRR_COST_BASED);
+
+  res =
+      handler::multi_range_read_info(keyno, n_ranges, keys, bufsz, flags, cost);
+  if (res || m_lock_rows != RDB_LOCK_NONE || !mrr_enabled) {
+    return res;
+  }
+
+  if (keyno == table->s->primary_key && (*flags & HA_MRR_FULL_EXTENDED_KEYS) != 0) {
+    *flags &= ~HA_MRR_USE_DEFAULT_IMPL;
+    *flags |= HA_MRR_CONVERT_REF_TO_RANGE;
+    *flags |= HA_MRR_SUPPORT_SORTED;
+  }
+
+  if (keyno != table->s->primary_key && (*flags & HA_MRR_INDEX_ONLY) == 0) {
+    *flags &= ~HA_MRR_USE_DEFAULT_IMPL;
+    *flags |= HA_MRR_CONVERT_REF_TO_RANGE;
+    *flags &= ~HA_MRR_SUPPORT_SORTED; // Non-sorted mode
+  }
+
+  return 0; // "0" means ok, despite the ha_rows return type.
+}
+
+//
+// Source of Rowids for the MRR scan
+//
+class Mrr_rowid_source {
+ public:
+  // Get the next rowid, in the on-disk mem-comparable form. Also, get the
+  // "range pointer" associated with the rowid (it is returned in *range_ptr).
+  virtual int get_next_rowid(uchar *buf, int *size, char **range_ptr) = 0;
+  virtual bool eof() = 0;
+  virtual ~Mrr_rowid_source() = default;
+};
+
+//
+// Rowid source that produces rowids by enumerating a sequence of ranges
+//
+class Mrr_pk_scan_rowid_source : public Mrr_rowid_source {
+  range_seq_t mrr_seq_it;
+  bool mrr_ranges_eof;  // true means we've got eof when enumerating the ranges.
+  ha_rocksdb *self;
+ public:
+  Mrr_pk_scan_rowid_source(ha_rocksdb *self_arg, void *seq_init_param,
+                           uint n_ranges, uint mode) :
+    mrr_ranges_eof(false), self(self_arg) {
+    mrr_seq_it = self->mrr_funcs.init(seq_init_param, n_ranges, mode);
+  }
+
+  int get_next_rowid(uchar *buf, int *size, char **range_ptr) override {
+    if (mrr_ranges_eof) {
+      return HA_ERR_END_OF_FILE; //  At eof already
+    }
+
+    KEY_MULTI_RANGE range{};
+    if ((mrr_ranges_eof = self->mrr_funcs.next(mrr_seq_it, &range))) {
+      return HA_ERR_END_OF_FILE; //  Got eof now
+    }
+
+    key_part_map all_parts_map =
+        (key_part_map(1) << self->m_pk_descr->get_key_parts()) - 1;
+    DBUG_ASSERT(range.start_key.keypart_map == all_parts_map);
+    DBUG_ASSERT(range.end_key.keypart_map == all_parts_map);
+    DBUG_ASSERT(range.start_key.flag == HA_READ_KEY_EXACT);
+    DBUG_ASSERT(range.end_key.flag == HA_READ_AFTER_KEY);
+
+    *range_ptr = range.ptr;
+    *size = self->m_pk_descr->pack_index_tuple(self->table,
+                                               self->m_pack_buffer,
+                                               buf, range.start_key.key,
+                                               all_parts_map);
+    return 0;
+  }
+
+  bool eof() override { return mrr_ranges_eof; }
+};
+
+//
+// Rowid source that produces rowids by doing an index-only scan on a
+// secondary index and returning rowids from the index records
+//
+class Mrr_sec_key_rowid_source : public Mrr_rowid_source {
+  ha_rocksdb *self;
+  int err;
+ public:
+  explicit Mrr_sec_key_rowid_source(ha_rocksdb *self_arg)
+    : self(self_arg), err(0) { }
+
+  int init(RANGE_SEQ_IF *seq, void *seq_init_param,
+           uint n_ranges, uint mode) {
+    self->m_keyread_only = true;
+    self->mrr_enabled_keyread = true;
+    return self->handler::multi_range_read_init(seq, seq_init_param, n_ranges,
+                                                mode, nullptr);
+  }
+
+  int get_next_rowid(uchar *buf, int *size, char **range_ptr) override {
+    if (err) {
+      return err;
+    }
+
+    while ((err = self->handler::multi_range_read_next(range_ptr)) == 0) {
+      if (self->mrr_funcs.skip_index_tuple != nullptr &&
+          self->mrr_funcs.skip_index_tuple(self->mrr_iter, *range_ptr)) {
+        // BKA's variant of "Index Condition Pushdown" check failed
+        continue;
+      }
+
+      if (self->mrr_funcs.skip_record != nullptr &&
+          self->mrr_funcs.skip_record(self->mrr_iter, *range_ptr,
+                                      (uchar*)self->m_last_rowkey.ptr())) {
+        continue;
+      }
+
+      memcpy(buf, self->m_last_rowkey.ptr(), self->m_last_rowkey.length());
+      *size = self->m_last_rowkey.length();
+      break;
+    }
+    return err;
+  }
+
+  bool eof() override {
+    return err != 0;
+  }
+};
+
+// Initialize an MRR scan
+int ha_rocksdb::multi_range_read_init(RANGE_SEQ_IF *seq, void *seq_init_param,
+                                      uint n_ranges, uint mode,
+                                      HANDLER_BUFFER *buf) {
+  int res;
+
+  if (!current_thd->optimizer_switch_flag(OPTIMIZER_SWITCH_MRR) ||
+      (mode & HA_MRR_USE_DEFAULT_IMPL) != 0 ||
+      (buf->buffer_end - buf->buffer < mrr_get_length_per_rec()) ||
+      (active_index != table->s->primary_key && (mode & HA_MRR_SORTED) != 0)) {
+    mrr_uses_default_impl = true;
+    res = handler::multi_range_read_init(seq, seq_init_param, n_ranges, mode,
+                                         buf);
+    return res;
+  }
+
+  // Ok, using a non-default MRR implementation, MultiGet-MRR
+
+  mrr_uses_default_impl = false;
+  mrr_n_elements = 0;  // nothing to cleanup, yet.
+  mrr_enabled_keyread = false;
+  mrr_rowid_reader = nullptr;
+
+  mrr_funcs = *seq;
+  mrr_buf = *buf;
+
+  bool is_mrr_assoc = !MY_TEST(mode & HA_MRR_NO_ASSOCIATION);
+  if (is_mrr_assoc) {
+    ++table->in_use->status_var.ha_multi_range_read_init_count;
+  }
+
+  mrr_sorted_mode = (mode & HA_MRR_SORTED) != 0;
+
+  if (active_index == table->s->primary_key) {
+    // ICP is not supported for PK, so we don't expect that BKA's variant
+    // of ICP would be used:
+    DBUG_ASSERT(!mrr_funcs.skip_index_tuple);
+    mrr_used_cpk = true;
+    mrr_rowid_reader =
+      new Mrr_pk_scan_rowid_source(this, seq_init_param, n_ranges, mode);
+  } else {
+    mrr_used_cpk = false;
+    auto reader = new Mrr_sec_key_rowid_source(this);
+    reader->init(seq, seq_init_param, n_ranges, mode);
+    mrr_rowid_reader = reader;
+  }
+
+  res = mrr_fill_buffer();
+
+  // note: here, we must NOT return HA_ERR_END_OF_FILE even if we know there
+  // are no matches. We should return 0 here and return HA_ERR_END_OF_FILE
+  // from the first multi_range_read_next() call.
+  if (res == HA_ERR_END_OF_FILE) {
+    res = 0;
+  }
+
+  return res;
+}
+
+// Return the amount of buffer space that MRR scan requires for each record
+// returned
+uint ha_rocksdb::mrr_get_length_per_rec() {
+  return sizeof(rocksdb::Slice) + sizeof(rocksdb::Status) +
+         sizeof(rocksdb::PinnableSlice) +
+         sizeof(char *) +  // this for KEY_MULTI_RANGE::ptr
+         m_pk_descr->max_storage_fmt_length();
+}
+
+template <typename T> void align_ptr(char **p) {
+  if ((reinterpret_cast<std::uintptr_t>(*p)) % alignof(T)) {
+    *p += alignof(T) - (reinterpret_cast<std::uintptr_t>(*p)) % alignof(T);
+  }
+}
+
+/*
+  We've got a buffer in mrr_buf, and in order to call RocksDB's MultiGet, we
+  need to use this space to construct several arrays of the same size N:
+
+    rocksdb::Slice[N]         - lookup keys
+    rocksdb::Status[N]        - return statuses
+    rocksdb::PinnableSlice[N] - return rows (*)
+    char*[N]                  - "ptr" value of KEY_MULTI_RANGE. This tells the
+                                SQL layer which lookup key the returned record
+                                matches with (**)
+    {PK lookup value}[N]      - The rowid (Primary Key) to lookup. The
+                                corresponding rocksdb::Slice object points to
+                                this key.
+
+  (*) The memory for rows is allocated somewhere inside RocksDB, there's no
+      way to make it use the user-supplied buffer.
+  (**) The engine could specify HA_MRR_NO_ASSOCIATION which would mean "we
+      cannot tell which key the returned records match" we don't do this.
+
+  The PK lookup value is in mem-comparable encoding. It may have variable
+  length (this is the case when table's PRIMARY KEY has VARCHAR() columns).
+  Currently, we optimize for fixed-size primary keys and consume
+  m_pk_descr->max_storage_fmt_length() bytes for each lookup value. One can
+  develop a solution for variable-length PKs but this is not a priority.
+
+  Note that the buffer may be much larger than necessary. For range scans,
+  @@rnd_buffer_size=256K is passed, even if there will be only a few lookup
+  values.
+*/
+int ha_rocksdb::mrr_fill_buffer() {
+  mrr_free_rows();
+  mrr_read_index = 0;
+
+  // This should agree with the code in mrr_get_length_per_rec():
+  ssize_t element_size = sizeof(rocksdb::Slice) + sizeof(rocksdb::Status) +
+                         sizeof(rocksdb::PinnableSlice) +
+                         sizeof(char *) +  // this for KEY_MULTI_RANGE::ptr
+                         m_pk_descr->max_storage_fmt_length();
+
+  // The buffer has space for this many elements:
+  ssize_t n_elements = (mrr_buf.buffer_end - mrr_buf.buffer) / element_size;
+
+  if (n_elements < 1) {
+    // We shouldn't get here as multi_range_read_init() has logic to fall back
+    // to the default MRR implementation in this case.
+    DBUG_ASSERT(0);
+    return HA_ERR_INTERNAL_ERROR;
+  }
+
+  char *buf = (char *)mrr_buf.buffer;
+
+  align_ptr<rocksdb::Slice>(&buf);
+  mrr_keys = (rocksdb::Slice*)buf;
+  buf += sizeof(rocksdb::Slice) * n_elements;
+
+  align_ptr<rocksdb::Status>(&buf);
+  mrr_statuses = (rocksdb::Status*)buf;
+  buf += sizeof(rocksdb::Status) * n_elements;
+
+  align_ptr<rocksdb::PinnableSlice>(&buf);
+  mrr_values = (rocksdb::PinnableSlice*)buf;
+  buf += sizeof(rocksdb::PinnableSlice) * n_elements;
+
+  align_ptr<char*>(&buf);
+  mrr_range_ptrs = (char **)buf;
+  buf += sizeof(char *) * n_elements;
+
+  if (buf + m_pk_descr->max_storage_fmt_length() >= (char*)mrr_buf.buffer_end) {
+    // a VERY unlikely scenario:  we were given a really small buffer,
+    // (probably for just one rowid), and also we had to use some bytes for
+    // alignment. As a result, there's no buffer space left to hold even one
+    // rowid. Return an error immediately to avoid looping.
+    DBUG_ASSERT(0);
+    return HA_ERR_INTERNAL_ERROR;  // error
+  }
+
+  ssize_t elem = 0;
+
+  mrr_n_elements = elem;
+  int key_size;
+  char *range_ptr;
+  int err;
+  while ((err = mrr_rowid_reader->get_next_rowid((uchar*)buf, &key_size,
+                                                 &range_ptr)) == 0) {
+    DEBUG_SYNC(table->in_use, "rocksdb.mrr_fill_buffer.loop");
+    if (table->in_use->killed) {
+      return HA_ERR_QUERY_INTERRUPTED;
+    }
+
+    new (&mrr_keys[elem]) rocksdb::Slice(buf, key_size);
+    new (&mrr_statuses[elem]) rocksdb::Status;
+    new (&mrr_values[elem]) rocksdb::PinnableSlice;
+    mrr_range_ptrs[elem] = range_ptr;
+    buf += key_size;
+
+    elem++;
+    mrr_n_elements= elem;
+
+    if ((elem == n_elements) || (buf + m_pk_descr->max_storage_fmt_length() >=
+                                 (char*)mrr_buf.buffer_end)) {
+      // No more buffer space
+      break;
+    }
+  }
+
+  if (err && err != HA_ERR_END_OF_FILE) {
+    return err;
+  }
+
+  if (mrr_n_elements == 0) {
+    return HA_ERR_END_OF_FILE;  // nothing to scan
+  }
+
+  Rdb_transaction *const tx = get_or_create_tx(table->in_use);
+
+  /* TODO - row stats are gone in 8.0
+  if (active_index == table->s->primary_key) {
+    stats.rows_requested += mrr_n_elements;
+  }
+  */
+
+  tx->multi_get(m_pk_descr->get_cf(), mrr_n_elements, mrr_keys, mrr_values,
+                mrr_statuses, mrr_sorted_mode);
+
+  return 0;
+}
+
+void ha_rocksdb::mrr_free() {
+  // Free everything
+  if (mrr_enabled_keyread) {
+    m_keyread_only = false;
+    mrr_enabled_keyread = false;
+  }
+  mrr_free_rows();
+  delete mrr_rowid_reader;
+  mrr_rowid_reader = nullptr;
+}
+
+void ha_rocksdb::mrr_free_rows() {
+  for (ssize_t i = 0; i < mrr_n_elements; i++) {
+    mrr_values[i].~PinnableSlice();
+    mrr_statuses[i].~Status();
+    // no need to free mrr_keys
+  }
+
+  // There could be rows that MultiGet has returned but MyRocks hasn't
+  // returned to the SQL layer (typically due to LIMIT clause)
+  // Count them in in "rows_read" anyway. (This is only necessary when using
+  // clustered PK. When using a secondary key, the index-only part of the scan
+  // that collects the rowids has caused all counters to be incremented)
+
+  /* TODO - row stats are gone in 8.0
+  if (mrr_used_cpk && mrr_n_elements) {
+    stats.rows_read += mrr_n_elements - mrr_read_index;
+  }
+  */
+
+  mrr_n_elements = 0;
+  // We can't rely on the data from HANDLER_BUFFER once the scan is over, so:
+  mrr_values = nullptr;
+}
+
+int ha_rocksdb::multi_range_read_next(char **range_info) {
+  if (mrr_uses_default_impl) {
+    return handler::multi_range_read_next(range_info);
+  }
+
+  Rdb_transaction *tx = get_tx_from_thd(table->in_use);
+  int rc;
+
+  while (true) {
+    while (true) {
+      if (table->in_use->killed) return HA_ERR_QUERY_INTERRUPTED;
+
+      if (mrr_read_index >= mrr_n_elements) {
+        if (mrr_rowid_reader->eof() || mrr_n_elements == 0) {
+          table->m_status = STATUS_NOT_FOUND;  // not sure if this is necessary?
+          mrr_free_rows();
+          return HA_ERR_END_OF_FILE;
+        }
+
+        if ((rc = mrr_fill_buffer())) {
+          if (rc == HA_ERR_END_OF_FILE) table->m_status = STATUS_NOT_FOUND;
+          return rc;
+        }
+      }
+      // If we found a status that has a row, leave the loop
+      if (mrr_statuses[mrr_read_index].ok()) break;
+
+      // Skip the NotFound errors, return any other error to the SQL layer
+      if (!mrr_statuses[mrr_read_index].IsNotFound())
+        return rdb_error_to_mysql(mrr_statuses[mrr_read_index]);
+
+      mrr_read_index++;
+    }
+    size_t cur_key = mrr_read_index++;
+
+    const rocksdb::Slice &rowkey = mrr_keys[cur_key];
+
+    if (mrr_funcs.skip_record &&
+        mrr_funcs.skip_record(mrr_iter, mrr_range_ptrs[cur_key],
+                              (uchar*)rowkey.data())) {
+      rc = HA_ERR_END_OF_FILE;
+      continue;
+    }
+
+    m_last_rowkey.copy((const char *)rowkey.data(), rowkey.size(),
+                       &my_charset_bin);
+
+    *range_info = mrr_range_ptrs[cur_key];
+
+    m_retrieved_record.Reset();
+    m_retrieved_record.PinSlice(mrr_values[cur_key], &mrr_values[cur_key]);
+
+    /* If we found the record, but it's expired, pretend we didn't find it.  */
+    if (m_pk_descr->has_ttl() &&
+        should_hide_ttl_rec(*m_pk_descr, m_retrieved_record,
+                            tx->m_snapshot_timestamp)) {
+      continue;
+    }
+
+    rc = convert_record_from_storage_format(&rowkey, table->record[0]);
+
+    // When using a secondary index, the scan on secondary index increments the
+    // count
+    if (active_index == table->s->primary_key) {
+      /* TODO - row stats are gone in 8.0
+      stats.rows_read++; */
+      update_row_stats(ROWS_READ);
+    }
+    break;
+  }
+  table->m_status = rc ? STATUS_NOT_FOUND : 0;
+  return rc;
 }
 
 }  // namespace myrocks

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -137,6 +137,8 @@ enum table_cardinality_scan_type {
   SCAN_TYPE_FULL_TABLE,
 };
 
+class Mrr_rowid_source;
+
 uint32_t rocksdb_perf_context_level(THD *const thd);
 
 /**
@@ -669,7 +671,58 @@ class ha_rocksdb : public my_core::handler {
   /*
     Default implementation from cancel_pushed_idx_cond() suits us
   */
+
+  // Multi-Range-Read implmentation
+  ha_rows multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
+                                      void *seq_init_param, uint n_ranges,
+                                      uint *bufsz, uint *flags,
+                                      Cost_estimate *cost) override;
+  ha_rows multi_range_read_info(uint keyno, uint n_ranges, uint keys,
+                                uint *bufsz, uint *flags,
+                                Cost_estimate *cost) override;
+  int multi_range_read_init(RANGE_SEQ_IF *seq, void *seq_init_param,
+                            uint n_ranges, uint mode,
+                            HANDLER_BUFFER *buf) override;
+  int multi_range_read_next(char **range_info) override;
+
+  // Note: the following is only used by DS-MRR, so not needed for MyRocks:
+  // longlong get_memory_buffer_size() const override { return 1024; }
+
  private:
+  // true <=> The scan uses the default MRR implementation, just redirect all
+  // calls to it
+  bool mrr_uses_default_impl;
+
+  bool mrr_sorted_mode;  // true <=> we are in ordered-keys, ordered-results
+                         // mode.
+
+  // RANGE_SEQ_IF is stored in handler::mrr_funcs
+  HANDLER_BUFFER mrr_buf;
+
+  Mrr_rowid_source *mrr_rowid_reader;
+
+  friend class Mrr_rowid_source;
+  friend class Mrr_pk_scan_rowid_source;
+  friend class Mrr_sec_key_rowid_source;
+
+  // MRR parameters and output values
+  rocksdb::Slice *mrr_keys;
+  rocksdb::Status *mrr_statuses;
+  char **mrr_range_ptrs;
+  rocksdb::PinnableSlice *mrr_values;
+
+  ssize_t mrr_n_elements;  // Number of elements in the above arrays
+  ssize_t mrr_read_index;  // Number of the element we will return next
+
+  // if true, MRR code has enabled keyread (and should disable it back)
+  bool mrr_enabled_keyread;
+  bool mrr_used_cpk;
+
+  int mrr_fill_buffer();
+  void mrr_free_rows();
+  void mrr_free();
+  uint mrr_get_length_per_rec();
+
   struct key_def_cf_info {
     std::shared_ptr<rocksdb::ColumnFamilyHandle> cf_handle;
     bool is_reverse_cf;


### PR DESCRIPTION
MultiGet-MRR implementation

Reference Patch: https://github.com/facebook/mysql-5.6/commit/45110dcda26
Reference Patch: https://github.com/facebook/mysql-5.6/commit/be12c8cfb44
Reference Patch: https://github.com/facebook/mysql-5.6/commit/d0c98c1e6a5
Reference Patch: https://github.com/facebook/mysql-5.6/commit/e99310c1197
Reference Patch: https://github.com/facebook/mysql-5.6/commit/888d47893f1
Reference Patch: https://github.com/facebook/mysql-5.6/commit/40d6766e57b

---------- https://github.com/facebook/mysql-5.6/commit/45110dcda26 ----------
Issue790: MultiGet-MRR implementation (#1041)

Summary:
First implementation.
Supports scans on full primary key
Cost-based choice whether to use MRR/BKA is not supported (set mrr=on,mrr_cost_based=off)
Pull Request resolved: #1041

fbshipit-source-id: dba1bfa
---------- https://github.com/facebook/mysql-5.6/commit/be12c8cfb44 ----------
Stabilize rocksdb.rocksdb_mrr

Summary:
This test was flaky because whenever flush/compaction runs, some rocksdb counters may have changed, and the sql query to find difference in counters could return additional changed counters.

To fix this, just disable background work when we run the counters collection query. Also, some unflushed stats on the background thread could also modify these counters. Force a flush using ANALYZE.

Squash with: D17058718

Originally Reviewed By: hermanlee

fbshipit-source-id: 1156d08

---------- https://github.com/facebook/mysql-5.6/commit/d0c98c1e6a5 ----------
Fix rocksdb.rocksdb_mrr

Summary:
Previous attempt at stabilizing (be12c8c) did not work because rocksdb sometimes acquires superversion for multigets depending on whether the thread local version is stale or not. This will depend on whether compaction/flush has happened or not, which is non deterministic.

Instead of trying to fix this, we will just query for the variables that we care about. I feel like querying for all variables with rocksdb_num prefix can potentially get very noisy anyway.

Originally Reviewed By: yizhang82

fbshipit-source-id: 8001e0d
---------- https://github.com/facebook/mysql-5.6/commit/e99310c1197 ----------
Summary:
in ha_rocksdb::multi_range_read_info_const(), when computing required buff size for MRR, it ignore buffer size limit specified in pass in bufsz. This ignorance will cause mysql allocate a lot memory(sometime Gig bytes memory) for some MRR queries.

The change is to honor pass in bufsz value and only allocate memory min(buffer size limit, calculate buffer size)
Pull Request resolved: #1078

Test Plan: MTR

Pulled By: luqun

fbshipit-source-id: dcb9e94
---------- https://github.com/facebook/mysql-5.6/commit/888d47893f1 ----------
Summary:
Previous PR #1078 incorrectly rebase  all_vars.results. As pointed out by sergey, the correct way is to add variable basic testcase.
Pull Request resolved: #1085

Test Plan: MTR

Pulled By: luqun

fbshipit-source-id: 2ad01878c0c
---------- https://github.com/facebook/mysql-5.6/commit/40d6766e57b ----------
Summary:
mrr_iter must be initialized before using in skip_record scenario. otherwise, mysqld will crash during [bka_range_seq_skip_record](https://github.com/facebook/mysql-5.6/blob/42a5444d52f264682c7805bf8117dd884095c476/sql/sql_join_buffer.cc#L2278)(rseq point to a null)

call stack:
```
```
#3 JOIN_CACHE::join_records
Pull Request resolved: #1088

Test Plan: MTR

Pulled By: luqun

fbshipit-source-id: 666dcd911d6