### PR TITLE
Explicitly specify std::max template type to use

### DIFF
--- a/storage/rocksdb/properties_collector.cc
+++ b/storage/rocksdb/properties_collector.cc
@@ -509,7 +509,8 @@ void Rdb_index_stats::merge(const Rdb_index_stats &s, const bool increment,
 
 void Rdb_index_stats::adjust_cardinality(double adjustment_factor) {
   for (int64_t &num_keys : m_distinct_keys_per_prefix) {
-    num_keys = std::max(1L, static_cast<int64_t>(num_keys * adjustment_factor));
+    num_keys = std::max<int64_t>(
+        1, static_cast<int64_t>(num_keys * adjustment_factor));
   }
 }
 


### PR DESCRIPTION
On macOS, one argument resolves to long, whereas the other resolves to long
long, leaving the compiler unable to deduce the template argument type. This is
not seen on Linux builds due to macOS std::int64_t definition differing from
that on Linux.

The build error is
```
/Users/laurynas/vilniusdb/fb-macos-port-draft/storage/rocksdb/properties_collector.cc:512:16: error: no matching function for call to 'max'
    num_keys = std::max(1L, static_cast<int64_t>(num_keys * adjustment_factor));
               ^~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__algorithm/max.h:39:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('long' vs. 'long long')
max(const _Tp& __a, const _Tp& __b)
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__algorithm/max.h:50:1: note: candidate template ignored: could not match 'initializer_list<type-parameter-0-0>' against 'long'
max(initializer_list<_Tp> __t, _Compare __comp)
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__algorithm/max.h:59:1: note: candidate function template not viable: requires single argument '__t', but 2 arguments were provided
max(initializer_list<_Tp> __t)
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__algorithm/max.h:30:1: note: candidate function template not viable: requires 3 arguments, but 2 were provided
max(const _Tp& __a, const _Tp& __b, _Compare __comp)
^
```