### PR TITLE
[RFC] Improve count(*) performance and fix index merge bug

### DIFF
--- a/sql/opt_range.h
+++ b/sql/opt_range.h
@@ -473,6 +473,7 @@ public:
   bool reverse_sorted() const { return false; }
   bool reverse_sort_possible() const { return true; }
   bool unique_key_range();
+  void mark_columns_ror_merged_scan();
   int init_ror_merged_scan(bool reuse_handler);
   void save_last_pos()
   { file->position(record); }

--- a/storage/rocksdb/rdb_converter.cc
+++ b/storage/rocksdb/rdb_converter.cc
@@ -337,14 +337,13 @@ void Rdb_converter::get_storage_type(Rdb_field_encoder *const encoder,
     Setup which fields will be unpacked when reading rows
 
   @detail
-    Three special cases when we still unpack all fields:
+    Two special cases when we still unpack all fields:
     - When client requires decode_all_fields, such as this table is being
   updated (m_lock_rows==RDB_LOCK_WRITE).
     - When @@rocksdb_verify_row_debug_checksums is ON (In this mode, we need
   to read all fields to find whether there is a row checksum at the end. We
   could skip the fields instead of decoding them, but currently we do
   decoding.)
-    - On index merge as bitmap is cleared during that operation
 
   @seealso
     Rdb_converter::setup_field_encoders()
@@ -358,10 +357,8 @@ void Rdb_converter::setup_field_decoders(const MY_BITMAP *field_map,
   int skip_size = 0;
 
   for (uint i = 0; i < m_table->s->fields; i++) {
-    // bitmap is cleared on index merge, but it still needs to decode columns
     bool field_requested =
         decode_all_fields || m_verify_row_debug_checksums ||
-        bitmap_is_clear_all(field_map) ||
         bitmap_is_set(field_map, m_table->field[i]->field_index);
 
     // We only need the decoder if the whole record is stored.


### PR DESCRIPTION
(Sending this in github to get broader feedback)

Today in `SELECT count(*)` MyRocks would still decode every single column due to this check, despite the readset being empty:

```
 // bitmap is cleared on index merge, but it still needs to decode columns
    bool field_requested =
        decode_all_fields || m_verify_row_debug_checksums ||
        bitmap_is_clear_all(field_map) ||
        bitmap_is_set(field_map, m_table->field[i]->field_index);
```

As a result MyRocks is significantly slower than InnoDB in this particular scenario.

Turns out in index merge, when it tries to reset, it calls ha_index_init with an empty column_bitmap, so our field decoders didn't know it needs to decode anything, so the entire query would return nothing. This is discussed in [this commit](https://github.com/facebook/mysql-5.6/commit/70f2bcd777b0fb58b72e9dbe5e5477e34248d7dd), and [issue 624](https://github.com/facebook/mysql-5.6/issues/624) and [PR 626](https://github.com/facebook/mysql-5.6/pull/626). So the workaround we had at that time is to simply treat empty map as implicitly everything, and the side effect is massively slowed down count(*).

Looking at the code in QUICK_RANGE_SELECT::init_ror_merged_scan, it actually fixes up the column_bitmap properly, but after init/reset, so the fix would simply be moving the bitmap set code up. For secondary keys, prepare_for_position will automatically call `mark_columns_used_by_index_no_reset(s->primary_key, read_set)` if HA_PRIMARY_KEY_REQUIRED_FOR_POSITION is set (true for both InnoDB and MyRocks), so we would know correctly that we need to unpack PK when walking SK during index merge. 

Note that InnoDB doesn't have this problem, because it actually initialize its template again in index_read for the 2nd time (relying on `prebuilt->sql_stat_start`), and during index_read `QUICK_RANGE_SELECT::column_bitmap` is already fixed up and the table read/write set is switched to it, so the new template would be built correctly. In theory we could also use similar technique, but I decided to go with a change that has smaller scope limiting to index merges, and is the better long term fix anyway.

With this MyRocks is on par with InnoDB with count(*) scenario in the scenario we tested, roughly 40% faster than before the fix.

Another alternative solution is to override `handler::column_bitmaps_signal` and recreate the MyRocks encoders there, however doing so revealed some additional issues. Because no storage engine today actually use `handler::column_bitmaps_signal` this path haven't been tested properly in index merge. In this case, `QUICK_RANGE_SELECT::init_ror_merged_scan` should call `set_column_bitmaps_no_signal` to avoid resetting the correct read/write set of head since head is used as first handler (reuses_handler=true) and subsequent place holders for read/write set updates (reuse_handler=false).

Given that `column_bitmaps_signal` is not being used by any storage engines (in the tree) today so it is not well tested, I think it is better to stick to the more established pattern to make sure init functions see the correct read/write set.