### PR TITLE
Disable DSCP functionality on macOS

### DIFF
--- a/mysql-test/suite/sys_vars/t/dscp_on_socket_basic.test
+++ b/mysql-test/suite/sys_vars/t/dscp_on_socket_basic.test
@@ -18,6 +18,7 @@
 #              * Data Integrity                                               #
 #                                                                             #
 ###############################################################################
+--source include/not_mac_os.inc
 
 --source include/load_sysvars.inc
 

--- a/mysql-test/suite/test_service_sql_api/t/test_sql_complex.test
+++ b/mysql-test/suite/test_service_sql_api/t/test_sql_complex.test
@@ -1,3 +1,4 @@
+--source include/not_mac_os.inc
 
 --echo ------ Run plugin ------------------------------------------------
 --replace_result $TEST_SQL_COMPLEX TEST_SQL_COMPLEX

--- a/sql/conn_handler/connection_handler_per_thread.cc
+++ b/sql/conn_handler/connection_handler_per_thread.cc
@@ -294,7 +294,9 @@ static void *handle_connection(void *arg) {
     MYSQL_SOCKET socket = thd->get_protocol_classic()->get_vio()->mysql_socket;
     mysql_socket_set_thread_owner(socket);
     thd->set_thread_priority();
+#ifndef __APPLE__
     thd->set_dscp_on_socket();
+#endif
 
     thd_manager->add_thd(thd);
 

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -4959,6 +4959,8 @@ void THD::get_query_digest(String *digest_buffer, const char **str,
   }
 }
 
+#ifndef __APPLE__
+
 bool THD::set_dscp_on_socket() {
   int dscp_val = variables.dscp_on_socket;
 
@@ -5019,3 +5021,5 @@ bool THD::set_dscp_on_socket() {
 
   return true;
 }
+
+#endif  // ! __APPLE__

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -5274,7 +5274,9 @@ class THD : public MDL_context_owner,
   }
 #endif
 
+#ifndef __APPLE__
   bool set_dscp_on_socket();
+#endif
 };
 
 /**

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -9047,6 +9047,8 @@ static Sys_var_enum Sys_commit_consensus_error_action(
     commit_consensus_error_actions, DEFAULT(ROLLBACK_TRXS_IN_GROUP),
     NO_MUTEX_GUARD, NOT_IN_BINLOG);
 
+#ifndef __APPLE__
+
 static bool update_session_dscp_on_socket(sys_var *, THD *thd,
                                           enum_var_type type) {
   if (type == OPT_GLOBAL) return false;
@@ -9061,6 +9063,8 @@ static Sys_var_ulong Sys_session_set_dscp_on_socket(
     SESSION_VAR(dscp_on_socket), CMD_LINE(OPT_ARG), VALID_RANGE(0, 63),
     DEFAULT(0), BLOCK_SIZE(1), NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(NULL),
     ON_UPDATE(update_session_dscp_on_socket));
+
+#endif  // ! __APPLE__
 
 static Sys_var_bool Sys_enable_group_replication_plugin_hooks(
     "group_replication_plugin_hooks",

--- a/sql/system_variables.h
+++ b/sql/system_variables.h
@@ -506,7 +506,9 @@ struct System_variables {
   ulong kill_conflicting_connections_timeout;
   long admission_control_queue_timeout;
   long admission_control_queue;
+#ifndef __APPLE__
   ulong dscp_on_socket;
+#endif
   bool enable_block_stale_hlc_read;
   bool enable_hlc_bound;
   bool enable_user_tables_engine_check;


### PR DESCRIPTION
Two separate commits because they will have to be squashed with different commits