### PR TITLE
Fix Oracle bug 106737 (Wrong SE called to ack clone application if >1…

### DIFF
--- a/plugin/clone/src/clone_client.cc
+++ b/plugin/clone/src/clone_client.cc
@@ -1687,6 +1687,7 @@ int Client::set_descriptor(const uchar *buffer, size_t length) {
 
   /* Apply using descriptor */
   assert(loc_index < m_tasks.size());
+  clone_callback->set_loc_index(loc_index);
   err = hton->clone_interface.clone_apply(loc->m_hton, get_thd(), loc->m_loc,
                                           loc->m_loc_len, m_tasks[loc_index], 0,
                                           clone_callback);


### PR DESCRIPTION
… SE)

In the current implementation, the clone client always uses the locator with
index zero to send COM_ACK to the server. This works as long as InnoDB is the
only clone-supporting engine but breaks otherwise.

Fix by setting the correct current locator index.