### PR TITLE
Fix mysql range query optimizer bug in key_or

### DIFF
--- a/mysql-test/include/range.inc
+++ b/mysql-test/include/range.inc
@@ -2841,3 +2841,25 @@ eval EXPLAIN $query2;
 eval $query2;
 
 DROP TABLE test_ref;
+
+--echo #
+--echo # BUG: Range optimizer loses keys when ORing identical ranges
+--echo #
+
+CREATE TABLE test_or (
+  a bigint unsigned NOT NULL,
+  b bigint unsigned NOT NULL,
+  c bigint unsigned NOT NULL,
+  d VARCHAR(10), PRIMARY KEY (a, b, c));
+
+INSERT INTO test_or VALUES (1, 1, 1, 'a'), (2, 2, 2, 'b'), (3, 3, 3, 'c');
+
+# This gives us range plan
+EXPLAIN SELECT * FROM test_or FORCE INDEX (PRIMARY) WHERE
+(a=1 and b=1 and c=1) OR (a=1 and b=2 and c=2);
+
+# Bug: this falls back to a ref plan
+EXPLAIN SELECT * FROM test_or FORCE INDEX (PRIMARY) WHERE
+(a=1 and b=1 and c=1) OR (a=1 and b=1 and c=1) OR (a=1 and b=2 and c=2);
+
+DROP TABLE test_or;

--- a/mysql-test/r/range_all.result
+++ b/mysql-test/r/range_all.result
@@ -3891,4 +3891,26 @@ LIMIT 1;
 a	b	c	d	id
 1770649	D003	gheennse	S	3
 DROP TABLE test_ref;
+#
+# BUG: Range optimizer loses keys when ORing identical ranges
+#
+CREATE TABLE test_or (
+a bigint unsigned NOT NULL,
+b bigint unsigned NOT NULL,
+c bigint unsigned NOT NULL,
+d VARCHAR(10), PRIMARY KEY (a, b, c));
+INSERT INTO test_or VALUES (1, 1, 1, 'a'), (2, 2, 2, 'b'), (3, 3, 3, 'c');
+EXPLAIN SELECT * FROM test_or FORCE INDEX (PRIMARY) WHERE
+(a=1 and b=1 and c=1) OR (a=1 and b=2 and c=2);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	test_or	NULL	range	PRIMARY	PRIMARY	24	NULL	2	100.00	Using index condition; Using MRR
+Warnings:
+Note	1003	/* select#1 */ select `test`.`test_or`.`a` AS `a`,`test`.`test_or`.`b` AS `b`,`test`.`test_or`.`c` AS `c`,`test`.`test_or`.`d` AS `d` from `test`.`test_or` FORCE INDEX (PRIMARY) where (((`test`.`test_or`.`c` = 1) and (`test`.`test_or`.`b` = 1) and (`test`.`test_or`.`a` = 1)) or ((`test`.`test_or`.`c` = 2) and (`test`.`test_or`.`b` = 2) and (`test`.`test_or`.`a` = 1)))
+EXPLAIN SELECT * FROM test_or FORCE INDEX (PRIMARY) WHERE
+(a=1 and b=1 and c=1) OR (a=1 and b=1 and c=1) OR (a=1 and b=2 and c=2);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	test_or	NULL	range	PRIMARY	PRIMARY	24	NULL	2	100.00	Using index condition; Using MRR
+Warnings:
+Note	1003	/* select#1 */ select `test`.`test_or`.`a` AS `a`,`test`.`test_or`.`b` AS `b`,`test`.`test_or`.`c` AS `c`,`test`.`test_or`.`d` AS `d` from `test`.`test_or` FORCE INDEX (PRIMARY) where (((`test`.`test_or`.`c` = 1) and (`test`.`test_or`.`b` = 1) and (`test`.`test_or`.`a` = 1)) or ((`test`.`test_or`.`c` = 1) and (`test`.`test_or`.`b` = 1) and (`test`.`test_or`.`a` = 1)) or ((`test`.`test_or`.`c` = 2) and (`test`.`test_or`.`b` = 2) and (`test`.`test_or`.`a` = 1)))
+DROP TABLE test_or;
 set optimizer_switch=default;

