### PR TITLE
MyRocks: define BSD-style endian conversion functions

### DIFF
--- a/storage/rocksdb/rdb_buff.h
+++ b/storage/rocksdb/rdb_buff.h
@@ -21,6 +21,21 @@
 #include <string>
 #include <vector>
 
+#ifdef __APPLE__
+
+#include <libkern/OSByteOrder.h>
+
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define htobe16(x) OSSwapHostToBigInt16(x)
+
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define htobe32(x) OSSwapHostToBigInt32(x)
+
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define htobe64(x) OSSwapHostToBigInt64(x)
+
+#endif  // __APPLE__
+
 /* MySQL header files */
 
 /* MyRocks header files */


### PR DESCRIPTION
macOS does not have beXXtoh and htobeXX functions. Define them using macOS
equivalents.

Both downstreams have done the same: https://github.com/percona/percona-server/pull/4808/files#diff-083593616349ef36e9a39f1251813d7c0fe6a93883f131fe041f0d167dfe941f, https://github.com/MariaDB/server/commit/b64910ce27a4df33e3ad2e3f40764e8b3271a9aa#diff-083593616349ef36e9a39f1251813d7c0fe6a93883f131fe041f0d167dfe941f

This patch is closer to MariaDB one instead of Percona : use general `__APPLE__` define instead of RocksDB core `OS_MACOSX`, define only used functions, and define them right after system header includes.