### PR TITLE
Support for building RocksDB plugins and custom file systems

### DIFF
--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -38,9 +38,30 @@ ELSE()
 
   SET(ROCKSDB_ROOT ${CMAKE_SOURCE_DIR}/rocksdb)
 
+  LIST(APPEND PLUGINS ${ROCKSDB_PLUGINS})
+  FOREACH(PLUGIN IN LISTS PLUGINS)
+    SET(PLUGIN_ROOT "${CMAKE_SOURCE_DIR}/rocksdb/plugin/${PLUGIN}/")
+    MESSAGE(STATUS "MyRocks: Building RocksDB plugin: ${PLUGIN}")
+    FILE(GLOB PLUGINMKFILE "${PLUGIN_ROOT}${PLUGIN}*.mk")
+    IF (NOT EXISTS ${PLUGINMKFILE})
+      MESSAGE(SEND_ERROR "Missing RocksDB plugin makefile in ${PLUGIN_ROOT}")
+    ELSE()
+      FILE(READ ${PLUGINMKFILE} PLUGINMK)
+      STRING(REGEX MATCH "SOURCES[ ]*=[ ]*([^\n]*)" FOO ${PLUGINMK})
+      SET(MK_SOURCES ${CMAKE_MATCH_1})
+      SEPARATE_ARGUMENTS(MK_SOURCES)
+      FOREACH(MK_FILE IN LISTS MK_SOURCES)
+        LIST(APPEND PLUGIN_SOURCES "${PLUGIN_ROOT}${MK_FILE}")
+      ENDFOREACH()
+      STRING(REGEX MATCH "LDFLAGS[ ]*=[ ]*([^\n]*)" FOO ${PLUGINMK})
+      LIST(APPEND PLUGIN_LD ${CMAKE_MATCH_1} )
+    ENDIF()
+  ENDFOREACH()
+
   # Statically include all RocksDB source
   SET(ROCKSDB_SOURCES
     ${ROCKSDB_LIB_SOURCES}
+    ${PLUGIN_SOURCES}
   )
 ENDIF()
 
@@ -225,7 +246,7 @@ IF (HAVE_ZLIB_H)
   SET(rocksdb_static_libs ${rocksdb_static_libs} ${ZLIB_LIBRARY})
 ENDIF()
 
-SET(rocksdb_static_libs ${rocksdb_static_libs} "-lrt" "-ldl" "-lpthread")
+SET(rocksdb_static_libs ${rocksdb_static_libs} "-lrt" "-ldl" "-lpthread" ${PLUGIN_LD})
 
 MYSQL_ADD_PLUGIN(rocksdb_se ${ROCKSDB_SOURCES} STORAGE_ENGINE DEFAULT STATIC_ONLY
   LINK_LIBRARIES ${rocksdb_static_libs}


### PR DESCRIPTION
RocksDB now supports building plugins from external repos (https://github.com/facebook/rocksdb/pull/7918) and this pull request adds the needed cmake magic to include these in myrocks builds. The plugins to include are specified by ROCKSDB_PLUGINS: 

```
git clone https://github.com/ajkr/dedupfs rocksdb/plugin/dedupfs
mkdir build
cd build
cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_SSL=system -DWITH_ZLIB=bundled\
DMYSQL_MAINTAINER_MODE=0 -DENABLED_LOCAL_INFILE=1 -DCMAKE_CXX_FLAGS="-march=native" \
-DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DROCKSDB_PLUGINS=dedupfs
```

Note: as this branch is not yet including the above pull request, the plugin directory does not exist, but can be created manually and the above example will work.

A configuration parameter, rocksdb_fs_uri is also added to allow the user to specify custom file systems.
```
rocksdb_fs_uri=dedupfs
```

These two changes allows external file systems to be included and used in myrocks. I've tested using dedupfs and a custom filesystem that i've developed for zoned block devices: zenfs.
