### PR TITLE
use lambda instead of std::bind

### DIFF
--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -2911,7 +2911,7 @@ void handler::ha_statistic_increment(
     (table->in_use->status_var.*offset)++;
     table->in_use->check_limit_rows_examined();
     table->in_use->update_sql_stats_periodic();
-    table->in_use->check_yield(std::bind(yield_condition, table));
+    table->in_use->check_yield([t=table]{ return yield_condition(t); });
   }
 }
 
@@ -6489,7 +6489,7 @@ ha_rows handler::multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
   while (!seq->next(seq_it, &range)) {
     if (unlikely(thd->killed != 0)) return HA_POS_ERROR;
 
-    thd->check_yield(std::bind(yield_condition, table));
+    thd->check_yield([t=table]{ return yield_condition(t); });
 
     n_ranges++;
     key_range *min_endp, *max_endp;

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -2731,7 +2731,7 @@ void THD::restore_sub_statement_state(Sub_statement_state *backup) {
 }
 
 void THD::check_yield(std::function<bool()> cond) {
-  yield_cond = cond;
+  yield_cond = std::move(cond);
   thd_wait_begin(this, THD_WAIT_YIELD);
   thd_wait_end(this);
   yield_cond = nullptr;


### PR DESCRIPTION
std::bind(yield_condition, table) will generate a functor which size is larger than std::function's local buf, thus std::function needs to new/delete memory to store the functor.

This PR use the lambda which just capture one pointer(table), which size can fit into std::function's local buf thus new/delete is not needed.