### PR TITLE
mysql-test/suite/rocksdb/t/add_index_inplace.test: fix race condition for finish_bulk_load

### DIFF
--- a/mysql-test/suite/rocksdb/t/add_index_inplace.test
+++ b/mysql-test/suite/rocksdb/t/add_index_inplace.test
@@ -193,6 +193,10 @@ INSERT INTO t1 VALUES (1,1);
 
 # Disconnect connection 1, this starts the code path that will call
 # rocksdb_close_connection, ending the bulk load.
+# set rocksdb_bulk_load will trigger finish_bulk_load
+# finish_bulk_load in rocksdb_close_connection may not finished
+# before client sees connection closed
+set global rocksdb_bulk_load=1;
 --echo # Disconnecting on con1
 disconnect con1;
 


### PR DESCRIPTION
When client sees connection closed, `finish_bulk_load` in `rocksdb_close_connection` may still inprogress, the new connection created instantly following would racing with finish_bulk_load.

I can not fix the myrocks code for this race condition, but fix the test. set rocksdb_bulk_load will force calling `finish_bulk_load` and   wait for `finish_bulk_load` ends.