### PR TITLE
Renice MyRocks table stats background thread under macOS

### DIFF
--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -891,7 +891,8 @@ ERROR 42S02: Unknown table 'test.t45'
 show variables where
 variable_name like 'rocksdb%' and
 variable_name not like 'rocksdb_max_open_files' and
-variable_name not like 'rocksdb_wsenv_%';
+variable_name not like 'rocksdb_wsenv_%' and
+variable_name not like 'rocksdb_table_stats_background_thread_nice_value';
 Variable_name	Value
 rocksdb_access_hint_on_compaction_start	1
 rocksdb_advise_random_on_open	ON
@@ -1044,7 +1045,6 @@ rocksdb_store_row_debug_checksums	OFF
 rocksdb_strict_collation_check	OFF
 rocksdb_strict_collation_exceptions	
 rocksdb_table_cache_numshardbits	6
-rocksdb_table_stats_background_thread_nice_value	19
 rocksdb_table_stats_max_num_rows_scanned	0
 rocksdb_table_stats_recalc_threshold_count	100
 rocksdb_table_stats_recalc_threshold_pct	10

--- a/mysql-test/suite/rocksdb/t/rocksdb.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb.test
@@ -793,7 +793,8 @@ drop table t45;
 show variables where
   variable_name like 'rocksdb%' and
   variable_name not like 'rocksdb_max_open_files' and
-  variable_name not like 'rocksdb_wsenv_%';
+  variable_name not like 'rocksdb_wsenv_%' and
+  variable_name not like 'rocksdb_table_stats_background_thread_nice_value';
 create table t47 (pk int primary key, col1 varchar(12)) ENGINE=RocksDB CHARSET=latin1;
 insert into t47 values (1, 'row1');
 insert into t47 values (2, 'row2');

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_table_stats_background_thread_nice_value_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_table_stats_background_thread_nice_value_basic.test
@@ -1,4 +1,5 @@
 --source include/have_rocksdb.inc
+--source include/not_mac_os.inc
 
 CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
 INSERT INTO valid_values VALUES(19);

--- a/storage/rocksdb/rdb_global.h
+++ b/storage/rocksdb/rdb_global.h
@@ -23,6 +23,10 @@
 #include <string>
 #include <vector>
 
+#ifdef __APPLE__
+#include <sys/resource.h>
+#endif
+
 /* MySQL header files */
 #include "./sql_string.h"
 #include "sql/handler.h" /* handler */
@@ -203,7 +207,12 @@ const char *const RDB_PARTIAL_INDEX_THRESHOLD_QUALIFIER =
 #define RDB_MIN_RECALC_INTERVAL 10 /* seconds */
 
 #define THREAD_PRIO_MIN -20
+#ifndef __APPLE__
 #define THREAD_PRIO_MAX 19
+#else
+#define THREAD_PRIO_MAX PRIO_DARWIN_BG
+#endif
+
 /*
   Default and maximum values for rocksdb-compaction-sequential-deletes and
   rocksdb-compaction-sequential-deletes-window to add basic boundary checking.


### PR DESCRIPTION
macOS setpriority differs from Linux one in that it can only renice the current
thread. Thus, keep the startup renice call and disable the runtime renicing by
making the rocksdb_table_stats_background_thread_nice_value a read-only server
variable under macOS.