### PR TITLE
Add missing #include <array> directives

### DIFF
--- a/libbinlogevents/include/control_events.h
+++ b/libbinlogevents/include/control_events.h
@@ -36,6 +36,7 @@
 #ifndef CONTROL_EVENT_INCLUDED
 #define CONTROL_EVENT_INCLUDED
 
+#include <array>
 #include <sys/types.h>
 #include <time.h>
 #include <list>

--- a/sql/sql_admission_control.h
+++ b/sql/sql_admission_control.h
@@ -42,6 +42,7 @@
 #include "mysql/components/services/psi_stage_bits.h"
 #include "mysql/psi/mysql_mutex.h"
 
+#include <array>
 #include <atomic>
 #include <list>
 #include <memory>

--- a/storage/perfschema/pfs_struct.h
+++ b/storage/perfschema/pfs_struct.h
@@ -28,6 +28,7 @@
   pfs structs for optimizing memory consumption
 */
 
+#include <array>
 #include <string.h>
 #include <sys/types.h>
 #include <string>

--- a/storage/rocksdb/rdb_buff.h
+++ b/storage/rocksdb/rdb_buff.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
 #include <string>
 #include <vector>
 

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -17,6 +17,7 @@
 
 /* C++ standard header files */
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <boost/optional.hpp>
 #include <map>


### PR DESCRIPTION
in MyRocks and patches elsewhere. Their absence is benign on Linux build, but it
produces actual compilation errors on XCode toolchain.

If you plan to squash the non-MyRocks bits with the feature patches, then:
- control_events.h patch goes with e5b0781e4cf9b0b6ac41a515c1f578c19b861715
- sql_admission_control.h with dbbe068c39679bf8d57979626fadde687b1e51e6
- pfs_struct.h with 45019198d5f7350ba1d311f292c888e29a91c9d3