### PR TITLE
cmake: check if -latomic is required

### DIFF
--- a/mysys/CMakeLists.txt
+++ b/mysys/CMakeLists.txt
@@ -186,7 +186,29 @@ ADD_CONVENIENCE_LIBRARY(mysys ${MYSYS_SOURCES}
   ${SSL_LIBRARIES}
   )
 
-TARGET_LINK_LIBRARIES(mysys atomic)
+# Check whether atomic operations require -latomic or not
+# See https://github.com/facebook/hhvm/issues/5217
+include(CheckCXXSourceCompiles)
+set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+set(CMAKE_REQUIRED_FLAGS "-std=c++1y")
+CHECK_CXX_SOURCE_COMPILES("
+  #include <atomic>
+  #include <iostream>
+  #include <stdint.h>
+  int main() {
+      struct Test { int64_t val1; int64_t val2; };
+      std::atomic<Test> s;
+      // Do this to stop modern compilers from optimizing away the libatomic
+      // calls.
+      bool (std::atomic<Test>::* volatile x)(void) const =
+        &std::atomic<Test>::is_lock_free;
+      std::cout << (s.*x)() << std::endl;
+  }
+  " NOT_REQUIRE_ATOMIC_LINKER_FLAG)
+if(NOT "${NOT_REQUIRE_ATOMIC_LINKER_FLAG}")
+  TARGET_LINK_LIBRARIES(mysys atomic)
+endif()
+set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
 
 # Need explicit pthread for gcc -fsanitize=address
 IF(CMAKE_USE_PTHREADS_INIT AND CMAKE_C_FLAGS MATCHES "-fsanitize=")


### PR DESCRIPTION
Apparently some systems require `-latomic` when linking, while other systems don't have the library and the linker fails with `-latomic`.

I copied this check from HHVM sources (https://github.com/facebook/hhvm/blob/master/CMake/HPHPFindLibs.cmake#L484), not sure if there's a better option.