### PR TITLE
PS-7027: MyRocks: Implement optimized support for utf8mb4_bin and other binary collations (5.6)

### DIFF
--- a/mysql-test/suite/rocksdb/r/add_index_inplace.result
+++ b/mysql-test/suite/rocksdb/r/add_index_inplace.result
@@ -276,9 +276,9 @@ SELECT COUNT(*) FROM t1;
 COUNT(*)
 100
 DROP TABLE t1;
-CREATE TABLE t1 (a INT, b TEXT);
+CREATE TABLE t1 (a INT, b TEXT CHARSET utf8 COLLATE utf8_general_ci);
 ALTER TABLE t1 ADD KEY kb(b(10));
-ERROR HY000: Unsupported collation on string indexed column test.t1.b Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.t1.b Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 ALTER TABLE t1 ADD PRIMARY KEY(a);
 DROP TABLE t1;
 set global rocksdb_bulk_load=1;

--- a/mysql-test/suite/rocksdb/r/bypass_select_unsupported.result
+++ b/mysql-test/suite/rocksdb/r/bypass_select_unsupported.result
@@ -211,7 +211,7 @@ ERROR 42000: SELECT statement pattern not supported: ORDER BY is not in index or
 SELECT /*+ bypass */ a, b, c FROM t1 FORCE INDEX(`a`) WHERE a=1 ORDER BY b, b;
 ERROR 42000: SELECT statement pattern not supported: ORDER BY is not in index order
 SELECT /*+ bypass */ a, b, c FROM t3 FORCE INDEX(`a`) WHERE a=1 ORDER BY b, b;
-ERROR 42000: SELECT statement pattern not supported: only utf8_bin, latin1_bin is supported for varchar field
+ERROR 42000: SELECT statement pattern not supported: ORDER BY is not in index order
 SHOW STATUS LIKE 'rocksdb_select_bypass%';
 Variable_name	Value
 rocksdb_select_bypass_executed	0

--- a/mysql-test/suite/rocksdb/r/collation.result
+++ b/mysql-test/suite/rocksdb/r/collation.result
@@ -1,12 +1,12 @@
 call mtr.add_suppression("Invalid pattern");
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text) engine=rocksdb charset utf8;
 ALTER TABLE t1 ADD INDEX (value);
-ERROR HY000: Unsupported collation on string indexed column test.t1.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.t1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 DROP TABLE t1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.t1.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.t1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value3(50))) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.t1.value3 Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.t1.value3 Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_check=0;
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value3(50))) engine=rocksdb charset utf8;
 DROP TABLE t1;
@@ -24,119 +24,119 @@ SET GLOBAL rocksdb_strict_collation_exceptions=t1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE t1;
 CREATE TABLE t2 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.t2.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.t2.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions="t.*";
 CREATE TABLE t123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE t123;
 CREATE TABLE s123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.s123.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.s123.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions=".t.*";
 CREATE TABLE xt123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE xt123;
 CREATE TABLE t123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.t123.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.t123.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions="s.*,t.*";
 CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE s1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE t1;
 CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions="s.*|t.*";
 CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE s1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE t1;
 CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions=",s.*,t.*";
 CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE s1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE t1;
 CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions="|s.*|t.*";
 CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE s1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE t1;
 CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions="s.*,,t.*";
 CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE s1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE t1;
 CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions="s.*||t.*";
 CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE s1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE t1;
 CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions="s.*,t.*,";
 CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE s1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE t1;
 CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions="s.*|t.*|";
 CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE s1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE t1;
 CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions="||||,,,,s.*,,|,,||,t.*,,|||,,,";
 CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE s1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE t1;
 CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions='t1';
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb;
+CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 ALTER TABLE t1 AUTO_INCREMENT=1;
 DROP TABLE t1;
-CREATE TABLE t2 (id INT primary key, value varchar(50), index(value)) engine=rocksdb;
-ERROR HY000: Unsupported collation on string indexed column test.t2.value Use binary collation (binary, latin1_bin, utf8_bin).
-CREATE TABLE t2 (id INT primary key, value varchar(50)) engine=rocksdb;
+CREATE TABLE t2 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
+ERROR HY000: Unsupported collation on string indexed column test.t2.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
+CREATE TABLE t2 (id INT primary key, value varchar(50)) engine=rocksdb charset utf8;
 ALTER TABLE t2 ADD INDEX(value);
