### PR TITLE
Use my_thread_self_setname to set current thread name

### DIFF
--- a/sql/rpl_shardbeats.cc
+++ b/sql/rpl_shardbeats.cc
@@ -10,6 +10,7 @@
 
 #include "include/mutex_lock.h"
 #include "mysql/com_data.h"
+#include "my_thread.h"
 
 #include "sql/auth/auth_acls.h"
 #include "sql/binlog.h"
@@ -504,7 +505,7 @@ void Shardbeats_manager::execute() {
   sb_thd->set_new_thread_id();
   sb_thd->thread_stack = (char *)&sb_thd;
   sb_thd->store_globals();
-  pthread_setname_np(pthread_self(), "shardbeats");
+  my_thread_self_setname("shardbeats");
 
   mysql_thread_set_psi_id(sb_thd->thread_id());
 


### PR DESCRIPTION
On Linux, pthread_setname_np takes two arguments and can set the name for any
thread, on macOS it takes one argument and can only set the name for the current
thread. Thus use portable my_thread_self_setname from mysys.

Squash with 62eeb97c93b70a877ea564f591e4801e01eef8c6