### PR TITLE
Extract a helper myrocks::file_in

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -982,7 +982,7 @@ static int rocksdb_tracing(THD *const thd MY_ATTRIBUTE((__unused__)),
     return HA_EXIT_FAILURE;
   }
   const std::string &trace_file_name = trace_opts_strs[2];
-  if (trace_file_name.find("/") != std::string::npos) {
+  if (trace_file_name.find('/') != std::string::npos) {
     // NO_LINT_DEBUG
     sql_print_information(
         "RocksDB: Start tracing failed (trace option string: %s). The file "
@@ -1000,7 +1000,7 @@ static int rocksdb_tracing(THD *const thd MY_ATTRIBUTE((__unused__)),
         trace_opt_str.c_str(), trace_dir.c_str(), s.ToString().c_str());
     return HA_EXIT_FAILURE;
   }
-  const std::string trace_file_path = trace_dir + "/" + trace_file_name;
+  const auto trace_file_path = rdb_concat_paths(trace_dir, trace_file_name);
   s = rdb->GetEnv()->FileExists(trace_file_path);
   if (s.ok() || !s.IsNotFound()) {
     // NO_LINT_DEBUG

--- a/storage/rocksdb/rdb_io_watchdog.cc
+++ b/storage/rocksdb/rdb_io_watchdog.cc
@@ -123,7 +123,7 @@ int Rdb_io_watchdog::check_write_access(const std::string &dirname) const {
   assert(!dirname.empty());
   assert(m_buf != nullptr);
 
-  const std::string fname = dirname + FN_DIRSEP + RDB_IO_DUMMY_FILE_NAME;
+  const auto fname = myrocks::file_in(dirname, RDB_IO_DUMMY_FILE_NAME);
 
   // O_DIRECT is a key flag here to make sure that we'll bypass the kernel's
   // buffer cache.

--- a/storage/rocksdb/rdb_sst_info.cc
+++ b/storage/rocksdb/rdb_sst_info.cc
@@ -317,7 +317,7 @@ Rdb_sst_info::Rdb_sst_info(rocksdb::DB *const db, const std::string &tablename,
       m_sst_file(nullptr),
       m_tracing(tracing),
       m_print_client_error(true) {
-  m_prefix = db->GetName() + "/";
+  m_prefix = db->GetName() + '/';
 
   std::string normalized_table;
   if (rdb_normalize_tablename(tablename.c_str(), &normalized_table)) {
@@ -546,7 +546,7 @@ void Rdb_sst_info::init(const rocksdb::DB *const db) {
     const size_t pos = file.find(m_suffix);
     if (pos != std::string::npos && file.size() - pos == m_suffix.size()) {
       // Remove
-      const std::string fullname = dir + FN_DIRSEP + file;
+      const auto fullname = rdb_concat_paths(dir, file);
       fs->DeleteFile(fullname, rocksdb::IOOptions(), nullptr);
     }
   }

--- a/storage/rocksdb/rdb_utils.cc
+++ b/storage/rocksdb/rdb_utils.cc
@@ -259,12 +259,21 @@ std::string rdb_hexdump(const char *data, const std::size_t data_len,
   return str;
 }
 
+// Return dir + '/' + file
+std::string rdb_concat_paths(const std::string &dir, const std::string &file) {
+  std::string result;
+  result.reserve(dir.length() + file.length() + 2);
+  result = dir;
+  result += FN_LIBCHAR;
+  result += file;
+  return result;
+}
+
 /*
   Attempt to access the database subdirectory to see if it exists
 */
 bool rdb_database_exists(const std::string &db_name) {
-  const std::string dir =
-      std::string(mysql_real_data_home) + FN_DIRSEP + db_name;
+  const auto dir = rdb_concat_paths(mysql_real_data_home, db_name);
   struct MY_DIR *const dir_info =
       my_dir(dir.c_str(), MYF(MY_DONT_SORT | MY_WANT_STAT));
   if (dir_info == nullptr) {

--- a/storage/rocksdb/rdb_utils.h
+++ b/storage/rocksdb/rdb_utils.h
@@ -289,6 +289,9 @@ std::string rdb_hexdump(const char *data, const std::size_t data_len,
                         const std::size_t maxsize = 0)
     MY_ATTRIBUTE((__nonnull__));
 
+// Return dir + '/' + file
+std::string rdb_concat_paths(const std::string &dir, const std::string &file);
+
 /*
   Helper function to see if a database exists
  */


### PR DESCRIPTION
This avoids temporary strings and memory re-allocations.

At the same time replace some uses of "/" with '/', where possible.