### PR TITLE
Refactor sql_print_error + abort pair into a new helper fatal_error

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -13490,13 +13490,11 @@ void Rdb_drop_index_thread::run() {
         for (const auto d : indices) {
           uint32 cf_flags = 0;
           if (!local_dict_manager->get_cf_flags(d.cf_id, &cf_flags)) {
-            // NO_LINT_DEBUG
-            sql_print_error(
+            rdb_fatal_error(
                 "RocksDB: Failed to get column family flags "
                 "from cf id %u. MyRocks data dictionary may "
                 "get corrupted.",
                 d.cf_id);
-            abort();
           }
 
           std::shared_ptr<rocksdb::ColumnFamilyHandle> cfh =
@@ -16987,23 +16985,17 @@ void rdb_handle_io_error(const rocksdb::Status status,
       case RDB_IO_ERROR_TX_COMMIT:
       case RDB_IO_ERROR_DICT_COMMIT: {
         rdb_log_status_error(status, "failed to write to WAL");
-        /* NO_LINT_DEBUG */
-        sql_print_error("MyRocks: aborting on WAL write error.");
-        abort();
+        rdb_fatal_error("MyRocks: aborting on WAL write error.");
         break;
       }
       case RDB_IO_ERROR_BG_THREAD: {
         rdb_log_status_error(status, "BG thread failed to write to RocksDB");
-        /* NO_LINT_DEBUG */
-        sql_print_error("MyRocks: aborting on BG write error.");
-        abort();
+        rdb_fatal_error("MyRocks: aborting on BG write error.");
         break;
       }
       case RDB_IO_ERROR_GENERAL: {
         rdb_log_status_error(status, "failed on I/O");
-        /* NO_LINT_DEBUG */
-        sql_print_error("MyRocks: aborting on I/O error.");
-        abort();
+        rdb_fatal_error("MyRocks: aborting on I/O error.");
         break;
       }
       default:
@@ -17013,17 +17005,13 @@ void rdb_handle_io_error(const rocksdb::Status status,
   } else if (status.IsCorruption()) {
     rdb_log_status_error(status, "data corruption detected!");
     rdb_persist_corruption_marker();
-    /* NO_LINT_DEBUG */
-    sql_print_error("MyRocks: aborting because of data corruption.");
-    abort();
+    rdb_fatal_error("MyRocks: aborting because of data corruption.");
   } else if (!status.ok()) {
     switch (err_type) {
       case RDB_IO_ERROR_TX_COMMIT:
       case RDB_IO_ERROR_DICT_COMMIT: {
         rdb_log_status_error(status, "Failed to write to WAL (non kIOError)");
-        /* NO_LINT_DEBUG */
-        sql_print_error("MyRocks: aborting on WAL write error.");
-        abort();
+        rdb_fatal_error("MyRocks: aborting on WAL write error.");
         break;
       }
       default:

--- a/storage/rocksdb/properties_collector.cc
+++ b/storage/rocksdb/properties_collector.cc
@@ -176,12 +176,10 @@ void Rdb_tbl_prop_coll::CollectStatsForRow(const rocksdb::Slice &key,
       stats->m_entry_others++;
       break;
     default:
-      // NO_LINT_DEBUG
-      sql_print_error(
+      rdb_fatal_error(
           "RocksDB: Unexpected entry type found: %u. "
           "This should not happen so aborting the system.",
           type);
-      abort();
       break;
   }
 
@@ -407,12 +405,10 @@ int Rdb_index_stats::unmaterialize(const std::string &s,
   // Make sure version is within supported range.
   if (version < INDEX_STATS_VERSION_INITIAL ||
       version > INDEX_STATS_VERSION_ENTRY_TYPES) {
-    // NO_LINT_DEBUG
-    sql_print_error(
+    rdb_fatal_error(
         "Index stats version %d was outside of supported range. "
         "This should not happen so aborting the system.",
         version);
-    abort();
   }
 
   size_t needed = sizeof(stats.m_gl_index_id.cf_id) +

--- a/storage/rocksdb/rdb_compact_filter.h
+++ b/storage/rocksdb/rdb_compact_filter.h
@@ -189,12 +189,10 @@ class Rdb_compact_filter : public rocksdb::CompactionFilter {
       std::string buf;
       buf = rdb_hexdump(existing_value.data(), existing_value.size(),
                         RDB_MAX_HEXDUMP_LEN);
-      // NO_LINT_DEBUG
-      sql_print_error(
+      rdb_fatal_error(
           "Decoding ttl from PK value failed in compaction filter, "
           "for index (%u,%u), val: %s",
           m_prev_index.cf_id, m_prev_index.index_id, buf.c_str());
-      abort();
     }
 
     /*

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -5485,14 +5485,12 @@ bool Rdb_dict_manager::get_index_info(
   }
 
   if (error) {
-    // NO_LINT_DEBUG
-    sql_print_error(
+    rdb_fatal_error(
         "RocksDB: Found invalid key version number (%u, %u, %u, %llu) "
         "from data dictionary. This should never happen "
         "and it may be a bug.",
         index_info->m_index_dict_version, index_info->m_index_type,
         index_info->m_kv_version, index_info->m_ttl_duration);
-    abort();
   }
 
   return found;
@@ -5869,14 +5867,12 @@ void Rdb_dict_manager::resume_drop_indexes() const {
   for (const auto &gl_index_id : gl_index_ids) {
     log_start_drop_index(gl_index_id, "Resume");
     if (max_index_id_in_dict < gl_index_id.index_id) {
-      // NO_LINT_DEBUG
-      sql_print_error(
+      rdb_fatal_error(
           "RocksDB: Found max index id %u from data dictionary "
           "but also found dropped index id (%u,%u) from drop_index "
           "dictionary. This should never happen and is possibly a "
           "bug.",
           max_index_id_in_dict, gl_index_id.cf_id, gl_index_id.index_id);
-      abort();
     }
   }
 }
@@ -5927,13 +5923,11 @@ void Rdb_dict_manager::log_start_drop_index(GL_INDEX_ID gl_index_id,
 
     if (!incomplete_create_indexes.count(gl_index_id)) {
       /* If it's not a partially created index, something is very wrong. */
-      // NO_LINT_DEBUG
-      sql_print_error(
+      rdb_fatal_error(
           "RocksDB: Failed to get column family info "
           "from index id (%u,%u). MyRocks data dictionary may "
           "get corrupted.",
           gl_index_id.cf_id, gl_index_id.index_id);
-      abort();
     }
   }
 }

--- a/storage/rocksdb/rdb_io_watchdog.cc
+++ b/storage/rocksdb/rdb_io_watchdog.cc
@@ -41,14 +41,11 @@ void Rdb_io_watchdog::expire_io_callback(
 
   // At this point we know that I/O has been stuck in `write()` for more than
   // `m_write_timeout` seconds. We'll log a message and shut down the service.
-  // NO_LINT_DEBUG
-  sql_print_error(
+  fatal_error(
       "MyRocks has detected a combination of I/O requests which "
       "have cumulatively been blocking for more than %u seconds. "
       "Shutting the service down.",
       m_write_timeout);
-
-  abort();
 }
 
 void Rdb_io_watchdog::io_check_callback(


### PR DESCRIPTION
Removes some repetition from the call sites.

The motivation for this changes comes from clone, where startup time fixup adds many such print-error-and-abort instances.