--- a/mysql-test/r/range_icp.result
+++ b/mysql-test/r/range_icp.result
@@ -3891,4 +3891,26 @@ LIMIT 1;
 a	b	c	d	id
 1770649	D003	gheennse	S	3
 DROP TABLE test_ref;
+#
+# BUG: Range optimizer loses keys when ORing identical ranges
+#
+CREATE TABLE test_or (
+a bigint unsigned NOT NULL,
+b bigint unsigned NOT NULL,
+c bigint unsigned NOT NULL,
+d VARCHAR(10), PRIMARY KEY (a, b, c));
+INSERT INTO test_or VALUES (1, 1, 1, 'a'), (2, 2, 2, 'b'), (3, 3, 3, 'c');
+EXPLAIN SELECT * FROM test_or FORCE INDEX (PRIMARY) WHERE
+(a=1 and b=1 and c=1) OR (a=1 and b=2 and c=2);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	test_or	NULL	range	PRIMARY	PRIMARY	24	NULL	2	100.00	Using index condition
+Warnings:
+Note	1003	/* select#1 */ select `test`.`test_or`.`a` AS `a`,`test`.`test_or`.`b` AS `b`,`test`.`test_or`.`c` AS `c`,`test`.`test_or`.`d` AS `d` from `test`.`test_or` FORCE INDEX (PRIMARY) where (((`test`.`test_or`.`c` = 1) and (`test`.`test_or`.`b` = 1) and (`test`.`test_or`.`a` = 1)) or ((`test`.`test_or`.`c` = 2) and (`test`.`test_or`.`b` = 2) and (`test`.`test_or`.`a` = 1)))
+EXPLAIN SELECT * FROM test_or FORCE INDEX (PRIMARY) WHERE
+(a=1 and b=1 and c=1) OR (a=1 and b=1 and c=1) OR (a=1 and b=2 and c=2);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	test_or	NULL	range	PRIMARY	PRIMARY	24	NULL	2	100.00	Using index condition
+Warnings:
+Note	1003	/* select#1 */ select `test`.`test_or`.`a` AS `a`,`test`.`test_or`.`b` AS `b`,`test`.`test_or`.`c` AS `c`,`test`.`test_or`.`d` AS `d` from `test`.`test_or` FORCE INDEX (PRIMARY) where (((`test`.`test_or`.`c` = 1) and (`test`.`test_or`.`b` = 1) and (`test`.`test_or`.`a` = 1)) or ((`test`.`test_or`.`c` = 1) and (`test`.`test_or`.`b` = 1) and (`test`.`test_or`.`a` = 1)) or ((`test`.`test_or`.`c` = 2) and (`test`.`test_or`.`b` = 2) and (`test`.`test_or`.`a` = 1)))
+DROP TABLE test_or;
 set optimizer_switch=default;

--- a/mysql-test/r/range_icp_mrr.result
+++ b/mysql-test/r/range_icp_mrr.result
@@ -3891,4 +3891,26 @@ LIMIT 1;
 a	b	c	d	id
 1770649	D003	gheennse	S	3
 DROP TABLE test_ref;
