### PR TITLE
Add refresh_iter to release pinned MemTable and SST

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -4061,6 +4061,32 @@ class Rdb_transaction {
     return get_iterator(options, column_family, table_type);
   }
 
+  rocksdb::Iterator *refresh_iterator(
+      const rocksdb::Snapshot* snapshot,
+      rocksdb::ColumnFamilyHandle *const column_family, bool skip_bloom_filter,
+      const rocksdb::Slice &eq_cond_lower_bound,
+      const rocksdb::Slice &eq_cond_upper_bound, TABLE_TYPE table_type) {
+    rocksdb::ReadOptions options = m_read_opts;
+    const bool fill_cache = !THDVAR(get_thd(), skip_fill_cache);
+    if (skip_bloom_filter) {
+      const bool enable_iterate_bounds =
+          THDVAR(get_thd(), enable_iterate_bounds);
+      options.total_order_seek = true;
+      options.iterate_lower_bound =
+          enable_iterate_bounds ? &eq_cond_lower_bound : nullptr;
+      options.iterate_upper_bound =
+          enable_iterate_bounds ? &eq_cond_upper_bound : nullptr;
+    } else {
+      // With this option, Iterator::Valid() returns false if key
+      // is outside of the prefix bloom filter range set at Seek().
+      // Must not be set to true if not using bloom filter.
+      options.prefix_same_as_start = true;
+    }
+    options.fill_cache = fill_cache;
+    options.snapshot = snapshot;
+    return get_iterator(options, column_family, table_type);
+  }
+
   virtual bool is_tx_started(TABLE_TYPE table_type) const = 0;
   virtual void start_tx(TABLE_TYPE table_type) = 0;
   virtual void start_stmt() = 0;
@@ -17483,6 +17509,16 @@ rocksdb::Iterator *rdb_tx_get_iterator(
                             eq_cond_upper_bound, table_type, read_current,
                             create_snapshot);
   }
+}
+
+rocksdb::Iterator *rdb_tx_refresh_iterator(
+    THD *thd, rocksdb::ColumnFamilyHandle *const cf, bool skip_bloom_filter,
+    const rocksdb::Slice &eq_cond_lower_bound,
+    const rocksdb::Slice &eq_cond_upper_bound,
+    const rocksdb::Snapshot *snapshot, TABLE_TYPE table_type) {
+  Rdb_transaction *tx = get_tx_from_thd(thd);
+  return tx->refresh_iterator(snapshot, cf, skip_bloom_filter,
+      eq_cond_lower_bound, eq_cond_upper_bound, table_type);
 }
 
 bool rdb_tx_started(Rdb_transaction *tx, TABLE_TYPE table_type) {

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -1148,6 +1148,12 @@ rocksdb::Iterator *rdb_tx_get_iterator(
     const rocksdb::Snapshot **snapshot, TABLE_TYPE table_type,
     bool read_current = false, bool create_snapshot = true);
 
+rocksdb::Iterator *rdb_tx_refresh_iterator(
+    THD *thd, rocksdb::ColumnFamilyHandle *const cf, bool skip_bloom_filter,
+    const rocksdb::Slice &eq_cond_lower_bound,
+    const rocksdb::Slice &eq_cond_upper_bound,
+    const rocksdb::Snapshot *snapshot, TABLE_TYPE table_type);
+
 rocksdb::Status rdb_tx_get(Rdb_transaction *tx,
                            rocksdb::ColumnFamilyHandle *const column_family,
                            const rocksdb::Slice &key,

--- a/storage/rocksdb/rdb_iterator.h
+++ b/storage/rocksdb/rdb_iterator.h
@@ -122,6 +122,8 @@ class Rdb_iterator_base : public Rdb_iterator {
 
   /* Iterator used for range scans and for full table/index scans */
   rocksdb::Iterator *m_scan_it;
+  uint32_t m_call_cnt = 0; // for refresh_iter
+  void refresh_iter();
 
   /* Whether m_scan_it was created with skip_bloom=true */
   bool m_scan_it_skips_bloom;


### PR DESCRIPTION
During long running trx, there is a rocksdb::Version object is referenced by iterator, thus the **MemTable**s and **SST**s referenced by **Version** can not be released even the **MemTable**s are flushed or **SST**s are compacted.

This PR is intended for releasing MemTable and SST objects held by
rocksdb::Version object which referenced by old rocksdb::Iterator, newly
created Iterator may reference a newer rocksdb::Version object, The data
view of these 2 iterators are identical.