### PR TITLE
Disable MyRocks I/O watchdog under macOS

### DIFF
--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -892,7 +892,8 @@ show variables where
 variable_name like 'rocksdb%' and
 variable_name not like 'rocksdb_max_open_files' and
 variable_name not like 'rocksdb_wsenv_%' and
-variable_name not like 'rocksdb_table_stats_background_thread_nice_value';
+variable_name not like 'rocksdb_table_stats_background_thread_nice_value' and
+variable_name not like 'rocksdb_io_write_timeout';
 Variable_name	Value
 rocksdb_access_hint_on_compaction_start	1
 rocksdb_advise_random_on_open	ON
@@ -978,7 +979,6 @@ rocksdb_force_index_records_in_range	0
 rocksdb_ignore_unknown_options	ON
 rocksdb_index_type	kBinarySearch
 rocksdb_info_log_level	error_level
-rocksdb_io_write_timeout	0
 rocksdb_is_fd_close_on_exec	ON
 rocksdb_keep_log_file_num	1000
 rocksdb_large_prefix	OFF

--- a/mysql-test/suite/rocksdb/t/rocksdb.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb.test
@@ -794,7 +794,8 @@ show variables where
   variable_name like 'rocksdb%' and
   variable_name not like 'rocksdb_max_open_files' and
   variable_name not like 'rocksdb_wsenv_%' and
-  variable_name not like 'rocksdb_table_stats_background_thread_nice_value';
+  variable_name not like 'rocksdb_table_stats_background_thread_nice_value' and
+  variable_name not like 'rocksdb_io_write_timeout';
 create table t47 (pk int primary key, col1 varchar(12)) ENGINE=RocksDB CHARSET=latin1;
 insert into t47 values (1, 'row1');
 insert into t47 values (2, 'row2');

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_io_write_timeout_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_io_write_timeout_basic.test
@@ -1,4 +1,5 @@
 --source include/have_rocksdb.inc
+--source include/not_mac_os.inc
 
 CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
 INSERT INTO valid_values VALUES(10);

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -306,7 +306,9 @@ static Rdb_dict_manager_selector dict_manager;
 static Rdb_cf_manager cf_manager;
 static Rdb_ddl_manager ddl_manager;
 static Rdb_binlog_manager binlog_manager;
+#ifndef __APPLE__
 static Rdb_io_watchdog *io_watchdog = nullptr;
+#endif
 
 /**
   MyRocks background thread control
@@ -804,7 +806,9 @@ static uint32_t rocksdb_binlog_ttl_compaction_ts_interval_secs = 0;
 static uint32_t rocksdb_binlog_ttl_compaction_ts_offset_secs = 0;
 static int rocksdb_debug_binlog_ttl_compaction_ts_delta = 0;
 static bool rocksdb_reset_stats = 0;
+#ifndef __APPLE__
 static uint32_t rocksdb_io_write_timeout_secs = 0;
+#endif
 static uint32_t rocksdb_seconds_between_stat_computes = 3600;
 static long long rocksdb_compaction_sequential_deletes = 0l;
 static long long rocksdb_compaction_sequential_deletes_window = 0l;
@@ -1147,6 +1151,8 @@ static void rocksdb_set_reset_stats(
   RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
 }
 
+#ifndef __APPLE__
+
 static void rocksdb_set_io_write_timeout(
     my_core::THD *const thd MY_ATTRIBUTE((__unused__)),
     my_core::SYS_VAR *const var MY_ATTRIBUTE((__unused__)),
@@ -1164,6 +1170,8 @@ static void rocksdb_set_io_write_timeout(
 
   RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
 }
+
+#endif  // !__APPLE__
 
 enum rocksdb_flush_log_at_trx_commit_type : unsigned int {
   FLUSH_LOG_NEVER = 0,
@@ -2252,12 +2260,16 @@ static MYSQL_SYSVAR_BOOL(
     "Reset the RocksDB internal statistics without restarting the DB.", nullptr,
     rocksdb_set_reset_stats, false);
 
+#ifndef __APPLE__
+
 static MYSQL_SYSVAR_UINT(io_write_timeout, rocksdb_io_write_timeout_secs,
                          PLUGIN_VAR_RQCMDARG,
                          "Timeout for experimental I/O watchdog.", nullptr,
                          rocksdb_set_io_write_timeout, /* default */ 0,
                          /* min */ 0L,
                          /* max */ UINT_MAX, 0);
+
+#endif  // !__APPLE__
 
 static MYSQL_SYSVAR_BOOL(enable_2pc, rocksdb_enable_2pc, PLUGIN_VAR_RQCMDARG,
                          "Enable two phase commit for MyRocks", nullptr,
@@ -2779,7 +2791,9 @@ static struct SYS_VAR *rocksdb_system_variables[] = {
     MYSQL_SYSVAR(binlog_ttl_compaction_ts_offset_secs),
     MYSQL_SYSVAR(debug_binlog_ttl_compaction_ts_delta),
     MYSQL_SYSVAR(reset_stats),
+#ifndef __APPLE__
     MYSQL_SYSVAR(io_write_timeout),
+#endif
     MYSQL_SYSVAR(seconds_between_stat_computes),
 
     MYSQL_SYSVAR(compaction_sequential_deletes),
@@ -7498,8 +7512,10 @@ static int rocksdb_init_internal(void *const p) {
     directories.push_back(myrocks::rocksdb_wal_dir);
   }
 
+#ifndef __APPLE__
   io_watchdog = new Rdb_io_watchdog(std::move(directories));
   io_watchdog->reset_timeout(rocksdb_io_write_timeout_secs);
+#endif
 
   compaction_stats.resize_history(rocksdb_max_compaction_history);
 
@@ -7651,8 +7667,10 @@ static int rocksdb_shutdown(bool minimalShutdown) {
     delete commit_latency_stats;
     commit_latency_stats = nullptr;
 
+#ifndef __APPLE__
     delete io_watchdog;
     io_watchdog = nullptr;
+#endif
 
     // Disown the cache data since we're shutting down.
     // This results in memory leaks but it improved the shutdown time.

--- a/storage/rocksdb/rdb_io_watchdog.cc
+++ b/storage/rocksdb/rdb_io_watchdog.cc
@@ -17,6 +17,8 @@
 /* This C++ file's header */
 #include "./rdb_io_watchdog.h"
 
+#ifndef __APPLE__
+
 /* C++ standard header files */
 #include <string>
 #include <vector>
@@ -236,3 +238,5 @@ int Rdb_io_watchdog::reset_timeout(const uint32_t write_timeout) {
 }
 
 }  // namespace myrocks
+
+#endif  // !__APPLE__

--- a/storage/rocksdb/rdb_io_watchdog.h
+++ b/storage/rocksdb/rdb_io_watchdog.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#ifndef __APPLE__
+
 /* C++ standard header files */
 #include <signal.h>
 #include <stdlib.h>
@@ -112,3 +114,5 @@ class Rdb_io_watchdog {
 };
 
 }  // namespace myrocks
+
+#endif  // !__APPLE__


### PR DESCRIPTION
macOS does not have the timer_create APIs. It should be possible to port the
feature to dispatch event source APIs, but such effort is hard to justify.