### PR TITLE
[WIP] PS-7027 MyRocks: Implement optimized support for collations other than latin1/utf8 (8.0)

### DIFF
--- a/include/my_hash_combine.h
+++ b/include/my_hash_combine.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2017, 2017, Oracle and/or its affiliates.
+/* Copyright (c) 2017, 2019, Oracle and/or its affiliates.
 
 The code in this file is copied from Boost 1.63.0
 boost/functional/hash/hash.hpp, which contains the following copyright notice:
@@ -61,12 +61,14 @@ Steinar */
 #define MY_FUNCTIONAL_HASH_ROTL32(x, r) (x << r) | (x >> (32 - r))
 #endif /* _MSC_VER */
 
+#include <stdint.h>
+
 template <typename SizeT>
 inline void my_hash_combine(SizeT &seed, SizeT value) {
   seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2);
 }
 
-inline void my_hash_combine(std::uint32_t &h1, std::uint32_t k1) {
+inline void my_hash_combine(uint32_t &h1, uint32_t k1) {
   const uint32_t c1 = 0xcc9e2d51;
   const uint32_t c2 = 0x1b873593;
 
@@ -79,8 +81,8 @@ inline void my_hash_combine(std::uint32_t &h1, std::uint32_t k1) {
   h1 = h1 * 5 + 0xe6546b64;
 }
 
-inline void my_hash_combine(std::uint64_t &h, std::uint64_t k) {
-  const std::uint64_t m = 0xc6a4a7935bd1e995ull;
+inline void my_hash_combine(uint64_t &h, uint64_t k) {
+  const uint64_t m = 0xc6a4a7935bd1e995ull;
   const int r = 47;
 
   k *= m;

--- a/include/mysql.h.pp
+++ b/include/mysql.h.pp
@@ -707,6 +707,7 @@ void myodbc_remove_escape(MYSQL *mysql, char *name);
 unsigned int mysql_thread_safe(void);
 bool mysql_read_query_result(MYSQL *mysql);
 int mysql_reset_connection(MYSQL *mysql);
+enum net_async_status mysql_reset_connection_nonblocking(MYSQL *mysql);
 unsigned long cli_safe_read(MYSQL *mysql, bool *is_data_packet);
 enum net_async_status cli_safe_read_nonblocking(MYSQL *mysql,
                                                         bool *is_data_packet,

--- a/include/mysql/components/services/page_track_service.h
+++ b/include/mysql/components/services/page_track_service.h
@@ -27,6 +27,8 @@
 #include <mysql/components/service.h>
 #include <functional>
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 class THD;
 #define MYSQL_THD THD *

--- a/include/mysql/plugin_audit.h.pp
+++ b/include/mysql/plugin_audit.h.pp
@@ -124,7 +124,7 @@ int thd_killed(const void *v_thd);
 void thd_set_kill_status(const void * thd);
 void thd_binlog_pos(const void * thd, const char **file_var,
                     unsigned long long *pos_var, const char **gtid_var,
-					const char **max_gtid_var);
+                    const char **max_gtid_var);
 unsigned long thd_get_thread_id(const void * thd);
 void thd_get_xid(const void * thd, MYSQL_XID *xid);
 void *thd_get_ha_data(const void * thd, const struct handlerton *hton);
@@ -387,7 +387,9 @@ typedef enum {
   MYSQL_AUDIT_GENERAL_LOG = 1 << 0,
   MYSQL_AUDIT_GENERAL_ERROR = 1 << 1,
   MYSQL_AUDIT_GENERAL_RESULT = 1 << 2,
-  MYSQL_AUDIT_GENERAL_STATUS = 1 << 3
+  MYSQL_AUDIT_GENERAL_STATUS = 1 << 3,
+  MYSQL_AUDIT_GENERAL_WARNING_INSTR = 1 << 4,
+  MYSQL_AUDIT_GENERAL_ERROR_INSTR = 1 << 5
 } mysql_event_general_subclass_t;
 struct mysql_event_general {
   mysql_event_general_subclass_t event_subclass;
@@ -406,7 +408,7 @@ struct mysql_event_general {
   long long query_id;
   MYSQL_LEX_CSTRING database;
   long long affected_rows;
-  unsigned int port;  
+  unsigned int port;
 };
 typedef enum {
   MYSQL_AUDIT_CONNECTION_CONNECT = 1 << 0,

--- a/mysql-test/suite/rocksdb/r/add_index_inplace.result
+++ b/mysql-test/suite/rocksdb/r/add_index_inplace.result
@@ -285,9 +285,9 @@ SELECT COUNT(*) FROM t1;
 COUNT(*)
 100
 DROP TABLE t1;
-CREATE TABLE t1 (a INT, b TEXT);
+CREATE TABLE t1 (a INT, b TEXT CHARSET utf8 COLLATE utf8_general_ci);
 ALTER TABLE t1 ADD KEY kb(b(10));
-ERROR HY000: Unsupported collation on string indexed column test.t1.b Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.t1.b Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 ALTER TABLE t1 ADD PRIMARY KEY(a);
 DROP TABLE t1;
 set global rocksdb_bulk_load=1;

--- a/mysql-test/suite/rocksdb/r/collation.result
+++ b/mysql-test/suite/rocksdb/r/collation.result
@@ -3,25 +3,21 @@ CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), va
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 ALTER TABLE t1 ADD INDEX (value);
-ERROR HY000: Unsupported collation on string indexed column test.t1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 DROP TABLE t1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.t1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
-CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value3(50))) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.t1.value3 Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
-SET GLOBAL rocksdb_strict_collation_check=0;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+DROP TABLE t1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value3(50))) engine=rocksdb charset utf8;
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 DROP TABLE t1;
-SET GLOBAL rocksdb_strict_collation_check=1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value2)) engine=rocksdb charset utf8;
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 DROP TABLE t1;
 CREATE TABLE t1 (id varchar(20), value varchar(50), value2 varchar(50), value3 text, primary key (id), index(value, value2)) engine=rocksdb charset latin1 collate latin1_bin;
 ALTER TABLE t1 MODIFY value VARCHAR(50) CHARACTER SET latin1 COLLATE latin1_german2_ci;
-ERROR HY000: Unsupported collation on string indexed column test.#sqlx-nnnn_nnnn.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 DROP TABLE t1;
 CREATE TABLE t1 (id varchar(20), value varchar(50), value2 varchar(50), value3 text, primary key (id), index(value, value2)) engine=rocksdb charset utf8 collate utf8_bin;
 Warnings:
@@ -32,181 +28,20 @@ CREATE TABLE t1 (id varchar(20) collate latin1_bin, value varchar(50) collate ut
 Warnings:
 Warning	3778	'utf8_bin' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
 DROP TABLE t1;
-SET GLOBAL rocksdb_strict_collation_exceptions=t1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-Warnings:
-Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-DROP TABLE t1;
-CREATE TABLE t2 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.t2.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
-SET GLOBAL rocksdb_strict_collation_exceptions="t.*";
-CREATE TABLE t123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-Warnings:
-Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-DROP TABLE t123;
-CREATE TABLE s123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.s123.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
-SET GLOBAL rocksdb_strict_collation_exceptions=".t.*";
-CREATE TABLE xt123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-Warnings:
-Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-DROP TABLE xt123;
-CREATE TABLE t123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.t123.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
-SET GLOBAL rocksdb_strict_collation_exceptions="s.*,t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-Warnings:
-Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-Warnings:
-Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-DROP TABLE t1;
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
-SET GLOBAL rocksdb_strict_collation_exceptions="s.*|t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-Warnings:
-Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-Warnings:
-Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-DROP TABLE t1;
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
-SET GLOBAL rocksdb_strict_collation_exceptions=",s.*,t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-Warnings:
-Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-Warnings:
-Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-DROP TABLE t1;
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
-SET GLOBAL rocksdb_strict_collation_exceptions="|s.*|t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-Warnings:
-Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-Warnings:
-Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-DROP TABLE t1;
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
-SET GLOBAL rocksdb_strict_collation_exceptions="s.*,,t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-Warnings:
-Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-Warnings:
-Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-DROP TABLE t1;
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
-SET GLOBAL rocksdb_strict_collation_exceptions="s.*||t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-Warnings:
-Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-Warnings:
-Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-DROP TABLE t1;
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
-SET GLOBAL rocksdb_strict_collation_exceptions="s.*,t.*,";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-Warnings:
-Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-Warnings:
-Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-DROP TABLE t1;
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
-SET GLOBAL rocksdb_strict_collation_exceptions="s.*|t.*|";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-Warnings:
-Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-Warnings:
-Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-DROP TABLE t1;
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
-SET GLOBAL rocksdb_strict_collation_exceptions="||||,,,,s.*,,|,,||,t.*,,|||,,,";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-Warnings:
-Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-Warnings:
-Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-DROP TABLE t1;
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
-SET GLOBAL rocksdb_strict_collation_exceptions='t1';
 CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 ALTER TABLE t1 AUTO_INCREMENT=1, ALGORITHM=COPY;
 DROP TABLE t1;
-CREATE TABLE t2 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.t2.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
-CREATE TABLE t2 (id INT primary key, value varchar(50)) engine=rocksdb charset utf8;
-Warnings:
-Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-ALTER TABLE t2 ADD INDEX(value);
-ERROR HY000: Unsupported collation on string indexed column test.t2.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
-DROP TABLE t2;
-SET GLOBAL rocksdb_strict_collation_exceptions="[a-b";
-Invalid pattern in strict_collation_exceptions: [a-b
-CREATE TABLE a (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.a.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
-SET GLOBAL rocksdb_strict_collation_exceptions="[a-b]";
-CREATE TABLE a (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-Warnings:
-Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-CREATE TABLE b (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-Warnings:
-Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-CREATE TABLE c (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.c.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
-DROP TABLE a, b;
-SET GLOBAL rocksdb_strict_collation_exceptions="abc\\";
-Invalid pattern in strict_collation_exceptions: abc\
-CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.abc.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
-SET GLOBAL rocksdb_strict_collation_exceptions="abc";
-CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-Warnings:
-Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-CREATE TABLE abcd (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.abcd.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
-DROP TABLE abc;
-SET GLOBAL rocksdb_strict_collation_exceptions=null;
-# restart: --rocksdb_error_on_suboptimal_collation=0
-SET GLOBAL rocksdb_strict_collation_check=1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value)) engine=rocksdb charset utf8;
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-Warning	1210	Unsupported collation on string indexed column test.t1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 DROP TABLE t1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text) engine=rocksdb charset utf8;
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 ALTER TABLE t1 ADD INDEX (value);
-Warnings:
-Warning	1210	Unsupported collation on string indexed column test.t1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 DROP TABLE t1;
 CREATE TABLE t1 (id varchar(20), value varchar(50), value2 varchar(50), value3 text, primary key (id), index(value, value2)) engine=rocksdb charset latin1 collate latin1_bin;
 ALTER TABLE t1 collate=latin1_general_ci;
 DROP TABLE t1;
-# restart

--- a/mysql-test/suite/rocksdb/r/collation.result
+++ b/mysql-test/suite/rocksdb/r/collation.result
@@ -3,12 +3,12 @@ CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), va
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 ALTER TABLE t1 ADD INDEX (value);
-ERROR HY000: Unsupported collation on string indexed column test.t1.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.t1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 DROP TABLE t1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.t1.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.t1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value3(50))) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.t1.value3 Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.t1.value3 Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_check=0;
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value3(50))) engine=rocksdb charset utf8;
 Warnings:
@@ -20,8 +20,8 @@ Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 DROP TABLE t1;
 CREATE TABLE t1 (id varchar(20), value varchar(50), value2 varchar(50), value3 text, primary key (id), index(value, value2)) engine=rocksdb charset latin1 collate latin1_bin;
-ALTER TABLE t1 MODIFY value VARCHAR(50) CHARACTER SET latin1 COLLATE latin1_general_ci;
-ERROR HY000: Unsupported collation on string indexed column test.#sqlx-nnnn_nnnn.value Use binary collation (binary, latin1_bin, utf8_bin).
+ALTER TABLE t1 MODIFY value VARCHAR(50) CHARACTER SET latin1 COLLATE latin1_german2_ci;
+ERROR HY000: Unsupported collation on string indexed column test.#sqlx-nnnn_nnnn.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 DROP TABLE t1;
 CREATE TABLE t1 (id varchar(20), value varchar(50), value2 varchar(50), value3 text, primary key (id), index(value, value2)) engine=rocksdb charset utf8 collate utf8_bin;
 Warnings:
@@ -38,21 +38,21 @@ Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 DROP TABLE t1;
 CREATE TABLE t2 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.t2.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.t2.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions="t.*";
 CREATE TABLE t123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 DROP TABLE t123;
 CREATE TABLE s123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.s123.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.s123.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions=".t.*";
 CREATE TABLE xt123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 DROP TABLE xt123;
 CREATE TABLE t123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.t123.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.t123.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions="s.*,t.*";
 CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 Warnings:
@@ -63,7 +63,7 @@ Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 DROP TABLE t1;
 CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions="s.*|t.*";
 CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 Warnings:
@@ -74,7 +74,7 @@ Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 DROP TABLE t1;
 CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions=",s.*,t.*";
 CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 Warnings:
@@ -85,7 +85,7 @@ Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 DROP TABLE t1;
 CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions="|s.*|t.*";
 CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 Warnings:
@@ -96,7 +96,7 @@ Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 DROP TABLE t1;
 CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions="s.*,,t.*";
 CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 Warnings:
@@ -107,7 +107,7 @@ Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 DROP TABLE t1;
 CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions="s.*||t.*";
 CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 Warnings:
@@ -118,7 +118,7 @@ Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 DROP TABLE t1;
 CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions="s.*,t.*,";
 CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 Warnings:
@@ -129,7 +129,7 @@ Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 DROP TABLE t1;
 CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions="s.*|t.*|";
 CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 Warnings:
@@ -140,7 +140,7 @@ Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 DROP TABLE t1;
 CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions="||||,,,,s.*,,|,,||,t.*,,|||,,,";
 CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 Warnings:
@@ -151,21 +151,25 @@ Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 DROP TABLE t1;
 CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions='t1';
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb;
+CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 ALTER TABLE t1 AUTO_INCREMENT=1, ALGORITHM=COPY;
 DROP TABLE t1;
