### PR TITLE
Bug #32871806 REMOVE LIBCRYPT AND LIBATOMIC FROM CMAKEFILES

### DIFF
--- a/cmake/os/WindowsCache.cmake
+++ b/cmake/os/WindowsCache.cmake
@@ -32,7 +32,6 @@ SET(CMAKE_HAVE_PTHREAD_H CACHE  INTERNAL "") # Only needed by CMake
 # Libraries
 # Not checked for Windows HAVE_LIBM
 # Not checked for Windows HAVE_LIBNSL
-# Not checked for Windows HAVE_LIBCRYPT
 # Not checked for Windows HAVE_LIBSOCKET
 # Not checked for Windows HAVE_LIBDL
 # Not checked for Windows HAVE_LIBRT

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -30,7 +30,6 @@
 /* Libraries */
 #cmakedefine HAVE_LIBM 1
 #cmakedefine HAVE_LIBNSL 1
-#cmakedefine HAVE_LIBCRYPT 1
 #cmakedefine HAVE_LIBSOCKET 1
 #cmakedefine HAVE_LIBDL 1
 #cmakedefine HAVE_LIBRT 1

--- a/configure.cmake
+++ b/configure.cmake
@@ -85,14 +85,10 @@ IF(UNIX)
   ENDIF()
   MY_SEARCH_LIBS(floor m LIBM)
   IF(NOT LIBM)
-    MY_SEARCH_LIBS(__infinity m LIBM)
-  ENDIF()
-  IF(NOT LIBM)
     MY_SEARCH_LIBS(log m LIBM)
   ENDIF()
   MY_SEARCH_LIBS(gethostbyname_r  "nsl_r;nsl" LIBNSL)
   MY_SEARCH_LIBS(bind "bind;socket" LIBBIND)
-  MY_SEARCH_LIBS(crypt crypt LIBCRYPT)
   MY_SEARCH_LIBS(setsockopt socket LIBSOCKET)
   MY_SEARCH_LIBS(dlopen dl LIBDL)
   # HAVE_dlopen_IN_LIBC
@@ -104,13 +100,12 @@ IF(UNIX)
     MY_SEARCH_LIBS(clock_gettime rt LIBRT)
   ENDIF()
   MY_SEARCH_LIBS(timer_create rt LIBRT)
-  MY_SEARCH_LIBS(atomic_thread_fence atomic LIBATOMIC)
   MY_SEARCH_LIBS(backtrace execinfo LIBEXECINFO)
   MY_SEARCH_LIBS(cap_get_proc cap LIBCAP)
 
   LIST(APPEND CMAKE_REQUIRED_LIBRARIES
-    ${LIBM} ${LIBNSL} ${LIBBIND} ${LIBCRYPT} ${LIBSOCKET} ${LIBDL}
-    ${CMAKE_THREAD_LIBS_INIT} ${LIBRT} ${LIBATOMIC} ${LIBEXECINFO} ${LIBCAP}
+    ${LIBM} ${LIBNSL} ${LIBBIND} ${LIBSOCKET} ${LIBDL} ${LIBCAP}
+    ${CMAKE_THREAD_LIBS_INIT} ${LIBRT} ${LIBEXECINFO}
   )
   # Need explicit pthread for gcc -fsanitize=address
   IF(CMAKE_C_FLAGS MATCHES "-fsanitize=")

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -810,8 +810,7 @@ ADD_DEPENDENCIES(sql_main GenBootstrapPriv)
 ADD_DEPENDENCIES(sql_main GenSysSchema)
 TARGET_LINK_LIBRARIES(sql_main ${MYSQLD_STATIC_PLUGIN_LIBS}
   mysql_server_component_services mysys strings vio
-  binlogevents_static ${LIBWRAP} ${LIBCRYPT} ${LIBDL} ${SSL_LIBRARIES}
-  ${LIBCAP})
+  binlogevents_static ${LIBWRAP} ${LIBDL} ${SSL_LIBRARIES})
 
 # sql/immutable_string.h uses
 # google::protobuf::io::CodedOutputStream::WriteVarint64ToArray


### PR DESCRIPTION
Remove obsolete functions/libraries from our cmake configure step.

Change-Id: Ie8ae2b09dfcb6d34c56a7317c305443fd48d1826
(cherry picked from commit d24d091b955c51f430b8421dcc05d1309de18a9e)