+#
+# BUG: Range optimizer loses keys when ORing identical ranges
+#
+CREATE TABLE test_or (
+a bigint unsigned NOT NULL,
+b bigint unsigned NOT NULL,
+c bigint unsigned NOT NULL,
+d VARCHAR(10), PRIMARY KEY (a, b, c));
+INSERT INTO test_or VALUES (1, 1, 1, 'a'), (2, 2, 2, 'b'), (3, 3, 3, 'c');
+EXPLAIN SELECT * FROM test_or FORCE INDEX (PRIMARY) WHERE
+(a=1 and b=1 and c=1) OR (a=1 and b=2 and c=2);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	test_or	NULL	range	PRIMARY	PRIMARY	24	NULL	2	100.00	Using index condition; Using MRR
+Warnings:
+Note	1003	/* select#1 */ select `test`.`test_or`.`a` AS `a`,`test`.`test_or`.`b` AS `b`,`test`.`test_or`.`c` AS `c`,`test`.`test_or`.`d` AS `d` from `test`.`test_or` FORCE INDEX (PRIMARY) where (((`test`.`test_or`.`c` = 1) and (`test`.`test_or`.`b` = 1) and (`test`.`test_or`.`a` = 1)) or ((`test`.`test_or`.`c` = 2) and (`test`.`test_or`.`b` = 2) and (`test`.`test_or`.`a` = 1)))
+EXPLAIN SELECT * FROM test_or FORCE INDEX (PRIMARY) WHERE
+(a=1 and b=1 and c=1) OR (a=1 and b=1 and c=1) OR (a=1 and b=2 and c=2);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	test_or	NULL	range	PRIMARY	PRIMARY	24	NULL	2	100.00	Using index condition; Using MRR
+Warnings:
+Note	1003	/* select#1 */ select `test`.`test_or`.`a` AS `a`,`test`.`test_or`.`b` AS `b`,`test`.`test_or`.`c` AS `c`,`test`.`test_or`.`d` AS `d` from `test`.`test_or` FORCE INDEX (PRIMARY) where (((`test`.`test_or`.`c` = 1) and (`test`.`test_or`.`b` = 1) and (`test`.`test_or`.`a` = 1)) or ((`test`.`test_or`.`c` = 1) and (`test`.`test_or`.`b` = 1) and (`test`.`test_or`.`a` = 1)) or ((`test`.`test_or`.`c` = 2) and (`test`.`test_or`.`b` = 2) and (`test`.`test_or`.`a` = 1)))
+DROP TABLE test_or;
 set optimizer_switch=default;

--- a/mysql-test/r/range_mrr.result
+++ b/mysql-test/r/range_mrr.result
@@ -3893,4 +3893,26 @@ LIMIT 1;
 a	b	c	d	id
 1770649	D003	gheennse	S	3
 DROP TABLE test_ref;
+#
+# BUG: Range optimizer loses keys when ORing identical ranges
+#
+CREATE TABLE test_or (
+a bigint unsigned NOT NULL,
+b bigint unsigned NOT NULL,
+c bigint unsigned NOT NULL,
+d VARCHAR(10), PRIMARY KEY (a, b, c));
+INSERT INTO test_or VALUES (1, 1, 1, 'a'), (2, 2, 2, 'b'), (3, 3, 3, 'c');
+EXPLAIN SELECT * FROM test_or FORCE INDEX (PRIMARY) WHERE
+(a=1 and b=1 and c=1) OR (a=1 and b=2 and c=2);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	test_or	NULL	range	PRIMARY	PRIMARY	24	NULL	2	100.00	Using where; Using MRR
+Warnings:
+Note	1003	/* select#1 */ select `test`.`test_or`.`a` AS `a`,`test`.`test_or`.`b` AS `b`,`test`.`test_or`.`c` AS `c`,`test`.`test_or`.`d` AS `d` from `test`.`test_or` FORCE INDEX (PRIMARY) where (((`test`.`test_or`.`c` = 1) and (`test`.`test_or`.`b` = 1) and (`test`.`test_or`.`a` = 1)) or ((`test`.`test_or`.`c` = 2) and (`test`.`test_or`.`b` = 2) and (`test`.`test_or`.`a` = 1)))
+EXPLAIN SELECT * FROM test_or FORCE INDEX (PRIMARY) WHERE
+(a=1 and b=1 and c=1) OR (a=1 and b=1 and c=1) OR (a=1 and b=2 and c=2);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	test_or	NULL	range	PRIMARY	PRIMARY	24	NULL	2	100.00	Using where; Using MRR
+Warnings:
+Note	1003	/* select#1 */ select `test`.`test_or`.`a` AS `a`,`test`.`test_or`.`b` AS `b`,`test`.`test_or`.`c` AS `c`,`test`.`test_or`.`d` AS `d` from `test`.`test_or` FORCE INDEX (PRIMARY) where (((`test`.`test_or`.`c` = 1) and (`test`.`test_or`.`b` = 1) and (`test`.`test_or`.`a` = 1)) or ((`test`.`test_or`.`c` = 1) and (`test`.`test_or`.`b` = 1) and (`test`.`test_or`.`a` = 1)) or ((`test`.`test_or`.`c` = 2) and (`test`.`test_or`.`b` = 2) and (`test`.`test_or`.`a` = 1)))
+DROP TABLE test_or;
 set optimizer_switch=default;

