### PR TITLE
PS-7636: Run a binary after a CPU or compiler feature detection in MyRocks

### DIFF
--- a/cmake/compiler_features.cmake
+++ b/cmake/compiler_features.cmake
@@ -16,20 +16,21 @@
 
 # Functions to detect features supported by compiler
 
-include(CheckCXXSourceCompiles)
+include(CheckCXXSourceRuns)
 
 set(CMAKE_REQUIRED_FLAGS "-msse4.2 --std=c++11 -Wno-error")
-CHECK_CXX_SOURCE_COMPILES("
+CHECK_CXX_SOURCE_RUNS("
 #include <cstdint>
 #include <nmmintrin.h>
 int main() {
   auto x = _mm_crc32_u32(0, 0);
+  return 0;
 }
 " HAVE_SSE42)
 
 
 set(CMAKE_REQUIRED_FLAGS "-mpclmul --std=c++11 -Wno-error")
-CHECK_CXX_SOURCE_COMPILES("
+CHECK_CXX_SOURCE_RUNS("
 #include <cstdint>
 #include <wmmintrin.h>
 int main() {
@@ -37,57 +38,62 @@ int main() {
   const auto b = _mm_set_epi64x(0, 0);
   const auto c = _mm_clmulepi64_si128(a, b, 0x00);
   auto d = _mm_cvtsi128_si64(c);
+  return 0;
 }
 " HAVE_PCLMUL)
 
 
 set(CMAKE_REQUIRED_FLAGS "-mavx2 --std=c++11 -Wno-error")
-CHECK_CXX_SOURCE_COMPILES("
+CHECK_CXX_SOURCE_RUNS("
 #include <cstdint>
 #include <immintrin.h>
 int main() {
   const auto a = _mm256_setr_epi32(0, 1, 2, 3, 4, 7, 6, 5);
   const auto b = _mm256_permutevar8x32_epi32(a, a);
+  return 0;
 }
 " HAVE_AVX2)
 
 
 set(CMAKE_REQUIRED_FLAGS "-mbmi --std=c++11 -Wno-error")
-CHECK_CXX_SOURCE_COMPILES("
+CHECK_CXX_SOURCE_RUNS("
 #include <cstdint>
 #include <immintrin.h>
 #include <cstdint>
 #include <immintrin.h>
 int main(int argc, char *argv[]) {
-  return (int)_tzcnt_u64((uint64_t)argc);
+  int a = (int)_tzcnt_u64((uint64_t)argc);
+  return 0;
 }
 " HAVE_BMI)
 
 
 set(CMAKE_REQUIRED_FLAGS "-mlzcnt --std=c++11 -Wno-error")
-CHECK_CXX_SOURCE_COMPILES("
+CHECK_CXX_SOURCE_RUNS("
 #include <cstdint>
 #include <immintrin.h>
 int main(int argc, char *argv[]) {
-  return (int)_lzcnt_u64((uint64_t)argc);
+  int a = (int)_lzcnt_u64((uint64_t)argc);
+  return 0;
 }
 " HAVE_LZCNT)
 
 
 set(CMAKE_REQUIRED_FLAGS "-faligned-new -Wno-error")
-CHECK_CXX_SOURCE_COMPILES("
+CHECK_CXX_SOURCE_RUNS("
 struct alignas(1024) t {int a;};
-int main() {}
+int main() { return 0; }
 " HAVE_ALIGNED_NEW)
 
 
 set(CMAKE_REQUIRED_FLAGS "--std=c++11 -Wno-error")
-CHECK_CXX_SOURCE_COMPILES("
+CHECK_CXX_SOURCE_RUNS("
 #include <cstdint>
 int main() {
   uint64_t a = 0xffffFFFFffffFFFF;
   __uint128_t b = __uint128_t(a) * a;
   a = static_cast<uint64_t>(b >> 64);
+  return 0;
 }
 " HAVE_UINT128_EXTENSION)
 
@@ -96,7 +102,7 @@ set(CMAKE_REQUIRED_FLAGS "${CMAKE_CXX_LINK_FLAGS} -Wno-error")
 FIND_LIBRARY(URING_LIBRARY NAMES liburing.a)
 IF (URING_LIBRARY)
 	set(CMAKE_REQUIRED_LIBRARIES ${URING_LIBRARY})
-	CHECK_CXX_SOURCE_COMPILES("
+	CHECK_CXX_SOURCE_RUNS("
 	#include <liburing.h>
 	int main() {
 	  struct io_uring ring;
@@ -110,7 +116,7 @@ ENDIF()
 FIND_LIBRARY(MEMKIND_LIBRARY NAMES libmemkind.a)
 IF (MEMKIND_LIBRARY)
 	set(CMAKE_REQUIRED_LIBRARIES ${MEMKIND_LIBRARY} -ldl -lpthread -lnuma)
-	CHECK_CXX_SOURCE_COMPILES("
+	CHECK_CXX_SOURCE_RUNS("
 	#include <memkind.h>
 	int main() {
 	  memkind_malloc(MEMKIND_DAX_KMEM, 1024);
@@ -123,35 +129,38 @@ unset(CMAKE_REQUIRED_LIBRARIES)
 
 
 set(CMAKE_REQUIRED_FLAGS "-Wno-error")
-CHECK_CXX_SOURCE_COMPILES("
+CHECK_CXX_SOURCE_RUNS("
 #if defined(_MSC_VER) && !defined(__thread)
 #define __thread __declspec(thread)
 #endif
 int main() {
   static __thread int tls;
+  return 0;
 }
 " HAVE_THREAD_LOCAL)
 
 
-CHECK_CXX_SOURCE_COMPILES("
+CHECK_CXX_SOURCE_RUNS("
 #include <fcntl.h>
 #include <linux/falloc.h>
 int main() {
   int fd = open(\"/dev/null\", 0);
   fallocate(fd, FALLOC_FL_KEEP_SIZE, 0, 1024);
+  return 0;
 }
 " HAVE_FALLOCATE)
 
 
-CHECK_CXX_SOURCE_COMPILES("
+CHECK_CXX_SOURCE_RUNS("
 #include <pthread.h>
 int main() {
   int x = PTHREAD_MUTEX_ADAPTIVE_NP;
+  return 0;
 }
 " HAVE_PTHREAD_MUTEX_ADAPTIVE_NP)
 
 
-CHECK_CXX_SOURCE_COMPILES("
+CHECK_CXX_SOURCE_RUNS("
 #include <pthread.h>
 #include <execinfo.h>
 int main() {
@@ -162,11 +171,12 @@ int main() {
 " HAVE_BACKTRACE_SYMBOLS)
 
 
-CHECK_CXX_SOURCE_COMPILES("
+CHECK_CXX_SOURCE_RUNS("
 #include <fcntl.h>
 int main() {
   int fd = open(\"/dev/null\", 0);
   sync_file_range(fd, 0, 1024, SYNC_FILE_RANGE_WRITE);
+  return 0;
 }
 " HAVE_SYNC_FILE_RANGE_WRITE)
 

--- a/include/mysql/components/services/page_track_service.h
+++ b/include/mysql/components/services/page_track_service.h
@@ -27,6 +27,7 @@
 #include <mysql/components/service.h>
 #include <functional>
 
+#include <stddef.h>  // size_t
 #include <stdint.h>
 
 #ifdef __cplusplus

--- a/sql-common/sql_string.cc
+++ b/sql-common/sql_string.cc
@@ -23,6 +23,7 @@
 #include "sql_string.h"
 
 #include <algorithm>
+#include <limits>  // std::numeric_limits
 
 #include "my_dbug.h"
 #include "my_macros.h"

--- a/sql/sql_hints.yy
+++ b/sql/sql_hints.yy
@@ -116,6 +116,12 @@ static bool parse_int(longlong *to, const char *from, size_t from_length)
 %token NO_ORDER_INDEX_HINT 1046
 
 /*
+  YYUNDEF in internal to Bison. Please don't change its number, or change
+  it in sync with YYUNDEF in sql_yacc.yy.
+*/
+%token YYUNDEF 1150
+
+/*
   Please add new tokens right above this line.
 
   To make DIGESTS stable, it is desirable to avoid changing token number values.

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -1251,11 +1251,14 @@ void warn_about_deprecated_binary(THD *thd)
 /*
   Here is an intentional gap in token numbers.
 
-  Token numbers starting 1000 till NOT_A_TOKEN_SYM are occupied by:
+  Token numbers starting 1000 till YYUNDEF are occupied by:
   1. hint terminals (see sql_hints.yy),
   2. digest special internal token numbers (see gen_lex_token.cc, PART 6).
+
+  Note: YYUNDEF in internal to Bison. Please don't change its number, or change
+  it in sync with YYUNDEF in sql_hints.yy.
 */
-%token NOT_A_TOKEN_SYM 1150                             /* INTERNAL */
+%token YYUNDEF 1150                /* INTERNAL (for use in the lexer) */
 
 
 /*

--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -48,9 +48,12 @@ ENDIF()
 
 include(compiler_features)
 
-IF (HAVE_SSE42 AND HAVE_PCLMUL)
-  add_compile_flags(${ROCKSDB_ROOT}/util/crc32c.cc COMPILE_FLAGS "-msse4.2 -mpclmul")
+IF (HAVE_SSE42)
   MESSAGE(STATUS "MyRocks: SSE42 support found")
+  add_compile_flags(${ROCKSDB_ROOT}/util/crc32c.cc COMPILE_FLAGS "-msse4.2") # use Fast_CRC32
+  IF (HAVE_PCLMUL)
+    add_compile_flags(${ROCKSDB_ROOT}/util/crc32c.cc COMPILE_FLAGS "-mpclmul") # use crc32c_3way instead of Fast_CRC32
+  ENDIF()
 ELSE()
   MESSAGE(WARNING "No SSE42 support found, building MyRocks but without SSE42/FastCRC32 support")
 ENDIF()

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -6164,7 +6164,7 @@ bool Rdb_ddl_manager::populate_db_nums() {
     return true;
   }
 
-  for (const auto it : db_entries) {
+  for (const auto &it : db_entries) {
     uint32_t db_num = it.first;
     if (m_assigned_db_nums.find(db_num) != m_assigned_db_nums.end()) {
       // NO_LINT_DEBUG


### PR DESCRIPTION
Some platforms allow code to be compiled but fail to run a binary:
```
$ g++ avx2.cc -o avx2 -std=c++11 -mavx2
$ ./avx2
Illegal instruction (core dumped)
$ cat avx2.cc
int main() {
  const auto a = _mm256_setr_epi32(0, 1, 2, 3, 4, 7, 6, 5);
  const auto b = _mm256_permutevar8x32_epi32(a, a);
}
```

This patch checks if a feature can be run successfully after a compilation.