-ERROR HY000: Unsupported collation on string indexed column test.t2.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.t2.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 DROP TABLE t2;
 SET GLOBAL rocksdb_strict_collation_exceptions="[a-b";
  Invalid pattern in strict_collation_exceptions: [a-b
 CREATE TABLE a (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.a.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.a.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions="[a-b]";
 CREATE TABLE a (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
 CREATE TABLE b (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
 CREATE TABLE c (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.c.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.c.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 DROP TABLE a, b;
 SET GLOBAL rocksdb_strict_collation_exceptions="abc\\";
  Invalid pattern in strict_collation_exceptions: abc\
 CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.abc.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.abc.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions="abc";
 CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
 CREATE TABLE abcd (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.abcd.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.abcd.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 DROP TABLE abc;
 SET GLOBAL rocksdb_strict_collation_exceptions=null;
 SET GLOBAL rocksdb_strict_collation_check=1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value)) engine=rocksdb charset utf8;
 Warnings:
-Warning	1210	Unsupported collation on string indexed column test.t1.value Use binary collation (binary, latin1_bin, utf8_bin).
+Warning	1210	Unsupported collation on string indexed column test.t1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 DROP TABLE t1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text) engine=rocksdb charset utf8;
 ALTER TABLE t1 ADD INDEX (value);
 Warnings:
-Warning	1210	Unsupported collation on string indexed column test.t1.value Use binary collation (binary, latin1_bin, utf8_bin).
+Warning	1210	Unsupported collation on string indexed column test.t1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 DROP TABLE t1;
 CREATE TABLE t1 (id varchar(20), value varchar(50), value2 varchar(50), value3 text, primary key (id), index(value, value2)) engine=rocksdb charset latin1 collate latin1_bin;
 ALTER TABLE t1 collate=latin1_general_ci;

--- a/mysql-test/suite/rocksdb/r/type_char_secondary_index_only_scan.result
+++ b/mysql-test/suite/rocksdb/r/type_char_secondary_index_only_scan.result
@@ -1,0 +1,220 @@
+CREATE TABLE collations AS SELECT * FROM information_schema.COLLATION_CHARACTER_SET_APPLICABILITY WHERE COLLATION_NAME NOT IN ("latin2_czech_cs", "cp1250_czech_cs") ORDER BY COLLATION_NAME;
+CharSet, Collate, Char Extra, VarChar Extra
+armscii8, armscii8_bin, Using index, Using index
+armscii8, armscii8_general_ci, Using index, Using index
+ascii, ascii_bin, Using index, Using index
+ascii, ascii_general_ci, Using index, Using index
+big5, big5_bin, NULL, NULL
+big5, big5_chinese_ci, NULL, NULL
+binary, binary, Using index, Using index
+cp1250, cp1250_bin, Using index, Using index
+cp1250, cp1250_croatian_ci, Using index, Using index
+cp1250, cp1250_general_ci, Using index, Using index
+cp1250, cp1250_polish_ci, Using index, Using index
+cp1251, cp1251_bin, Using index, Using index
+cp1251, cp1251_bulgarian_ci, Using index, Using index
+cp1251, cp1251_general_ci, Using index, Using index
+cp1251, cp1251_general_cs, Using index, Using index
+cp1251, cp1251_ukrainian_ci, Using index, Using index
+cp1256, cp1256_bin, Using index, Using index
+cp1256, cp1256_general_ci, Using index, Using index
+cp1257, cp1257_bin, Using index, Using index
+cp1257, cp1257_general_ci, Using index, Using index
+cp1257, cp1257_lithuanian_ci, Using index, Using index
+cp850, cp850_bin, Using index, Using index
+cp850, cp850_general_ci, Using index, Using index
+cp852, cp852_bin, Using index, Using index
+cp852, cp852_general_ci, Using index, Using index
+cp866, cp866_bin, Using index, Using index
+cp866, cp866_general_ci, Using index, Using index
+cp932, cp932_bin, NULL, NULL
+cp932, cp932_japanese_ci, NULL, NULL
+dec8, dec8_bin, Using index, Using index
+dec8, dec8_swedish_ci, Using index, Using index
+eucjpms, eucjpms_bin, NULL, NULL
+eucjpms, eucjpms_japanese_ci, NULL, NULL
+euckr, euckr_bin, NULL, NULL
+euckr, euckr_korean_ci, NULL, NULL
+gb2312, gb2312_bin, NULL, NULL
+gb2312, gb2312_chinese_ci, NULL, NULL
+gbk, gbk_bin, NULL, NULL
+gbk, gbk_chinese_ci, NULL, NULL
+geostd8, geostd8_bin, Using index, Using index
+geostd8, geostd8_general_ci, Using index, Using index
+greek, greek_bin, Using index, Using index
+greek, greek_general_ci, Using index, Using index
+hebrew, hebrew_bin, Using index, Using index
+hebrew, hebrew_general_ci, Using index, Using index
+hp8, hp8_bin, Using index, Using index
+hp8, hp8_english_ci, Using index, Using index
+keybcs2, keybcs2_bin, Using index, Using index
+keybcs2, keybcs2_general_ci, Using index, Using index
+koi8r, koi8r_bin, Using index, Using index
+koi8r, koi8r_general_ci, Using index, Using index
+koi8u, koi8u_bin, Using index, Using index
+koi8u, koi8u_general_ci, Using index, Using index
+latin1, latin1_bin, Using index, Using index
+latin1, latin1_danish_ci, Using index, Using index
+latin1, latin1_general_ci, Using index, Using index
+latin1, latin1_general_cs, Using index, Using index
+latin1, latin1_german1_ci, Using index, Using index
+latin1, latin1_german2_ci, NULL, NULL
+latin1, latin1_spanish_ci, Using index, Using index
+latin1, latin1_swedish_ci, Using index, Using index
+latin2, latin2_bin, Using index, Using index
+latin2, latin2_croatian_ci, Using index, Using index
+latin2, latin2_general_ci, Using index, Using index
+latin2, latin2_hungarian_ci, Using index, Using index
+latin5, latin5_bin, Using index, Using index
+latin5, latin5_turkish_ci, Using index, Using index
+latin7, latin7_bin, Using index, Using index
+latin7, latin7_estonian_cs, Using index, Using index
+latin7, latin7_general_ci, Using index, Using index
+latin7, latin7_general_cs, Using index, Using index
+macce, macce_bin, Using index, Using index
+macce, macce_general_ci, Using index, Using index
+macroman, macroman_bin, Using index, Using index
+macroman, macroman_general_ci, Using index, Using index
+sjis, sjis_bin, NULL, NULL
+sjis, sjis_japanese_ci, NULL, NULL
+swe7, swe7_bin, Using index, Using index
+swe7, swe7_swedish_ci, Using index, Using index
+tis620, tis620_bin, Using index, Using index
+tis620, tis620_thai_ci, NULL, NULL
+ucs2, ucs2_bin, NULL, NULL
+ucs2, ucs2_croatian_ci, NULL, NULL
+ucs2, ucs2_czech_ci, NULL, NULL
+ucs2, ucs2_danish_ci, NULL, NULL
+ucs2, ucs2_esperanto_ci, NULL, NULL
+ucs2, ucs2_estonian_ci, NULL, NULL
+ucs2, ucs2_general_ci, NULL, NULL
+ucs2, ucs2_general_mysql500_ci, NULL, NULL
+ucs2, ucs2_german2_ci, NULL, NULL
+ucs2, ucs2_hungarian_ci, NULL, NULL
+ucs2, ucs2_icelandic_ci, NULL, NULL
+ucs2, ucs2_latvian_ci, NULL, NULL
+ucs2, ucs2_lithuanian_ci, NULL, NULL
+ucs2, ucs2_persian_ci, NULL, NULL
+ucs2, ucs2_polish_ci, NULL, NULL
+ucs2, ucs2_romanian_ci, NULL, NULL
+ucs2, ucs2_roman_ci, NULL, NULL
+ucs2, ucs2_sinhala_ci, NULL, NULL
+ucs2, ucs2_slovak_ci, NULL, NULL
+ucs2, ucs2_slovenian_ci, NULL, NULL
+ucs2, ucs2_spanish2_ci, NULL, NULL
+ucs2, ucs2_spanish_ci, NULL, NULL
+ucs2, ucs2_swedish_ci, NULL, NULL
+ucs2, ucs2_turkish_ci, NULL, NULL
+ucs2, ucs2_unicode_520_ci, NULL, NULL
+ucs2, ucs2_unicode_ci, NULL, NULL
+ucs2, ucs2_vietnamese_ci, NULL, NULL
+ujis, ujis_bin, NULL, NULL
+ujis, ujis_japanese_ci, NULL, NULL
+utf16le, utf16le_bin, NULL, NULL
+utf16le, utf16le_general_ci, NULL, NULL
+utf16, utf16_bin, NULL, NULL
+utf16, utf16_croatian_ci, NULL, NULL
+utf16, utf16_czech_ci, NULL, NULL
+utf16, utf16_danish_ci, NULL, NULL
+utf16, utf16_esperanto_ci, NULL, NULL
+utf16, utf16_estonian_ci, NULL, NULL
+utf16, utf16_general_ci, NULL, NULL
+utf16, utf16_german2_ci, NULL, NULL
+utf16, utf16_hungarian_ci, NULL, NULL
+utf16, utf16_icelandic_ci, NULL, NULL
+utf16, utf16_latvian_ci, NULL, NULL
+utf16, utf16_lithuanian_ci, NULL, NULL
+utf16, utf16_persian_ci, NULL, NULL
+utf16, utf16_polish_ci, NULL, NULL
+utf16, utf16_romanian_ci, NULL, NULL
+utf16, utf16_roman_ci, NULL, NULL
+utf16, utf16_sinhala_ci, NULL, NULL
+utf16, utf16_slovak_ci, NULL, NULL
+utf16, utf16_slovenian_ci, NULL, NULL
+utf16, utf16_spanish2_ci, NULL, NULL
+utf16, utf16_spanish_ci, NULL, NULL
+utf16, utf16_swedish_ci, NULL, NULL
+utf16, utf16_turkish_ci, NULL, NULL
+utf16, utf16_unicode_520_ci, NULL, NULL
+utf16, utf16_unicode_ci, NULL, NULL
+utf16, utf16_vietnamese_ci, NULL, NULL
+utf32, utf32_bin, NULL, NULL
+utf32, utf32_croatian_ci, NULL, NULL
+utf32, utf32_czech_ci, NULL, NULL
+utf32, utf32_danish_ci, NULL, NULL
+utf32, utf32_esperanto_ci, NULL, NULL
+utf32, utf32_estonian_ci, NULL, NULL
+utf32, utf32_general_ci, NULL, NULL
+utf32, utf32_german2_ci, NULL, NULL
+utf32, utf32_hungarian_ci, NULL, NULL
+utf32, utf32_icelandic_ci, NULL, NULL
+utf32, utf32_latvian_ci, NULL, NULL
+utf32, utf32_lithuanian_ci, NULL, NULL
+utf32, utf32_persian_ci, NULL, NULL
+utf32, utf32_polish_ci, NULL, NULL
+utf32, utf32_romanian_ci, NULL, NULL
+utf32, utf32_roman_ci, NULL, NULL
+utf32, utf32_sinhala_ci, NULL, NULL
+utf32, utf32_slovak_ci, NULL, NULL
+utf32, utf32_slovenian_ci, NULL, NULL
+utf32, utf32_spanish2_ci, NULL, NULL
+utf32, utf32_spanish_ci, NULL, NULL
+utf32, utf32_swedish_ci, NULL, NULL
+utf32, utf32_turkish_ci, NULL, NULL
+utf32, utf32_unicode_520_ci, NULL, NULL
+utf32, utf32_unicode_ci, NULL, NULL
+utf32, utf32_vietnamese_ci, NULL, NULL
+utf8mb4, utf8mb4_bin, Using index, Using index
+utf8mb4, utf8mb4_croatian_ci, NULL, NULL
+utf8mb4, utf8mb4_czech_ci, NULL, NULL
+utf8mb4, utf8mb4_danish_ci, NULL, NULL
+utf8mb4, utf8mb4_esperanto_ci, NULL, NULL
+utf8mb4, utf8mb4_estonian_ci, NULL, NULL
+utf8mb4, utf8mb4_general_ci, NULL, NULL
+utf8mb4, utf8mb4_german2_ci, NULL, NULL
+utf8mb4, utf8mb4_hungarian_ci, NULL, NULL
+utf8mb4, utf8mb4_icelandic_ci, NULL, NULL
+utf8mb4, utf8mb4_latvian_ci, NULL, NULL
+utf8mb4, utf8mb4_lithuanian_ci, NULL, NULL
+utf8mb4, utf8mb4_persian_ci, NULL, NULL
+utf8mb4, utf8mb4_polish_ci, NULL, NULL
+utf8mb4, utf8mb4_romanian_ci, NULL, NULL
+utf8mb4, utf8mb4_roman_ci, NULL, NULL
+utf8mb4, utf8mb4_sinhala_ci, NULL, NULL
+utf8mb4, utf8mb4_slovak_ci, NULL, NULL
+utf8mb4, utf8mb4_slovenian_ci, NULL, NULL
+utf8mb4, utf8mb4_spanish2_ci, NULL, NULL
+utf8mb4, utf8mb4_spanish_ci, NULL, NULL
+utf8mb4, utf8mb4_swedish_ci, NULL, NULL
+utf8mb4, utf8mb4_turkish_ci, NULL, NULL
+utf8mb4, utf8mb4_unicode_520_ci, NULL, NULL
+utf8mb4, utf8mb4_unicode_ci, NULL, NULL
+utf8mb4, utf8mb4_vietnamese_ci, NULL, NULL
+utf8, utf8_bin, Using index, Using index
+utf8, utf8_croatian_ci, NULL, NULL
+utf8, utf8_czech_ci, NULL, NULL
+utf8, utf8_danish_ci, NULL, NULL
+utf8, utf8_esperanto_ci, NULL, NULL
+utf8, utf8_estonian_ci, NULL, NULL
+utf8, utf8_general_ci, NULL, NULL
+utf8, utf8_general_mysql500_ci, NULL, NULL
+utf8, utf8_german2_ci, NULL, NULL
+utf8, utf8_hungarian_ci, NULL, NULL
+utf8, utf8_icelandic_ci, NULL, NULL
+utf8, utf8_latvian_ci, NULL, NULL
+utf8, utf8_lithuanian_ci, NULL, NULL
+utf8, utf8_persian_ci, NULL, NULL
+utf8, utf8_polish_ci, NULL, NULL
+utf8, utf8_romanian_ci, NULL, NULL
+utf8, utf8_roman_ci, NULL, NULL
+utf8, utf8_sinhala_ci, NULL, NULL
+utf8, utf8_slovak_ci, NULL, NULL
+utf8, utf8_slovenian_ci, NULL, NULL
+utf8, utf8_spanish2_ci, NULL, NULL
+utf8, utf8_spanish_ci, NULL, NULL
+utf8, utf8_swedish_ci, NULL, NULL
+utf8, utf8_turkish_ci, NULL, NULL
+utf8, utf8_unicode_520_ci, NULL, NULL
+utf8, utf8_unicode_ci, NULL, NULL
+utf8, utf8_vietnamese_ci, NULL, NULL
+DROP TABLE collations;

--- a/mysql-test/suite/rocksdb/t/add_index_inplace.test
+++ b/mysql-test/suite/rocksdb/t/add_index_inplace.test
@@ -168,7 +168,7 @@ SELECT COUNT(*) FROM t1;
 DROP TABLE t1;
 
 # test failure in prepare phase (due to collation)
-CREATE TABLE t1 (a INT, b TEXT);
+CREATE TABLE t1 (a INT, b TEXT CHARSET utf8 COLLATE utf8_general_ci);
 
 --error ER_UNSUPPORTED_COLLATION
 ALTER TABLE t1 ADD KEY kb(b(10));

--- a/mysql-test/suite/rocksdb/t/collation.test
+++ b/mysql-test/suite/rocksdb/t/collation.test
@@ -142,12 +142,12 @@ CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=roc
 
 # test allowing alters to create temporary tables
 SET GLOBAL rocksdb_strict_collation_exceptions='t1';
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb;
+CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 ALTER TABLE t1 AUTO_INCREMENT=1;
 DROP TABLE t1;
 --error ER_UNSUPPORTED_COLLATION
-CREATE TABLE t2 (id INT primary key, value varchar(50), index(value)) engine=rocksdb;
-CREATE TABLE t2 (id INT primary key, value varchar(50)) engine=rocksdb;
+CREATE TABLE t2 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
+CREATE TABLE t2 (id INT primary key, value varchar(50)) engine=rocksdb charset utf8;
 --error ER_UNSUPPORTED_COLLATION
 ALTER TABLE t2 ADD INDEX(value);
 DROP TABLE t2;

--- a/mysql-test/suite/rocksdb/t/type_char_secondary_index_only_scan.test
+++ b/mysql-test/suite/rocksdb/t/type_char_secondary_index_only_scan.test
@@ -1,0 +1,50 @@
+# 1. Find all collations that support index-only scans with secondary
+#    keys using the "Extra" field from "EXPLAIN SELECT"
+# 2. Verify if the original string is reconstructed correctly from SK
+#    (or from PK when index-only scans with SK are not supported)
+
+--source include/have_rocksdb.inc
+
+CREATE TABLE collations AS SELECT * FROM information_schema.COLLATION_CHARACTER_SET_APPLICABILITY WHERE COLLATION_NAME NOT IN ("latin2_czech_cs", "cp1250_czech_cs") ORDER BY COLLATION_NAME;
+
+--disable_query_log
+--let $i=1
+--let $charset = query_get_value(select * from collations, CHARACTER_SET_NAME, $i)
+--let $collate = query_get_value(select * from collations, COLLATION_NAME, $i)
+--echo CharSet, Collate, Char Extra, VarChar Extra
+while ($charset != 'No such row')
+{
+  --let table_name=t_$charset
+  if ($charset == "binary")
+  {
+    --eval CREATE TABLE $table_name (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, vch VARBINARY(64), ch BINARY(64), KEY vch_idx (vch), KEY ch_idx (ch)) ENGINE=rocksdb
+  }
+  if ($charset != "binary")
+  {
+    --eval CREATE TABLE $table_name (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, vch VARCHAR(64), ch CHAR(64), KEY vch_idx (vch), KEY ch_idx (ch)) ENGINE=rocksdb CHARSET $charset COLLATE $collate
+  }
+  --eval INSERT INTO $table_name (vch, ch) VALUES('VARCHAR', 'char')
+  --let $vch_extra = query_get_value(EXPLAIN SELECT vch FROM $table_name, Extra, 1)
+  --let $ch_extra = query_get_value(EXPLAIN SELECT ch FROM $table_name, Extra, 1)
+  --echo $charset, $collate, $ch_extra, $vch_extra
+  --let $ch_value = query_get_value(SELECT ch FROM $table_name, ch, 1)
+  --let $vch_value = query_get_value(SELECT vch FROM $table_name, vch, 1)
+  if ($ch_value != "char")
+  {
+    --echo ERROR for $charset, $collate: \$ch_value=$ch_value, \$vch_value=$vch_value
+    --die
+  }
+  if ($vch_value != "VARCHAR")
+  {
+    --echo ERROR for $charset, $collate: \$ch_value=$ch_value, \$vch_value=$vch_value
+    --die
+  }
+  --eval DROP TABLE $table_name
+
+  --inc $i
+  --let $charset=query_get_value(select * from collations, CHARACTER_SET_NAME, $i)
+  --let $collate=query_get_value(select * from collations, COLLATION_NAME, $i)
+}
+--enable_query_log
+
+DROP TABLE collations;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -7046,7 +7046,8 @@ int ha_rocksdb::rdb_error_to_mysql(const rocksdb::Status &s,
 
 /* MyRocks supports only the following collations for indexed columns */
 static const std::set<const my_core::CHARSET_INFO *> RDB_INDEX_COLLATIONS = {
-    &my_charset_bin, &my_charset_utf8_bin, &my_charset_latin1_bin};
+    &my_charset_bin, &my_charset_utf8_bin, &my_charset_utf8mb4_bin,
+    &my_charset_latin1_bin};
 
 static bool rdb_is_index_collation_supported(
     const my_core::Field *const field) {
@@ -7054,8 +7055,10 @@ static bool rdb_is_index_collation_supported(
   /* Handle [VAR](CHAR|BINARY) or TEXT|BLOB */
   if (type == MYSQL_TYPE_VARCHAR || type == MYSQL_TYPE_STRING ||
       type == MYSQL_TYPE_BLOB) {
-    return RDB_INDEX_COLLATIONS.find(field->charset()) !=
-           RDB_INDEX_COLLATIONS.end();
+    return rdb_is_simple_collation(field->charset()) ||
+           rdb_is_binary_collation(field->charset()) ||
+           RDB_INDEX_COLLATIONS.find(field->charset()) !=
+               RDB_INDEX_COLLATIONS.end();
   }
   return true;
 }

--- a/storage/rocksdb/nosql_access.cc
+++ b/storage/rocksdb/nosql_access.cc
@@ -350,10 +350,10 @@ class select_parser {
 
       auto field_type = field->real_type();
       if (field_type == MYSQL_TYPE_VARCHAR &&
-          field->charset() != &my_charset_utf8_bin &&
-          field->charset() != &my_charset_latin1_bin) {
+          rdb_is_binary_collation(field->charset())) {
         m_error_msg =
-            "only utf8_bin, latin1_bin is supported for varchar field";
+            "only utf8_bin, utf8mb4_bin, latin1_bin is supported for varchar "
+            "field";
         return true;
       }
 

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -2098,14 +2098,15 @@ int Rdb_key_def::unpack_binary_str(
 
 /*
   Function of type rdb_index_field_unpack_t.
-  For UTF-8, we need to convert 2-byte wide-character entities back into
+  For UTF-8, we need to convert 2- or 3-byte wide-character entities back into
   UTF8 sequences.
 */
 
-int Rdb_key_def::unpack_utf8_str(
-    Rdb_field_packing *const fpi, Field *const field, uchar *dst,
-    Rdb_string_reader *const reader,
-    Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__))) {
+template <const int bytes>
+int unpack_utf8_str_templ(Rdb_field_packing *const fpi, Field *const field,
+                          uchar *dst, Rdb_string_reader *const reader,
+                          Rdb_string_reader *const unp_reader
+                              MY_ATTRIBUTE((__unused__))) {
   my_core::CHARSET_INFO *const cset = (my_core::CHARSET_INFO *)field->charset();
   const uchar *src;
   if (!(src = (const uchar *)reader->read(fpi->m_max_image_len))) {
@@ -2117,10 +2118,11 @@ int Rdb_key_def::unpack_utf8_str(
   uchar *const dst_end = dst + field->pack_length();
 
   while (src < src_end) {
-    my_wc_t wc = (src[0] << 8) | src[1];
-    src += 2;
+    my_wc_t wc = (bytes == 3) ? (src[0] << 16) | (src[1] << 8) | src[2]
+                              : (src[0] << 8) | src[1];
+    src += bytes;
     int res = cset->cset->wc_mb(cset, wc, dst, dst_end);
-    DBUG_ASSERT(res > 0 && res <= 3);
+    DBUG_ASSERT(res > 0 && res <= bytes + 1);
     if (res < 0) return UNPACK_FAILURE;
     dst += res;
   }
@@ -2129,6 +2131,11 @@ int Rdb_key_def::unpack_utf8_str(
                    cset->pad_char);
   return UNPACK_SUCCESS;
 }
+
+rdb_index_field_unpack_t Rdb_key_def::unpack_utf8mb4_str =
+    unpack_utf8_str_templ<3>;
+rdb_index_field_unpack_t Rdb_key_def::unpack_utf8_str =
+    unpack_utf8_str_templ<2>;
 
 /*
   This is the original algorithm to encode a variable binary field.  It
@@ -2471,34 +2478,56 @@ uint Rdb_key_def::calc_unpack_variable_format(uchar flag, bool *done) {
   return RDB_ESCAPE_LENGTH - 1;
 }
 
+template <const int bytes>
+bool check_src_len(uint src_len);
+
+template <>
+bool check_src_len<2>(uint src_len) {
+  if (src_len & 1) {
+    /*
+      utf8mb3 characters are encoded into two-byte entities. There is no way
+      we can have an odd number of bytes after encoding.
+    */
+    return false;
+  }
+  return true;
+}
+
+template <>
+bool check_src_len<3>(uint src_len) {
+  if (src_len % 3) {
+    /*
+      utf8mb4 characters are encoded into three-byte entities. There is no way
+      we can have 1 or 2 bytes after encoding.
+    */
+    return false;
+  }
+  return true;
+}
+
 /*
   Unpack data that has charset information.  Each two bytes of the input is
   treated as a wide-character and converted to its multibyte equivalent in
   the output.
  */
-static int unpack_charset(
-    const CHARSET_INFO *cset,  // character set information
-    const uchar *src,          // source data to unpack
-    uint src_len,              // length of source data
-    uchar *dst,                // destination of unpacked data
-    uint dst_len,              // length of destination data
-    uint *used_bytes)          // output number of bytes used
+template <const int bytes>
+int unpack_charset(const CHARSET_INFO *cset,  // character set information
+                   const uchar *src,          // source data to unpack
+                   uint src_len,              // length of source data
+                   uchar *dst,                // destination of unpacked data
+                   uint dst_len,              // length of destination data
+                   uint *used_bytes)          // output number of bytes used
 {
-  if (src_len & 1) {
-    /*
-      UTF-8 characters are encoded into two-byte entities. There is no way
-      we can have an odd number of bytes after encoding.
-    */
-    return UNPACK_FAILURE;
-  }
+  if (!check_src_len<bytes>(src_len)) return UNPACK_FAILURE;
 
   uchar *dst_end = dst + dst_len;
   uint used = 0;
 
-  for (uint ii = 0; ii < src_len; ii += 2) {
-    my_wc_t wc = (src[ii] << 8) | src[ii + 1];
+  for (uint i = 0; i < src_len; i += bytes) {
+    my_wc_t wc = (bytes == 3) ? (src[i] << 16) | (src[i + 1] << 8) | src[i + 2]
+                              : (src[i] << 8) | src[i + 1];
     int res = cset->cset->wc_mb(cset, wc, dst + used, dst_end);
-    DBUG_ASSERT(res > 0 && res <= 3);
+    DBUG_ASSERT(res > 0 && res <= bytes + 1);
     if (res < 0) {
       return UNPACK_FAILURE;
     }
@@ -2514,10 +2543,11 @@ static int unpack_charset(
   Function of type rdb_index_field_unpack_t
 */
 
-int Rdb_key_def::unpack_binary_or_utf8_varchar(
+int Rdb_key_def::unpack_binary_varchar(
     Rdb_field_packing *const fpi, Field *const field, uchar *dst,
     Rdb_string_reader *const reader,
     Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__))) {
+  DBUG_ASSERT(fpi->m_varchar_charset == &my_charset_bin);
   const uchar *ptr;
   size_t len = 0;
   bool finished = false;
@@ -2549,15 +2579,7 @@ int Rdb_key_def::unpack_binary_or_utf8_varchar(
     /*
       Now, we need to decode used_bytes of data and append them to the value.
     */
-    if (fpi->m_varchar_charset == &my_charset_utf8_bin) {
-      int err = unpack_charset(fpi->m_varchar_charset, ptr, used_bytes, dst,
-                               dst_len, &used_bytes);
-      if (err != UNPACK_SUCCESS) {
-        return err;
-      }
-    } else {
-      memcpy(dst, ptr, used_bytes);
-    }
+    memcpy(dst, ptr, used_bytes);
 
     dst += used_bytes;
     dst_len -= used_bytes;
@@ -2589,7 +2611,8 @@ int Rdb_key_def::unpack_binary_or_utf8_varchar(
     charsets.
     skip_variable_space_pad - skip function
 */
-int Rdb_key_def::unpack_binary_or_utf8_varchar_space_pad(
+template <const int bytes>
+int unpack_binary_or_utf8_varchar_space_pad(
     Rdb_field_packing *const fpi, Field *const field, uchar *dst,
     Rdb_string_reader *const reader, Rdb_string_reader *const unp_reader) {
   const uchar *ptr;
@@ -2638,23 +2661,18 @@ int Rdb_key_def::unpack_binary_or_utf8_varchar_space_pad(
     }
 
     // Now, need to decode used_bytes of data and append them to the value.
-    if (fpi->m_varchar_charset == &my_charset_utf8_bin) {
-      if (used_bytes & 1) {
-        /*
-          UTF-8 characters are encoded into two-byte entities. There is no way
-          we can have an odd number of bytes after encoding.
-        */
-        return UNPACK_FAILURE;
-      }
+    if (bytes > 1) {
+      if (!check_src_len<bytes>(used_bytes)) return UNPACK_FAILURE;
 
       const uchar *src = ptr;
       const uchar *const src_end = ptr + used_bytes;
       while (src < src_end) {
-        my_wc_t wc = (src[0] << 8) | src[1];
-        src += 2;
+        my_wc_t wc = (bytes == 3) ? (src[0] << 16) | (src[1] << 8) | src[2]
+                                  : (src[0] << 8) | src[1];
+        src += bytes;
         const CHARSET_INFO *cset = fpi->m_varchar_charset;
         int res = cset->cset->wc_mb(cset, wc, dst, dst_end);
-        DBUG_ASSERT(res <= 3);
+        DBUG_ASSERT(res <= bytes + 1);
         if (res <= 0) return UNPACK_FAILURE;
         dst += res;
         len += res;
@@ -2689,6 +2707,13 @@ int Rdb_key_def::unpack_binary_or_utf8_varchar_space_pad(
   }
   return UNPACK_SUCCESS;
 }
+
+rdb_index_field_unpack_t Rdb_key_def::unpack_binary_varchar_space_pad =
+    unpack_binary_or_utf8_varchar_space_pad<1>;
+rdb_index_field_unpack_t Rdb_key_def::unpack_utf8_varchar_space_pad =
+    unpack_binary_or_utf8_varchar_space_pad<2>;
+rdb_index_field_unpack_t Rdb_key_def::unpack_utf8mb4_varchar_space_pad =
+    unpack_binary_or_utf8_varchar_space_pad<3>;
 
 /////////////////////////////////////////////////////////////////////////
 
@@ -3090,8 +3115,13 @@ std::array<const Rdb_collation_codec *, MY_ALL_CHARSETS_SIZE>
     rdb_collation_data;
 mysql_mutex_t rdb_collation_data_mutex;
 
-static bool rdb_is_collation_supported(const my_core::CHARSET_INFO *const cs) {
+bool rdb_is_simple_collation(const my_core::CHARSET_INFO *const cs) {
   return (cs->coll == &my_collation_8bit_simple_ci_handler);
+}
+
+bool rdb_is_binary_collation(const my_core::CHARSET_INFO *const cs) {
+  return (cs->coll == &my_collation_8bit_bin_handler) ||
+         (cs == &my_charset_utf8mb4_bin) || (cs == &my_charset_utf8_bin);
 }
 
 static const Rdb_collation_codec *rdb_init_collation_mapping(
@@ -3099,7 +3129,7 @@ static const Rdb_collation_codec *rdb_init_collation_mapping(
   DBUG_ASSERT(cs && cs->state & MY_CS_AVAILABLE);
   const Rdb_collation_codec *codec = rdb_collation_data[cs->number];
 
-  if (codec == nullptr && rdb_is_collation_supported(cs)) {
+  if (codec == nullptr && rdb_is_simple_collation(cs)) {
     RDB_MUTEX_LOCK_CHECK(rdb_collation_data_mutex);
 
     codec = rdb_collation_data[cs->number];
@@ -3107,37 +3137,32 @@ static const Rdb_collation_codec *rdb_init_collation_mapping(
       Rdb_collation_codec *cur = nullptr;
 
       // Compute reverse mapping for simple collations.
-      if (cs->coll == &my_collation_8bit_simple_ci_handler) {
-        cur = new Rdb_collation_codec;
-        std::map<uchar, std::vector<uchar>> rev_map;
-        size_t max_conflict_size = 0;
-        for (int src = 0; src < 256; src++) {
-          uchar dst = cs->sort_order[src];
-          rev_map[dst].push_back(src);
-          max_conflict_size = std::max(max_conflict_size, rev_map[dst].size());
-        }
-        cur->m_dec_idx.resize(max_conflict_size);
-
-        for (auto const &p : rev_map) {
-          uchar dst = p.first;
-          for (uint idx = 0; idx < p.second.size(); idx++) {
-            uchar src = p.second[idx];
-            uchar bits =
-                my_bit_log2(my_round_up_to_next_power(p.second.size()));
-            cur->m_enc_idx[src] = idx;
-            cur->m_enc_size[src] = bits;
-            cur->m_dec_size[dst] = bits;
-            cur->m_dec_idx[idx][dst] = src;
-          }
-        }
-
-        cur->m_make_unpack_info_func = {Rdb_key_def::make_unpack_simple_varchar,
-                                        Rdb_key_def::make_unpack_simple};
-        cur->m_unpack_func = {Rdb_key_def::unpack_simple_varchar_space_pad,
-                              Rdb_key_def::unpack_simple};
-      } else {
-        // Out of luck for now.
+      cur = new Rdb_collation_codec;
+      std::map<uchar, std::vector<uchar>> rev_map;
+      size_t max_conflict_size = 0;
+      for (int src = 0; src < 256; src++) {
+        uchar dst = cs->sort_order[src];
+        rev_map[dst].push_back(src);
+        max_conflict_size = std::max(max_conflict_size, rev_map[dst].size());
       }
+      cur->m_dec_idx.resize(max_conflict_size);
+
+      for (auto const &p : rev_map) {
+        uchar dst = p.first;
+        for (uint idx = 0; idx < p.second.size(); idx++) {
+          uchar src = p.second[idx];
+          uchar bits = my_bit_log2(my_round_up_to_next_power(p.second.size()));
+          cur->m_enc_idx[src] = idx;
+          cur->m_enc_size[src] = bits;
+          cur->m_dec_size[dst] = bits;
+          cur->m_dec_idx[idx][dst] = src;
+        }
+      }
+
+      cur->m_make_unpack_info_func = {Rdb_key_def::make_unpack_simple_varchar,
+                                      Rdb_key_def::make_unpack_simple};
+      cur->m_unpack_func = {Rdb_key_def::unpack_simple_varchar_space_pad,
+                            Rdb_key_def::unpack_simple};
 
       if (cur != nullptr) {
         codec = cur;
@@ -3354,10 +3379,14 @@ bool Rdb_field_packing::setup(const Rdb_key_def *const key_descr,
       // - For VARBINARY(N), values may have different lengths, so we're using
       //   variable-length encoding. This is also the only charset where the
       //   values are not space-padded for comparison.
-      m_unpack_func = is_varchar ? Rdb_key_def::unpack_binary_or_utf8_varchar
+      DBUG_ASSERT((is_varchar &&
+                   m_pack_func == Rdb_key_def::pack_with_varchar_encoding) ||
+                  m_pack_func == Rdb_key_def::pack_with_make_sort_key);
+      DBUG_ASSERT(m_make_unpack_info_func == nullptr);
+      m_unpack_func = is_varchar ? Rdb_key_def::unpack_binary_varchar
                                  : Rdb_key_def::unpack_binary_str;
       res = true;
-    } else if (cs == &my_charset_latin1_bin || cs == &my_charset_utf8_bin) {
+    } else if (rdb_is_binary_collation(cs)) {
       // For _bin collations, mem-comparable form of the string is the string
       // itself.
 
@@ -3365,7 +3394,13 @@ bool Rdb_field_packing::setup(const Rdb_key_def *const key_descr,
         // VARCHARs - are compared as if they were space-padded - but are
         // not actually space-padded (reading the value back produces the
         // original value, without the padding)
-        m_unpack_func = Rdb_key_def::unpack_binary_or_utf8_varchar_space_pad;
+        m_unpack_func =
+            (cs == &my_charset_utf8mb4_bin)
+                ? Rdb_key_def::unpack_utf8mb4_varchar_space_pad
+                : (cs == &my_charset_utf8_bin)
+                      ? Rdb_key_def::unpack_utf8_varchar_space_pad
+                      : Rdb_key_def::unpack_binary_varchar_space_pad;
+
         m_skip_func = Rdb_key_def::skip_variable_space_pad;
         m_pack_func = Rdb_key_def::pack_with_varchar_space_pad;
         m_make_unpack_info_func = Rdb_key_def::dummy_make_unpack_info;
@@ -3378,9 +3413,13 @@ bool Rdb_field_packing::setup(const Rdb_key_def *const key_descr,
       } else {
         // SQL layer pads CHAR(N) values to their maximum length.
         // We just store that and restore it back.
-        m_unpack_func = (cs == &my_charset_latin1_bin)
-                            ? Rdb_key_def::unpack_binary_str
-                            : Rdb_key_def::unpack_utf8_str;
+        DBUG_ASSERT(m_pack_func == Rdb_key_def::pack_with_make_sort_key);
+        DBUG_ASSERT(m_make_unpack_info_func == nullptr);
+        m_unpack_func = (cs == &my_charset_utf8mb4_bin)
+                            ? Rdb_key_def::unpack_utf8mb4_str
+                            : (cs == &my_charset_utf8_bin)
+                                  ? Rdb_key_def::unpack_utf8_str
+                                  : Rdb_key_def::unpack_binary_str;
       }
       res = true;
     } else {

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -678,14 +678,14 @@ class Rdb_key_def {
                                Rdb_string_reader *const unp_reader
                                    MY_ATTRIBUTE((__unused__)));
 
-  static int unpack_binary_or_utf8_varchar(
+  static int unpack_binary_varchar(
       Rdb_field_packing *const fpi, Field *const field, uchar *dst,
       Rdb_string_reader *const reader,
       Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__)));
 
-  static int unpack_binary_or_utf8_varchar_space_pad(
-      Rdb_field_packing *const fpi, Field *const field, uchar *dst,
-      Rdb_string_reader *const reader, Rdb_string_reader *const unp_reader);
+  static rdb_index_field_unpack_t unpack_binary_varchar_space_pad;
+  static rdb_index_field_unpack_t unpack_utf8_varchar_space_pad;
+  static rdb_index_field_unpack_t unpack_utf8mb4_varchar_space_pad;
 
   static int unpack_newdate(
       Rdb_field_packing *const fpi,
@@ -693,10 +693,8 @@ class Rdb_key_def {
       Rdb_string_reader *const reader,
       Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__)));
 
-  static int unpack_utf8_str(Rdb_field_packing *const fpi, Field *const field,
-                             uchar *dst, Rdb_string_reader *const reader,
-                             Rdb_string_reader *const unp_reader
-                                 MY_ATTRIBUTE((__unused__)));
+  static rdb_index_field_unpack_t unpack_utf8_str;
+  static rdb_index_field_unpack_t unpack_utf8mb4_str;
 
   static int unpack_unknown_varchar(Rdb_field_packing *const fpi,
                                     Field *const field, uchar *dst,
@@ -1700,5 +1698,8 @@ class Rdb_system_merge_op : public rocksdb::AssociativeMergeOperator {
     return rdb_netbuf_to_uint16(reinterpret_cast<const uchar *>(s.data()));
   }
 };
+
+bool rdb_is_simple_collation(const my_core::CHARSET_INFO *const cs);
+bool rdb_is_binary_collation(const my_core::CHARSET_INFO *const cs);
 
 }  // namespace myrocks


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7027

This patch adds optimized support for `utf8mb4_bin` and all collations based on `my_collation_8bit_bin_handler` (i.e. `latinX_bin`, `cp12XX_bin`, `cp85X_bin`, `armscii8_bin`, `ascii_bin` and many more).

It also introduces the `rocksdb.type_char_secondary_index_only_scan` test that:
1. Finds all collations that support index-only scans with secondary keys using the "Extra" field from "EXPLAIN SELECT"
2. Verifies if the original string is reconstructed correctly from SK (or from PK when index-only scans with SK are not supported)