### PR TITLE
Fix Oracle bug 108317 (clone_os_copy_file_to_buf partial read handlin…

### DIFF
--- a/plugin/clone/include/clone_os.h
+++ b/plugin/clone/include/clone_os.h
@@ -42,12 +42,12 @@ const uint CLONE_DEF_CON = 16;
 
 /** Copy data from file to buffer
 @param[in]	from_file	source file descriptor
-@param[in,out]	to_buffer	buffer to copy data
-@param[in,out]	length		buffer/data length
+@param[in]	to_buffer	buffer to copy data
+@param[in]	length		buffer/data length
 @param[in]	src_name	source file name
 @return error code */
-int clone_os_copy_file_to_buf(Ha_clone_file from_file, uchar *&to_buffer,
-                              uint &length, const char *src_name);
+int clone_os_copy_file_to_buf(Ha_clone_file from_file, uchar *to_buffer,
+                              uint length, const char *src_name);
 
 /** Check zero copy support
 @return true if supports zero copy */

--- a/plugin/clone/src/clone_os.cc
+++ b/plugin/clone/src/clone_os.cc
@@ -154,8 +154,8 @@ static int read_from_file(Ha_clone_file from_file, uchar *buffer,
   return (0);
 }
 
-int clone_os_copy_file_to_buf(Ha_clone_file from_file, uchar *&to_buffer,
-                              uint &length, const char *src_name) {
+int clone_os_copy_file_to_buf(Ha_clone_file from_file, uchar *to_buffer,
+                              uint length, const char *src_name) {
   CLONE_OS_CHECK_FILE(from_file);
 
   /* Assert buffer alignment to CLONE_OS_ALIGN[4K] for O_DIRECT */
@@ -166,7 +166,7 @@ int clone_os_copy_file_to_buf(Ha_clone_file from_file, uchar *&to_buffer,
   while (len_left > 0) {
     uint ret_length = 0;
     auto error =
-        read_from_file(from_file, to_buffer, length, src_name, ret_length);
+        read_from_file(from_file, to_buffer, len_left, src_name, ret_length);
 
     if (error != 0) {
       DBUG_PRINT("debug", ("Error: clone read failed."
@@ -177,6 +177,7 @@ int clone_os_copy_file_to_buf(Ha_clone_file from_file, uchar *&to_buffer,
     }
 
     len_left -= ret_length;
+    to_buffer += ret_length;
   }
 
   return (0);


### PR DESCRIPTION
…g completely broken)

1) Pass the remaining bytes to read instead of total bytes to read_from_file. 2) Advance the read buffer pointer after a read.
3) To avoid saving and restoring these in/out arguments to the correct out values, observe that no callers are using their out values and convert them to in-only arguments.