### PR TITLE
Compile out setting DSCP for binlog senders on macOS

### DIFF
--- a/sql/rpl_binlog_sender.cc
+++ b/sql/rpl_binlog_sender.cc
@@ -267,6 +267,8 @@ Binlog_sender::Binlog_sender(THD *thd, const char *start_file,
       m_orig_query(NULL_CSTR),
       m_skip_state_update(0) {}
 
+#ifndef __APPLE__
+
 bool Binlog_sender::get_dscp_value(int &ret_val) {
   ret_val = 0;
   bool found_conn = false;
@@ -353,6 +355,8 @@ bool Binlog_sender::set_dscp(void) {
   return true;
 }
 
+#endif  // ! __APPLE__
+
 void Binlog_sender::init() {
   DBUG_TRACE;
   THD *thd = m_thd;
@@ -427,7 +431,9 @@ void Binlog_sender::init() {
        ))
     sql_print_warning("Failed to set SO_SNDBUF with (error: %s).",
                       strerror(errno));
+#ifndef __APPLE__
   (void)set_dscp();
+#endif  // ! __APPLE__
 
   init_checksum_alg();
   /*

--- a/sql/rpl_binlog_sender.h
+++ b/sql/rpl_binlog_sender.h
@@ -513,6 +513,8 @@ class Binlog_sender {
   */
   void processlist_slave_offset(const char *log_file_name, my_off_t log_pos);
 
+#ifndef __APPLE__
+
   /**
    Sets DSCP parameters on the binlog socket.
 
@@ -526,6 +528,8 @@ class Binlog_sender {
    @return true if succeeded, false if error occurred
   */
   bool get_dscp_value(int &ret_val);
+
+#endif  // ! __APPLE__
 
   /**
     host:port of the client for this dump thread


### PR DESCRIPTION
macOS does not have SO_DOMAIN.

Squash with f460a33d304a2a0f2ef448c211dffd07fd202bff