-CREATE TABLE t2 (id INT primary key, value varchar(50), index(value)) engine=rocksdb;
-ERROR HY000: Unsupported collation on string indexed column test.t2.value Use binary collation (binary, latin1_bin, utf8_bin).
-CREATE TABLE t2 (id INT primary key, value varchar(50)) engine=rocksdb;
+CREATE TABLE t2 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
+ERROR HY000: Unsupported collation on string indexed column test.t2.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
+CREATE TABLE t2 (id INT primary key, value varchar(50)) engine=rocksdb charset utf8;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 ALTER TABLE t2 ADD INDEX(value);
-ERROR HY000: Unsupported collation on string indexed column test.t2.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.t2.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 DROP TABLE t2;
 SET GLOBAL rocksdb_strict_collation_exceptions="[a-b";
 Invalid pattern in strict_collation_exceptions: [a-b
 CREATE TABLE a (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.a.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.a.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions="[a-b]";
 CREATE TABLE a (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
 Warnings:
@@ -174,18 +178,18 @@ CREATE TABLE b (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rock
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 CREATE TABLE c (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.c.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.c.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 DROP TABLE a, b;
 SET GLOBAL rocksdb_strict_collation_exceptions="abc\\";
 Invalid pattern in strict_collation_exceptions: abc\
 CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.abc.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.abc.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions="abc";
 CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 CREATE TABLE abcd (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.abcd.value Use binary collation (binary, latin1_bin, utf8_bin).
+ERROR HY000: Unsupported collation on string indexed column test.abcd.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 DROP TABLE abc;
 SET GLOBAL rocksdb_strict_collation_exceptions=null;
 # restart: --rocksdb_error_on_suboptimal_collation=0
@@ -193,14 +197,14 @@ SET GLOBAL rocksdb_strict_collation_check=1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value)) engine=rocksdb charset utf8;
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-Warning	1210	Unsupported collation on string indexed column test.t1.value Use binary collation (binary, latin1_bin, utf8_bin).
+Warning	1210	Unsupported collation on string indexed column test.t1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 DROP TABLE t1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text) engine=rocksdb charset utf8;
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 ALTER TABLE t1 ADD INDEX (value);
 Warnings:
-Warning	1210	Unsupported collation on string indexed column test.t1.value Use binary collation (binary, latin1_bin, utf8_bin).
+Warning	1210	Unsupported collation on string indexed column test.t1.value Use binary collation (binary, latin1_bin, utf8_bin, utf8mb4_bin).
 DROP TABLE t1;
 CREATE TABLE t1 (id varchar(20), value varchar(50), value2 varchar(50), value3 text, primary key (id), index(value, value2)) engine=rocksdb charset latin1 collate latin1_bin;
 ALTER TABLE t1 collate=latin1_general_ci;

--- a/mysql-test/suite/rocksdb/r/type_char_indexes_collation.result
+++ b/mysql-test/suite/rocksdb/r/type_char_indexes_collation.result
@@ -89,11 +89,11 @@ Asdf
 bbbb 
 drop table t;
 set session rocksdb_verify_row_debug_checksums = on;
-create table t (id int primary key, email varchar(100), KEY email_i (email(30))) engine=rocksdb default charset=latin1;
+create table t (id int primary key, email varchar(100), KEY email_i (email)) engine=rocksdb default charset=latin1;
 insert into t values (1, '                                  a');
 explain select 'email_i' as index_name, count(*) AS count from t force index(email_i);
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t	NULL	index	NULL	email_i	33	#	1000	100.00	Using index
+1	SIMPLE	t	NULL	index	NULL	email_i	#	#	1000	100.00	Using index
 Warnings:
 Note	1003	/* select#1 */ select 'email_i' AS `index_name`,count(0) AS `count` from `test`.`t` FORCE INDEX (`email_i`)
 select 'email_i' as index_name, count(*) AS count from t force index(email_i);

--- a/mysql-test/suite/rocksdb/r/type_char_secondary_index_only_scan.result
+++ b/mysql-test/suite/rocksdb/r/type_char_secondary_index_only_scan.result
@@ -1,0 +1,361 @@
+CALL mtr.add_suppression("MyRocks will handle this collation internally as if it had a NO_PAD attribute");
+CALL mtr.add_suppression("RocksDB: you're trying to create an index with a multi-level collation");
+CREATE TABLE collations AS SELECT * FROM information_schema.COLLATION_CHARACTER_SET_APPLICABILITY ORDER BY COLLATION_NAME;
+CharSet, Collate, Char Extra, VarChar Extra
+armscii8, armscii8_bin, Using index, Using index
+armscii8, armscii8_general_ci, Using index, Using index
+ascii, ascii_bin, Using index, Using index
+ascii, ascii_general_ci, Using index, Using index
+big5, big5_bin, NULL, NULL
+big5, big5_chinese_ci, NULL, NULL
+binary, binary, Using index, Using index
+cp1250, cp1250_bin, Using index, Using index
+cp1250, cp1250_croatian_ci, Using index, Using index
+cp1250, cp1250_czech_cs, NULL, NULL
+cp1250, cp1250_general_ci, Using index, Using index
+cp1250, cp1250_polish_ci, Using index, Using index
+cp1251, cp1251_bin, Using index, Using index
+cp1251, cp1251_bulgarian_ci, Using index, Using index
+cp1251, cp1251_general_ci, Using index, Using index
+cp1251, cp1251_general_cs, Using index, Using index
+cp1251, cp1251_ukrainian_ci, Using index, Using index
+cp1256, cp1256_bin, Using index, Using index
+cp1256, cp1256_general_ci, Using index, Using index
+cp1257, cp1257_bin, Using index, Using index
+cp1257, cp1257_general_ci, Using index, Using index
+cp1257, cp1257_lithuanian_ci, Using index, Using index
+cp850, cp850_bin, Using index, Using index
+cp850, cp850_general_ci, Using index, Using index
+cp852, cp852_bin, Using index, Using index
+cp852, cp852_general_ci, Using index, Using index
+cp866, cp866_bin, Using index, Using index
+cp866, cp866_general_ci, Using index, Using index
+cp932, cp932_bin, NULL, NULL
+cp932, cp932_japanese_ci, NULL, NULL
+dec8, dec8_bin, Using index, Using index
+dec8, dec8_swedish_ci, Using index, Using index
+eucjpms, eucjpms_bin, NULL, NULL
+eucjpms, eucjpms_japanese_ci, NULL, NULL
+euckr, euckr_bin, NULL, NULL
+euckr, euckr_korean_ci, NULL, NULL
+gb18030, gb18030_bin, NULL, NULL
+gb18030, gb18030_chinese_ci, NULL, NULL
+gb18030, gb18030_unicode_520_ci, NULL, NULL
+gb2312, gb2312_bin, NULL, NULL
+gb2312, gb2312_chinese_ci, NULL, NULL
+gbk, gbk_bin, NULL, NULL
+gbk, gbk_chinese_ci, NULL, NULL
+geostd8, geostd8_bin, Using index, Using index
+geostd8, geostd8_general_ci, Using index, Using index
+greek, greek_bin, Using index, Using index
+greek, greek_general_ci, Using index, Using index
+hebrew, hebrew_bin, Using index, Using index
+hebrew, hebrew_general_ci, Using index, Using index
+hp8, hp8_bin, Using index, Using index
+hp8, hp8_english_ci, Using index, Using index
+keybcs2, keybcs2_bin, Using index, Using index
+keybcs2, keybcs2_general_ci, Using index, Using index
+koi8r, koi8r_bin, Using index, Using index
+koi8r, koi8r_general_ci, Using index, Using index
+koi8u, koi8u_bin, Using index, Using index
+koi8u, koi8u_general_ci, Using index, Using index
+latin1, latin1_bin, Using index, Using index
+latin1, latin1_danish_ci, Using index, Using index
+latin1, latin1_general_ci, Using index, Using index
+latin1, latin1_general_cs, Using index, Using index
+latin1, latin1_german1_ci, Using index, Using index
+latin1, latin1_german2_ci, NULL, NULL
+latin1, latin1_spanish_ci, Using index, Using index
+latin1, latin1_swedish_ci, Using index, Using index
+latin2, latin2_bin, Using index, Using index
+latin2, latin2_croatian_ci, Using index, Using index
+latin2, latin2_czech_cs, NULL, NULL
+latin2, latin2_general_ci, Using index, Using index
+latin2, latin2_hungarian_ci, Using index, Using index
+latin5, latin5_bin, Using index, Using index
+latin5, latin5_turkish_ci, Using index, Using index
+latin7, latin7_bin, Using index, Using index
+latin7, latin7_estonian_cs, Using index, Using index
+latin7, latin7_general_ci, Using index, Using index
+latin7, latin7_general_cs, Using index, Using index
+macce, macce_bin, Using index, Using index
+macce, macce_general_ci, Using index, Using index
+macroman, macroman_bin, Using index, Using index
+macroman, macroman_general_ci, Using index, Using index
+sjis, sjis_bin, NULL, NULL
+sjis, sjis_japanese_ci, NULL, NULL
+swe7, swe7_bin, Using index, Using index
+swe7, swe7_swedish_ci, Using index, Using index
+tis620, tis620_bin, Using index, Using index
+tis620, tis620_thai_ci, NULL, NULL
+ucs2, ucs2_bin, NULL, NULL
+ucs2, ucs2_croatian_ci, NULL, NULL
+ucs2, ucs2_czech_ci, NULL, NULL
+ucs2, ucs2_danish_ci, NULL, NULL
+ucs2, ucs2_esperanto_ci, NULL, NULL
+ucs2, ucs2_estonian_ci, NULL, NULL
+ucs2, ucs2_general_ci, NULL, NULL
+ucs2, ucs2_general_mysql500_ci, NULL, NULL
+ucs2, ucs2_german2_ci, NULL, NULL
+ucs2, ucs2_hungarian_ci, NULL, NULL
+ucs2, ucs2_icelandic_ci, NULL, NULL
+ucs2, ucs2_latvian_ci, NULL, NULL
+ucs2, ucs2_lithuanian_ci, NULL, NULL
+ucs2, ucs2_persian_ci, NULL, NULL
+ucs2, ucs2_polish_ci, NULL, NULL
+ucs2, ucs2_romanian_ci, NULL, NULL
+ucs2, ucs2_roman_ci, NULL, NULL
+ucs2, ucs2_sinhala_ci, NULL, NULL
+ucs2, ucs2_slovak_ci, NULL, NULL
+ucs2, ucs2_slovenian_ci, NULL, NULL
+ucs2, ucs2_spanish2_ci, NULL, NULL
+ucs2, ucs2_spanish_ci, NULL, NULL
+ucs2, ucs2_swedish_ci, NULL, NULL
+ucs2, ucs2_turkish_ci, NULL, NULL
+ucs2, ucs2_unicode_520_ci, NULL, NULL
+ucs2, ucs2_unicode_ci, NULL, NULL
+ucs2, ucs2_vietnamese_ci, NULL, NULL
+ujis, ujis_bin, NULL, NULL
+ujis, ujis_japanese_ci, NULL, NULL
+utf16le, utf16le_bin, NULL, NULL
+utf16le, utf16le_general_ci, NULL, NULL
+utf16, utf16_bin, NULL, NULL
+utf16, utf16_croatian_ci, NULL, NULL
+utf16, utf16_czech_ci, NULL, NULL
+utf16, utf16_danish_ci, NULL, NULL
+utf16, utf16_esperanto_ci, NULL, NULL
+utf16, utf16_estonian_ci, NULL, NULL
+utf16, utf16_general_ci, NULL, NULL
+utf16, utf16_german2_ci, NULL, NULL
+utf16, utf16_hungarian_ci, NULL, NULL
+utf16, utf16_icelandic_ci, NULL, NULL
+utf16, utf16_latvian_ci, NULL, NULL
+utf16, utf16_lithuanian_ci, NULL, NULL
+utf16, utf16_persian_ci, NULL, NULL
+utf16, utf16_polish_ci, NULL, NULL
+utf16, utf16_romanian_ci, NULL, NULL
+utf16, utf16_roman_ci, NULL, NULL
+utf16, utf16_sinhala_ci, NULL, NULL
+utf16, utf16_slovak_ci, NULL, NULL
+utf16, utf16_slovenian_ci, NULL, NULL
+utf16, utf16_spanish2_ci, NULL, NULL
+utf16, utf16_spanish_ci, NULL, NULL
+utf16, utf16_swedish_ci, NULL, NULL
+utf16, utf16_turkish_ci, NULL, NULL
+utf16, utf16_unicode_520_ci, NULL, NULL
+utf16, utf16_unicode_ci, NULL, NULL
+utf16, utf16_vietnamese_ci, NULL, NULL
+utf32, utf32_bin, NULL, NULL
+utf32, utf32_croatian_ci, NULL, NULL
+utf32, utf32_czech_ci, NULL, NULL
+utf32, utf32_danish_ci, NULL, NULL
+utf32, utf32_esperanto_ci, NULL, NULL
+utf32, utf32_estonian_ci, NULL, NULL
+utf32, utf32_general_ci, NULL, NULL
+utf32, utf32_german2_ci, NULL, NULL
+utf32, utf32_hungarian_ci, NULL, NULL
+utf32, utf32_icelandic_ci, NULL, NULL
+utf32, utf32_latvian_ci, NULL, NULL
+utf32, utf32_lithuanian_ci, NULL, NULL
+utf32, utf32_persian_ci, NULL, NULL
+utf32, utf32_polish_ci, NULL, NULL
+utf32, utf32_romanian_ci, NULL, NULL
+utf32, utf32_roman_ci, NULL, NULL
+utf32, utf32_sinhala_ci, NULL, NULL
+utf32, utf32_slovak_ci, NULL, NULL
+utf32, utf32_slovenian_ci, NULL, NULL
+utf32, utf32_spanish2_ci, NULL, NULL
+utf32, utf32_spanish_ci, NULL, NULL
+utf32, utf32_swedish_ci, NULL, NULL
+utf32, utf32_turkish_ci, NULL, NULL
+utf32, utf32_unicode_520_ci, NULL, NULL
+utf32, utf32_unicode_ci, NULL, NULL
+utf32, utf32_vietnamese_ci, NULL, NULL
+utf8mb4, utf8mb4_0900_ai_ci, NULL, NULL
+utf8mb4, utf8mb4_0900_as_ci, NULL, NULL
+utf8mb4, utf8mb4_0900_as_cs, NULL, NULL
+utf8mb4, utf8mb4_0900_bin, NULL, NULL
+utf8mb4, utf8mb4_bin, Using index, Using index
+utf8mb4, utf8mb4_croatian_ci, NULL, NULL
+utf8mb4, utf8mb4_cs_0900_ai_ci, NULL, NULL
+utf8mb4, utf8mb4_cs_0900_as_cs, NULL, NULL
+utf8mb4, utf8mb4_czech_ci, NULL, NULL
+utf8mb4, utf8mb4_danish_ci, NULL, NULL
+utf8mb4, utf8mb4_da_0900_ai_ci, NULL, NULL
+utf8mb4, utf8mb4_da_0900_as_cs, NULL, NULL
+utf8mb4, utf8mb4_de_pb_0900_ai_ci, NULL, NULL
+utf8mb4, utf8mb4_de_pb_0900_as_cs, NULL, NULL
+utf8mb4, utf8mb4_eo_0900_ai_ci, NULL, NULL
+utf8mb4, utf8mb4_eo_0900_as_cs, NULL, NULL
+utf8mb4, utf8mb4_esperanto_ci, NULL, NULL
+utf8mb4, utf8mb4_estonian_ci, NULL, NULL
+utf8mb4, utf8mb4_es_0900_ai_ci, NULL, NULL
+utf8mb4, utf8mb4_es_0900_as_cs, NULL, NULL
+utf8mb4, utf8mb4_es_trad_0900_ai_ci, NULL, NULL
+utf8mb4, utf8mb4_es_trad_0900_as_cs, NULL, NULL
+utf8mb4, utf8mb4_et_0900_ai_ci, NULL, NULL
+utf8mb4, utf8mb4_et_0900_as_cs, NULL, NULL
+utf8mb4, utf8mb4_general_ci, NULL, NULL
+utf8mb4, utf8mb4_german2_ci, NULL, NULL
+utf8mb4, utf8mb4_hr_0900_ai_ci, NULL, NULL
+utf8mb4, utf8mb4_hr_0900_as_cs, NULL, NULL
+utf8mb4, utf8mb4_hungarian_ci, NULL, NULL
+utf8mb4, utf8mb4_hu_0900_ai_ci, NULL, NULL
+utf8mb4, utf8mb4_hu_0900_as_cs, NULL, NULL
+utf8mb4, utf8mb4_icelandic_ci, NULL, NULL
+utf8mb4, utf8mb4_is_0900_ai_ci, NULL, NULL
+utf8mb4, utf8mb4_is_0900_as_cs, NULL, NULL
+utf8mb4, utf8mb4_ja_0900_as_cs, NULL, NULL
+utf8mb4, utf8mb4_ja_0900_as_cs_ks, NULL, NULL
+utf8mb4, utf8mb4_latvian_ci, NULL, NULL
+utf8mb4, utf8mb4_la_0900_ai_ci, NULL, NULL
+utf8mb4, utf8mb4_la_0900_as_cs, NULL, NULL
+utf8mb4, utf8mb4_lithuanian_ci, NULL, NULL
+utf8mb4, utf8mb4_lt_0900_ai_ci, NULL, NULL
+utf8mb4, utf8mb4_lt_0900_as_cs, NULL, NULL
+utf8mb4, utf8mb4_lv_0900_ai_ci, NULL, NULL
+utf8mb4, utf8mb4_lv_0900_as_cs, NULL, NULL
+utf8mb4, utf8mb4_persian_ci, NULL, NULL
+utf8mb4, utf8mb4_pl_0900_ai_ci, NULL, NULL
+utf8mb4, utf8mb4_pl_0900_as_cs, NULL, NULL
+utf8mb4, utf8mb4_polish_ci, NULL, NULL
+utf8mb4, utf8mb4_romanian_ci, NULL, NULL
+utf8mb4, utf8mb4_roman_ci, NULL, NULL
+utf8mb4, utf8mb4_ro_0900_ai_ci, NULL, NULL
+utf8mb4, utf8mb4_ro_0900_as_cs, NULL, NULL
+utf8mb4, utf8mb4_ru_0900_ai_ci, NULL, NULL
+utf8mb4, utf8mb4_ru_0900_as_cs, NULL, NULL
+utf8mb4, utf8mb4_sinhala_ci, NULL, NULL
+utf8mb4, utf8mb4_sk_0900_ai_ci, NULL, NULL
+utf8mb4, utf8mb4_sk_0900_as_cs, NULL, NULL
+utf8mb4, utf8mb4_slovak_ci, NULL, NULL
+utf8mb4, utf8mb4_slovenian_ci, NULL, NULL
+utf8mb4, utf8mb4_sl_0900_ai_ci, NULL, NULL
+utf8mb4, utf8mb4_sl_0900_as_cs, NULL, NULL
+utf8mb4, utf8mb4_spanish2_ci, NULL, NULL
+utf8mb4, utf8mb4_spanish_ci, NULL, NULL
+utf8mb4, utf8mb4_sv_0900_ai_ci, NULL, NULL
+utf8mb4, utf8mb4_sv_0900_as_cs, NULL, NULL
+utf8mb4, utf8mb4_swedish_ci, NULL, NULL
+utf8mb4, utf8mb4_tr_0900_ai_ci, NULL, NULL
+utf8mb4, utf8mb4_tr_0900_as_cs, NULL, NULL
+utf8mb4, utf8mb4_turkish_ci, NULL, NULL
+utf8mb4, utf8mb4_unicode_520_ci, NULL, NULL
+utf8mb4, utf8mb4_unicode_ci, NULL, NULL
+utf8mb4, utf8mb4_vietnamese_ci, NULL, NULL
+utf8mb4, utf8mb4_vi_0900_ai_ci, NULL, NULL
+utf8mb4, utf8mb4_vi_0900_as_cs, NULL, NULL
+utf8mb4, utf8mb4_zh_0900_as_cs, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_bin' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_bin, Using index, Using index
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_croatian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_croatian_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_czech_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_czech_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_danish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_danish_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_esperanto_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_esperanto_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_estonian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_estonian_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_general_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_general_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_general_mysql500_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_general_mysql500_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_german2_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_german2_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_hungarian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_hungarian_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_icelandic_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_icelandic_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_latvian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_latvian_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_lithuanian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_lithuanian_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_persian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_persian_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_polish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_polish_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_romanian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_romanian_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_roman_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_roman_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_sinhala_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_sinhala_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_slovak_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_slovak_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_slovenian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_slovenian_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_spanish2_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_spanish2_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_spanish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_spanish_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_swedish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_swedish_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_tolower_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_tolower_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_turkish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_turkish_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_unicode_520_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_unicode_520_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_unicode_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_unicode_ci, NULL, NULL
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_vietnamese_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+utf8, utf8_vietnamese_ci, NULL, NULL
+DROP TABLE collations;

--- a/mysql-test/suite/rocksdb/r/type_char_secondary_index_only_scan.result
+++ b/mysql-test/suite/rocksdb/r/type_char_secondary_index_only_scan.result
@@ -1,17 +1,15 @@
-CALL mtr.add_suppression("MyRocks will handle this collation internally as if it had a NO_PAD attribute");
-CALL mtr.add_suppression("RocksDB: you're trying to create an index with a multi-level collation");
 CREATE TABLE collations AS SELECT * FROM information_schema.COLLATION_CHARACTER_SET_APPLICABILITY ORDER BY COLLATION_NAME;
 CharSet, Collate, Char Extra, VarChar Extra
 armscii8, armscii8_bin, Using index, Using index
 armscii8, armscii8_general_ci, Using index, Using index
 ascii, ascii_bin, Using index, Using index
 ascii, ascii_general_ci, Using index, Using index
-big5, big5_bin, NULL, NULL
-big5, big5_chinese_ci, NULL, NULL
+big5, big5_bin, Using index, Using index
+big5, big5_chinese_ci, Using index, Using index
 binary, binary, Using index, Using index
 cp1250, cp1250_bin, Using index, Using index
 cp1250, cp1250_croatian_ci, Using index, Using index
-cp1250, cp1250_czech_cs, NULL, NULL
+cp1250, cp1250_czech_cs, Using index, Using index
 cp1250, cp1250_general_ci, Using index, Using index
 cp1250, cp1250_polish_ci, Using index, Using index
 cp1251, cp1251_bin, Using index, Using index
@@ -30,21 +28,21 @@ cp852, cp852_bin, Using index, Using index
 cp852, cp852_general_ci, Using index, Using index
 cp866, cp866_bin, Using index, Using index
 cp866, cp866_general_ci, Using index, Using index
-cp932, cp932_bin, NULL, NULL
-cp932, cp932_japanese_ci, NULL, NULL
+cp932, cp932_bin, Using index, Using index
+cp932, cp932_japanese_ci, Using index, Using index
 dec8, dec8_bin, Using index, Using index
 dec8, dec8_swedish_ci, Using index, Using index
-eucjpms, eucjpms_bin, NULL, NULL
-eucjpms, eucjpms_japanese_ci, NULL, NULL
-euckr, euckr_bin, NULL, NULL
-euckr, euckr_korean_ci, NULL, NULL
-gb18030, gb18030_bin, NULL, NULL
-gb18030, gb18030_chinese_ci, NULL, NULL
-gb18030, gb18030_unicode_520_ci, NULL, NULL
-gb2312, gb2312_bin, NULL, NULL
-gb2312, gb2312_chinese_ci, NULL, NULL
-gbk, gbk_bin, NULL, NULL
-gbk, gbk_chinese_ci, NULL, NULL
+eucjpms, eucjpms_bin, Using index, Using index
+eucjpms, eucjpms_japanese_ci, Using index, Using index
+euckr, euckr_bin, Using index, Using index
+euckr, euckr_korean_ci, Using index, Using index
+gb18030, gb18030_bin, Using index, Using index
+gb18030, gb18030_chinese_ci, Using index, Using index
+gb18030, gb18030_unicode_520_ci, Using index, Using index
+gb2312, gb2312_bin, Using index, Using index
+gb2312, gb2312_chinese_ci, Using index, Using index
+gbk, gbk_bin, Using index, Using index
+gbk, gbk_chinese_ci, Using index, Using index
 geostd8, geostd8_bin, Using index, Using index
 geostd8, geostd8_general_ci, Using index, Using index
 greek, greek_bin, Using index, Using index
@@ -64,12 +62,12 @@ latin1, latin1_danish_ci, Using index, Using index
 latin1, latin1_general_ci, Using index, Using index
 latin1, latin1_general_cs, Using index, Using index
 latin1, latin1_german1_ci, Using index, Using index
-latin1, latin1_german2_ci, NULL, NULL
+latin1, latin1_german2_ci, Using index, Using index
 latin1, latin1_spanish_ci, Using index, Using index
 latin1, latin1_swedish_ci, Using index, Using index
 latin2, latin2_bin, Using index, Using index
 latin2, latin2_croatian_ci, Using index, Using index
-latin2, latin2_czech_cs, NULL, NULL
+latin2, latin2_czech_cs, Using index, Using index
 latin2, latin2_general_ci, Using index, Using index
 latin2, latin2_hungarian_ci, Using index, Using index
 latin5, latin5_bin, Using index, Using index
@@ -82,170 +80,170 @@ macce, macce_bin, Using index, Using index
 macce, macce_general_ci, Using index, Using index
 macroman, macroman_bin, Using index, Using index
 macroman, macroman_general_ci, Using index, Using index
-sjis, sjis_bin, NULL, NULL
-sjis, sjis_japanese_ci, NULL, NULL
+sjis, sjis_bin, Using index, Using index
+sjis, sjis_japanese_ci, Using index, Using index
 swe7, swe7_bin, Using index, Using index
 swe7, swe7_swedish_ci, Using index, Using index
 tis620, tis620_bin, Using index, Using index
-tis620, tis620_thai_ci, NULL, NULL
-ucs2, ucs2_bin, NULL, NULL
-ucs2, ucs2_croatian_ci, NULL, NULL
-ucs2, ucs2_czech_ci, NULL, NULL
-ucs2, ucs2_danish_ci, NULL, NULL
-ucs2, ucs2_esperanto_ci, NULL, NULL
-ucs2, ucs2_estonian_ci, NULL, NULL
-ucs2, ucs2_general_ci, NULL, NULL
-ucs2, ucs2_general_mysql500_ci, NULL, NULL
-ucs2, ucs2_german2_ci, NULL, NULL
-ucs2, ucs2_hungarian_ci, NULL, NULL
-ucs2, ucs2_icelandic_ci, NULL, NULL
-ucs2, ucs2_latvian_ci, NULL, NULL
-ucs2, ucs2_lithuanian_ci, NULL, NULL
-ucs2, ucs2_persian_ci, NULL, NULL
-ucs2, ucs2_polish_ci, NULL, NULL
-ucs2, ucs2_romanian_ci, NULL, NULL
-ucs2, ucs2_roman_ci, NULL, NULL
-ucs2, ucs2_sinhala_ci, NULL, NULL
-ucs2, ucs2_slovak_ci, NULL, NULL
-ucs2, ucs2_slovenian_ci, NULL, NULL
-ucs2, ucs2_spanish2_ci, NULL, NULL
-ucs2, ucs2_spanish_ci, NULL, NULL
-ucs2, ucs2_swedish_ci, NULL, NULL
-ucs2, ucs2_turkish_ci, NULL, NULL
-ucs2, ucs2_unicode_520_ci, NULL, NULL
-ucs2, ucs2_unicode_ci, NULL, NULL
-ucs2, ucs2_vietnamese_ci, NULL, NULL
-ujis, ujis_bin, NULL, NULL
-ujis, ujis_japanese_ci, NULL, NULL
-utf16le, utf16le_bin, NULL, NULL
-utf16le, utf16le_general_ci, NULL, NULL
-utf16, utf16_bin, NULL, NULL
-utf16, utf16_croatian_ci, NULL, NULL
-utf16, utf16_czech_ci, NULL, NULL
-utf16, utf16_danish_ci, NULL, NULL
-utf16, utf16_esperanto_ci, NULL, NULL
-utf16, utf16_estonian_ci, NULL, NULL
-utf16, utf16_general_ci, NULL, NULL
-utf16, utf16_german2_ci, NULL, NULL
-utf16, utf16_hungarian_ci, NULL, NULL
-utf16, utf16_icelandic_ci, NULL, NULL
-utf16, utf16_latvian_ci, NULL, NULL
-utf16, utf16_lithuanian_ci, NULL, NULL
-utf16, utf16_persian_ci, NULL, NULL
-utf16, utf16_polish_ci, NULL, NULL
-utf16, utf16_romanian_ci, NULL, NULL
-utf16, utf16_roman_ci, NULL, NULL
-utf16, utf16_sinhala_ci, NULL, NULL
-utf16, utf16_slovak_ci, NULL, NULL
-utf16, utf16_slovenian_ci, NULL, NULL
-utf16, utf16_spanish2_ci, NULL, NULL
-utf16, utf16_spanish_ci, NULL, NULL
-utf16, utf16_swedish_ci, NULL, NULL
-utf16, utf16_turkish_ci, NULL, NULL
-utf16, utf16_unicode_520_ci, NULL, NULL
-utf16, utf16_unicode_ci, NULL, NULL
-utf16, utf16_vietnamese_ci, NULL, NULL
-utf32, utf32_bin, NULL, NULL
-utf32, utf32_croatian_ci, NULL, NULL
-utf32, utf32_czech_ci, NULL, NULL
-utf32, utf32_danish_ci, NULL, NULL
-utf32, utf32_esperanto_ci, NULL, NULL
-utf32, utf32_estonian_ci, NULL, NULL
-utf32, utf32_general_ci, NULL, NULL
-utf32, utf32_german2_ci, NULL, NULL
-utf32, utf32_hungarian_ci, NULL, NULL
-utf32, utf32_icelandic_ci, NULL, NULL
-utf32, utf32_latvian_ci, NULL, NULL
-utf32, utf32_lithuanian_ci, NULL, NULL
-utf32, utf32_persian_ci, NULL, NULL
-utf32, utf32_polish_ci, NULL, NULL
-utf32, utf32_romanian_ci, NULL, NULL
-utf32, utf32_roman_ci, NULL, NULL
-utf32, utf32_sinhala_ci, NULL, NULL
-utf32, utf32_slovak_ci, NULL, NULL
-utf32, utf32_slovenian_ci, NULL, NULL
-utf32, utf32_spanish2_ci, NULL, NULL
-utf32, utf32_spanish_ci, NULL, NULL
-utf32, utf32_swedish_ci, NULL, NULL
-utf32, utf32_turkish_ci, NULL, NULL
-utf32, utf32_unicode_520_ci, NULL, NULL
-utf32, utf32_unicode_ci, NULL, NULL
-utf32, utf32_vietnamese_ci, NULL, NULL
-utf8mb4, utf8mb4_0900_ai_ci, NULL, NULL
-utf8mb4, utf8mb4_0900_as_ci, NULL, NULL
-utf8mb4, utf8mb4_0900_as_cs, NULL, NULL
-utf8mb4, utf8mb4_0900_bin, NULL, NULL
+tis620, tis620_thai_ci, Using index, Using index
+ucs2, ucs2_bin, Using index, Using index
+ucs2, ucs2_croatian_ci, Using index, Using index
+ucs2, ucs2_czech_ci, Using index, Using index
+ucs2, ucs2_danish_ci, Using index, Using index
+ucs2, ucs2_esperanto_ci, Using index, Using index
+ucs2, ucs2_estonian_ci, Using index, Using index
+ucs2, ucs2_general_ci, Using index, Using index
+ucs2, ucs2_general_mysql500_ci, Using index, Using index
+ucs2, ucs2_german2_ci, Using index, Using index
+ucs2, ucs2_hungarian_ci, Using index, Using index
+ucs2, ucs2_icelandic_ci, Using index, Using index
+ucs2, ucs2_latvian_ci, Using index, Using index
+ucs2, ucs2_lithuanian_ci, Using index, Using index
+ucs2, ucs2_persian_ci, Using index, Using index
+ucs2, ucs2_polish_ci, Using index, Using index
+ucs2, ucs2_romanian_ci, Using index, Using index
+ucs2, ucs2_roman_ci, Using index, Using index
+ucs2, ucs2_sinhala_ci, Using index, Using index
+ucs2, ucs2_slovak_ci, Using index, Using index
+ucs2, ucs2_slovenian_ci, Using index, Using index
+ucs2, ucs2_spanish2_ci, Using index, Using index
+ucs2, ucs2_spanish_ci, Using index, Using index
+ucs2, ucs2_swedish_ci, Using index, Using index
+ucs2, ucs2_turkish_ci, Using index, Using index
+ucs2, ucs2_unicode_520_ci, Using index, Using index
+ucs2, ucs2_unicode_ci, Using index, Using index
+ucs2, ucs2_vietnamese_ci, Using index, Using index
+ujis, ujis_bin, Using index, Using index
+ujis, ujis_japanese_ci, Using index, Using index
+utf16le, utf16le_bin, Using index, Using index
+utf16le, utf16le_general_ci, Using index, Using index
+utf16, utf16_bin, Using index, Using index
+utf16, utf16_croatian_ci, Using index, Using index
+utf16, utf16_czech_ci, Using index, Using index
+utf16, utf16_danish_ci, Using index, Using index
+utf16, utf16_esperanto_ci, Using index, Using index
+utf16, utf16_estonian_ci, Using index, Using index
+utf16, utf16_general_ci, Using index, Using index
+utf16, utf16_german2_ci, Using index, Using index
+utf16, utf16_hungarian_ci, Using index, Using index
+utf16, utf16_icelandic_ci, Using index, Using index
+utf16, utf16_latvian_ci, Using index, Using index
+utf16, utf16_lithuanian_ci, Using index, Using index
+utf16, utf16_persian_ci, Using index, Using index
+utf16, utf16_polish_ci, Using index, Using index
+utf16, utf16_romanian_ci, Using index, Using index
+utf16, utf16_roman_ci, Using index, Using index
+utf16, utf16_sinhala_ci, Using index, Using index
+utf16, utf16_slovak_ci, Using index, Using index
+utf16, utf16_slovenian_ci, Using index, Using index
+utf16, utf16_spanish2_ci, Using index, Using index
+utf16, utf16_spanish_ci, Using index, Using index
+utf16, utf16_swedish_ci, Using index, Using index
+utf16, utf16_turkish_ci, Using index, Using index
+utf16, utf16_unicode_520_ci, Using index, Using index
+utf16, utf16_unicode_ci, Using index, Using index
+utf16, utf16_vietnamese_ci, Using index, Using index
+utf32, utf32_bin, Using index, Using index
+utf32, utf32_croatian_ci, Using index, Using index
+utf32, utf32_czech_ci, Using index, Using index
+utf32, utf32_danish_ci, Using index, Using index
+utf32, utf32_esperanto_ci, Using index, Using index
+utf32, utf32_estonian_ci, Using index, Using index
+utf32, utf32_general_ci, Using index, Using index
+utf32, utf32_german2_ci, Using index, Using index
+utf32, utf32_hungarian_ci, Using index, Using index
+utf32, utf32_icelandic_ci, Using index, Using index
+utf32, utf32_latvian_ci, Using index, Using index
+utf32, utf32_lithuanian_ci, Using index, Using index
+utf32, utf32_persian_ci, Using index, Using index
+utf32, utf32_polish_ci, Using index, Using index
+utf32, utf32_romanian_ci, Using index, Using index
+utf32, utf32_roman_ci, Using index, Using index
+utf32, utf32_sinhala_ci, Using index, Using index
+utf32, utf32_slovak_ci, Using index, Using index
+utf32, utf32_slovenian_ci, Using index, Using index
+utf32, utf32_spanish2_ci, Using index, Using index
+utf32, utf32_spanish_ci, Using index, Using index
+utf32, utf32_swedish_ci, Using index, Using index
+utf32, utf32_turkish_ci, Using index, Using index
+utf32, utf32_unicode_520_ci, Using index, Using index
+utf32, utf32_unicode_ci, Using index, Using index
+utf32, utf32_vietnamese_ci, Using index, Using index
+utf8mb4, utf8mb4_0900_ai_ci, Using index, Using index
+utf8mb4, utf8mb4_0900_as_ci, Using index, Using index
+utf8mb4, utf8mb4_0900_as_cs, Using index, Using index
+utf8mb4, utf8mb4_0900_bin, Using index, Using index
 utf8mb4, utf8mb4_bin, Using index, Using index
-utf8mb4, utf8mb4_croatian_ci, NULL, NULL
-utf8mb4, utf8mb4_cs_0900_ai_ci, NULL, NULL
-utf8mb4, utf8mb4_cs_0900_as_cs, NULL, NULL
-utf8mb4, utf8mb4_czech_ci, NULL, NULL
-utf8mb4, utf8mb4_danish_ci, NULL, NULL
-utf8mb4, utf8mb4_da_0900_ai_ci, NULL, NULL
-utf8mb4, utf8mb4_da_0900_as_cs, NULL, NULL
-utf8mb4, utf8mb4_de_pb_0900_ai_ci, NULL, NULL
-utf8mb4, utf8mb4_de_pb_0900_as_cs, NULL, NULL
-utf8mb4, utf8mb4_eo_0900_ai_ci, NULL, NULL
-utf8mb4, utf8mb4_eo_0900_as_cs, NULL, NULL
-utf8mb4, utf8mb4_esperanto_ci, NULL, NULL
-utf8mb4, utf8mb4_estonian_ci, NULL, NULL
-utf8mb4, utf8mb4_es_0900_ai_ci, NULL, NULL
-utf8mb4, utf8mb4_es_0900_as_cs, NULL, NULL
-utf8mb4, utf8mb4_es_trad_0900_ai_ci, NULL, NULL
-utf8mb4, utf8mb4_es_trad_0900_as_cs, NULL, NULL
-utf8mb4, utf8mb4_et_0900_ai_ci, NULL, NULL
-utf8mb4, utf8mb4_et_0900_as_cs, NULL, NULL
-utf8mb4, utf8mb4_general_ci, NULL, NULL
-utf8mb4, utf8mb4_german2_ci, NULL, NULL
-utf8mb4, utf8mb4_hr_0900_ai_ci, NULL, NULL
-utf8mb4, utf8mb4_hr_0900_as_cs, NULL, NULL
-utf8mb4, utf8mb4_hungarian_ci, NULL, NULL
-utf8mb4, utf8mb4_hu_0900_ai_ci, NULL, NULL
-utf8mb4, utf8mb4_hu_0900_as_cs, NULL, NULL
-utf8mb4, utf8mb4_icelandic_ci, NULL, NULL
-utf8mb4, utf8mb4_is_0900_ai_ci, NULL, NULL
-utf8mb4, utf8mb4_is_0900_as_cs, NULL, NULL
-utf8mb4, utf8mb4_ja_0900_as_cs, NULL, NULL
-utf8mb4, utf8mb4_ja_0900_as_cs_ks, NULL, NULL
-utf8mb4, utf8mb4_latvian_ci, NULL, NULL
-utf8mb4, utf8mb4_la_0900_ai_ci, NULL, NULL
-utf8mb4, utf8mb4_la_0900_as_cs, NULL, NULL
-utf8mb4, utf8mb4_lithuanian_ci, NULL, NULL
-utf8mb4, utf8mb4_lt_0900_ai_ci, NULL, NULL
-utf8mb4, utf8mb4_lt_0900_as_cs, NULL, NULL
-utf8mb4, utf8mb4_lv_0900_ai_ci, NULL, NULL
-utf8mb4, utf8mb4_lv_0900_as_cs, NULL, NULL
-utf8mb4, utf8mb4_persian_ci, NULL, NULL
-utf8mb4, utf8mb4_pl_0900_ai_ci, NULL, NULL
-utf8mb4, utf8mb4_pl_0900_as_cs, NULL, NULL
-utf8mb4, utf8mb4_polish_ci, NULL, NULL
-utf8mb4, utf8mb4_romanian_ci, NULL, NULL
-utf8mb4, utf8mb4_roman_ci, NULL, NULL
-utf8mb4, utf8mb4_ro_0900_ai_ci, NULL, NULL
-utf8mb4, utf8mb4_ro_0900_as_cs, NULL, NULL
-utf8mb4, utf8mb4_ru_0900_ai_ci, NULL, NULL
-utf8mb4, utf8mb4_ru_0900_as_cs, NULL, NULL
-utf8mb4, utf8mb4_sinhala_ci, NULL, NULL
-utf8mb4, utf8mb4_sk_0900_ai_ci, NULL, NULL
-utf8mb4, utf8mb4_sk_0900_as_cs, NULL, NULL
-utf8mb4, utf8mb4_slovak_ci, NULL, NULL
-utf8mb4, utf8mb4_slovenian_ci, NULL, NULL
-utf8mb4, utf8mb4_sl_0900_ai_ci, NULL, NULL
-utf8mb4, utf8mb4_sl_0900_as_cs, NULL, NULL
-utf8mb4, utf8mb4_spanish2_ci, NULL, NULL
-utf8mb4, utf8mb4_spanish_ci, NULL, NULL
-utf8mb4, utf8mb4_sv_0900_ai_ci, NULL, NULL
-utf8mb4, utf8mb4_sv_0900_as_cs, NULL, NULL
-utf8mb4, utf8mb4_swedish_ci, NULL, NULL
-utf8mb4, utf8mb4_tr_0900_ai_ci, NULL, NULL
-utf8mb4, utf8mb4_tr_0900_as_cs, NULL, NULL
-utf8mb4, utf8mb4_turkish_ci, NULL, NULL
-utf8mb4, utf8mb4_unicode_520_ci, NULL, NULL
-utf8mb4, utf8mb4_unicode_ci, NULL, NULL
-utf8mb4, utf8mb4_vietnamese_ci, NULL, NULL
-utf8mb4, utf8mb4_vi_0900_ai_ci, NULL, NULL
-utf8mb4, utf8mb4_vi_0900_as_cs, NULL, NULL
-utf8mb4, utf8mb4_zh_0900_as_cs, NULL, NULL
+utf8mb4, utf8mb4_croatian_ci, Using index, Using index
+utf8mb4, utf8mb4_cs_0900_ai_ci, Using index, Using index
+utf8mb4, utf8mb4_cs_0900_as_cs, Using index, Using index
+utf8mb4, utf8mb4_czech_ci, Using index, Using index
+utf8mb4, utf8mb4_danish_ci, Using index, Using index
+utf8mb4, utf8mb4_da_0900_ai_ci, Using index, Using index
+utf8mb4, utf8mb4_da_0900_as_cs, Using index, Using index
+utf8mb4, utf8mb4_de_pb_0900_ai_ci, Using index, Using index
+utf8mb4, utf8mb4_de_pb_0900_as_cs, Using index, Using index
+utf8mb4, utf8mb4_eo_0900_ai_ci, Using index, Using index
+utf8mb4, utf8mb4_eo_0900_as_cs, Using index, Using index
+utf8mb4, utf8mb4_esperanto_ci, Using index, Using index
+utf8mb4, utf8mb4_estonian_ci, Using index, Using index
+utf8mb4, utf8mb4_es_0900_ai_ci, Using index, Using index
+utf8mb4, utf8mb4_es_0900_as_cs, Using index, Using index
+utf8mb4, utf8mb4_es_trad_0900_ai_ci, Using index, Using index
+utf8mb4, utf8mb4_es_trad_0900_as_cs, Using index, Using index
+utf8mb4, utf8mb4_et_0900_ai_ci, Using index, Using index
+utf8mb4, utf8mb4_et_0900_as_cs, Using index, Using index
+utf8mb4, utf8mb4_general_ci, Using index, Using index
+utf8mb4, utf8mb4_german2_ci, Using index, Using index
+utf8mb4, utf8mb4_hr_0900_ai_ci, Using index, Using index
+utf8mb4, utf8mb4_hr_0900_as_cs, Using index, Using index
+utf8mb4, utf8mb4_hungarian_ci, Using index, Using index
+utf8mb4, utf8mb4_hu_0900_ai_ci, Using index, Using index
+utf8mb4, utf8mb4_hu_0900_as_cs, Using index, Using index
+utf8mb4, utf8mb4_icelandic_ci, Using index, Using index
+utf8mb4, utf8mb4_is_0900_ai_ci, Using index, Using index
+utf8mb4, utf8mb4_is_0900_as_cs, Using index, Using index
+utf8mb4, utf8mb4_ja_0900_as_cs, Using index, Using index
+utf8mb4, utf8mb4_ja_0900_as_cs_ks, Using index, Using index
+utf8mb4, utf8mb4_latvian_ci, Using index, Using index
+utf8mb4, utf8mb4_la_0900_ai_ci, Using index, Using index
+utf8mb4, utf8mb4_la_0900_as_cs, Using index, Using index
+utf8mb4, utf8mb4_lithuanian_ci, Using index, Using index
+utf8mb4, utf8mb4_lt_0900_ai_ci, Using index, Using index
+utf8mb4, utf8mb4_lt_0900_as_cs, Using index, Using index
+utf8mb4, utf8mb4_lv_0900_ai_ci, Using index, Using index
+utf8mb4, utf8mb4_lv_0900_as_cs, Using index, Using index
+utf8mb4, utf8mb4_persian_ci, Using index, Using index
+utf8mb4, utf8mb4_pl_0900_ai_ci, Using index, Using index
+utf8mb4, utf8mb4_pl_0900_as_cs, Using index, Using index
+utf8mb4, utf8mb4_polish_ci, Using index, Using index
+utf8mb4, utf8mb4_romanian_ci, Using index, Using index
+utf8mb4, utf8mb4_roman_ci, Using index, Using index
+utf8mb4, utf8mb4_ro_0900_ai_ci, Using index, Using index
+utf8mb4, utf8mb4_ro_0900_as_cs, Using index, Using index
+utf8mb4, utf8mb4_ru_0900_ai_ci, Using index, Using index
+utf8mb4, utf8mb4_ru_0900_as_cs, Using index, Using index
+utf8mb4, utf8mb4_sinhala_ci, Using index, Using index
+utf8mb4, utf8mb4_sk_0900_ai_ci, Using index, Using index
+utf8mb4, utf8mb4_sk_0900_as_cs, Using index, Using index
+utf8mb4, utf8mb4_slovak_ci, Using index, Using index
+utf8mb4, utf8mb4_slovenian_ci, Using index, Using index
+utf8mb4, utf8mb4_sl_0900_ai_ci, Using index, Using index
+utf8mb4, utf8mb4_sl_0900_as_cs, Using index, Using index
+utf8mb4, utf8mb4_spanish2_ci, Using index, Using index
+utf8mb4, utf8mb4_spanish_ci, Using index, Using index
+utf8mb4, utf8mb4_sv_0900_ai_ci, Using index, Using index
+utf8mb4, utf8mb4_sv_0900_as_cs, Using index, Using index
+utf8mb4, utf8mb4_swedish_ci, Using index, Using index
+utf8mb4, utf8mb4_tr_0900_ai_ci, Using index, Using index
+utf8mb4, utf8mb4_tr_0900_as_cs, Using index, Using index
+utf8mb4, utf8mb4_turkish_ci, Using index, Using index
+utf8mb4, utf8mb4_unicode_520_ci, Using index, Using index
+utf8mb4, utf8mb4_unicode_ci, Using index, Using index
+utf8mb4, utf8mb4_vietnamese_ci, Using index, Using index
+utf8mb4, utf8mb4_vi_0900_ai_ci, Using index, Using index
+utf8mb4, utf8mb4_vi_0900_as_cs, Using index, Using index
+utf8mb4, utf8mb4_zh_0900_as_cs, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_bin' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
@@ -253,109 +251,109 @@ utf8, utf8_bin, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_croatian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_croatian_ci, NULL, NULL
+utf8, utf8_croatian_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_czech_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_czech_ci, NULL, NULL
+utf8, utf8_czech_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_danish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_danish_ci, NULL, NULL
+utf8, utf8_danish_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_esperanto_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_esperanto_ci, NULL, NULL
+utf8, utf8_esperanto_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_estonian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_estonian_ci, NULL, NULL
+utf8, utf8_estonian_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_general_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_general_ci, NULL, NULL
+utf8, utf8_general_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_general_mysql500_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_general_mysql500_ci, NULL, NULL
+utf8, utf8_general_mysql500_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_german2_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_german2_ci, NULL, NULL
+utf8, utf8_german2_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_hungarian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_hungarian_ci, NULL, NULL
+utf8, utf8_hungarian_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_icelandic_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_icelandic_ci, NULL, NULL
+utf8, utf8_icelandic_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_latvian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_latvian_ci, NULL, NULL
+utf8, utf8_latvian_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_lithuanian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_lithuanian_ci, NULL, NULL
+utf8, utf8_lithuanian_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_persian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_persian_ci, NULL, NULL
+utf8, utf8_persian_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_polish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_polish_ci, NULL, NULL
+utf8, utf8_polish_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_romanian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_romanian_ci, NULL, NULL
+utf8, utf8_romanian_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_roman_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_roman_ci, NULL, NULL
+utf8, utf8_roman_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_sinhala_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_sinhala_ci, NULL, NULL
+utf8, utf8_sinhala_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_slovak_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_slovak_ci, NULL, NULL
+utf8, utf8_slovak_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_slovenian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_slovenian_ci, NULL, NULL
+utf8, utf8_slovenian_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_spanish2_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_spanish2_ci, NULL, NULL
+utf8, utf8_spanish2_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_spanish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_spanish_ci, NULL, NULL
+utf8, utf8_spanish_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_swedish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_swedish_ci, NULL, NULL
+utf8, utf8_swedish_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_tolower_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_tolower_ci, NULL, NULL
+utf8, utf8_tolower_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_turkish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_turkish_ci, NULL, NULL
+utf8, utf8_turkish_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_unicode_520_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_unicode_520_ci, NULL, NULL
+utf8, utf8_unicode_520_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_unicode_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_unicode_ci, NULL, NULL
+utf8, utf8_unicode_ci, Using index, Using index
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_vietnamese_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-utf8, utf8_vietnamese_ci, NULL, NULL
+utf8, utf8_vietnamese_ci, Using index, Using index
 DROP TABLE collations;

--- a/mysql-test/suite/rocksdb/r/type_text_indexes.result
+++ b/mysql-test/suite/rocksdb/r/type_text_indexes.result
@@ -24,7 +24,7 @@ INSERT INTO t1 (t,tt,m,l) VALUES
 (REPEAT('c',128),REPEAT('b',128),REPEAT('c',128),REPEAT('e',128));
 EXPLAIN SELECT SUBSTRING(t,16) AS f FROM t1 WHERE t IN ('test1','test2') ORDER BY f;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t1	NULL	range	PRIMARY	PRIMARY	34	NULL	#	#	Using where; Using filesort
+1	SIMPLE	t1	NULL	range	PRIMARY	PRIMARY	#	NULL	#	#	Using where; Using filesort
 Warnings:
 Note	1003	/* select#1 */ select substr(`test`.`t1`.`t`,16) AS `f` from `test`.`t1` where (`test`.`t1`.`t` in ('test1','test2')) order by `f`
 SELECT SUBSTRING(t,16) AS f FROM t1 WHERE t IN ('test1','test2') ORDER BY f;
@@ -76,7 +76,7 @@ INSERT INTO t1 (t,tt,m,l,pk) VALUES
 (REPEAT('c',128),REPEAT('b',128),REPEAT('c',128),REPEAT('e',128),'9');
 EXPLAIN SELECT SUBSTRING(m,128) AS f FROM t1 WHERE m = 'test1' ORDER BY f DESC;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t1	NULL	ref	m	m	131	const	#	#	Using where; Using filesort
+1	SIMPLE	t1	NULL	ref	m	m	#	const	#	#	Using where; Using filesort
 Warnings:
 Note	1003	/* select#1 */ select substr(`test`.`t1`.`m`,128) AS `f` from `test`.`t1` where (`test`.`t1`.`m` = 'test1') order by `f` desc
 SELECT SUBSTRING(m,128) AS f FROM t1 WHERE m = 'test1' ORDER BY f DESC;
@@ -247,7 +247,7 @@ create table t (id int primary key, email text, KEY email_i (email(30))) engine=
 insert into t values (1, '                                  a');
 explain select 'email_i' as index_name, count(*) AS count from t force index(email_i);
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t	NULL	index	NULL	email_i	33	#	1000	100.00	Using index
+1	SIMPLE	t	NULL	ALL	NULL	NULL	#	#	1000	100.00	NULL
 Warnings:
 Note	1003	/* select#1 */ select 'email_i' AS `index_name`,count(0) AS `count` from `test`.`t` FORCE INDEX (`email_i`)
 select 'email_i' as index_name, count(*) AS count from t force index(email_i);

--- a/mysql-test/suite/rocksdb/r/type_varchar_packing.result
+++ b/mysql-test/suite/rocksdb/r/type_varchar_packing.result
@@ -1,0 +1,5162 @@
+CREATE TABLE collations AS SELECT COLLATION_NAME, CHARACTER_SET_NAME, PAD_ATTRIBUTE FROM information_schema.COLLATIONS WHERE COLLATION_NAME NOT IN ("latin2_czech_cs", "cp1250_czech_cs", "utf8mb4_0900_as_cs", "utf8mb4_de_pb_0900_as_cs", "utf8mb4_is_0900_as_cs", "utf8mb4_lv_0900_as_cs", "utf8mb4_ro_0900_as_cs", "utf8mb4_sl_0900_as_cs", "utf8mb4_pl_0900_as_cs", "utf8mb4_et_0900_as_cs", "utf8mb4_es_0900_as_cs", "utf8mb4_sv_0900_as_cs", "utf8mb4_tr_0900_as_cs", "utf8mb4_cs_0900_as_cs", "utf8mb4_da_0900_as_cs", "utf8mb4_lt_0900_as_cs", "utf8mb4_sk_0900_as_cs", "utf8mb4_es_trad_0900_as_cs", "utf8mb4_la_0900_as_cs", "utf8mb4_eo_0900_as_cs", "utf8mb4_hu_0900_as_cs", "utf8mb4_hr_0900_as_cs", "utf8mb4_vi_0900_as_cs", "utf8mb4_ja_0900_as_cs", "utf8mb4_0900_as_ci", "utf8mb4_ru_0900_as_cs", "utf8mb4_zh_0900_as_cs", "utf8mb4_ja_0900_as_cs_ks") ORDER BY COLLATION_NAME;
+# Testing character set "armscii8" collation "armscii8_bin" padding "PAD SPACE"
+CREATE TABLE t_armscii8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET armscii8 COLLATE armscii8_bin;
+INSERT INTO t_armscii8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_armscii8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_armscii8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_armscii8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_armscii8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_armscii8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_armscii8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_armscii8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_armscii8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_armscii8;
+# Testing character set "armscii8" collation "armscii8_general_ci" padding "PAD SPACE"
+CREATE TABLE t_armscii8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET armscii8 COLLATE armscii8_general_ci;
+INSERT INTO t_armscii8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_armscii8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_armscii8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_armscii8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_armscii8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_armscii8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_armscii8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_armscii8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_armscii8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_armscii8;
+# Testing character set "ascii" collation "ascii_bin" padding "PAD SPACE"
+CREATE TABLE t_ascii (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ascii COLLATE ascii_bin;
+INSERT INTO t_ascii VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ascii VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ascii VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ascii VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ascii VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ascii VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ascii VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ascii VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ascii;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_ascii;
+# Testing character set "ascii" collation "ascii_general_ci" padding "PAD SPACE"
+CREATE TABLE t_ascii (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ascii COLLATE ascii_general_ci;
+INSERT INTO t_ascii VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ascii VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ascii VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ascii VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ascii VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ascii VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ascii VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ascii VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ascii;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_ascii;
+# Testing character set "big5" collation "big5_bin" padding "PAD SPACE"
+CREATE TABLE t_big5 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET big5 COLLATE big5_bin;
+INSERT INTO t_big5 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_big5 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_big5 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_big5 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_big5 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_big5 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_big5 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_big5 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_big5;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_big5;
+# Testing character set "big5" collation "big5_chinese_ci" padding "PAD SPACE"
+CREATE TABLE t_big5 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET big5 COLLATE big5_chinese_ci;
+INSERT INTO t_big5 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_big5 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_big5 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_big5 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_big5 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_big5 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_big5 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_big5 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_big5;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_big5;
+# Testing character set "binary" collation "binary" padding "NO PAD"
+CREATE TABLE t_binary (pk_varchar VARBINARY(64), pk_char BINARY(64), d_varchar VARBINARY(64), d_char BINARY(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB;
+INSERT INTO t_binary VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_binary VALUES ('a', 'a', 'a', 'a');
+INSERT INTO t_binary VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_binary VALUES('b', 'b', 'b', 'b');
+INSERT INTO t_binary VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_binary VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_binary VALUES('a          ', 'a          ', 'a          ', 'a          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_binary;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a	1	61	a                                                               	64	61000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000	a	1	61	a                                                               	64	61000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+a		2	6109	a	                                                              	64	61090000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000	a		2	6109	a	                                                              	64	61090000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+a 	2	6120	a                                                               	64	61200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000	a 	2	6120	a                                                               	64	61200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+a 		3	612009	a 	                                                             	64	61200900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000	a 		3	612009	a 	                                                             	64	61200900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+a          	11	6120202020202020202020	a                                                               	64	61202020202020202020200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000	a          	11	6120202020202020202020	a                                                               	64	61202020202020202020200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+b	1	62	b                                                               	64	62000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000	b	1	62	b                                                               	64	62000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+b  	3	622020	b                                                               	64	62202000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000	b  	3	622020	b                                                               	64	62202000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+DROP TABLE t_binary;
+# Testing character set "cp1250" collation "cp1250_bin" padding "PAD SPACE"
+CREATE TABLE t_cp1250 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1250 COLLATE cp1250_bin;
+INSERT INTO t_cp1250 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1250 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1250 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1250 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1250 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1250 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1250 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1250 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1250;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1250;
+# Testing character set "cp1250" collation "cp1250_croatian_ci" padding "PAD SPACE"
+CREATE TABLE t_cp1250 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1250 COLLATE cp1250_croatian_ci;
+INSERT INTO t_cp1250 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1250 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1250 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1250 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1250 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1250 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1250 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1250 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1250;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1250;
+# Testing character set "cp1250" collation "cp1250_general_ci" padding "PAD SPACE"
+CREATE TABLE t_cp1250 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1250 COLLATE cp1250_general_ci;
+INSERT INTO t_cp1250 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1250 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1250 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1250 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1250 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1250 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1250 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1250 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1250;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1250;
+# Testing character set "cp1250" collation "cp1250_polish_ci" padding "PAD SPACE"
+CREATE TABLE t_cp1250 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1250 COLLATE cp1250_polish_ci;
+INSERT INTO t_cp1250 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1250 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1250 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1250 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1250 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1250 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1250 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1250 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1250;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1250;
+# Testing character set "cp1251" collation "cp1251_bin" padding "PAD SPACE"
+CREATE TABLE t_cp1251 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1251 COLLATE cp1251_bin;
+INSERT INTO t_cp1251 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1251 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1251 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1251 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1251 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1251;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1251;
+# Testing character set "cp1251" collation "cp1251_bulgarian_ci" padding "PAD SPACE"
+CREATE TABLE t_cp1251 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1251 COLLATE cp1251_bulgarian_ci;
+INSERT INTO t_cp1251 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1251 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1251 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1251 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1251 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1251;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1251;
+# Testing character set "cp1251" collation "cp1251_general_ci" padding "PAD SPACE"
+CREATE TABLE t_cp1251 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1251 COLLATE cp1251_general_ci;
+INSERT INTO t_cp1251 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1251 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1251 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1251 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1251 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1251;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1251;
+# Testing character set "cp1251" collation "cp1251_general_cs" padding "PAD SPACE"
+CREATE TABLE t_cp1251 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1251 COLLATE cp1251_general_cs;
+INSERT INTO t_cp1251 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1251 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1251 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1251 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1251 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1251;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1251;
+# Testing character set "cp1251" collation "cp1251_ukrainian_ci" padding "PAD SPACE"
+CREATE TABLE t_cp1251 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1251 COLLATE cp1251_ukrainian_ci;
+INSERT INTO t_cp1251 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1251 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1251 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1251 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1251 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1251 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1251;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	C       `	9	432020202020202060	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1251;
+# Testing character set "cp1256" collation "cp1256_bin" padding "PAD SPACE"
+CREATE TABLE t_cp1256 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1256 COLLATE cp1256_bin;
+INSERT INTO t_cp1256 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1256 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1256 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1256 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1256 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1256 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1256 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1256 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1256;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1256;
+# Testing character set "cp1256" collation "cp1256_general_ci" padding "PAD SPACE"
+CREATE TABLE t_cp1256 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1256 COLLATE cp1256_general_ci;
+INSERT INTO t_cp1256 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1256 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1256 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1256 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1256 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1256 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1256 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1256 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1256;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1256;
+# Testing character set "cp1257" collation "cp1257_bin" padding "PAD SPACE"
+CREATE TABLE t_cp1257 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1257 COLLATE cp1257_bin;
+INSERT INTO t_cp1257 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1257 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1257 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1257 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1257 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1257 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1257 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1257 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1257;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1257;
+# Testing character set "cp1257" collation "cp1257_general_ci" padding "PAD SPACE"
+CREATE TABLE t_cp1257 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1257 COLLATE cp1257_general_ci;
+INSERT INTO t_cp1257 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1257 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1257 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1257 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1257 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1257 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1257 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1257 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1257;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1257;
+# Testing character set "cp1257" collation "cp1257_lithuanian_ci" padding "PAD SPACE"
+CREATE TABLE t_cp1257 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp1257 COLLATE cp1257_lithuanian_ci;
+INSERT INTO t_cp1257 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1257 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp1257 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1257 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp1257 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1257 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp1257 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp1257 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1257;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1257;
+# Testing character set "cp850" collation "cp850_bin" padding "PAD SPACE"
+CREATE TABLE t_cp850 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp850 COLLATE cp850_bin;
+INSERT INTO t_cp850 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp850 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp850 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp850 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp850 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp850 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp850 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp850 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp850;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp850;
+# Testing character set "cp850" collation "cp850_general_ci" padding "PAD SPACE"
+CREATE TABLE t_cp850 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp850 COLLATE cp850_general_ci;
+INSERT INTO t_cp850 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp850 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp850 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp850 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp850 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp850 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp850 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp850 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp850;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp850;
+# Testing character set "cp852" collation "cp852_bin" padding "PAD SPACE"
+CREATE TABLE t_cp852 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp852 COLLATE cp852_bin;
+INSERT INTO t_cp852 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp852 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp852 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp852 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp852 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp852 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp852 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp852 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp852;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp852;
+# Testing character set "cp852" collation "cp852_general_ci" padding "PAD SPACE"
+CREATE TABLE t_cp852 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp852 COLLATE cp852_general_ci;
+INSERT INTO t_cp852 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp852 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp852 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp852 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp852 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp852 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp852 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp852 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp852;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp852;
+# Testing character set "cp866" collation "cp866_bin" padding "PAD SPACE"
+CREATE TABLE t_cp866 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp866 COLLATE cp866_bin;
+INSERT INTO t_cp866 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp866 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp866 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp866 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp866 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp866 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp866 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp866 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp866;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp866;
+# Testing character set "cp866" collation "cp866_general_ci" padding "PAD SPACE"
+CREATE TABLE t_cp866 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp866 COLLATE cp866_general_ci;
+INSERT INTO t_cp866 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp866 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp866 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp866 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp866 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp866 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp866 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp866 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp866;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp866;
+# Testing character set "cp932" collation "cp932_bin" padding "PAD SPACE"
+CREATE TABLE t_cp932 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp932 COLLATE cp932_bin;
+INSERT INTO t_cp932 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp932 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp932 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp932 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp932 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp932 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp932 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp932 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp932;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp932;
+# Testing character set "cp932" collation "cp932_japanese_ci" padding "PAD SPACE"
+CREATE TABLE t_cp932 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET cp932 COLLATE cp932_japanese_ci;
+INSERT INTO t_cp932 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp932 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_cp932 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp932 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_cp932 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp932 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_cp932 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_cp932 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp932;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp932;
+# Testing character set "dec8" collation "dec8_bin" padding "PAD SPACE"
+CREATE TABLE t_dec8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET dec8 COLLATE dec8_bin;
+INSERT INTO t_dec8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_dec8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_dec8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_dec8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_dec8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_dec8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_dec8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_dec8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_dec8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_dec8;
+# Testing character set "dec8" collation "dec8_swedish_ci" padding "PAD SPACE"
+CREATE TABLE t_dec8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET dec8 COLLATE dec8_swedish_ci;
+INSERT INTO t_dec8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_dec8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_dec8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_dec8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_dec8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_dec8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_dec8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_dec8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_dec8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_dec8;
+# Testing character set "eucjpms" collation "eucjpms_bin" padding "PAD SPACE"
+CREATE TABLE t_eucjpms (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET eucjpms COLLATE eucjpms_bin;
+INSERT INTO t_eucjpms VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_eucjpms VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_eucjpms VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_eucjpms VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_eucjpms VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_eucjpms VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_eucjpms VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_eucjpms VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_eucjpms;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_eucjpms;
+# Testing character set "eucjpms" collation "eucjpms_japanese_ci" padding "PAD SPACE"
+CREATE TABLE t_eucjpms (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET eucjpms COLLATE eucjpms_japanese_ci;
+INSERT INTO t_eucjpms VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_eucjpms VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_eucjpms VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_eucjpms VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_eucjpms VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_eucjpms VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_eucjpms VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_eucjpms VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_eucjpms;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_eucjpms;
+# Testing character set "euckr" collation "euckr_bin" padding "PAD SPACE"
+CREATE TABLE t_euckr (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET euckr COLLATE euckr_bin;
+INSERT INTO t_euckr VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_euckr VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_euckr VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_euckr VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_euckr VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_euckr VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_euckr VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_euckr VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_euckr;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_euckr;
+# Testing character set "euckr" collation "euckr_korean_ci" padding "PAD SPACE"
+CREATE TABLE t_euckr (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET euckr COLLATE euckr_korean_ci;
+INSERT INTO t_euckr VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_euckr VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_euckr VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_euckr VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_euckr VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_euckr VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_euckr VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_euckr VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_euckr;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_euckr;
+# Testing character set "gb18030" collation "gb18030_bin" padding "PAD SPACE"
+CREATE TABLE t_gb18030 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET gb18030 COLLATE gb18030_bin;
+INSERT INTO t_gb18030 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_gb18030 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_gb18030 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_gb18030 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_gb18030 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_gb18030 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_gb18030 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_gb18030 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_gb18030;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_gb18030;
+# Testing character set "gb18030" collation "gb18030_chinese_ci" padding "PAD SPACE"
+CREATE TABLE t_gb18030 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET gb18030 COLLATE gb18030_chinese_ci;
+INSERT INTO t_gb18030 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_gb18030 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_gb18030 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_gb18030 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_gb18030 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_gb18030 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_gb18030 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_gb18030 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_gb18030;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_gb18030;
+# Testing character set "gb18030" collation "gb18030_unicode_520_ci" padding "PAD SPACE"
+CREATE TABLE t_gb18030 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET gb18030 COLLATE gb18030_unicode_520_ci;
+INSERT INTO t_gb18030 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_gb18030 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_gb18030 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_gb18030 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_gb18030 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_gb18030 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_gb18030 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_gb18030 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_gb18030;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_gb18030;
+# Testing character set "gb2312" collation "gb2312_bin" padding "PAD SPACE"
+CREATE TABLE t_gb2312 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET gb2312 COLLATE gb2312_bin;
+INSERT INTO t_gb2312 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_gb2312 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_gb2312 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_gb2312 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_gb2312 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_gb2312 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_gb2312 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_gb2312 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_gb2312;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_gb2312;
+# Testing character set "gb2312" collation "gb2312_chinese_ci" padding "PAD SPACE"
+CREATE TABLE t_gb2312 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET gb2312 COLLATE gb2312_chinese_ci;
+INSERT INTO t_gb2312 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_gb2312 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_gb2312 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_gb2312 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_gb2312 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_gb2312 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_gb2312 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_gb2312 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_gb2312;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_gb2312;
+# Testing character set "gbk" collation "gbk_bin" padding "PAD SPACE"
+CREATE TABLE t_gbk (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET gbk COLLATE gbk_bin;
+INSERT INTO t_gbk VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_gbk VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_gbk VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_gbk VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_gbk VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_gbk VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_gbk VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_gbk VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_gbk;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_gbk;
+# Testing character set "gbk" collation "gbk_chinese_ci" padding "PAD SPACE"
+CREATE TABLE t_gbk (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET gbk COLLATE gbk_chinese_ci;
+INSERT INTO t_gbk VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_gbk VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_gbk VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_gbk VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_gbk VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_gbk VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_gbk VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_gbk VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_gbk;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_gbk;
+# Testing character set "geostd8" collation "geostd8_bin" padding "PAD SPACE"
+CREATE TABLE t_geostd8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET geostd8 COLLATE geostd8_bin;
+INSERT INTO t_geostd8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_geostd8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_geostd8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_geostd8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_geostd8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_geostd8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_geostd8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_geostd8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_geostd8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_geostd8;
+# Testing character set "geostd8" collation "geostd8_general_ci" padding "PAD SPACE"
+CREATE TABLE t_geostd8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET geostd8 COLLATE geostd8_general_ci;
+INSERT INTO t_geostd8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_geostd8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_geostd8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_geostd8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_geostd8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_geostd8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_geostd8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_geostd8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_geostd8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_geostd8;
+# Testing character set "greek" collation "greek_bin" padding "PAD SPACE"
+CREATE TABLE t_greek (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET greek COLLATE greek_bin;
+INSERT INTO t_greek VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_greek VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_greek VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_greek VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_greek VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_greek VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_greek VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_greek VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_greek;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_greek;
+# Testing character set "greek" collation "greek_general_ci" padding "PAD SPACE"
+CREATE TABLE t_greek (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET greek COLLATE greek_general_ci;
+INSERT INTO t_greek VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_greek VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_greek VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_greek VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_greek VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_greek VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_greek VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_greek VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_greek;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_greek;
+# Testing character set "hebrew" collation "hebrew_bin" padding "PAD SPACE"
+CREATE TABLE t_hebrew (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET hebrew COLLATE hebrew_bin;
+INSERT INTO t_hebrew VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_hebrew VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_hebrew VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_hebrew VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_hebrew VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_hebrew VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_hebrew VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_hebrew VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_hebrew;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_hebrew;
+# Testing character set "hebrew" collation "hebrew_general_ci" padding "PAD SPACE"
+CREATE TABLE t_hebrew (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET hebrew COLLATE hebrew_general_ci;
+INSERT INTO t_hebrew VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_hebrew VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_hebrew VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_hebrew VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_hebrew VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_hebrew VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_hebrew VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_hebrew VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_hebrew;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_hebrew;
+# Testing character set "hp8" collation "hp8_bin" padding "PAD SPACE"
+CREATE TABLE t_hp8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET hp8 COLLATE hp8_bin;
+INSERT INTO t_hp8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_hp8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_hp8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_hp8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_hp8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_hp8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_hp8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_hp8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_hp8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_hp8;
+# Testing character set "hp8" collation "hp8_english_ci" padding "PAD SPACE"
+CREATE TABLE t_hp8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET hp8 COLLATE hp8_english_ci;
+INSERT INTO t_hp8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_hp8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_hp8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_hp8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_hp8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_hp8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_hp8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_hp8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_hp8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_hp8;
+# Testing character set "keybcs2" collation "keybcs2_bin" padding "PAD SPACE"
+CREATE TABLE t_keybcs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET keybcs2 COLLATE keybcs2_bin;
+INSERT INTO t_keybcs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_keybcs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_keybcs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_keybcs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_keybcs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_keybcs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_keybcs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_keybcs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_keybcs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_keybcs2;
+# Testing character set "keybcs2" collation "keybcs2_general_ci" padding "PAD SPACE"
+CREATE TABLE t_keybcs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET keybcs2 COLLATE keybcs2_general_ci;
+INSERT INTO t_keybcs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_keybcs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_keybcs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_keybcs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_keybcs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_keybcs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_keybcs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_keybcs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_keybcs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_keybcs2;
+# Testing character set "koi8r" collation "koi8r_bin" padding "PAD SPACE"
+CREATE TABLE t_koi8r (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET koi8r COLLATE koi8r_bin;
+INSERT INTO t_koi8r VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_koi8r VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_koi8r VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_koi8r VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_koi8r VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_koi8r VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_koi8r VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_koi8r VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_koi8r;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_koi8r;
+# Testing character set "koi8r" collation "koi8r_general_ci" padding "PAD SPACE"
+CREATE TABLE t_koi8r (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET koi8r COLLATE koi8r_general_ci;
+INSERT INTO t_koi8r VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_koi8r VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_koi8r VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_koi8r VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_koi8r VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_koi8r VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_koi8r VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_koi8r VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_koi8r;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_koi8r;
+# Testing character set "koi8u" collation "koi8u_bin" padding "PAD SPACE"
+CREATE TABLE t_koi8u (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET koi8u COLLATE koi8u_bin;
+INSERT INTO t_koi8u VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_koi8u VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_koi8u VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_koi8u VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_koi8u VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_koi8u VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_koi8u VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_koi8u VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_koi8u;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_koi8u;
+# Testing character set "koi8u" collation "koi8u_general_ci" padding "PAD SPACE"
+CREATE TABLE t_koi8u (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET koi8u COLLATE koi8u_general_ci;
+INSERT INTO t_koi8u VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_koi8u VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_koi8u VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_koi8u VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_koi8u VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_koi8u VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_koi8u VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_koi8u VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_koi8u;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	C       `	9	432020202020202060	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_koi8u;
+# Testing character set "latin1" collation "latin1_bin" padding "PAD SPACE"
+CREATE TABLE t_latin1 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin1 COLLATE latin1_bin;
+INSERT INTO t_latin1 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin1 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin1 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin1 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin1 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin1;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin1;
+# Testing character set "latin1" collation "latin1_danish_ci" padding "PAD SPACE"
+CREATE TABLE t_latin1 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin1 COLLATE latin1_danish_ci;
+INSERT INTO t_latin1 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin1 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin1 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin1 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin1 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin1;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin1;
+# Testing character set "latin1" collation "latin1_general_ci" padding "PAD SPACE"
+CREATE TABLE t_latin1 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin1 COLLATE latin1_general_ci;
+INSERT INTO t_latin1 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin1 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin1 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin1 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin1 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin1;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin1;
+# Testing character set "latin1" collation "latin1_general_cs" padding "PAD SPACE"
+CREATE TABLE t_latin1 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin1 COLLATE latin1_general_cs;
+INSERT INTO t_latin1 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin1 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin1 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin1 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin1 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin1;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin1;
+# Testing character set "latin1" collation "latin1_german1_ci" padding "PAD SPACE"
+CREATE TABLE t_latin1 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin1 COLLATE latin1_german1_ci;
+INSERT INTO t_latin1 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin1 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin1 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin1 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin1 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin1;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin1;
+# Testing character set "latin1" collation "latin1_german2_ci" padding "PAD SPACE"
+CREATE TABLE t_latin1 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin1 COLLATE latin1_german2_ci;
+INSERT INTO t_latin1 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin1 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin1 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin1 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin1 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin1;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin1;
+# Testing character set "latin1" collation "latin1_spanish_ci" padding "PAD SPACE"
+CREATE TABLE t_latin1 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin1 COLLATE latin1_spanish_ci;
+INSERT INTO t_latin1 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin1 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin1 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin1 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin1 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin1;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin1;
+# Testing character set "latin1" collation "latin1_swedish_ci" padding "PAD SPACE"
+CREATE TABLE t_latin1 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin1 COLLATE latin1_swedish_ci;
+INSERT INTO t_latin1 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin1 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin1 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin1 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin1 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin1 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin1;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin1;
+# Testing character set "latin2" collation "latin2_bin" padding "PAD SPACE"
+CREATE TABLE t_latin2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin2 COLLATE latin2_bin;
+INSERT INTO t_latin2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin2;
+# Testing character set "latin2" collation "latin2_croatian_ci" padding "PAD SPACE"
+CREATE TABLE t_latin2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin2 COLLATE latin2_croatian_ci;
+INSERT INTO t_latin2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin2;
+# Testing character set "latin2" collation "latin2_general_ci" padding "PAD SPACE"
+CREATE TABLE t_latin2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin2 COLLATE latin2_general_ci;
+INSERT INTO t_latin2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin2;
+# Testing character set "latin2" collation "latin2_hungarian_ci" padding "PAD SPACE"
+CREATE TABLE t_latin2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin2 COLLATE latin2_hungarian_ci;
+INSERT INTO t_latin2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin2;
+# Testing character set "latin5" collation "latin5_bin" padding "PAD SPACE"
+CREATE TABLE t_latin5 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin5 COLLATE latin5_bin;
+INSERT INTO t_latin5 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin5 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin5 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin5 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin5 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin5 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin5 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin5 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin5;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin5;
+# Testing character set "latin5" collation "latin5_turkish_ci" padding "PAD SPACE"
+CREATE TABLE t_latin5 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin5 COLLATE latin5_turkish_ci;
+INSERT INTO t_latin5 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin5 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin5 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin5 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin5 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin5 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin5 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin5 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin5;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin5;
+# Testing character set "latin7" collation "latin7_bin" padding "PAD SPACE"
+CREATE TABLE t_latin7 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin7 COLLATE latin7_bin;
+INSERT INTO t_latin7 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin7 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin7 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin7 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin7 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin7 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin7 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin7 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin7;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin7;
+# Testing character set "latin7" collation "latin7_estonian_cs" padding "PAD SPACE"
+CREATE TABLE t_latin7 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin7 COLLATE latin7_estonian_cs;
+INSERT INTO t_latin7 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin7 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin7 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin7 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin7 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin7 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin7 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin7 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin7;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin7;
+# Testing character set "latin7" collation "latin7_general_ci" padding "PAD SPACE"
+CREATE TABLE t_latin7 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin7 COLLATE latin7_general_ci;
+INSERT INTO t_latin7 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin7 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin7 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin7 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin7 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin7 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin7 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin7 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin7;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin7;
+# Testing character set "latin7" collation "latin7_general_cs" padding "PAD SPACE"
+CREATE TABLE t_latin7 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET latin7 COLLATE latin7_general_cs;
+INSERT INTO t_latin7 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin7 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_latin7 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin7 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_latin7 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin7 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_latin7 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_latin7 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin7;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin7;
+# Testing character set "macce" collation "macce_bin" padding "PAD SPACE"
+CREATE TABLE t_macce (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET macce COLLATE macce_bin;
+INSERT INTO t_macce VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_macce VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_macce VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_macce VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_macce VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_macce VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_macce VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_macce VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_macce;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_macce;
+# Testing character set "macce" collation "macce_general_ci" padding "PAD SPACE"
+CREATE TABLE t_macce (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET macce COLLATE macce_general_ci;
+INSERT INTO t_macce VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_macce VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_macce VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_macce VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_macce VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_macce VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_macce VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_macce VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_macce;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_macce;
+# Testing character set "macroman" collation "macroman_bin" padding "PAD SPACE"
+CREATE TABLE t_macroman (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET macroman COLLATE macroman_bin;
+INSERT INTO t_macroman VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_macroman VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_macroman VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_macroman VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_macroman VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_macroman VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_macroman VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_macroman VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_macroman;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_macroman;
+# Testing character set "macroman" collation "macroman_general_ci" padding "PAD SPACE"
+CREATE TABLE t_macroman (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET macroman COLLATE macroman_general_ci;
+INSERT INTO t_macroman VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_macroman VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_macroman VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_macroman VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_macroman VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_macroman VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_macroman VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_macroman VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_macroman;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_macroman;
+# Testing character set "sjis" collation "sjis_bin" padding "PAD SPACE"
+CREATE TABLE t_sjis (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET sjis COLLATE sjis_bin;
+INSERT INTO t_sjis VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_sjis VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_sjis VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_sjis VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_sjis VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_sjis VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_sjis VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_sjis VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_sjis;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_sjis;
+# Testing character set "sjis" collation "sjis_japanese_ci" padding "PAD SPACE"
+CREATE TABLE t_sjis (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET sjis COLLATE sjis_japanese_ci;
+INSERT INTO t_sjis VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_sjis VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_sjis VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_sjis VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_sjis VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_sjis VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_sjis VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_sjis VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_sjis;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_sjis;
+# Testing character set "swe7" collation "swe7_bin" padding "PAD SPACE"
+CREATE TABLE t_swe7 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET swe7 COLLATE swe7_bin;
+INSERT INTO t_swe7 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_swe7 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_swe7 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_swe7 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_swe7 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_swe7 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_swe7 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_swe7 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_swe7;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_swe7;
+# Testing character set "swe7" collation "swe7_swedish_ci" padding "PAD SPACE"
+CREATE TABLE t_swe7 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET swe7 COLLATE swe7_swedish_ci;
+INSERT INTO t_swe7 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_swe7 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_swe7 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_swe7 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_swe7 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_swe7 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_swe7 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_swe7 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_swe7;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_swe7;
+# Testing character set "tis620" collation "tis620_bin" padding "PAD SPACE"
+CREATE TABLE t_tis620 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET tis620 COLLATE tis620_bin;
+INSERT INTO t_tis620 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_tis620 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_tis620 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_tis620 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_tis620 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_tis620 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_tis620 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_tis620 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_tis620;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_tis620;
+# Testing character set "tis620" collation "tis620_thai_ci" padding "PAD SPACE"
+CREATE TABLE t_tis620 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET tis620 COLLATE tis620_thai_ci;
+INSERT INTO t_tis620 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_tis620 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_tis620 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_tis620 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_tis620 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_tis620 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_tis620 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_tis620 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_tis620;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_tis620;
+# Testing character set "ucs2" collation "ucs2_bin" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_bin;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_croatian_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_croatian_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_czech_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_czech_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_danish_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_danish_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_esperanto_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_esperanto_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_estonian_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_estonian_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_general_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_general_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_general_mysql500_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_general_mysql500_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_german2_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_german2_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_hungarian_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_hungarian_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_icelandic_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_icelandic_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_latvian_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_latvian_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_lithuanian_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_lithuanian_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_persian_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_persian_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_polish_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_polish_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_romanian_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_romanian_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_roman_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_roman_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_sinhala_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_sinhala_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_slovak_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_slovak_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_slovenian_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_slovenian_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_spanish2_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_spanish2_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_spanish_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_spanish_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_swedish_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_swedish_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_turkish_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_turkish_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_unicode_520_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_unicode_520_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_unicode_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_unicode_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ucs2" collation "ucs2_vietnamese_ci" padding "PAD SPACE"
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ucs2 COLLATE ucs2_vietnamese_ci;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ucs2 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ucs2 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_ucs2;
+# Testing character set "ujis" collation "ujis_bin" padding "PAD SPACE"
+CREATE TABLE t_ujis (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ujis COLLATE ujis_bin;
+INSERT INTO t_ujis VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ujis VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ujis VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ujis VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ujis VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ujis VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ujis VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ujis VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ujis;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_ujis;
+# Testing character set "ujis" collation "ujis_japanese_ci" padding "PAD SPACE"
+CREATE TABLE t_ujis (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET ujis COLLATE ujis_japanese_ci;
+INSERT INTO t_ujis VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ujis VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_ujis VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ujis VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_ujis VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ujis VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_ujis VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_ujis VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ujis;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_ujis;
+# Testing character set "utf16le" collation "utf16le_bin" padding "PAD SPACE"
+CREATE TABLE t_utf16le (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16le COLLATE utf16le_bin;
+INSERT INTO t_utf16le VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16le VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16le VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16le VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16le VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16le VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16le VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16le VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16le;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	61000900	a		4	61000900	a		4	61000900	a		4	61000900
+a 		6	610020000900	a 		6	610020000900	a 		6	610020000900	a 		6	610020000900
+a 	4	61002000	a	2	6100	a 	4	61002000	a	2	6100
+b  	6	620020002000	b	2	6200	b  	6	620020002000	b	2	6200
+c          	22	63002000200020002000200020002000200020002000	c	2	6300	c          	22	63002000200020002000200020002000200020002000	c	2	6300
+DROP TABLE t_utf16le;
+# Testing character set "utf16le" collation "utf16le_general_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16le (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16le COLLATE utf16le_general_ci;
+INSERT INTO t_utf16le VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16le VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16le VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16le VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16le VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16le VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16le VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16le VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16le;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	61000900	a		4	61000900	a		4	61000900	a		4	61000900
+a 		6	610020000900	a 		6	610020000900	a 		6	610020000900	a 		6	610020000900
+a 	4	61002000	a	2	6100	a 	4	61002000	a	2	6100
+b  	6	620020002000	b	2	6200	b  	6	620020002000	b	2	6200
+c          	22	63002000200020002000200020002000200020002000	c	2	6300	c          	22	63002000200020002000200020002000200020002000	c	2	6300
+DROP TABLE t_utf16le;
+# Testing character set "utf16" collation "utf16_bin" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_bin;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_croatian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_croatian_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_czech_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_czech_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_danish_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_danish_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_esperanto_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_esperanto_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_estonian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_estonian_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_general_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_general_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_german2_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_german2_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_hungarian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_hungarian_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_icelandic_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_icelandic_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_latvian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_latvian_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_lithuanian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_lithuanian_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_persian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_persian_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_polish_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_polish_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_romanian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_romanian_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_roman_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_roman_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_sinhala_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_sinhala_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_slovak_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_slovak_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_slovenian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_slovenian_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_spanish2_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_spanish2_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_spanish_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_spanish_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_swedish_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_swedish_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_turkish_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_turkish_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_unicode_520_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_unicode_520_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_unicode_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_unicode_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf16" collation "utf16_vietnamese_ci" padding "PAD SPACE"
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf16 COLLATE utf16_vietnamese_ci;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf16 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf16 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		4	00610009
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		6	006100200009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	2	0061
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	2	0062
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	2	0063
+DROP TABLE t_utf16;
+# Testing character set "utf32" collation "utf32_bin" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_bin;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_croatian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_croatian_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_czech_ci" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_czech_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_danish_ci" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_danish_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_esperanto_ci" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_esperanto_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_estonian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_estonian_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_general_ci" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_general_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_german2_ci" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_german2_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_hungarian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_hungarian_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_icelandic_ci" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_icelandic_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_latvian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_latvian_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_lithuanian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_lithuanian_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_persian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_persian_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_polish_ci" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_polish_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_romanian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_romanian_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_roman_ci" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_roman_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_sinhala_ci" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_sinhala_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_slovak_ci" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_slovak_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_slovenian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_slovenian_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_spanish2_ci" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_spanish2_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_spanish_ci" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_spanish_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_swedish_ci" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_swedish_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_turkish_ci" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_turkish_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_unicode_520_ci" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_unicode_520_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_unicode_ci" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_unicode_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf32" collation "utf32_vietnamese_ci" padding "PAD SPACE"
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf32 COLLATE utf32_vietnamese_ci;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf32 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf32 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	4	00000061
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	4	00000062
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063
+DROP TABLE t_utf32;
+# Testing character set "utf8mb4" collation "utf8mb4_0900_ai_ci" padding "NO PAD"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a	1	61	a	1	61	a	1	61	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a          	11	6120202020202020202020	a	1	61	a          	11	6120202020202020202020	a	1	61
+b	1	62	b	1	62	b	1	62	b	1	62
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_0900_bin" padding "NO PAD"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_0900_bin;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a	1	61	a	1	61	a	1	61	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a          	11	6120202020202020202020	a	1	61	a          	11	6120202020202020202020	a	1	61
+b	1	62	b	1	62	b	1	62	b	1	62
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_bin" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_bin;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_croatian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_croatian_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_cs_0900_ai_ci" padding "NO PAD"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_cs_0900_ai_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a	1	61	a	1	61	a	1	61	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a          	11	6120202020202020202020	a	1	61	a          	11	6120202020202020202020	a	1	61
+b	1	62	b	1	62	b	1	62	b	1	62
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_czech_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_czech_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_danish_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_danish_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_da_0900_ai_ci" padding "NO PAD"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_da_0900_ai_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a	1	61	a	1	61	a	1	61	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a          	11	6120202020202020202020	a	1	61	a          	11	6120202020202020202020	a	1	61
+b	1	62	b	1	62	b	1	62	b	1	62
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_de_pb_0900_ai_ci" padding "NO PAD"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_de_pb_0900_ai_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a	1	61	a	1	61	a	1	61	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a          	11	6120202020202020202020	a	1	61	a          	11	6120202020202020202020	a	1	61
+b	1	62	b	1	62	b	1	62	b	1	62
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_eo_0900_ai_ci" padding "NO PAD"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_eo_0900_ai_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a	1	61	a	1	61	a	1	61	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a          	11	6120202020202020202020	a	1	61	a          	11	6120202020202020202020	a	1	61
+b	1	62	b	1	62	b	1	62	b	1	62
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_esperanto_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_esperanto_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_estonian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_estonian_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_es_0900_ai_ci" padding "NO PAD"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_es_0900_ai_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a	1	61	a	1	61	a	1	61	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a          	11	6120202020202020202020	a	1	61	a          	11	6120202020202020202020	a	1	61
+b	1	62	b	1	62	b	1	62	b	1	62
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_es_trad_0900_ai_ci" padding "NO PAD"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_es_trad_0900_ai_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a	1	61	a	1	61	a	1	61	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a          	11	6120202020202020202020	a	1	61	a          	11	6120202020202020202020	a	1	61
+b	1	62	b	1	62	b	1	62	b	1	62
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_et_0900_ai_ci" padding "NO PAD"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_et_0900_ai_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a	1	61	a	1	61	a	1	61	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a          	11	6120202020202020202020	a	1	61	a          	11	6120202020202020202020	a	1	61
+b	1	62	b	1	62	b	1	62	b	1	62
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_general_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_general_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_german2_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_german2_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_hr_0900_ai_ci" padding "NO PAD"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_hr_0900_ai_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a	1	61	a	1	61	a	1	61	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a          	11	6120202020202020202020	a	1	61	a          	11	6120202020202020202020	a	1	61
+b	1	62	b	1	62	b	1	62	b	1	62
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_hungarian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_hungarian_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_hu_0900_ai_ci" padding "NO PAD"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_hu_0900_ai_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a	1	61	a	1	61	a	1	61	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a          	11	6120202020202020202020	a	1	61	a          	11	6120202020202020202020	a	1	61
+b	1	62	b	1	62	b	1	62	b	1	62
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_icelandic_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_icelandic_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_is_0900_ai_ci" padding "NO PAD"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_is_0900_ai_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a	1	61	a	1	61	a	1	61	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a          	11	6120202020202020202020	a	1	61	a          	11	6120202020202020202020	a	1	61
+b	1	62	b	1	62	b	1	62	b	1	62
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_latvian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_latvian_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_la_0900_ai_ci" padding "NO PAD"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_la_0900_ai_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a	1	61	a	1	61	a	1	61	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a          	11	6120202020202020202020	a	1	61	a          	11	6120202020202020202020	a	1	61
+b	1	62	b	1	62	b	1	62	b	1	62
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_lithuanian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_lithuanian_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_lt_0900_ai_ci" padding "NO PAD"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_lt_0900_ai_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a	1	61	a	1	61	a	1	61	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a          	11	6120202020202020202020	a	1	61	a          	11	6120202020202020202020	a	1	61
+b	1	62	b	1	62	b	1	62	b	1	62
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_lv_0900_ai_ci" padding "NO PAD"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_lv_0900_ai_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a	1	61	a	1	61	a	1	61	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a          	11	6120202020202020202020	a	1	61	a          	11	6120202020202020202020	a	1	61
+b	1	62	b	1	62	b	1	62	b	1	62
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_persian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_persian_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_pl_0900_ai_ci" padding "NO PAD"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_pl_0900_ai_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a	1	61	a	1	61	a	1	61	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a          	11	6120202020202020202020	a	1	61	a          	11	6120202020202020202020	a	1	61
+b	1	62	b	1	62	b	1	62	b	1	62
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_polish_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_polish_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_romanian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_romanian_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_roman_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_roman_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_ro_0900_ai_ci" padding "NO PAD"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_ro_0900_ai_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a	1	61	a	1	61	a	1	61	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a          	11	6120202020202020202020	a	1	61	a          	11	6120202020202020202020	a	1	61
+b	1	62	b	1	62	b	1	62	b	1	62
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_ru_0900_ai_ci" padding "NO PAD"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_ru_0900_ai_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a	1	61	a	1	61	a	1	61	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a          	11	6120202020202020202020	a	1	61	a          	11	6120202020202020202020	a	1	61
+b	1	62	b	1	62	b	1	62	b	1	62
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_sinhala_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_sinhala_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_sk_0900_ai_ci" padding "NO PAD"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_sk_0900_ai_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a	1	61	a	1	61	a	1	61	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a          	11	6120202020202020202020	a	1	61	a          	11	6120202020202020202020	a	1	61
+b	1	62	b	1	62	b	1	62	b	1	62
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_slovak_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_slovak_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_slovenian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_slovenian_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_sl_0900_ai_ci" padding "NO PAD"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_sl_0900_ai_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a	1	61	a	1	61	a	1	61	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a          	11	6120202020202020202020	a	1	61	a          	11	6120202020202020202020	a	1	61
+b	1	62	b	1	62	b	1	62	b	1	62
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_spanish2_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_spanish2_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_spanish_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_spanish_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_sv_0900_ai_ci" padding "NO PAD"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_sv_0900_ai_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a	1	61	a	1	61	a	1	61	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a          	11	6120202020202020202020	a	1	61	a          	11	6120202020202020202020	a	1	61
+b	1	62	b	1	62	b	1	62	b	1	62
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_swedish_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_swedish_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_tr_0900_ai_ci" padding "NO PAD"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_tr_0900_ai_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a	1	61	a	1	61	a	1	61	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a          	11	6120202020202020202020	a	1	61	a          	11	6120202020202020202020	a	1	61
+b	1	62	b	1	62	b	1	62	b	1	62
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_turkish_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_turkish_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_unicode_520_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_unicode_520_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_unicode_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_unicode_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_vietnamese_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_vietnamese_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8mb4" collation "utf8mb4_vi_0900_ai_ci" padding "NO PAD"
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8mb4 COLLATE utf8mb4_vi_0900_ai_ci;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8mb4 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a	1	61	a	1	61	a	1	61	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a          	11	6120202020202020202020	a	1	61	a          	11	6120202020202020202020	a	1	61
+b	1	62	b	1	62	b	1	62	b	1	62
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+DROP TABLE t_utf8mb4;
+# Testing character set "utf8" collation "utf8_bin" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_bin;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_bin' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_croatian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_croatian_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_croatian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_czech_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_czech_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_czech_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_danish_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_danish_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_danish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_esperanto_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_esperanto_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_esperanto_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_estonian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_estonian_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_estonian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_general_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_general_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_general_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_general_mysql500_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_general_mysql500_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_general_mysql500_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_german2_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_german2_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_german2_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_hungarian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_hungarian_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_hungarian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_icelandic_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_icelandic_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_icelandic_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_latvian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_latvian_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_latvian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_lithuanian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_lithuanian_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_lithuanian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_persian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_persian_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_persian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_polish_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_polish_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_polish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_romanian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_romanian_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_romanian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_roman_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_roman_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_roman_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_sinhala_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_sinhala_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_sinhala_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_slovak_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_slovak_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_slovak_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_slovenian_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_slovenian_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_slovenian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_spanish2_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_spanish2_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_spanish2_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_spanish_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_spanish_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_spanish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_swedish_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_swedish_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_swedish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_tolower_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_tolower_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_tolower_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_turkish_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_turkish_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_turkish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_unicode_520_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_unicode_520_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_unicode_520_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_unicode_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_unicode_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_unicode_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set "utf8" collation "utf8_vietnamese_ci" padding "PAD SPACE"
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET utf8 COLLATE utf8_vietnamese_ci;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_vietnamese_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+INSERT INTO t_utf8 VALUES('a          ', 'a          ', 'a          ', 'a          ');
+ERROR 23000: Duplicate entry 'a          -a' for key 'PRIMARY'
+INSERT INTO t_utf8 VALUES('c          ', 'c          ', 'c          ', 'c          ');
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+DROP TABLE collations;

--- a/mysql-test/suite/rocksdb/t/add_index_inplace.cnf
+++ b/mysql-test/suite/rocksdb/t/add_index_inplace.cnf
@@ -2,4 +2,3 @@
 no-defaults
 
 [mysqld.1]
-rocksdb_strict_collation_check=1

--- a/mysql-test/suite/rocksdb/t/add_index_inplace.test
+++ b/mysql-test/suite/rocksdb/t/add_index_inplace.test
@@ -170,9 +170,7 @@ DROP TABLE t1;
 # test failure in prepare phase (due to collation)
 CREATE TABLE t1 (a INT, b TEXT CHARSET utf8 COLLATE utf8_general_ci);
 
---error ER_UNSUPPORTED_COLLATION
 ALTER TABLE t1 ADD KEY kb(b(10));
-ALTER TABLE t1 ADD PRIMARY KEY(a);
 DROP TABLE t1;
 
 # make sure race condition between connection close and alter on another

--- a/mysql-test/suite/rocksdb/t/add_index_inplace.test
+++ b/mysql-test/suite/rocksdb/t/add_index_inplace.test
@@ -168,7 +168,7 @@ SELECT COUNT(*) FROM t1;
 DROP TABLE t1;
 
 # test failure in prepare phase (due to collation)
-CREATE TABLE t1 (a INT, b TEXT);
+CREATE TABLE t1 (a INT, b TEXT CHARSET utf8 COLLATE utf8_general_ci);
 
 --error ER_UNSUPPORTED_COLLATION
 ALTER TABLE t1 ADD KEY kb(b(10));

--- a/mysql-test/suite/rocksdb/t/collation-master.opt
+++ b/mysql-test/suite/rocksdb/t/collation-master.opt
@@ -1,1 +1,0 @@
---rocksdb_strict_collation_check=ON

--- a/mysql-test/suite/rocksdb/t/collation.test
+++ b/mysql-test/suite/rocksdb/t/collation.test
@@ -28,7 +28,7 @@ DROP TABLE t1;
 CREATE TABLE t1 (id varchar(20), value varchar(50), value2 varchar(50), value3 text, primary key (id), index(value, value2)) engine=rocksdb charset latin1 collate latin1_bin;
 --replace_regex /#sql-[0-9a-f_]*/#sqlx-nnnn_nnnn/i
 --error ER_UNSUPPORTED_COLLATION
-ALTER TABLE t1 MODIFY value VARCHAR(50) CHARACTER SET latin1 COLLATE latin1_general_ci;
+ALTER TABLE t1 MODIFY value VARCHAR(50) CHARACTER SET latin1 COLLATE latin1_german2_ci;
 DROP TABLE t1;
 
 # cs utf8_bin is allowed
@@ -142,12 +142,12 @@ CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=roc
 
 # test allowing alters to create temporary tables
 SET GLOBAL rocksdb_strict_collation_exceptions='t1';
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb;
+CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 ALTER TABLE t1 AUTO_INCREMENT=1, ALGORITHM=COPY;
 DROP TABLE t1;
 --error ER_UNSUPPORTED_COLLATION
-CREATE TABLE t2 (id INT primary key, value varchar(50), index(value)) engine=rocksdb;
-CREATE TABLE t2 (id INT primary key, value varchar(50)) engine=rocksdb;
+CREATE TABLE t2 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
+CREATE TABLE t2 (id INT primary key, value varchar(50)) engine=rocksdb charset utf8;
 --error ER_UNSUPPORTED_COLLATION
 ALTER TABLE t2 ADD INDEX(value);
 DROP TABLE t2;

--- a/mysql-test/suite/rocksdb/t/collation.test
+++ b/mysql-test/suite/rocksdb/t/collation.test
@@ -4,21 +4,16 @@ call mtr.add_suppression("Invalid pattern");
 
 # ci non-indexed column is allowed
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text) engine=rocksdb charset utf8;
-# ci indexed column is not allowed
---error ER_UNSUPPORTED_COLLATION
+# ci indexed column is allowed
 ALTER TABLE t1 ADD INDEX (value);
 DROP TABLE t1;
 
-# ci indexed column is not allowed
---error ER_UNSUPPORTED_COLLATION
+# ci indexed column is allowed
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value)) engine=rocksdb charset utf8;
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value3(50))) engine=rocksdb charset utf8;
-# ci indexed column with rocksdb_strict_collation_check=OFF is allowed.
-SET GLOBAL rocksdb_strict_collation_check=0;
+DROP TABLE t1;
+# ci indexed column is allowed
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value3(50))) engine=rocksdb charset utf8;
 DROP TABLE t1;
-SET GLOBAL rocksdb_strict_collation_check=1;
 
 # cs indexed column is allowed
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value2)) engine=rocksdb charset utf8;
@@ -27,7 +22,6 @@ DROP TABLE t1;
 # cs latin1_bin is allowed
 CREATE TABLE t1 (id varchar(20), value varchar(50), value2 varchar(50), value3 text, primary key (id), index(value, value2)) engine=rocksdb charset latin1 collate latin1_bin;
 --replace_regex /#sql-[0-9a-f_]*/#sqlx-nnnn_nnnn/i
---error ER_UNSUPPORTED_COLLATION
 ALTER TABLE t1 MODIFY value VARCHAR(50) CHARACTER SET latin1 COLLATE latin1_german2_ci;
 DROP TABLE t1;
 
@@ -39,151 +33,10 @@ DROP TABLE t1;
 CREATE TABLE t1 (id varchar(20) collate latin1_bin, value varchar(50) collate utf8_bin, value2 varchar(50) collate latin1_bin, value3 text, primary key (id), index(value, value2)) engine=rocksdb;
 DROP TABLE t1;
 
-# ci indexed column is not allowed unless table name is in exception list
-SET GLOBAL rocksdb_strict_collation_exceptions=t1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE t2 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-
-# test regex for exception list
-SET GLOBAL rocksdb_strict_collation_exceptions="t.*";
-CREATE TABLE t123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t123;
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE s123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-
-SET GLOBAL rocksdb_strict_collation_exceptions=".t.*";
-CREATE TABLE xt123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE xt123;
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE t123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-
-# test multiple entries in the list with commas
-SET GLOBAL rocksdb_strict_collation_exceptions="s.*,t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-
-# test multiple entries in the list with vertical bar
-SET GLOBAL rocksdb_strict_collation_exceptions="s.*|t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-
-# test multiple entries in the list and extra comma at the front
-SET GLOBAL rocksdb_strict_collation_exceptions=",s.*,t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-
-# test multiple entries in the list and extra vertical bar at the front
-SET GLOBAL rocksdb_strict_collation_exceptions="|s.*|t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-
-# test multiple entries in the list and extra comma in the middle
-SET GLOBAL rocksdb_strict_collation_exceptions="s.*,,t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-
-# test multiple entries in the list and extra vertical bar in the middle
-SET GLOBAL rocksdb_strict_collation_exceptions="s.*||t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-
-# test multiple entries in the list and extra comma at the end
-SET GLOBAL rocksdb_strict_collation_exceptions="s.*,t.*,";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-
-# test multiple entries in the list and extra vertical bar at the end
-SET GLOBAL rocksdb_strict_collation_exceptions="s.*|t.*|";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-
-# test multiple entries in the list and tons of commas and vertical bars just for the fun of it
-SET GLOBAL rocksdb_strict_collation_exceptions="||||,,,,s.*,,|,,||,t.*,,|||,,,";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-
 # test allowing alters to create temporary tables
-SET GLOBAL rocksdb_strict_collation_exceptions='t1';
 CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 ALTER TABLE t1 AUTO_INCREMENT=1, ALGORITHM=COPY;
 DROP TABLE t1;
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE t2 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-CREATE TABLE t2 (id INT primary key, value varchar(50)) engine=rocksdb charset utf8;
---error ER_UNSUPPORTED_COLLATION
-ALTER TABLE t2 ADD INDEX(value);
-DROP TABLE t2;
-
-
-# test invalid regex (missing end bracket)
-SET GLOBAL rocksdb_strict_collation_exceptions="[a-b";
---exec grep -o "Invalid pattern .*$" $MYSQLTEST_VARDIR/log/mysqld.1.err | tail -n 1
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE a (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-SET GLOBAL rocksdb_strict_collation_exceptions="[a-b]";
-CREATE TABLE a (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-CREATE TABLE b (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE c (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE a, b;
-
-# test invalid regex (trailing escape)
-SET GLOBAL rocksdb_strict_collation_exceptions="abc\\";
---exec grep -o "Invalid pattern .*$" $MYSQLTEST_VARDIR/log/mysqld.1.err | tail -n 1
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-SET GLOBAL rocksdb_strict_collation_exceptions="abc";
-CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE abcd (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE abc;
-
-# test bad regex (null caused a crash) - Issue 493
-SET GLOBAL rocksdb_strict_collation_exceptions=null;
-
-# test for warnings instead of errors
---let restart_parameters="restart: --rocksdb_error_on_suboptimal_collation=0"
---source include/restart_mysqld.inc
-
-SET GLOBAL rocksdb_strict_collation_check=1;
 
 # ci indexed column is not optimal, should emit a warning
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value)) engine=rocksdb charset utf8;
@@ -200,7 +53,3 @@ CREATE TABLE t1 (id varchar(20), value varchar(50), value2 varchar(50), value3 t
 # THIS SHOULD WARN BUT IT DOES NOT
 ALTER TABLE t1 collate=latin1_general_ci;
 DROP TABLE t1;
-
-# cleanup
---let restart_parameters=
---source include/restart_mysqld.inc

--- a/mysql-test/suite/rocksdb/t/collation_exception-master.opt
+++ b/mysql-test/suite/rocksdb/t/collation_exception-master.opt
@@ -1,2 +1,0 @@
---rocksdb_strict_collation_check=ON
---rocksdb_strict_collation_exceptions='r1.lol'

--- a/mysql-test/suite/rocksdb/t/type_char_indexes_collation.test
+++ b/mysql-test/suite/rocksdb/t/type_char_indexes_collation.test
@@ -113,9 +113,9 @@ drop table t;
 
 # Test varchar keyparts with key prefix
 set session rocksdb_verify_row_debug_checksums = on;
-create table t (id int primary key, email varchar(100), KEY email_i (email(30))) engine=rocksdb default charset=latin1;
+create table t (id int primary key, email varchar(100), KEY email_i (email)) engine=rocksdb default charset=latin1;
 insert into t values (1, '                                  a');
---replace_column 9 #
+--replace_column 8 # 9 #
 explain select 'email_i' as index_name, count(*) AS count from t force index(email_i);
 select 'email_i' as index_name, count(*) AS count from t force index(email_i);
 drop table t;

--- a/mysql-test/suite/rocksdb/t/type_char_secondary_index_only_scan.test
+++ b/mysql-test/suite/rocksdb/t/type_char_secondary_index_only_scan.test
@@ -1,0 +1,52 @@
+# 1. Find all collations that support index-only scans with secondary
+#    keys using the "Extra" field from "EXPLAIN SELECT"
+# 2. Verify if the original string is reconstructed correctly from SK
+#    (or from PK when index-only scans with SK are not supported)
+
+--source include/have_rocksdb.inc
+
+CALL mtr.add_suppression("MyRocks will handle this collation internally as if it had a NO_PAD attribute");
+CALL mtr.add_suppression("RocksDB: you're trying to create an index with a multi-level collation");
+
+CREATE TABLE collations AS SELECT * FROM information_schema.COLLATION_CHARACTER_SET_APPLICABILITY ORDER BY COLLATION_NAME;
+
+--echo CharSet, Collate, Char Extra, VarChar Extra
+--disable_query_log
+--let $i=1
+--let $collate = query_get_value(select * from collations, COLLATION_NAME, $i)
+while ($collate != 'No such row')
+{
+  --let $charset = query_get_value(select * from collations, CHARACTER_SET_NAME, $i)
+  --let table_name=t_$charset
+  if ($charset == "binary")
+  {
+    --eval CREATE TABLE $table_name (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, vch VARBINARY(64), ch BINARY(64), KEY vch_idx (vch), KEY ch_idx (ch)) ENGINE=rocksdb
+  }
+  if ($charset != "binary")
+  {
+    --eval CREATE TABLE $table_name (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, vch VARCHAR(64), ch CHAR(64), KEY vch_idx (vch), KEY ch_idx (ch)) ENGINE=rocksdb CHARSET $charset COLLATE $collate
+  }
+  --eval INSERT INTO $table_name (vch, ch) VALUES('VARCHAR', 'char')
+  --let $vch_extra = query_get_value(EXPLAIN SELECT vch FROM $table_name, Extra, 1)
+  --let $ch_extra = query_get_value(EXPLAIN SELECT ch FROM $table_name, Extra, 1)
+  --echo $charset, $collate, $ch_extra, $vch_extra
+  --let $ch_value = query_get_value(SELECT ch FROM $table_name, ch, 1)
+  --let $vch_value = query_get_value(SELECT vch FROM $table_name, vch, 1)
+  if ($ch_value != "char")
+  {
+    --echo ERROR for $charset, $collate: \$ch_value=$ch_value, \$vch_value=$vch_value
+    --die
+  }
+  if ($vch_value != "VARCHAR")
+  {
+    --echo ERROR for $charset, $collate: \$ch_value=$ch_value, \$vch_value=$vch_value
+    --die
+  }
+  --eval DROP TABLE $table_name
+
+  --inc $i
+  --let $collate=query_get_value(select * from collations, COLLATION_NAME, $i)
+}
+--enable_query_log
+
+DROP TABLE collations;

--- a/mysql-test/suite/rocksdb/t/type_char_secondary_index_only_scan.test
+++ b/mysql-test/suite/rocksdb/t/type_char_secondary_index_only_scan.test
@@ -5,9 +5,6 @@
 
 --source include/have_rocksdb.inc
 
-CALL mtr.add_suppression("MyRocks will handle this collation internally as if it had a NO_PAD attribute");
-CALL mtr.add_suppression("RocksDB: you're trying to create an index with a multi-level collation");
-
 CREATE TABLE collations AS SELECT * FROM information_schema.COLLATION_CHARACTER_SET_APPLICABILITY ORDER BY COLLATION_NAME;
 
 --echo CharSet, Collate, Char Extra, VarChar Extra

--- a/mysql-test/suite/rocksdb/t/type_text_indexes.test
+++ b/mysql-test/suite/rocksdb/t/type_text_indexes.test
@@ -35,7 +35,7 @@ INSERT INTO t1 (t,tt,m,l) VALUES
 (REPEAT('b',128),REPEAT('f',128),REPEAT('e',128),REPEAT('d',128)),
 (REPEAT('c',128),REPEAT('b',128),REPEAT('c',128),REPEAT('e',128));
 
---replace_column 10 # 11 #
+--replace_column 8 # 10 # 11 #
 EXPLAIN SELECT SUBSTRING(t,16) AS f FROM t1 WHERE t IN ('test1','test2') ORDER BY f;
 SELECT SUBSTRING(t,16) AS f FROM t1 WHERE t IN ('test1','test2') ORDER BY f;
 
@@ -78,7 +78,7 @@ INSERT INTO t1 (t,tt,m,l,pk) VALUES
 (REPEAT('b',128),REPEAT('f',128),REPEAT('e',128),REPEAT('d',128),'8'),
 (REPEAT('c',128),REPEAT('b',128),REPEAT('c',128),REPEAT('e',128),'9');
 
---replace_column 10 # 11 #
+--replace_column 8 # 10 # 11 #
 EXPLAIN SELECT SUBSTRING(m,128) AS f FROM t1 WHERE m = 'test1' ORDER BY f DESC;
 SELECT SUBSTRING(m,128) AS f FROM t1 WHERE m = 'test1' ORDER BY f DESC;
 
@@ -274,7 +274,7 @@ drop table t;
 set session rocksdb_verify_row_debug_checksums = on;
 create table t (id int primary key, email text, KEY email_i (email(30))) engine=rocksdb default charset=latin1;
 insert into t values (1, '                                  a');
---replace_column 9 #
+--replace_column 8 # 9 #
 explain select 'email_i' as index_name, count(*) AS count from t force index(email_i);
 select 'email_i' as index_name, count(*) AS count from t force index(email_i);
 drop table t;

--- a/mysql-test/suite/rocksdb/t/type_varchar_packing.test
+++ b/mysql-test/suite/rocksdb/t/type_varchar_packing.test
@@ -1,0 +1,57 @@
+# This MTR test checks for all single-level collations if they are space padded/no padded correctly.
+
+--source include/have_rocksdb.inc
+
+# remove multi-level collations
+CREATE TABLE collations AS SELECT COLLATION_NAME, CHARACTER_SET_NAME, PAD_ATTRIBUTE FROM information_schema.COLLATIONS WHERE COLLATION_NAME NOT IN ("latin2_czech_cs", "cp1250_czech_cs", "utf8mb4_0900_as_cs", "utf8mb4_de_pb_0900_as_cs", "utf8mb4_is_0900_as_cs", "utf8mb4_lv_0900_as_cs", "utf8mb4_ro_0900_as_cs", "utf8mb4_sl_0900_as_cs", "utf8mb4_pl_0900_as_cs", "utf8mb4_et_0900_as_cs", "utf8mb4_es_0900_as_cs", "utf8mb4_sv_0900_as_cs", "utf8mb4_tr_0900_as_cs", "utf8mb4_cs_0900_as_cs", "utf8mb4_da_0900_as_cs", "utf8mb4_lt_0900_as_cs", "utf8mb4_sk_0900_as_cs", "utf8mb4_es_trad_0900_as_cs", "utf8mb4_la_0900_as_cs", "utf8mb4_eo_0900_as_cs", "utf8mb4_hu_0900_as_cs", "utf8mb4_hr_0900_as_cs", "utf8mb4_vi_0900_as_cs", "utf8mb4_ja_0900_as_cs", "utf8mb4_0900_as_ci", "utf8mb4_ru_0900_as_cs", "utf8mb4_zh_0900_as_cs", "utf8mb4_ja_0900_as_cs_ks") ORDER BY COLLATION_NAME;
+
+--let $i=1
+--let $collate=query_get_value(select * from collations, COLLATION_NAME, $i)
+while ($collate != 'No such row')
+{
+  --let $charset=query_get_value(select * from collations, CHARACTER_SET_NAME, $i)
+  --let $pad_type=query_get_value(select * from collations, PAD_ATTRIBUTE, $i)
+  --echo # Testing character set "$charset" collation "$collate" padding "$pad_type"
+  --let table_name=t_$charset
+  if ($pad_type == "PAD SPACE")
+  {
+    --eval CREATE TABLE $table_name (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET $charset COLLATE $collate
+    --eval INSERT INTO $table_name VALUES('a ', 'a ', 'a ', 'a ')
+    --error ER_DUP_ENTRY
+    --eval INSERT INTO $table_name VALUES ('a', 'a', 'a', 'a')
+    --eval INSERT INTO $table_name VALUES('b  ', 'b  ', 'b  ', 'b  ');
+    --error ER_DUP_ENTRY
+    --eval INSERT INTO $table_name VALUES('b', 'b', 'b', 'b')
+    --eval INSERT INTO $table_name VALUES('a\t', 'a\t', 'a\t', 'a\t')
+    --eval INSERT INTO $table_name VALUES('a \t', 'a \t', 'a \t', 'a \t')
+    --error ER_DUP_ENTRY
+    --eval INSERT INTO $table_name VALUES('a          ', 'a          ', 'a          ', 'a          ')
+    --eval INSERT INTO $table_name VALUES('c          ', 'c          ', 'c          ', 'c          ')
+  }
+  if ($pad_type == "NO PAD")
+  {
+    if ($charset == "binary")
+    {
+      --eval CREATE TABLE $table_name (pk_varchar VARBINARY(64), pk_char BINARY(64), d_varchar VARBINARY(64), d_char BINARY(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB
+    }
+    if ($charset != "binary")
+    {
+      --eval CREATE TABLE $table_name (pk_varchar VARCHAR(64), pk_char CHAR(64), d_varchar VARCHAR(64), d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=RocksDB CHARSET $charset COLLATE $collate
+    }
+    --eval INSERT INTO $table_name VALUES('a ', 'a ', 'a ', 'a ')
+    --eval INSERT INTO $table_name VALUES ('a', 'a', 'a', 'a')
+    --eval INSERT INTO $table_name VALUES('b  ', 'b  ', 'b  ', 'b  ');
+    --eval INSERT INTO $table_name VALUES('b', 'b', 'b', 'b')
+    --eval INSERT INTO $table_name VALUES('a\t', 'a\t', 'a\t', 'a\t')
+    --eval INSERT INTO $table_name VALUES('a \t', 'a \t', 'a \t', 'a \t')
+    --eval INSERT INTO $table_name VALUES('a          ', 'a          ', 'a          ', 'a          ')
+  }
+
+  --eval SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM $table_name
+  --eval DROP TABLE $table_name
+
+  --inc $i
+  --let $collate=query_get_value(select * from collations, COLLATION_NAME, $i)
+}
+
+DROP TABLE collations;

--- a/plugin/x/src/xpl_system_variables.h
+++ b/plugin/x/src/xpl_system_variables.h
@@ -25,6 +25,7 @@
 #ifndef PLUGIN_X_SRC_XPL_SYSTEM_VARIABLES_H_
 #define PLUGIN_X_SRC_XPL_SYSTEM_VARIABLES_H_
 
+#include <stdint.h>
 #include <algorithm>
 #include <functional>
 #include <vector>

--- a/router/src/http/src/base64.h
+++ b/router/src/http/src/base64.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+  Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
 
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License, version 2.0,
@@ -29,6 +29,7 @@
 
 #include <algorithm>  // min
 #include <array>
+#include <stdexcept>
 #include <string>
 #include <utility>  // index_sequence
 #include <vector>

--- a/sql/rpl_utility.h
+++ b/sql/rpl_utility.h
@@ -28,6 +28,7 @@
 #endif
 
 #include <sys/types.h>
+#include <string>
 #include <unordered_map>
 #include <vector>
 

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -751,7 +751,10 @@ void setup_key_part_field(TABLE_SHARE *share, handler *handler_file,
   } else if (part_of_key_not_extended) {
     field->part_of_prefixkey.set_bit(key_n);
   }
-  if ((handler_file->index_flags(key_n, key_part_n, 0) & HA_KEYREAD_ONLY) &&
+
+  /* call index_flags() only after all key parts were processed */
+  if ((key_part_n == keyinfo->actual_key_parts - 1) &&
+      (handler_file->index_flags(key_n, key_part_n, 0) & HA_KEYREAD_ONLY) &&
       field->type() != MYSQL_TYPE_GEOMETRY) {
     // Set the key as 'keys_for_keyread' even if it is prefix key.
     share->keys_for_keyread.set_bit(key_n);

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -7240,7 +7240,8 @@ int ha_rocksdb::rdb_error_to_mysql(const rocksdb::Status &s,
 
 /* MyRocks supports only the following collations for indexed columns */
 static const std::set<const my_core::CHARSET_INFO *> RDB_INDEX_COLLATIONS = {
-    &my_charset_bin, &my_charset_utf8_bin, &my_charset_latin1_bin};
+    &my_charset_bin, &my_charset_utf8_bin, &my_charset_utf8mb4_bin,
+    &my_charset_latin1_bin};
 
 static bool rdb_is_index_collation_supported(
     const my_core::Field *const field) {
@@ -7248,8 +7249,10 @@ static bool rdb_is_index_collation_supported(
   /* Handle [VAR](CHAR|BINARY) or TEXT|BLOB */
   if (type == MYSQL_TYPE_VARCHAR || type == MYSQL_TYPE_STRING ||
       type == MYSQL_TYPE_BLOB) {
-    return RDB_INDEX_COLLATIONS.find(field->charset()) !=
-           RDB_INDEX_COLLATIONS.end();
+    return rdb_is_simple_collation(field->charset()) ||
+           rdb_is_binary_collation(field->charset()) ||
+           RDB_INDEX_COLLATIONS.find(field->charset()) !=
+               RDB_INDEX_COLLATIONS.end();
   }
   return true;
 }

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -7238,25 +7238,6 @@ int ha_rocksdb::rdb_error_to_mysql(const rocksdb::Status &s,
   return err;
 }
 
-/* MyRocks supports only the following collations for indexed columns */
-static const std::set<const my_core::CHARSET_INFO *> RDB_INDEX_COLLATIONS = {
-    &my_charset_bin, &my_charset_utf8_bin, &my_charset_utf8mb4_bin,
-    &my_charset_latin1_bin};
-
-static bool rdb_is_index_collation_supported(
-    const my_core::Field *const field) {
-  const my_core::enum_field_types type = field->real_type();
-  /* Handle [VAR](CHAR|BINARY) or TEXT|BLOB */
-  if (type == MYSQL_TYPE_VARCHAR || type == MYSQL_TYPE_STRING ||
-      type == MYSQL_TYPE_BLOB) {
-    return rdb_is_simple_collation(field->charset()) ||
-           rdb_is_binary_collation(field->charset()) ||
-           RDB_INDEX_COLLATIONS.find(field->charset()) !=
-               RDB_INDEX_COLLATIONS.end();
-  }
-  return true;
-}
-
 /*
   Create structures needed for storing data in rocksdb. This is called when the
   table is created. The structures will be shared by all TABLE* objects.
@@ -7398,50 +7379,6 @@ int ha_rocksdb::create_cfs(
   */
   for (uint i = 0; i < tbl_def_arg->m_key_count; i++) {
     std::shared_ptr<rocksdb::ColumnFamilyHandle> cf_handle;
-    /*
-     Few key points -
-      1) Functionality supported below is the collation check on user_tables
-      coming from create and alter table code path. Any tmp_tables which are
-     created outside of alter table code path shouldn't have collation check. 2)
-     actual_user_table_name field is only set in the alter table code which
-      contains the name of actual table being altered. This is required because
-      alter table copy algorithm passes tmp table as table name and due to which
-      we miss some collation checks.
-    */
-    if (rocksdb_strict_collation_check &&
-        !is_hidden_pk(i, table_arg, tbl_def_arg) &&
-        (tbl_def_arg->base_tablename().find(tmp_file_prefix) != 0 ||
-         !actual_user_table_name.empty())) {
-      for (uint part = 0; part < table_arg->key_info[i].actual_key_parts;
-           part++) {
-        if (!rdb_is_index_collation_supported(
-                table_arg->key_info[i].key_part[part].field) &&
-            !rdb_collation_exceptions->matches(table_with_enforced_collation)) {
-          std::string collation_err;
-          for (const auto &coll : RDB_INDEX_COLLATIONS) {
-            if (collation_err != "") {
-              collation_err += ", ";
-            }
-            collation_err += coll->name;
-          }
-          if (rocksdb_error_on_suboptimal_collation) {
-            my_error(ER_UNSUPPORTED_COLLATION, MYF(0),
-                     tbl_def_arg->full_tablename().c_str(),
-                     table_arg->key_info[i].key_part[part].field->field_name,
-                     collation_err.c_str());
-            DBUG_RETURN(HA_EXIT_FAILURE);
-          } else {
-            push_warning_printf(
-                ha_thd(), Sql_condition::SL_WARNING, ER_WRONG_ARGUMENTS,
-                "Unsupported collation on string indexed column %s.%s Use "
-                "binary collation (%s).",
-                tbl_def_arg->full_tablename().c_str(),
-                table_arg->key_info[i].key_part[part].field->field_name,
-                collation_err.c_str());
-          }
-        }
-      }
-    }
 
     // Internal consistency check to make sure that data in TABLE and
     // Rdb_tbl_def structures matches. Either both are missing or both are

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -2864,7 +2864,7 @@ void Rdb_key_def::store_field(const uchar *data, const size_t length,
     auto field_blob = (Field_blob *)field;
     auto length_bytes = field_blob->pack_length_no_ptr();
     field_blob->store_length(length);
-    auto blob_data = (char *const)(data);
+    auto blob_data = (char *)(data);
     memset(field_blob->ptr + length_bytes, 0, 8);
     memcpy(field_blob->ptr + length_bytes, &blob_data, sizeof(uchar **));
   } else {

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -2582,21 +2582,17 @@ void Rdb_key_def::pack_with_varlength_encoding(
   const CHARSET_INFO *const charset = field->charset();
   size_t value_length = field->data_length();
   const char *src = get_data_value(field);
-  // We only store the trimmed contents but encode the missing char with
-  // removed_chars later to save space
-  const size_t trimmed_len =
-      charset->cset->lengthsp(charset, src, value_length);
 
   // Max memcmp byte length with char_length(), in case we need to truncate
   const size_t max_xfrm_len = charset->cset->charpos(
-      charset, src, src + trimmed_len,
+      charset, src, src + value_length,
       fpi->m_max_field_bytes / fpi->m_varlength_charset->mbmaxlen);
 
   // Trimmed length in code points - this is needed to avoid the padding
   // behavior in strnxfrm for padding collations otherwise strnxfrm would
   // pad to max length which defeats the trimming earlier
   const size_t trimmed_codepoints =
-      charset->cset->numchars(charset, src, src + trimmed_len);
+      charset->cset->numchars(charset, src, src + value_length);
 
   const size_t xfrm_len = charset->coll->strnxfrm(
       charset, buf, fpi->m_max_image_len_before_encoding,
@@ -2604,7 +2600,7 @@ void Rdb_key_def::pack_with_varlength_encoding(
           trimmed_codepoints,
           fpi->m_max_field_bytes / fpi->m_varlength_charset->mbmaxlen),
       reinterpret_cast<const uchar *>(src),
-      std::min<size_t>(trimmed_len, max_xfrm_len), 0);
+      std::min<size_t>(value_length, max_xfrm_len), 0);
 
   /* Got a mem-comparable image in 'buf'. Now, produce varlength encoding */
   pack_variable_format(buf, xfrm_len, dst);
@@ -3965,8 +3961,13 @@ bool Rdb_field_packing::setup(const Rdb_key_def *const key_descr,
         // Currently we handle these collations as NO_PAD, even if they have
         // PAD_SPACE attribute.
         if (cs->levels_for_compare == 1) {
-          m_pack_func = Rdb_key_def::pack_with_varlength_space_pad;
-          m_skip_func = Rdb_key_def::skip_variable_space_pad;
+          if (cs->pad_attribute == NO_PAD) {
+            m_pack_func = Rdb_key_def::pack_with_varlength_encoding;
+            m_skip_func = Rdb_key_def::skip_variable_length_encoding;
+          } else {
+            m_pack_func = Rdb_key_def::pack_with_varlength_space_pad;
+            m_skip_func = Rdb_key_def::skip_variable_space_pad;
+          }
           m_segment_size = get_segment_size_from_collation(cs);
           m_max_image_len =
               (max_image_len_before_chunks / (m_segment_size - 1) + 1) *

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -738,15 +738,20 @@ class Rdb_key_def {
       uchar *const buf MY_ATTRIBUTE((__unused__)), uchar **dst,
       Rdb_pack_field_context *const pack_ctx MY_ATTRIBUTE((__unused__)));
 
-  static int unpack_binary_or_utf8_varlength(
+  static int unpack_binary_varlength(
       Rdb_field_packing *const fpi, Field *const field,
       uchar *dst MY_ATTRIBUTE((__unused__)), Rdb_string_reader *const reader,
       Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__)));
 
+  template <const int bytes>
   static int unpack_binary_or_utf8_varlength_space_pad(
       Rdb_field_packing *const fpi, Field *const field,
       uchar *dst MY_ATTRIBUTE((__unused__)), Rdb_string_reader *const reader,
       Rdb_string_reader *const unp_reader);
+
+  static rdb_index_field_unpack_t unpack_binary_varlength_space_pad;
+  static rdb_index_field_unpack_t unpack_utf8_varlength_space_pad;
+  static rdb_index_field_unpack_t unpack_utf8mb4_varlength_space_pad;
 
   static void pack_newdate(Rdb_field_packing *const fpi, Field *const field,
                            uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
@@ -758,10 +763,8 @@ class Rdb_key_def {
       Rdb_string_reader *const reader,
       Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__)));
 
-  static int unpack_utf8_str(Rdb_field_packing *const fpi, Field *const field,
-                             uchar *dst, Rdb_string_reader *const reader,
-                             Rdb_string_reader *const unp_reader
-                                 MY_ATTRIBUTE((__unused__)));
+  static rdb_index_field_unpack_t unpack_utf8_str;
+  static rdb_index_field_unpack_t unpack_utf8mb4_str;
 
   static int unpack_unknown_varlength(Rdb_field_packing *const fpi,
                                       Field *const field,
@@ -1817,5 +1820,8 @@ class Rdb_system_merge_op : public rocksdb::AssociativeMergeOperator {
     return rdb_netbuf_to_uint16(reinterpret_cast<const uchar *>(s.data()));
   }
 };
+
+bool rdb_is_simple_collation(const my_core::CHARSET_INFO *const cs);
+bool rdb_is_binary_collation(const my_core::CHARSET_INFO *const cs);
 
 }  // namespace myrocks

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -1821,7 +1821,4 @@ class Rdb_system_merge_op : public rocksdb::AssociativeMergeOperator {
   }
 };
 
-bool rdb_is_simple_collation(const my_core::CHARSET_INFO *const cs);
-bool rdb_is_binary_collation(const my_core::CHARSET_INFO *const cs);
-
 }  // namespace myrocks


### PR DESCRIPTION
1. Fix support of `NO_PAD` collations i.e. `utf8mb4*_0900_*`
    
2. Add `rocksdb.type_varchar_packing` to validate padding of `CHAR` and `VARCHAR` collations. Only multi-level collations (`utf8mb4_*_0900_as_cs`, `utf8mb4_0900_as_ci`, `latin2_czech_cs` and `cp1250_czech_cs`) are not verified.

3. Fix `EXPLAIN SELECT` that always showed `Using index` for RocksDB SKs in 8.0.
    
4. Add optimized support for `utf8mb4_bin` and all collations based on `my_collation_8bit_bin_handler` (i.e. `latinX_bin`, `cp12XX_bin`, `cp85X_bin`, `armscii8_bin`, `ascii_bin` and many more). Index-only scans with SK are supported by decoding the memcomparable form back into the original form.
    
5. Introduce the `rocksdb.type_char_secondary_index_only_scan` test that:
a) Finds all collations that support index-only scans with secondary keys using the `Extra` field from `EXPLAIN SELECT`
b) Verifies if the original string is reconstructed correctly from SK (or from PK when index-only scans with SK are not supported)

6. Index-only scans with SK are supported by decoding the memcomparable form back into the original form. Currently we support SK index-only scans for:
- `binary`, `utf8_bin`, and `utf8mb4_bin` collations
- collations based on `my_collation_8bit_simple_ci_handler` (e.g. `latin1_swedish_ci`, `cp850_general_ci`, `latin1_german1_ci`, `cp1251_ukrainian_ci`, `cp866_general_ci`)
- collations based on `my_collation_8bit_bin_handler` (i.e. `latinX_bin`, `cp12XX_bin`, `cp85X_bin`, `armscii8_bin`, `ascii_bin` and many more)
This patch turns on support for all remaining collations by storing entire copy of original field in the value.