--- a/mysql-test/r/range_mrr_cost.result
+++ b/mysql-test/r/range_mrr_cost.result
@@ -3893,4 +3893,26 @@ LIMIT 1;
 a	b	c	d	id
 1770649	D003	gheennse	S	3
 DROP TABLE test_ref;
+#
+# BUG: Range optimizer loses keys when ORing identical ranges
+#
+CREATE TABLE test_or (
+a bigint unsigned NOT NULL,
+b bigint unsigned NOT NULL,
+c bigint unsigned NOT NULL,
+d VARCHAR(10), PRIMARY KEY (a, b, c));
+INSERT INTO test_or VALUES (1, 1, 1, 'a'), (2, 2, 2, 'b'), (3, 3, 3, 'c');
+EXPLAIN SELECT * FROM test_or FORCE INDEX (PRIMARY) WHERE
+(a=1 and b=1 and c=1) OR (a=1 and b=2 and c=2);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	test_or	NULL	range	PRIMARY	PRIMARY	24	NULL	2	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select `test`.`test_or`.`a` AS `a`,`test`.`test_or`.`b` AS `b`,`test`.`test_or`.`c` AS `c`,`test`.`test_or`.`d` AS `d` from `test`.`test_or` FORCE INDEX (PRIMARY) where (((`test`.`test_or`.`c` = 1) and (`test`.`test_or`.`b` = 1) and (`test`.`test_or`.`a` = 1)) or ((`test`.`test_or`.`c` = 2) and (`test`.`test_or`.`b` = 2) and (`test`.`test_or`.`a` = 1)))
+EXPLAIN SELECT * FROM test_or FORCE INDEX (PRIMARY) WHERE
+(a=1 and b=1 and c=1) OR (a=1 and b=1 and c=1) OR (a=1 and b=2 and c=2);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	test_or	NULL	range	PRIMARY	PRIMARY	24	NULL	2	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select `test`.`test_or`.`a` AS `a`,`test`.`test_or`.`b` AS `b`,`test`.`test_or`.`c` AS `c`,`test`.`test_or`.`d` AS `d` from `test`.`test_or` FORCE INDEX (PRIMARY) where (((`test`.`test_or`.`c` = 1) and (`test`.`test_or`.`b` = 1) and (`test`.`test_or`.`a` = 1)) or ((`test`.`test_or`.`c` = 1) and (`test`.`test_or`.`b` = 1) and (`test`.`test_or`.`a` = 1)) or ((`test`.`test_or`.`c` = 2) and (`test`.`test_or`.`b` = 2) and (`test`.`test_or`.`a` = 1)))
+DROP TABLE test_or;
 set optimizer_switch=default;

--- a/mysql-test/r/range_none.result
+++ b/mysql-test/r/range_none.result
@@ -3892,4 +3892,26 @@ LIMIT 1;
 a	b	c	d	id
 1770649	D003	gheennse	S	3
 DROP TABLE test_ref;
