### PR TITLE
Fixed PS-7882 (Assertion `m_output_buf->m_curr_offset <= m_output_buf->m_total_size' failed)

### DIFF
--- a/mysql-test/suite/rocksdb/r/bug_ps7882.result
+++ b/mysql-test/suite/rocksdb/r/bug_ps7882.result
@@ -1,0 +1,12 @@
+call mtr.add_suppression("Sort buffer size is too small to process merge. Please set merge buffer size to a higher value");
+CREATE TABLE t (
+id INT,
+a VARCHAR(100)
+) ENGINE=RocksDB;
+INSERT INTO t (id, a) VALUES (1, '1');
+INSERT INTO t (id, a) VALUES (2, '123456789012345678901234567890');
+include/assert.inc ["Expected @@rocksdb_merge_buf_size to be set to 100"]
+# Current merge buffer size is too small to fit all key-value pairs.
+ALTER TABLE t ADD INDEX k1 (a, id);
+ERROR HY000: MyRocks failed populating secondary key during alter.
+DROP TABLE t;

--- a/mysql-test/suite/rocksdb/t/bug_ps7882-master.opt
+++ b/mysql-test/suite/rocksdb/t/bug_ps7882-master.opt
@@ -1,0 +1,1 @@
+--loose-rocksdb_merge_buf_size=100

--- a/mysql-test/suite/rocksdb/t/bug_ps7882.test
+++ b/mysql-test/suite/rocksdb/t/bug_ps7882.test
@@ -1,0 +1,28 @@
+--source include/have_rocksdb.inc
+--source include/have_debug.inc
+
+# Test if smallest possible merge buffer size ("rocksdb_merge_buf_size") is
+# handled correctly. Actual value for the merge buffer size is set in ".opt"
+# file.
+
+# When key-pair value are too big to fit into a merge buffer, RocksDB mentions
+# that in error logs.
+call mtr.add_suppression("Sort buffer size is too small to process merge. Please set merge buffer size to a higher value");
+
+CREATE TABLE t (
+  id INT,
+  a VARCHAR(100)
+) ENGINE=RocksDB;
+
+INSERT INTO t (id, a) VALUES (1, '1');
+INSERT INTO t (id, a) VALUES (2, '123456789012345678901234567890');
+
+--let $assert_text="Expected @@rocksdb_merge_buf_size to be set to 100"
+--let $assert_cond="[SELECT @@rocksdb_merge_buf_size]" = 100
+--source include/assert.inc
+
+--echo # Current merge buffer size is too small to fit all key-value pairs.
+--error ER_SK_POPULATE_DURING_ALTER
+ALTER TABLE t ADD INDEX k1 (a, id);
+
+DROP TABLE t;


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7882

Problem:
There was a missing size check in `Rdb_index_merge::add()` just after `merge_buf_write()` emptied the unsorted buffer. With extremely small merge buffer sizes, moderately big data could trigger a buffer overflow. Shortly after, a failed assertion terminates the server (debug builds only).

Fix:
Check if the unsorted buffer size is enough to fit a key-value pair right after an unsorted buffer is flushed and cleared.
