### PR TITLE
Support for building RocksDB plugins and custom file systems

### DIFF
--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -38,9 +38,30 @@ ELSE()
 
   SET(ROCKSDB_ROOT ${CMAKE_SOURCE_DIR}/rocksdb)
 
+  LIST(APPEND PLUGINS ${ROCKSDB_PLUGINS})
+  FOREACH(PLUGIN IN LISTS PLUGINS)
+    SET(PLUGIN_ROOT "${CMAKE_SOURCE_DIR}/rocksdb/plugin/${PLUGIN}/")
+    MESSAGE(STATUS "MyRocks: Building RocksDB plugin: ${PLUGIN}")
+    FILE(GLOB PLUGINMKFILE "${PLUGIN_ROOT}${PLUGIN}*.mk")
+    IF (NOT EXISTS ${PLUGINMKFILE})
+      MESSAGE(SEND_ERROR "Missing RocksDB plugin makefile in ${PLUGIN_ROOT}")
+    ELSE()
+      FILE(READ ${PLUGINMKFILE} PLUGINMK)
+      STRING(REGEX MATCH "SOURCES[ ]*=[ ]*([^\n]*)" FOO ${PLUGINMK})
+      SET(MK_SOURCES ${CMAKE_MATCH_1})
+      SEPARATE_ARGUMENTS(MK_SOURCES)
+      FOREACH(MK_FILE IN LISTS MK_SOURCES)
+        LIST(APPEND PLUGIN_SOURCES "${PLUGIN_ROOT}${MK_FILE}")
+      ENDFOREACH()
+      STRING(REGEX MATCH "LDFLAGS[ ]*=[ ]*([^\n]*)" FOO ${PLUGINMK})
+      LIST(APPEND PLUGIN_LD ${CMAKE_MATCH_1} )
+    ENDIF()
+  ENDFOREACH()
+
   # Statically include all RocksDB source
   SET(ROCKSDB_SOURCES
     ${ROCKSDB_LIB_SOURCES}
+    ${PLUGIN_SOURCES}
   )
 ENDIF()
 
@@ -173,7 +194,7 @@ IF (HAVE_ZLIB_H)
   SET(rocksdb_static_libs ${rocksdb_static_libs} ${ZLIB_LIBRARY})
 ENDIF()
 
-SET(rocksdb_static_libs ${rocksdb_static_libs} "-lrt" "-ldl" "-lpthread")
+SET(rocksdb_static_libs ${rocksdb_static_libs} "-lrt" "-ldl" "-lpthread" ${PLUGIN_LD})
 
 MYSQL_ADD_PLUGIN(rocksdb_se ${ROCKSDB_SOURCES} STORAGE_ENGINE DEFAULT STATIC_ONLY
   LINK_LIBRARIES ${rocksdb_static_libs}

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -686,6 +686,7 @@ static long long rocksdb_compaction_sequential_deletes_window = 0l;
 static long long rocksdb_compaction_sequential_deletes_file_size = 0l;
 static uint32_t rocksdb_validate_tables = 1;
 static char *rocksdb_datadir;
+static char *rocksdb_fs_uri;
 static uint32_t rocksdb_max_bottom_pri_background_compactions=0;
 static uint32_t rocksdb_table_stats_sampling_pct;
 static uint32_t rocksdb_table_stats_recalc_threshold_pct = 10;
@@ -894,6 +895,12 @@ static std::unique_ptr<rocksdb::DBOptions> rdb_init_rocksdb_db_options(void) {
   o->two_write_queues = true;
   o->manual_wal_flush = true;
   return o;
+}
+
+static ROCKSDB_NAMESPACE::Env *GetCompositeEnv(std::shared_ptr<ROCKSDB_NAMESPACE::FileSystem> fs)
+{
+  static std::shared_ptr<ROCKSDB_NAMESPACE::Env> composite_env = ROCKSDB_NAMESPACE::NewCompositeEnv(fs);
+  return composite_env.get();
 }
 
 /* DBOptions contains Statistics and needs to be destructed last */
@@ -2147,6 +2154,11 @@ static MYSQL_SYSVAR_STR(datadir, rocksdb_datadir,
                         "RocksDB data directory", nullptr, nullptr,
                         "./.rocksdb");
 
+static MYSQL_SYSVAR_STR(fs_uri, rocksdb_fs_uri,
+                        PLUGIN_VAR_OPCMDARG | PLUGIN_VAR_READONLY,
+                        "Custom filesystem URI", nullptr,
+                        nullptr, nullptr);
+
 static MYSQL_SYSVAR_UINT(
     table_stats_sampling_pct, rocksdb_table_stats_sampling_pct,
     PLUGIN_VAR_RQCMDARG,
@@ -2483,6 +2495,7 @@ static struct st_mysql_sys_var *rocksdb_system_variables[] = {
     MYSQL_SYSVAR(print_snapshot_conflict_queries),
 
     MYSQL_SYSVAR(datadir),
+    MYSQL_SYSVAR(fs_uri),
     MYSQL_SYSVAR(create_checkpoint),
 
     MYSQL_SYSVAR(checksums_pct),
@@ -5615,6 +5628,21 @@ static int rocksdb_init_func(void *const p) {
         "RocksDB: Can't enable both use_direct_reads "
         "and allow_mmap_reads\n");
     DBUG_RETURN(HA_EXIT_FAILURE);
+  }
+
+  if (rocksdb_fs_uri) {
+          std::shared_ptr<ROCKSDB_NAMESPACE::FileSystem> fs;
+          sql_print_information(
+              "RocksDB: Setting up custom file system, URI: %s\n",
+              rocksdb_fs_uri);
+          s = ROCKSDB_NAMESPACE::FileSystem::Load(rocksdb_fs_uri, &fs);
+          if (fs == nullptr) {
+                 sql_print_error(
+                    "RocksDB: Setting up custom file system failed: %s\n",
+                    s.ToString().c_str());
+                 DBUG_RETURN(HA_EXIT_FAILURE);
+          }
+          rocksdb_db_options->env = GetCompositeEnv(fs);
   }
 
   // Check whether the filesystem backing rocksdb_datadir allows O_DIRECT


### PR DESCRIPTION
RocksDB now supports building plugins from external repos (https://github.com/facebook/rocksdb/pull/7918) and this pull request adds the needed cmake magic to include these in myrocks builds. The plugins to include are specified by ROCKSDB_PLUGINS: 

```
git clone https://github.com/ajkr/dedupfs rocksdb/plugin/dedupfs
mkdir build
cd build
cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_SSL=system -DWITH_ZLIB=bundled\
DMYSQL_MAINTAINER_MODE=0 -DENABLED_LOCAL_INFILE=1 -DCMAKE_CXX_FLAGS="-march=native" \
-DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DROCKSDB_PLUGINS=dedupfs
```

Note: as this branch is not yet including the above pull request, the plugin directory does not exist, but can be created manually and the above example will work.

A configuration parameter, rocksdb_fs_uri is also added to allow the user to specify custom file systems.
```
rocksdb_fs_uri=dedupfs
```

These two changes allows external file systems to be included and used my myrocks. I've tested using dedupfs and a custom filesystem that i've developed for zoned block devices: zenfs.
