### PR TITLE
Replace including service_rpc_plugin.h in handler.h with forward decl…

### DIFF
--- a/include/mysql/service_rpc_plugin.h
+++ b/include/mysql/service_rpc_plugin.h
@@ -98,7 +98,7 @@ struct myrocks_where_in_item {
 };
 
 // This rpc buffer is allocated per each thrift io thread
-const int MAX_COLUMNS_PER_RPC_BUFFER = 200;
+constexpr int MAX_COLUMNS_PER_RPC_BUFFER = 200;
 using myrocks_columns =
     std::array<myrocks_column_value, MAX_COLUMNS_PER_RPC_BUFFER>;
 

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -44,8 +44,7 @@
 #include <vector>
 
 #include <mysql/components/services/page_track_service.h>
-#include <mysql/service_rpc_plugin.h>  // bypass_rpc
-#include "ft_global.h"                 // ft_hints
+#include "ft_global.h"  // ft_hints
 #include "lex_string.h"
 #include "m_ctype.h"
 #include "map_helpers.h"
@@ -2201,6 +2200,13 @@ typedef bool (*is_reserved_db_name_t)(handlerton *hton, const char *name);
 
 /* Overriding single table SELECT implementation if returns TRUE */
 typedef bool (*handle_single_table_select_t)(THD *thd, Query_block *select_lex);
+
+struct bypass_rpc_exception;
+struct myrocks_column_value;
+// 200 == MAX_COLUMNS_PER_RPC_BUFFER in service_rpc_plugin.h. Compiler will tell
+// if they desync.
+using myrocks_columns = std::array<myrocks_column_value, 200>;
+struct myrocks_select_from_rpc;
 
 /* Send select query directly to storage engine, bypassing mysql parser */
 typedef bypass_rpc_exception (*bypass_select_by_key_t)(


### PR DESCRIPTION
…arations

With the include, service_rpc_plugin.h gets pulled in while compiling sql_yacc.yy, where its declarations conflict with Bison 2.3 macros. Use forward declarations instead.

While looking at service_rpc_plugin.h, replace const int with constexpr int for a related constant, as it does not need allocated storage in every including source file.

Squash with bdcce837df3fbde9b488bab978f353c6b7c31d09

This fixes a new macOS system Bison 2.3 build regression:
```
[ 52%] Building CXX object sql/CMakeFiles/sql_main.dir/sql_yacc.cc.o
In file included from sql_yacc.yy:102:
In file included from /Users/laurynas/vilniusdb/fb-mysql/sql/handler.h:47:
/Users/laurynas/vilniusdb/fb-mysql/include/mysql/service_rpc_plugin.h:55:5: error: expected identifier
    EQ = 0,
    ^
/Users/laurynas/vilniusdb/fb-mysql/_build-debug/sql/sql_yacc.cc:1045:12: note: expanded from macro 'EQ'
#define EQ 415
           ^
In file included from sql_yacc.yy:102:
In file included from /Users/laurynas/vilniusdb/fb-mysql/sql/handler.h:47:
/Users/laurynas/vilniusdb/fb-mysql/include/mysql/service_rpc_plugin.h:56:5: error: expected identifier
    LT = 1,
    ^
/Users/laurynas/vilniusdb/fb-mysql/_build-debug/sql/sql_yacc.cc:1179:12: note: expanded from macro 'LT'
#define LT 549
           ^
In file included from sql_yacc.yy:102:
In file included from /Users/laurynas/vilniusdb/fb-mysql/sql/handler.h:47:
/Users/laurynas/vilniusdb/fb-mysql/include/mysql/service_rpc_plugin.h:58:5: error: expected identifier
    LE = 3,
    ^
/Users/laurynas/vilniusdb/fb-mysql/_build-debug/sql/sql_yacc.cc:1152:12: note: expanded from macro 'LE'
#define LE 522
           ^
In file included from sql_yacc.yy:102:
In file included from /Users/laurynas/vilniusdb/fb-mysql/sql/handler.h:47:
/Users/laurynas/vilniusdb/fb-mysql/include/mysql/service_rpc_plugin.h:59:5: error: expected identifier
    GE = 4,
    ^
/Users/laurynas/vilniusdb/fb-mysql/_build-debug/sql/sql_yacc.cc:1086:12: note: expanded from macro 'GE'
#define GE 456
           ^
In file included from sql_yacc.yy:102:
In file included from /Users/laurynas/vilniusdb/fb-mysql/sql/handler.h:47:
/Users/laurynas/vilniusdb/fb-mysql/include/mysql/service_rpc_plugin.h:69:5: error: expected identifier
    ASC = 0,
    ^
/Users/laurynas/vilniusdb/fb-mysql/_build-debug/sql/sql_yacc.cc:907:13: note: expanded from macro 'ASC'
#define ASC 277
            ^
In file included from sql_yacc.yy:102:
In file included from /Users/laurynas/vilniusdb/fb-mysql/sql/handler.h:47:
/Users/laurynas/vilniusdb/fb-mysql/include/mysql/service_rpc_plugin.h:70:5: error: expected identifier
    DESC = 1,
    ^
/Users/laurynas/vilniusdb/fb-mysql/_build-debug/sql/sql_yacc.cc:1016:14: note: expanded from macro 'DESC'
#define DESC 386
             ^
6 errors generated.
```
In that it is similar to https://github.com/facebook/mysql-5.6/commit/14f7e5c374b97c6ca7a0c69164286eb55f05e5e2