+#
+# BUG: Range optimizer loses keys when ORing identical ranges
+#
+CREATE TABLE test_or (
+a bigint unsigned NOT NULL,
+b bigint unsigned NOT NULL,
+c bigint unsigned NOT NULL,
+d VARCHAR(10), PRIMARY KEY (a, b, c));
+INSERT INTO test_or VALUES (1, 1, 1, 'a'), (2, 2, 2, 'b'), (3, 3, 3, 'c');
+EXPLAIN SELECT * FROM test_or FORCE INDEX (PRIMARY) WHERE
+(a=1 and b=1 and c=1) OR (a=1 and b=2 and c=2);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	test_or	NULL	range	PRIMARY	PRIMARY	24	NULL	2	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select `test`.`test_or`.`a` AS `a`,`test`.`test_or`.`b` AS `b`,`test`.`test_or`.`c` AS `c`,`test`.`test_or`.`d` AS `d` from `test`.`test_or` FORCE INDEX (PRIMARY) where (((`test`.`test_or`.`c` = 1) and (`test`.`test_or`.`b` = 1) and (`test`.`test_or`.`a` = 1)) or ((`test`.`test_or`.`c` = 2) and (`test`.`test_or`.`b` = 2) and (`test`.`test_or`.`a` = 1)))
+EXPLAIN SELECT * FROM test_or FORCE INDEX (PRIMARY) WHERE
+(a=1 and b=1 and c=1) OR (a=1 and b=1 and c=1) OR (a=1 and b=2 and c=2);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	test_or	NULL	range	PRIMARY	PRIMARY	24	NULL	2	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select `test`.`test_or`.`a` AS `a`,`test`.`test_or`.`b` AS `b`,`test`.`test_or`.`c` AS `c`,`test`.`test_or`.`d` AS `d` from `test`.`test_or` FORCE INDEX (PRIMARY) where (((`test`.`test_or`.`c` = 1) and (`test`.`test_or`.`b` = 1) and (`test`.`test_or`.`a` = 1)) or ((`test`.`test_or`.`c` = 1) and (`test`.`test_or`.`b` = 1) and (`test`.`test_or`.`a` = 1)) or ((`test`.`test_or`.`c` = 2) and (`test`.`test_or`.`b` = 2) and (`test`.`test_or`.`a` = 1)))
+DROP TABLE test_or;
 set optimizer_switch=default;

--- a/mysql-test/r/range_with_memory_limit.result
+++ b/mysql-test/r/range_with_memory_limit.result
@@ -4422,5 +4422,29 @@ a	b	c	d	id
 Warnings:
 Warning	3170	Memory capacity of 10 bytes for 'range_optimizer_max_mem_size' exceeded. Range optimization was not done for this query.
 DROP TABLE test_ref;
+#
+# BUG: Range optimizer loses keys when ORing identical ranges
+#
+CREATE TABLE test_or (
+a bigint unsigned NOT NULL,
+b bigint unsigned NOT NULL,
+c bigint unsigned NOT NULL,
+d VARCHAR(10), PRIMARY KEY (a, b, c));
+INSERT INTO test_or VALUES (1, 1, 1, 'a'), (2, 2, 2, 'b'), (3, 3, 3, 'c');
+EXPLAIN SELECT * FROM test_or FORCE INDEX (PRIMARY) WHERE
+(a=1 and b=1 and c=1) OR (a=1 and b=2 and c=2);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	test_or	NULL	ref	PRIMARY	PRIMARY	8	const	1	33.33	Using index condition
+Warnings:
+Warning	3170	Memory capacity of 10 bytes for 'range_optimizer_max_mem_size' exceeded. Range optimization was not done for this query.
+Note	1003	/* select#1 */ select `test`.`test_or`.`a` AS `a`,`test`.`test_or`.`b` AS `b`,`test`.`test_or`.`c` AS `c`,`test`.`test_or`.`d` AS `d` from `test`.`test_or` FORCE INDEX (PRIMARY) where (((`test`.`test_or`.`c` = 1) and (`test`.`test_or`.`b` = 1) and (`test`.`test_or`.`a` = 1)) or ((`test`.`test_or`.`c` = 2) and (`test`.`test_or`.`b` = 2) and (`test`.`test_or`.`a` = 1)))
+EXPLAIN SELECT * FROM test_or FORCE INDEX (PRIMARY) WHERE
+(a=1 and b=1 and c=1) OR (a=1 and b=1 and c=1) OR (a=1 and b=2 and c=2);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	test_or	NULL	ref	PRIMARY	PRIMARY	8	const	1	33.33	Using index condition
+Warnings:
+Warning	3170	Memory capacity of 10 bytes for 'range_optimizer_max_mem_size' exceeded. Range optimization was not done for this query.
+Note	1003	/* select#1 */ select `test`.`test_or`.`a` AS `a`,`test`.`test_or`.`b` AS `b`,`test`.`test_or`.`c` AS `c`,`test`.`test_or`.`d` AS `d` from `test`.`test_or` FORCE INDEX (PRIMARY) where (((`test`.`test_or`.`c` = 1) and (`test`.`test_or`.`b` = 1) and (`test`.`test_or`.`a` = 1)) or ((`test`.`test_or`.`c` = 1) and (`test`.`test_or`.`b` = 1) and (`test`.`test_or`.`a` = 1)) or ((`test`.`test_or`.`c` = 2) and (`test`.`test_or`.`b` = 2) and (`test`.`test_or`.`a` = 1)))
+DROP TABLE test_or;
 SET RANGE_OPTIMIZER_MAX_MEM_SIZE= DEFAULT;
 # End of test for Bug#17769777 and Bug#17413040

