### PR TITLE
Explicitly specify std::min template type to use

### DIFF
--- a/sql/rpl_rli.cc
+++ b/sql/rpl_rli.cc
@@ -2865,7 +2865,7 @@ void Relay_log_info::set_last_master_timestamp(time_t ts, ulonglong ts_millis) {
   */
   if (ts > last_master_timestamp) {
     // penultimate_master_timestamp= last_master_timestamp;
-    last_master_timestamp = std::min(ts, now_sec);
+    last_master_timestamp = std::min<long long>(ts, now_sec);
     mysql_bin_log.last_master_timestamp.store(last_master_timestamp);
   }
 


### PR DESCRIPTION
On macOS, one argument resolves to long, whereas the other resolves to long
long, leaving the compiler unable to deduce the template argument type. This is
not seen on Linux builds due to macOS std::int64_t definition differing from
that on Linux.

The build error is
```
/Users/laurynas/vilniusdb/fb-macos-port-draft/sql/rpl_rli.cc:2868:29: error: no matching function for call to 'min'
    last_master_timestamp = std::min(ts, now_sec);
                            ^~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__algorithm/min.h:39:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('long' vs. 'long long')
min(const _Tp& __a, const _Tp& __b)
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__algorithm/min.h:50:1: note: candidate template ignored: could not match 'initializer_list<type-parameter-0-0>' against 'long'
min(initializer_list<_Tp> __t, _Compare __comp)
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__algorithm/min.h:59:1: note: candidate function template not viable: requires single argument '__t', but 2 arguments were provided
min(initializer_list<_Tp> __t)
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__algorithm/min.h:30:1: note: candidate function template not viable: requires 3 arguments, but 2 were provided
min(const _Tp& __a, const _Tp& __b, _Compare __comp)
^
```
Squash with 046624b2ff47197fefc2f3233b9a4fdd3036d416