### PR TITLE
Disable INFORMATION_SCHEMA.SOCKET_DIAG_SLAVES table on macOS

### DIFF
--- a/mysql-test/include/mysqlshow.inc
+++ b/mysql-test/include/mysqlshow.inc
@@ -1,6 +1,7 @@
 # Test lists tables in Information_schema, and InnoDB adds some
 # Don't test when thread_pool active
 --source include/not_threadpool.inc
+--source include/not_mac_os.inc
 
 --disable_warnings
 DROP TABLE IF EXISTS t1,t2,test1,test2;

--- a/mysql-test/suite/information_schema/t/information_schema_db.test
+++ b/mysql-test/suite/information_schema/t/information_schema_db.test
@@ -1,4 +1,4 @@
-
+--source include/not_mac_os.inc
 #Don't run this test when thread_pool active
 --source include/not_threadpool.inc
 

--- a/mysql-test/t/dd_is_compatibility_cs.test
+++ b/mysql-test/t/dd_is_compatibility_cs.test
@@ -1,3 +1,4 @@
+--source include/not_mac_os.inc
 # Result differences depending on FS case sensitivity.
 if (!$require_case_insensitive_file_system)
 {

--- a/mysql-test/t/information_schema_cs.test
+++ b/mysql-test/t/information_schema_cs.test
@@ -1,3 +1,4 @@
+--source include/not_mac_os.inc
 # Result differences depending on FS case sensitivity.
 if (!$require_case_insensitive_file_system)
 {

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -38,12 +38,15 @@
 #include <utility>
 #include <vector>
 
+#ifdef __linux__
 #include <linux/inet_diag.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #include <linux/sock_diag.h>
 #include <linux/tcp.h>
 #include <linux/unix_diag.h>
+#endif
+
 #include <netdb.h>
 #include <sys/socket.h>
 #include <sys/un.h>
@@ -3443,6 +3446,8 @@ static int fill_slave_db_load(THD *thd, TABLE_LIST *tables, Item *) {
   DBUG_RETURN(error);
 }
 
+#ifdef __linux__
+
 /* Return pid/seq for matching netlink socket */
 static void get_pid_seq(uint32_t *pid, uint32_t *seq) noexcept {
   pid_t cur_pid = getpid();
@@ -3894,6 +3899,8 @@ int fill_socket_diag_slaves(THD *thd, TABLE_LIST *tables, Item *) {
 
   DBUG_RETURN(0);
 }
+
+#endif  // __linux__
 
 int fill_rbr_bi_inconsistencies(THD *thd, TABLE_LIST *tables, Item *) {
   DBUG_ENTER("fill_rbr_bi_inconsistencies");
@@ -5783,6 +5790,8 @@ ST_FIELD_INFO failure_injection_points_fields_info[] = {
     {"FAILURE_INJECTION_POINT_VALUE", NAME_LEN, MYSQL_TYPE_STRING, 0, 0, 0, 0},
     {0, 0, MYSQL_TYPE_STRING, 0, 0, 0, 0}};
 
+#ifdef __linux__
+
 #define LIST_PROCESS_HOST_LEN 64
 
 ST_FIELD_INFO socket_diag_slaves_fields_info[] = {
@@ -5806,6 +5815,8 @@ ST_FIELD_INFO socket_diag_slaves_fields_info[] = {
     {"IS_SEMI_SYNC", 7, MYSQL_TYPE_LONG, 0, MY_I_S_UNSIGNED, 0, 0},
     {"REPLICATION STATUS", 64, MYSQL_TYPE_STRING, 0, 0, 0, 0},
     {0, 0, MYSQL_TYPE_STRING, 0, 0, 0, 0}};
+
+#endif  // __linux__
 
 ST_FIELD_INFO admission_control_queue_fields_info[] = {
     {"SCHEMA_NAME", NAME_LEN, MYSQL_TYPE_STRING, 0, 0, 0, 0},
@@ -5888,8 +5899,10 @@ ST_SCHEMA_TABLE schema_tables[] = {
      nullptr, false},
     {"RBR_BI_INCONSISTENCIES", rbr_bi_inconsistencies_fields_info,
      fill_rbr_bi_inconsistencies, nullptr, nullptr, false},
+#ifdef __linux__
     {"SOCKET_DIAG_SLAVES", socket_diag_slaves_fields_info,
      fill_socket_diag_slaves, make_old_format, nullptr, false},
+#endif
     {"DATABASE_APPLIED_HLC", db_applied_hlc_fields_info, fill_db_applied_hlc,
      nullptr, nullptr, false},
     {"ADMISSION_CONTROL_ENTITIES", admission_control_entities_fields_info,


### PR DESCRIPTION
Because macOS does not have the required functionality.

Squash with accb01cc760345cba3f01776c997780935b6546b