### PR TITLE
Deserialization of Untrusted Data in Apache OpenJPA

### DIFF
--- a/storage/ndb/clusterj/pom.xml
+++ b/storage/ndb/clusterj/pom.xml
@@ -76,7 +76,7 @@
       <dependency>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.2</version>
       </dependency>
     <dependency>
       <groupId>mysql</groupId>


### PR DESCRIPTION
The BrokerFactory functionality in Apache OpenJPA 1.x before 1.2.3 and 2.x before 2.2.2 creates local executable JSP files containing logging trace data produced during deserialization of certain crafted OpenJPA objects, which makes it easier for remote attackers to execute arbitrary code by creating a serialized object and leveraging improperly secured server programs.

**CVE-2013-1768**
`GHSA-j65f-mvgw-prp2`


## Fixing a security update for org.apache.openjpa:openjpa
@imhunterand is creating a security update to fix [1 vulnerabilities alert](https://github.com/facebook/mysql-5.6/blob/-/storage/ndb/clusterj/pom.xml) on org.apache.openjpa:openjpa in [storage/ndb/clusterj/pom.xml](https://github.com/facebook/mysql-5.6/blob/-/storage/ndb/clusterj/pom.xml).

Or, manually upgrade org.apache.openjpa:openjpa to version 2.2.2 or later. For example:

```xml
<dependency>
  <groupId>org.apache.openjpa</groupId>
  <artifactId>openjpa</artifactId>
  <version>[2.2.2,)</version>
</dependency>
```