### PR TITLE
MyRocks: fix thread_id_indexer_t::get_rnd_index compilation under macOS

### DIFF
--- a/storage/rocksdb/ut0counter.h
+++ b/storage/rocksdb/ut0counter.h
@@ -83,7 +83,9 @@ struct thread_id_indexer_t : public generic_indexer_t<Type, N> {
   /* @return a random number, currently we use the thread id. Where
   thread id is represented as a pointer, it may not work as
   effectively. */
-  size_t get_rnd_index() const { return get_curr_thread_id(); }
+  size_t get_rnd_index() const {
+    return reinterpret_cast<std::uintptr_t>(get_curr_thread_id());
+  }
 };
 
 /** For counters wher N=1 */


### PR DESCRIPTION
On macOS, get_curr_thread_id returns a pointer, which does not implicitly
convert to std::size_t. So reinterpret_cast it to std::uintptr_t first, which
then implicitly converts to std::size_t.

Patch by @percona-ysorokin taken from
https://github.com/percona/percona-server/pull/4808/files#diff-981be3a881c5028de47081c4e03740624d79a39ae1109a8e09814d135bd152ed