### PR TITLE
Remove a misleading comment from commit and rollback by XID handlerto…

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -5056,10 +5056,6 @@ static int rocksdb_prepare(handlerton *const hton MY_ATTRIBUTE((__unused__)),
   return HA_EXIT_SUCCESS;
 }
 
-/**
- do nothing for prepare/commit by xid
- this is needed to avoid crashes in XA scenarios
-*/
 /* TODO(yzha) - Review failures code as return type as changed to xa_status_code
  */
 static xa_status_code rocksdb_commit_by_xid(


### PR DESCRIPTION
…n methods

The "do nothing" commit originates from
346c587763e0540eac30a633eddd42e0e8e09663, which added the methods as no-op
stubs. They were later properly implemented in
d59142529e587c363eb845baf69f2a938fab96c6, but the comment survived and is
actively misleading.