### PR TITLE
Fix conflict between Bison 2.3 and service_rpc_plugin.h

### DIFF
--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -44,6 +44,10 @@ Note: YYTHD is passed as an argument to yyparse(), and subsequently to yylex().
 #define Lex (YYTHD->lex)
 #define Select Lex->current_query_block()
 
+// Avoid conflicts between GNU Bison 2.3 output macros and service_rpc_plugin.h
+// symbols
+#define MYSQL_PLUGIN_STRUCT_DEFS_ONLY
+
 #include <sys/types.h>  // TODO: replace with cstdint
 
 #include <algorithm>


### PR DESCRIPTION
GNU Bison 2.3 (bundled with macOS) output contains macros named EQ, LT, etc. and
service_rpc_plugin.h contains an enum with the same names. Avoid the conflict by
defining MYSQL_PLUGIN_STRUCT_DEFS_ONLY, which excludes the plugin enum from the
SQL parser compilation.

Squash with 5910d041eab700b7eb4f2225202f3b6b591ccf95