### PR TITLE
Fix LLVM codegen for struct st_filenum_pos atomic operations

### DIFF
--- a/mysys/CMakeLists.txt
+++ b/mysys/CMakeLists.txt
@@ -203,10 +203,6 @@ ADD_CONVENIENCE_LIBRARY(mysys ${MYSYS_SOURCES}
   ${SSL_LIBRARIES}
   )
 
-IF(MY_COMPILER_IS_CLANG)
-  TARGET_LINK_LIBRARIES(mysys atomic)
-ENDIF()
-
 # For targets that link with mysys, and are independent of other targets.
 IF(TARGET copy_openssl_dlls)
   ADD_DEPENDENCIES(mysys copy_openssl_dlls)


### PR DESCRIPTION
LLVM has an issue where atomic operations on a struct with 32-bit fields are
compiled using libatomic library calls instead of direct assembly, as if the
whole struct were 32-bit aligned, i.e. its objects could cross machine word
boundary: https://bugs.llvm.org/show_bug.cgi?id=45055.

Workaround this issue by aligning the first 32-bit field at 64 bits.

This allows not linking mysys with libatomic.

Squash with 894aea72d40277eaf5636bf37b95e7206c8ff2aa