--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -8676,6 +8676,10 @@ static SEL_ROOT *key_or(RANGE_OPT_PARAM *param, SEL_ROOT *key1,
         */
         cur_key1->merge_flags(cur_key2);    // Copy maybe flags
         cur_key2->release_next_key_part();  // Free not used tree
+
+        /* Move on to next range in key2 */
+        cur_key2 = cur_key2->next;
+        continue;
       } else {
         SEL_ARG *last = cur_key1;
         SEL_ARG *first = cur_key1;


### PR DESCRIPTION
For range query case with multiple OR, optimizer rely on tree_or and key_or to 'merge' the OR sub-tree together.
And in the case of having multiple ranges that are the same, key_or would see that both ranges key1 and key2 are exactly the same, release key2->next_key_part, and then OR key1->next_key_part and key2->next_key_part= NULL (since it is released) with key_or. However, because NULL sub-tree are treat as TRUE (same as is_always), the entirety of key1->next_key_part gets dropped, so you end up with just the first key.

It makes sense for NULL sub-tree to be treat as TRUE for key_or, because for example (A > 1 AND NULL) OR (A > 1 AND B > 1 AND NULL) should be merged as (A > 1 AND NULL), so it makes sense for NULL to be treated as TRUE so that key_or(NULL, key) should come back as NULL. So the right way to fix this is to stop handling current range and simply move to the next range (without falling through to the remaining logic).

Because of this bug the range query plan end up using much less keys and end up being more expensive, so usually a ref plan gets picked with less keys, and the query becomes much more expensive.

A small repro:

```
CREATE TABLE test_or (
  a bigint unsigned NOT NULL,
  b bigint unsigned NOT NULL,
  c bigint unsigned NOT NULL,
  d VARCHAR(10), PRIMARY KEY (a, b, c))
```

Before:
```
mysql> explain select * from test_or FORCE INDEX (PRIMARY) where (a=1 and b=1 and c=1) OR (a=1 and B=1 and c=1) OR (a=1 and b=2 and c=2);
+----+-------------+---------+------------+------+---------------+---------+---------+-------+------+----------+-------------+
| id | select_type | table   | partitions | type | possible_keys | key     | key_len | ref   | rows | filtered | Extra       |
+----+-------------+---------+------------+------+---------------+---------+---------+-------+------+----------+-------------+
|  1 | SIMPLE      | test_or | NULL       | ref  | PRIMARY       | PRIMARY | 8       | const |    1 |    33.33 | Using where |
+----+-------------+---------+------------+------+---------------+---------+---------+-------+------+----------+-------------+
1 row in set, 1 warning (0.00 sec)
```

After:
```
mysql> explain select * from test_or FORCE INDEX (PRIMARY) where (a=1 and b=1 and c=1) OR (a=1 and B=1 and c=1) OR (a=1 and b=2 and c=2);
+----+-------------+---------+------------+-------+---------------+---------+---------+------+------+----------+-------------+
| id | select_type | table   | partitions | type  | possible_keys | key     | key_len | ref  | rows | filtered | Extra       |
+----+-------------+---------+------------+-------+---------------+---------+---------+------+------+----------+-------------+
|  1 | SIMPLE      | test_or | NULL       | range | PRIMARY       | PRIMARY | 24      | NULL |    2 |   100.00 | Using where |
+----+-------------+---------+------------+-------+---------------+---------+---------+------+------+----------+-------------+
1 row in set, 1 warning (0.00 sec)
```