### PR TITLE
MyRocks to support both dynamic and static plugins

### DIFF
--- a/mysql-test/suite/rocksdb/r/truncate_failures.result
+++ b/mysql-test/suite/rocksdb/r/truncate_failures.result
@@ -89,7 +89,7 @@ pk
 SET DEBUG = "+d,rocksdb_truncate_failure_crash";
 TRUNCATE TABLE t1_crash;
 ERROR HY000: Lost connection to MySQL server during query
- [MY-000000
+1
 DROP TABLE IF EXISTS t1_crash;
 Warnings:
 Warning	1146	Table 'test.t1_crash' doesn't exist

--- a/mysql-test/suite/rocksdb/t/rocksdb_checksums.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_checksums.test
@@ -23,7 +23,7 @@ show variables like 'rocksdb_%checksum%';
 create table t1 (pk int primary key, a int, b int, key(a), key(b)) engine=rocksdb;
 insert into t1 values (1,1,1),(2,2,2),(3,3,3);
 check table t1;
---exec grep "\[Server\] CHECKTABLE t1" $LOG | cut -d] -f4
+--exec grep "Server" $LOG | grep "CHECKTABLE t1"  | cut -d] -f4 | perl -pe "s/Plugin rocksdb reported: '//"  | perl -pe "s/'//g"
 
 drop table t1;
 
@@ -31,7 +31,7 @@ set session rocksdb_store_row_debug_checksums=on;
 create table t2 (pk int primary key, a int, b int, key(a), key(b)) engine=rocksdb;
 insert into t2 values (1,1,1),(2,2,2),(3,3,3);
 check table t2;
---exec grep "\[Server\] CHECKTABLE t2" $LOG | cut -d] -f4
+--exec grep "Server" $LOG | grep "CHECKTABLE t2"  | cut -d] -f4 | perl -pe "s/Plugin rocksdb reported: '//"  | perl -pe "s/'//g"
 
 --echo # Now, make a table that has both rows with checksums and without
 create table t3 (pk int primary key, a int, b int, key(a), key(b)) engine=rocksdb;
@@ -40,7 +40,7 @@ set session rocksdb_store_row_debug_checksums=off;
 update t3 set b=3 where a=2;
 set session rocksdb_store_row_debug_checksums=on;
 check table t3;
---exec grep "\[Server\] CHECKTABLE t3" $LOG | cut -d] -f4
+--exec grep "Server" $LOG | grep "CHECKTABLE t3"  | cut -d] -f4 | perl -pe "s/Plugin rocksdb reported: '//"  | perl -pe "s/'//g"
 
 set session rocksdb_store_row_debug_checksums=on;
 set session rocksdb_checksums_pct=5;
@@ -57,7 +57,7 @@ while ($i<4000)
 }
 --enable_query_log
 check table t4;
---exec grep "\[Server\] CHECKTABLE t4" $LOG | cut -d] -f4 > $MYSQL_TMP_DIR/rocksdb_checksums.log
+--exec  grep "Server" $LOG | grep "CHECKTABLE t4"  | cut -d] -f4 | perl -pe "s/Plugin rocksdb reported: '//"  | perl -pe "s/'//g" > $MYSQL_TMP_DIR/rocksdb_checksums.log
 --exec perl suite/rocksdb/t/rocksdb_checksums.pl $MYSQL_TMP_DIR/rocksdb_checksums.log 4000 5
 --remove_file $MYSQL_TMP_DIR/rocksdb_checksums.log
 set session rocksdb_checksums_pct=100;

--- a/mysql-test/suite/rocksdb/t/rocksdb_datadir.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_datadir.test
@@ -4,6 +4,12 @@ let $ddir = $MYSQL_TMP_DIR/.rocksdb_datadir.test.install.db;
 let $rdb_ddir = $MYSQL_TMP_DIR/.rocksdb_datadir.test;
 let $sql_file = $MYSQL_TMP_DIR/rocksdb_datadir.sql;
 
+let $is_dynamic_plugin = `select plugin_library='ha_rocksdb.so' from information_schema.plugins where plugin_name='RocksDB'`;
+
+if ($is_dynamic_plugin == 1) {
+  --skip "dynamic plugin bootstrap is not supported."
+}
+
 --write_file $sql_file
 DROP DATABASE IF EXISTS mysqltest;
 CREATE DATABASE mysqltest;

--- a/mysql-test/suite/rocksdb/t/truncate_failures.test
+++ b/mysql-test/suite/rocksdb/t/truncate_failures.test
@@ -104,7 +104,7 @@ TRUNCATE TABLE t1_crash;
 --enable_reconnect
 --source include/wait_until_connected_again.inc
 --disable_reconnect
---exec grep 'Removing truncated leftover' $LOG | cut -d] -f2
+--exec grep 'Removing truncated leftover' $LOG | wc -l
 DROP TABLE IF EXISTS t1_crash;
 --remove_file $LOG
 

--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_compact_cf_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_compact_cf_basic.result
@@ -1,4 +1,4 @@
-call mtr.add_suppression(" Column family '[a-z]*' not found.");
+call mtr.add_suppression("Column family '[a-z]*' not found.");
 CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
 INSERT INTO valid_values VALUES('abc');
 INSERT INTO valid_values VALUES('def');

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_compact_cf_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_compact_cf_basic.test
@@ -1,5 +1,5 @@
 
-call mtr.add_suppression(" Column family '[a-z]*' not found.");
+call mtr.add_suppression("Column family '[a-z]*' not found.");
 
 --source include/have_rocksdb.inc
 

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -1068,6 +1068,15 @@ IF(WITH_ICU STREQUAL "bundled")
   TARGET_LINK_LIBRARIES(sql_main ${ICU_LIBRARIES})
 ENDIF()
 
+# linking with jemalloc here since sql/sql_show.cc uses it.
+IF (WITH_JEMALLOC)
+  TARGET_LINK_LIBRARIES(sql_main ${JEMALLOC_LIBRARY})
+  FIND_LIBRARY(UNWIND_LIBRARY
+    NAMES libunwind${PIC_EXT}.a unwind
+    HINTS ${WITH_UNWIND}/lib)
+  TARGET_LINK_LIBRARIES(sql_main ${UNWIND_LIBRARY})
+ENDIF()
+
 IF(WIN32)
   SET(MYSQLD_SOURCE main.cc nt_servc.cc nt_servc.h message.rc)
 ELSE()

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -605,7 +605,7 @@ typedef struct {
   char *end;
 } malloc_status;
 
-#if defined(HAVE_JEMALLOC) && defined(ROCKSDB_PLATFORM_POSIX)
+#if defined(HAVE_JEMALLOC)
 static void get_jemalloc_status(void *mstat_arg, const char *status) {
   malloc_status *mstat = (malloc_status *)mstat_arg;
   size_t status_len = status ? strlen(status) : 0;
@@ -640,9 +640,7 @@ static int show_memory_status(THD *thd) {
   mstat.end = buf + MALLOC_STATUS_LEN;
   if (!buf) return true;
 
-// We check ROCKSDB_PLATFORM_POSIX because malloc_stats_print is defined in
-// rocksdb submodule.
-#if defined(HAVE_JEMALLOC) && defined(ROCKSDB_PLATFORM_POSIX)
+#if defined(HAVE_JEMALLOC)
   /*
     get_jemalloc_status will be called many times per call to
     malloc_stats_print.

--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -1,5 +1,12 @@
 # TODO: Copyrights
 
+IF(WITHOUT_ROCKSDB_STORAGE_ENGINE)
+  RETURN()
+ENDIF()
+IF(ROCKSDB_DYNAMIC_PLUGIN)
+  SET (WITH_ROCKSDB 1)
+ENDIF()
+
 # This is a strong requirement coming from RocksDB. No conditional checks here.
 ADD_DEFINITIONS(-DROCKSDB_PLATFORM_POSIX -DROCKSDB_LIB_IO_POSIX)
 
@@ -172,13 +179,22 @@ SET(ROCKSDB_SOURCES
   rdb_utils.cc rdb_utils.h rdb_buff.h
   rdb_threads.cc rdb_threads.h
   ha_rockspart.cc ha_rockspart.h
-  ../../sql/partitioning/partition_base.cc
   nosql_access.cc nosql_access.h
   sql_dd.cc sql_dd.h
   ${ROCKSDB_LIB_SOURCES}
 )
 
-IF(WITH_FB_TSAN)
+IF(NOT ROCKSDB_DYNAMIC_PLUGIN)
+  SET(ROCKSDB_SOURCES
+  ${ROCKSDB_SOURCES}
+  ../../sql/partitioning/partition_base.cc
+  )
+ENDIF()
+
+# To avoid compiler error on rdb_fatal_error() in rdb_util.h
+add_compile_flags(${ROCKSDB_SOURCES} COMPILE_FLAGS "-Wno-format-security")
+
+IF(WITH_FB_TSAN OR ROCKSDB_DYNAMIC_PLUGIN)
   SET(PIC_EXT "_pic")
 ELSE()
   SET(PIC_EXT "")
@@ -189,8 +205,12 @@ IF(HAVE_EXTERNAL_ROCKSDB)
 ENDIF()
 
 IF (WITH_JEMALLOC)
-  SET(rocksdb_static_libs ${rocksdb_static_libs} -Wl,-rpath=$ORIGIN
-    ${JEMALLOC_LIBRARY})
+  # Not staic linking jemalloc with a dynamic plugin to avoid
+  # "cannot allocate memory in static TLS block" error
+  IF(NOT ROCKSDB_DYNAMIC_PLUGIN)
+    SET(rocksdb_static_libs ${rocksdb_static_libs} -Wl,-rpath=$ORIGIN
+      ${JEMALLOC_LIBRARY})
+  ENDIF()
   ADD_DEFINITIONS(-DROCKSDB_JEMALLOC)
   ADD_DEFINITIONS(-DROCKSDB_MALLOC_USABLE_SIZE)
 ENDIF()
@@ -253,15 +273,19 @@ IF(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin")
   SET(rocksdb_static_libs ${rocksdb_static_libs} "-lrt")
 ENDIF()
 
-MYSQL_ADD_PLUGIN(rocksdb_se ${ROCKSDB_SOURCES} STORAGE_ENGINE DEFAULT STATIC_ONLY
-  LINK_LIBRARIES ${rocksdb_static_libs}
-)
+IF (ROCKSDB_DYNAMIC_PLUGIN)
+  MYSQL_ADD_PLUGIN(rocksdb ${ROCKSDB_SOURCES} STORAGE_ENGINE DEFAULT
+    MODULE_ONLY LINK_LIBRARIES ${rocksdb_static_libs})
+ELSE()
+  MYSQL_ADD_PLUGIN(rocksdb_se ${ROCKSDB_SOURCES} STORAGE_ENGINE DEFAULT
+    STATIC_ONLY LINK_LIBRARIES ${rocksdb_static_libs})
+ENDIF()
 
 IF(WITH_EMBEDDED_SERVER)
   ADD_SUBDIRECTORY(unittest)
 ENDIF()
 
-IF (WITH_ROCKSDB_SE_STORAGE_ENGINE AND (NOT HAVE_EXTERNAL_ROCKSDB))
+IF (NOT HAVE_EXTERNAL_ROCKSDB)
   # TODO: read this file list from src.mk:TOOL_SOURCES
   SET(ROCKSDB_TOOL_SOURCES
     ${CMAKE_SOURCE_DIR}/rocksdb/tools/ldb_tool.cc
@@ -269,10 +293,22 @@ IF (WITH_ROCKSDB_SE_STORAGE_ENGINE AND (NOT HAVE_EXTERNAL_ROCKSDB))
     ${CMAKE_SOURCE_DIR}/rocksdb/tools/sst_dump_tool.cc
     ${CMAKE_SOURCE_DIR}/rocksdb/utilities/blob_db/blob_dump_tool.cc
   )
-  MYSQL_ADD_EXECUTABLE(sst_dump ${CMAKE_SOURCE_DIR}/rocksdb/tools/sst_dump.cc ${ROCKSDB_TOOL_SOURCES})
-  TARGET_LINK_LIBRARIES(sst_dump rocksdb_se)
 
-  MYSQL_ADD_EXECUTABLE(ldb ${CMAKE_SOURCE_DIR}/rocksdb/tools/ldb.cc ${ROCKSDB_TOOL_SOURCES})
-  TARGET_LINK_LIBRARIES(ldb rocksdb_se)
+  IF (ROCKSDB_DYNAMIC_PLUGIN)
+    SET(ROCKSDB_TOOL_SOURCES ${ROCKSDB_TOOL_SOURCES} ${ROCKSDB_LIB_SOURCES})
+  ENDIF()
+
+  MYSQL_ADD_EXECUTABLE(sst_dump ${CMAKE_SOURCE_DIR}/rocksdb/tools/sst_dump.cc
+                       ${ROCKSDB_TOOL_SOURCES})
+  MYSQL_ADD_EXECUTABLE(ldb ${CMAKE_SOURCE_DIR}/rocksdb/tools/ldb.cc
+                       ${ROCKSDB_TOOL_SOURCES})
+
+  IF (ROCKSDB_DYNAMIC_PLUGIN)
+    TARGET_LINK_LIBRARIES(sst_dump ${rocksdb_static_libs})
+    TARGET_LINK_LIBRARIES(ldb ${rocksdb_static_libs})
+  ELSE()
+    TARGET_LINK_LIBRARIES(sst_dump rocksdb_se)
+    TARGET_LINK_LIBRARIES(ldb rocksdb_se)
+  ENDIF()
 
 ENDIF()

--- a/storage/rocksdb/event_listener.cc
+++ b/storage/rocksdb/event_listener.cc
@@ -117,7 +117,8 @@ void Rdb_event_listener::OnBackgroundError(
     rocksdb::BackgroundErrorReason reason, rocksdb::Status *status) {
   rdb_log_status_error(*status, "Error detected in background");
   // NO_LINT_DEBUG
-  sql_print_error("RocksDB: BackgroundErrorReason: %d", (int)reason);
+  LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                  "RocksDB: BackgroundErrorReason: %d", (int)reason);
   if (status->IsCorruption()) {
     rdb_persist_corruption_marker();
     abort();

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -42,7 +42,6 @@
 #include <vector>
 
 /* MySQL includes */
-#include <mysql/components/services/log_builtins.h>
 #include <mysql/psi/mysql_file.h>
 #include <mysql/psi/mysql_table.h>
 #include <mysql/thread_pool_priv.h>
@@ -104,6 +103,13 @@
 
 #ifdef FB_HAVE_WSENV
 #include "./ObjectFactory.h"
+#endif
+
+#ifdef MYSQL_DYNAMIC_PLUGIN
+// MySQL 8.0 logger service interface
+static SERVICE_TYPE(registry) *reg_srv = nullptr;
+SERVICE_TYPE(log_builtins) *log_bi = nullptr;
+SERVICE_TYPE(log_builtins_string) *log_bs = nullptr;
 #endif
 
 // Internal MySQL APIs not exposed in any header.
@@ -436,16 +442,18 @@ static int rocksdb_create_checkpoint(const char *checkpoint_dir_raw) {
   assert(checkpoint_dir_raw);
 
   const auto checkpoint_dir = rdb_normalize_dir(checkpoint_dir_raw);
-  sql_print_information("creating checkpoint in directory: %s\n",
-                        checkpoint_dir.c_str());
+  LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                  "creating checkpoint in directory: %s\n",
+                  checkpoint_dir.c_str());
   rocksdb::Checkpoint *checkpoint;
   auto status = rocksdb::Checkpoint::Create(rdb, &checkpoint);
   if (status.ok()) {
     status = checkpoint->CreateCheckpoint(checkpoint_dir.c_str());
     delete checkpoint;
     if (status.ok()) {
-      sql_print_information("created checkpoint in directory: %s\n",
-                            checkpoint_dir.c_str());
+      LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                      "created checkpoint in directory: %s\n",
+                      checkpoint_dir.c_str());
       return HA_EXIT_SUCCESS;
     } else {
       my_error(ER_GET_ERRMSG, MYF(0), status.code(), status.ToString().c_str(),
@@ -461,8 +469,9 @@ static int rocksdb_create_checkpoint(const char *checkpoint_dir_raw) {
 
 static int rocksdb_remove_checkpoint(const char *checkpoint_dir_raw) {
   const auto checkpoint_dir = rdb_normalize_dir(checkpoint_dir_raw);
-  sql_print_information("deleting temporary checkpoint in directory : %s\n",
-                        checkpoint_dir.c_str());
+  LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                  "deleting temporary checkpoint in directory : %s\n",
+                  checkpoint_dir.c_str());
   const auto status = rocksdb::DestroyDB(checkpoint_dir, rocksdb::Options());
   if (status.ok()) {
     return HA_EXIT_SUCCESS;
@@ -543,7 +552,8 @@ static int rocksdb_force_flush_memtable_now(
   }
 
   // NO_LINT_DEBUG
-  sql_print_information("RocksDB: Manual memtable flush.");
+  LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                  "RocksDB: Manual memtable flush.");
   rocksdb_flush_all_memtables();
   return HA_EXIT_SUCCESS;
 }
@@ -560,7 +570,8 @@ static int rocksdb_force_flush_memtable_and_lzero_now(
     void *const var_ptr MY_ATTRIBUTE((__unused__)),
     struct st_mysql_value *const value MY_ATTRIBUTE((__unused__))) {
   // NO_LINT_DEBUG
-  sql_print_information("RocksDB: Manual memtable and L0 flush.");
+  LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                  "RocksDB: Manual memtable and L0 flush.");
   rocksdb_flush_all_memtables();
 
   const Rdb_cf_manager &cf_manager = rdb_get_cf_manager();
@@ -597,8 +608,9 @@ static int rocksdb_force_flush_memtable_and_lzero_now(
         // error. We are done with this CF and proceed to the next CF.
         if (!cfh) {
           // NO_LINT_DEBUG
-          sql_print_information("cf %s has been dropped during CompactFiles.",
-                                cf_handle->GetName().c_str());
+          LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                          "cf %s has been dropped during CompactFiles.",
+                          cf_handle->GetName().c_str());
           break;
         }
 
@@ -637,10 +649,12 @@ static int rocksdb_cancel_manual_compactions(
     struct st_mysql_value *const value MY_ATTRIBUTE((__unused__))) {
   rdb_mc_thread.cancel_all_pending_manual_compaction_requests();
   // NO_LINT_DEBUG
-  sql_print_information("RocksDB: Stopping all Manual Compactions.");
+  LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                  "RocksDB: Stopping all Manual Compactions.");
   rdb->GetBaseDB()->DisableManualCompaction();
   // NO_LINT_DEBUG
-  sql_print_information("RocksDB: Enabling Manual Compactions.");
+  LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                  "RocksDB: Enabling Manual Compactions.");
   rdb->GetBaseDB()->EnableManualCompaction();
   return HA_EXIT_SUCCESS;
 }
@@ -943,8 +957,8 @@ static int rocksdb_tracing(THD *const thd MY_ATTRIBUTE((__unused__)),
   if (trace_opt_str.empty()) {
     // End tracing block cache accesses or queries.
     // NO_LINT_DEBUG
-    sql_print_information(
-        "RocksDB: Stop tracing block cache accesses or queries.\n");
+    LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: Stop tracing block cache accesses or queries.\n");
     s = trace_block_cache_access ? rdb->EndBlockCacheTrace() : rdb->EndTrace();
 
     if (!s.ok()) {
@@ -972,7 +986,8 @@ static int rocksdb_tracing(THD *const thd MY_ATTRIBUTE((__unused__)),
     trace_opt.max_trace_file_size = std::stoull(trace_opts_strs[1]);
   } catch (const std::exception &e) {
     // NO_LINT_DEBUG
-    sql_print_information(
+    LogPluginErrMsg(
+        INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
         "RocksDB: Failed to parse trace option string: %s. The correct "
         "format is sampling_frequency:max_trace_file_size:trace_file_name. "
         "sampling_frequency and max_trace_file_size are positive integers. "
@@ -984,7 +999,8 @@ static int rocksdb_tracing(THD *const thd MY_ATTRIBUTE((__unused__)),
   const std::string &trace_file_name = trace_opts_strs[2];
   if (trace_file_name.find('/') != std::string::npos) {
     // NO_LINT_DEBUG
-    sql_print_information(
+    LogPluginErrMsg(
+        INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
         "RocksDB: Start tracing failed (trace option string: %s). The file "
         "name contains directory separator.\n",
         trace_opt_str.c_str());
@@ -994,7 +1010,8 @@ static int rocksdb_tracing(THD *const thd MY_ATTRIBUTE((__unused__)),
   s = rdb->GetEnv()->CreateDirIfMissing(trace_dir);
   if (!s.ok()) {
     // NO_LINT_DEBUG
-    sql_print_information(
+    LogPluginErrMsg(
+        INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
         "RocksDB: Start tracing failed (trace option string: %s). Failed to "
         "create the trace directory %s: %s\n",
         trace_opt_str.c_str(), trace_dir.c_str(), s.ToString().c_str());
@@ -1004,7 +1021,8 @@ static int rocksdb_tracing(THD *const thd MY_ATTRIBUTE((__unused__)),
   s = rdb->GetEnv()->FileExists(trace_file_path);
   if (s.ok() || !s.IsNotFound()) {
     // NO_LINT_DEBUG
-    sql_print_information(
+    LogPluginErrMsg(
+        INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
         "RocksDB: Start tracing failed (trace option string: %s). The trace "
         "file either already exists or we encountered an error "
         "when calling rdb->GetEnv()->FileExists. The returned status string "
@@ -1030,7 +1048,8 @@ static int rocksdb_tracing(THD *const thd MY_ATTRIBUTE((__unused__)),
     return HA_EXIT_FAILURE;
   }
   // NO_LINT_DEBUG
-  sql_print_information(
+  LogPluginErrMsg(
+      INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
       "RocksDB: Start tracing block cache accesses or queries. Sampling "
       "frequency: %lu, "
       "Maximum trace file size: %lu, Trace file path %s.\n",
@@ -1045,13 +1064,15 @@ static int handle_rocksdb_corrupt_data_error() {
   switch (rocksdb_corrupt_data_action) {
     case corrupt_data_action::ABORT_SERVER:
       // NO_LINT_DEBUG
-      sql_print_error(
+      LogPluginErrMsg(
+          ERROR_LEVEL, ER_LOG_PRINTF_MSG,
           "MyRocks: aborting on HA_ERR_ROCKSDB_CORRUPT_DATA error.");
       rdb_persist_corruption_marker();
       abort();
     case corrupt_data_action::WARNING:
       // NO_LINT_DEBUG
-      sql_print_warning("MyRocks: hit error HA_ERR_ROCKSDB_CORRUPT_DATA.");
+      LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                      "MyRocks: hit error HA_ERR_ROCKSDB_CORRUPT_DATA.");
       return 0;
     default:
       return HA_ERR_ROCKSDB_CORRUPT_DATA;
@@ -1456,10 +1477,10 @@ static void rocksdb_set_max_bottom_pri_background_compactions_internal(
     // the threads in the BOTTOM pool run with lower OS priority (19 in Linux).
     rdb->GetEnv()->SetBackgroundThreads(val, rocksdb::Env::Priority::BOTTOM);
     rdb->GetEnv()->LowerThreadPoolCPUPriority(rocksdb::Env::Priority::BOTTOM);
-    sql_print_information(
-        "Set %d compaction thread(s) with "
-        "lower scheduling priority.",
-        val);
+    LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Set %d compaction thread(s) with "
+                    "lower scheduling priority.",
+                    val);
   }
 }
 
@@ -3008,8 +3029,8 @@ static int rocksdb_compact_column_family(
       auto grd =
           create_scope_guard([&]() { rdb_mc_thread.set_client_done(mc_id); });
       // NO_LINT_DEBUG
-      sql_print_information("RocksDB: Manual compaction of column family: %s\n",
-                            cf);
+      LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                      "RocksDB: Manual compaction of column family: %s\n", cf);
       // Checking thd state every short cycle (100ms). This is for allowing to
       // exiting this function without waiting for CompactRange to finish.
       Rdb_manual_compaction_thread::Manual_compaction_request::mc_state
@@ -3352,10 +3373,10 @@ class Rdb_transaction {
         char user_host_buff[MAX_USER_HOST_SIZE + 1];
         make_user_name(thd->security_context(), user_host_buff);
         // NO_LINT_DEBUG
-        sql_print_warning(
-            "Got snapshot conflict errors: User: %s "
-            "Query: %s",
-            user_host_buff, thd->query());
+        LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                        "Got snapshot conflict errors: User: %s "
+                        "Query: %s",
+                        user_host_buff, thd->query().str);
       }
       m_detailed_error = String(" (snapshot conflict)", system_charset_info);
       /* TODO(yzha) - row stats are gone in 8.0
@@ -3615,7 +3636,8 @@ class Rdb_transaction {
 
     if (THDVAR(m_thd, trace_sst_api)) {
       // NO_LINT_DEBUG
-      sql_print_information(
+      LogPluginErrMsg(
+          INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
           "SST Tracing : Finishing bulk loading operation for table '%s'",
           m_curr_bulk_load_tablename.c_str());
     }
@@ -3636,8 +3658,9 @@ class Rdb_transaction {
     // collect all Rdb_sst_commit_info containing (SST files, cf)
     if (THDVAR(m_thd, trace_sst_api)) {
       // NO_LINT_DEBUG
-      sql_print_information("SST Tracing : Finishing '%zu' active SST files",
-                            m_curr_bulk_load.size());
+      LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                      "SST Tracing : Finishing '%zu' active SST files",
+                      m_curr_bulk_load.size());
     }
 
     int rc2 = 0;
@@ -3664,7 +3687,8 @@ class Rdb_transaction {
 
     if (THDVAR(m_thd, trace_sst_api)) {
       // NO_LINT_DEBUG
-      sql_print_information("SST Tracing : All active SST files finished");
+      LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                      "SST Tracing : All active SST files finished");
     }
 
     if (rc) {
@@ -3677,7 +3701,8 @@ class Rdb_transaction {
     if (!m_key_merge.empty()) {
       if (THDVAR(m_thd, trace_sst_api)) {
         // NO_LINT_DEBUG
-        sql_print_information(
+        LogPluginErrMsg(
+            INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
             "SST Tracing : Started flushing index_merge sort buffer");
       }
 
@@ -3746,7 +3771,8 @@ class Rdb_transaction {
           }
 
           // NO_LINT_DEBUG
-          sql_print_information(
+          LogPluginErrMsg(
+              INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
               "SST Tracing : Flushing index_merge sort buffer for table '%s' "
               "and index '%s'",
               full_name.c_str(), index_name.c_str());
@@ -3936,7 +3962,8 @@ class Rdb_transaction {
 
       if (THDVAR(m_thd, trace_sst_api)) {
         // NO_LINT_DEBUG
-        sql_print_information(
+        LogPluginErrMsg(
+            INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
             "SST Tracing : Flushing index_merge sort buffer completed");
       }
     }
@@ -3981,16 +4008,17 @@ class Rdb_transaction {
 
     if (THDVAR(m_thd, trace_sst_api)) {
       // NO_LINT_DEBUG
-      sql_print_information(
+      LogPluginErrMsg(
+          INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
           "SST Tracing: Calling IngestExternalFile with '%zu' files",
           file_count);
     }
     const rocksdb::Status s = rdb->IngestExternalFiles(args);
     if (THDVAR(m_thd, trace_sst_api)) {
       // NO_LINT_DEBUG
-      sql_print_information(
-          "SST Tracing: IngestExternalFile '%zu' files returned %s", file_count,
-          s.ok() ? "ok" : "not ok");
+      LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                      "SST Tracing: IngestExternalFile '%zu' files returned %s",
+                      file_count, s.ok() ? "ok" : "not ok");
     }
 
     if (!s.ok()) {
@@ -3998,7 +4026,8 @@ class Rdb_transaction {
         Rdb_sst_info::report_error_msg(s, nullptr);
       }
       // NO_LINT_DEBUG
-      sql_print_warning(
+      LogPluginErrMsg(
+          WARNING_LEVEL, ER_LOG_PRINTF_MSG,
           "MyRocks: failed to bulk load. "
           "status code = %d, status = %s, IngestExternalFileOptions=%s",
           s.code(), s.ToString().c_str(),
@@ -4016,7 +4045,8 @@ class Rdb_transaction {
 
     if (THDVAR(m_thd, trace_sst_api)) {
       // NO_LINT_DEBUG
-      sql_print_information(
+      LogPluginErrMsg(
+          INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
           "SST Tracing : Bulk loading operation completed for table '%s'",
           m_curr_bulk_load_tablename.c_str());
     }
@@ -4082,7 +4112,8 @@ class Rdb_transaction {
 
     if (THDVAR(m_thd, trace_sst_api)) {
       // NO_LINT_DEBUG
-      sql_print_information(
+      LogPluginErrMsg(
+          INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
           "SST Tracing : Starting bulk loading operation for table '%s'",
           bulk_load->get_table_basename().c_str());
     }
@@ -5471,10 +5502,10 @@ static int rocksdb_close_connection(
     int rc = tx->finish_bulk_load(&is_critical_error, false);
     if (rc != 0 && is_critical_error) {
       // NO_LINT_DEBUG
-      sql_print_error(
-          "RocksDB: Error %d finalizing last SST file while "
-          "disconnecting",
-          rc);
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "RocksDB: Error %d finalizing last SST file while "
+                      "disconnecting",
+                      rc);
     }
 
     delete tx;
@@ -6540,7 +6571,8 @@ static bool rocksdb_show_status(handlerton *const hton, THD *const thd,
     // ROCKSDB_USING_THREAD_STATUS is not defined
     if (!s.ok() && !s.IsNotSupported()) {
       // NO_LINT_DEBUG
-      sql_print_error("RocksDB: Returned error (%s) from GetThreadList.\n",
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "RocksDB: Returned error (%s) from GetThreadList.\n",
                       s.ToString().c_str());
       res |= true;
     } else {
@@ -7030,8 +7062,9 @@ static void rocksdb_truncation_table_cleanup(void) {
   ha_rocksdb table(rocksdb_hton, nullptr);
   for (Rdb_tbl_def *tbl_def : collector.m_tbl_list) {
     // NO_LINT_DEBUG
-    sql_print_warning("MyRocks: Removing truncated leftover table %s",
-                      tbl_def->full_tablename().c_str());
+    LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                    "MyRocks: Removing truncated leftover table %s",
+                    tbl_def->full_tablename().c_str());
     table.delete_table(tbl_def);
   }
 }
@@ -7043,14 +7076,21 @@ static void rocksdb_truncation_table_cleanup(void) {
 static int rocksdb_init_internal(void *const p) {
   DBUG_ENTER_FUNC();
 
+#ifdef MYSQL_DYNAMIC_PLUGIN
+  // Initialize error logging service.
+  if (init_logging_service_for_plugin(&reg_srv, &log_bi, &log_bs)) {
+    DBUG_RETURN(HA_EXIT_FAILURE);
+  }
+#endif
+
 #ifdef FB_HAVE_WSENV
   // Initialize WSEnv with rocksdb_ws_env_path
   if (rdb_has_wsenv()) {
     // NO_LINT_DEBUG
-    sql_print_information(
-        "RocksDB: Initializing WSEnvironment: "
-        "rocksdb_wsenv_path = %s, rocksdb_wsenv_tenant = %s",
-        rocksdb_wsenv_path, rocksdb_wsenv_tenant);
+    LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: Initializing WSEnvironment: "
+                    "rocksdb_wsenv_path = %s, rocksdb_wsenv_tenant = %s",
+                    rocksdb_wsenv_path, rocksdb_wsenv_tenant);
 
     std::string rdb_tenant(rocksdb_wsenv_tenant);
     facebook::rocks::WSEnvCreationArgs args(rdb_tenant);
@@ -7068,31 +7108,35 @@ static int rocksdb_init_internal(void *const p) {
   if (rocksdb_wsenv_path != nullptr && *rocksdb_wsenv_path) {
     // We've turned on WSEnv in the wrong build
     // NO_LINT_DEBUG
-    sql_print_error("RocksDB: WSEnvironment not supported. ");
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: WSEnvironment not supported. ");
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 #endif
 
   if (rdb_has_rocksdb_corruption()) {
     // NO_LINT_DEBUG
-    sql_print_error(
-        "RocksDB: There was a corruption detected in RockDB files. "
-        "Check error log emitted earlier for more details.");
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: There was a corruption detected in RockDB files. "
+                    "Check error log emitted earlier for more details.");
     if (rocksdb_allow_to_start_after_corruption) {
       // NO_LINT_DEBUG
-      sql_print_information(
+      LogPluginErrMsg(
+          INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
           "RocksDB: Remove rocksdb_allow_to_start_after_corruption to prevent "
           "server operating if RocksDB corruption is detected.");
     } else {
       // NO_LINT_DEBUG
-      sql_print_error(
-          "RocksDB: The server will exit normally and stop restart "
-          "attempts. Remove %s file from data directory and "
-          "start mysqld manually.",
-          rdb_corruption_marker_file_name().c_str());
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "RocksDB: The server will exit normally and stop restart "
+                      "attempts. Remove %s file from data directory and "
+                      "start mysqld manually.",
+                      rdb_corruption_marker_file_name().c_str());
 
+#ifndef MYSQL_DYNAMIC_PLUGIN
       // Flush error log to ensure everything is written before exit
       flush_error_log_messages();
+#endif
       exit(0);
     }
   }
@@ -7117,7 +7161,8 @@ static int rocksdb_init_internal(void *const p) {
 
     uint32_t seed = rand();
     // NO_LINT_DEBUG
-    sql_print_information(
+    LogPluginErrMsg(
+        INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
         "RocksDB: Initializing fault injection with params (retry=%d, "
         "failure_ratio=%d, seed=%d)",
         retryable, failure_ratio, seed);
@@ -7214,11 +7259,11 @@ static int rocksdb_init_internal(void *const p) {
 
   if (rocksdb_db_options->max_open_files > (long)open_files_limit) {
     // NO_LINT_DEBUG
-    sql_print_information(
-        "RocksDB: rocksdb_max_open_files should not be "
-        "greater than the open_files_limit, effective value "
-        "of rocksdb_max_open_files is being set to "
-        "open_files_limit / 2.");
+    LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: rocksdb_max_open_files should not be "
+                    "greater than the open_files_limit, effective value "
+                    "of rocksdb_max_open_files is being set to "
+                    "open_files_limit / 2.");
     rocksdb_db_options->max_open_files = open_files_limit / 2;
   } else if (rocksdb_db_options->max_open_files == -2) {
     rocksdb_db_options->max_open_files = open_files_limit / 2;
@@ -7266,9 +7311,9 @@ static int rocksdb_init_internal(void *const p) {
       rocksdb_db_options->use_direct_reads) {
     // allow_mmap_reads implies !use_direct_reads and RocksDB will not open if
     // mmap_reads and direct_reads are both on.   (NO_LINT_DEBUG)
-    sql_print_error(
-        "RocksDB: Can't enable both use_direct_reads "
-        "and allow_mmap_reads\n");
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: Can't enable both use_direct_reads "
+                    "and allow_mmap_reads\n");
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
@@ -7296,10 +7341,10 @@ static int rocksdb_init_internal(void *const p) {
 
     if (!check_status.ok()) {
       // NO_LINT_DEBUG
-      sql_print_error(
-          "RocksDB: Unable to use direct io in rocksdb-datadir:"
-          "(%s)",
-          check_status.ToString().c_str());
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "RocksDB: Unable to use direct io in rocksdb-datadir:"
+                      "(%s)",
+                      check_status.ToString().c_str());
       DBUG_RETURN(HA_EXIT_FAILURE);
     }
   }
@@ -7311,19 +7356,19 @@ static int rocksdb_init_internal(void *const p) {
   if (rocksdb_db_options->allow_mmap_writes &&
       rocksdb_db_options->use_direct_io_for_flush_and_compaction) {
     // See above comment for allow_mmap_reads. (NO_LINT_DEBUG)
-    sql_print_error(
-        "RocksDB: Can't enable both "
-        "use_direct_io_for_flush_and_compaction and "
-        "allow_mmap_writes\n");
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: Can't enable both "
+                    "use_direct_io_for_flush_and_compaction and "
+                    "allow_mmap_writes\n");
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
   if (rocksdb_db_options->allow_mmap_writes &&
       rocksdb_flush_log_at_trx_commit != FLUSH_LOG_NEVER) {
     // NO_LINT_DEBUG
-    sql_print_error(
-        "RocksDB: rocksdb_flush_log_at_trx_commit needs to be 0 "
-        "to use allow_mmap_writes");
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: rocksdb_flush_log_at_trx_commit needs to be 0 "
+                    "to use allow_mmap_writes");
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
@@ -7349,20 +7394,21 @@ static int rocksdb_init_internal(void *const p) {
     */
     if (status.IsPathNotFound()) {
       // NO_LINT_DEBUG
-      sql_print_information(
+      LogPluginErrMsg(
+          INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
           "RocksDB: Got kPathNotFound when listing column families");
 
       // NO_LINT_DEBUG
-      sql_print_information(
-          "RocksDB:   assuming that we're creating a new database");
+      LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                      "RocksDB:   assuming that we're creating a new database");
     } else {
       rdb_log_status_error(status, "Error listing column families");
       DBUG_RETURN(HA_EXIT_FAILURE);
     }
   } else {
     // NO_LINT_DEBUG
-    sql_print_information("RocksDB: %ld column families found",
-                          cf_names.size());
+    LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: %ld column families found", cf_names.size());
   }
 
   std::vector<rocksdb::ColumnFamilyDescriptor> cf_descr;
@@ -7394,7 +7440,8 @@ static int rocksdb_init_internal(void *const p) {
       }
 #else
       // NO_LINT_DEBUG
-      sql_print_warning(
+      LogPluginErrMsg(
+          WARNING_LEVEL, ER_LOG_PRINTF_MSG,
           "Ignoring rocksdb_cache_dump because jemalloc is missing.");
 #endif  // HAVE_JEMALLOC
     }
@@ -7462,14 +7509,16 @@ static int rocksdb_init_internal(void *const p) {
         cache_size_bytes, myrocks_logger, true, &pcache);
     if (!status.ok()) {
       // NO_LINT_DEBUG
-      sql_print_error("RocksDB: Persistent cache returned error: (%s)",
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "RocksDB: Persistent cache returned error: (%s)",
                       status.getState());
       DBUG_RETURN(HA_EXIT_FAILURE);
     }
     rocksdb_tbl_options->persistent_cache = pcache;
   } else if (strlen(rocksdb_persistent_cache_path)) {
     // NO_LINT_DEBUG
-    sql_print_error("RocksDB: Must specify rocksdb_persistent_cache_size_mb");
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: Must specify rocksdb_persistent_cache_size_mb");
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
@@ -7482,7 +7531,8 @@ static int rocksdb_init_internal(void *const p) {
                             rocksdb_default_cf_options,
                             rocksdb_override_cf_options)) {
     // NO_LINT_DEBUG
-    sql_print_error("RocksDB: Failed to initialize CF options map.");
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: Failed to initialize CF options map.");
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
@@ -7499,20 +7549,24 @@ static int rocksdb_init_internal(void *const p) {
   std::set<std::string> prev_compaction_enabled_cf_names;
 
   // NO_LINT_DEBUG
-  sql_print_information("RocksDB: Column Families at start:");
+  LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                  "RocksDB: Column Families at start:");
   for (size_t i = 0; i < cf_names.size(); ++i) {
     rocksdb::ColumnFamilyOptions opts;
     cf_options_map->get_cf_options(cf_names[i], &opts);
 
     // NO_LINT_DEBUG
-    sql_print_information("  cf=%s", cf_names[i].c_str());
+    LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG, "  cf=%s",
+                    cf_names[i].c_str());
 
     // NO_LINT_DEBUG
-    sql_print_information("    write_buffer_size=%ld", opts.write_buffer_size);
+    LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                    "    write_buffer_size=%ld", opts.write_buffer_size);
 
     // NO_LINT_DEBUG
-    sql_print_information("    target_file_size_base=%" PRIu64,
-                          opts.target_file_size_base);
+    LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                    "    target_file_size_base=%" PRIu64,
+                    opts.target_file_size_base);
 
     /*
       Temporarily disable compactions to prevent a race condition where
@@ -7551,7 +7605,8 @@ static int rocksdb_init_internal(void *const p) {
   }
 
   // NO_LINT_DEBUG
-  sql_print_information("RocksDB: Opening TransactionDB...");
+  LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                  "RocksDB: Opening TransactionDB...");
   status = rocksdb::TransactionDB::Open(
       main_opts, tx_db_options, rocksdb_datadir, cf_descr, &cf_handles, &rdb);
 
@@ -7568,28 +7623,33 @@ static int rocksdb_init_internal(void *const p) {
   }
 
   // NO_LINT_DEBUG
-  sql_print_information("RocksDB:Init column families...");
+  LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                  "RocksDB:Init column families...");
   if (st_rdb_exec_time.exec("cf_manager::init", [&]() {
         return cf_manager.init(rdb, std::move(cf_options_map), &cf_handles);
       })) {
     // NO_LINT_DEBUG
-    sql_print_error("RocksDB: Failed to init column families.");
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: Failed to init column families.");
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
   // NO_LINT_DEBUG
-  sql_print_information("RocksDB: Initializing data dictionary...");
+  LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                  "RocksDB: Initializing data dictionary...");
   if (st_rdb_exec_time.exec("Rdb_dict_manager_selector::init", [&]() {
         return dict_manager.init(rdb, &cf_manager,
                                  rocksdb_enable_remove_orphaned_dropped_cfs);
       })) {
     // NO_LINT_DEBUG
-    sql_print_error("RocksDB: Failed to initialize data dictionary.");
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: Failed to initialize data dictionary.");
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
   // NO_LINT_DEBUG
-  sql_print_information("RocksDB: Initializing binlog manager...");
+  LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                  "RocksDB: Initializing binlog manager...");
 
   if (st_rdb_exec_time.exec("Rdb_binlog_manager::init", [&]() {
         return binlog_manager.init(
@@ -7597,19 +7657,22 @@ static int rocksdb_init_internal(void *const p) {
                 false /*is_tmp_table*/));
       })) {
     // NO_LINT_DEBUG
-    sql_print_error("RocksDB: Failed to initialize binlog manager.");
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: Failed to initialize binlog manager.");
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
   // NO_LINT_DEBUG
-  sql_print_information("RocksDB: Initializing DDL Manager...");
+  LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                  "RocksDB: Initializing DDL Manager...");
 
   if (st_rdb_exec_time.exec("Rdb_ddl_manager::init", [&]() {
         return ddl_manager.init(&dict_manager, &cf_manager,
                                 rocksdb_validate_tables);
       })) {
     // NO_LINT_DEBUG
-    sql_print_error("RocksDB: Failed to initialize DDL manager.");
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: Failed to initialize DDL manager.");
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
@@ -7644,7 +7707,8 @@ static int rocksdb_init_internal(void *const p) {
 #endif
   if (err != 0) {
     // NO_LINT_DEBUG
-    sql_print_error("RocksDB: Couldn't start the background thread: (errno=%d)",
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: Couldn't start the background thread: (errno=%d)",
                     err);
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
@@ -7657,7 +7721,8 @@ static int rocksdb_init_internal(void *const p) {
 #endif
   if (err != 0) {
     // NO_LINT_DEBUG
-    sql_print_error("RocksDB: Couldn't start the drop index thread: (errno=%d)",
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: Couldn't start the drop index thread: (errno=%d)",
                     err);
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
@@ -7670,7 +7735,8 @@ static int rocksdb_init_internal(void *const p) {
 #endif
   if (err != 0) {
     // NO_LINT_DEBUG
-    sql_print_error(
+    LogPluginErrMsg(
+        ERROR_LEVEL, ER_LOG_PRINTF_MSG,
         "RocksDB: Couldn't start the index stats calculation thread: "
         "(errno=%d)",
         err);
@@ -7685,7 +7751,8 @@ static int rocksdb_init_internal(void *const p) {
   );
   if (err != 0) {
     // NO_LINT_DEBUG
-    sql_print_error(
+    LogPluginErrMsg(
+        ERROR_LEVEL, ER_LOG_PRINTF_MSG,
         "RocksDB: Couldn't start the manual compaction thread: (errno=%d)",
         err);
     DBUG_RETURN(HA_EXIT_FAILURE);
@@ -7701,14 +7768,15 @@ static int rocksdb_init_internal(void *const p) {
   }
 
   // NO_LINT_DEBUG
-  sql_print_information("RocksDB: global statistics using %s indexer",
-                        STRINGIFY_ARG(RDB_INDEXER));
+  LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                  "RocksDB: global statistics using %s indexer",
+                  STRINGIFY_ARG(RDB_INDEXER));
 #if defined(HAVE_SCHED_GETCPU)
   if (sched_getcpu() == -1) {
     // NO_LINT_DEBUG
-    sql_print_information(
-        "RocksDB: sched_getcpu() failed - "
-        "global statistics will use thread_id_indexer_t instead");
+    LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: sched_getcpu() failed - "
+                    "global statistics will use thread_id_indexer_t instead");
   }
 #endif
 
@@ -7716,7 +7784,8 @@ static int rocksdb_init_internal(void *const p) {
                           HA_ERR_ROCKSDB_LAST);
   if (err != 0) {
     // NO_LINT_DEBUG
-    sql_print_error("RocksDB: Couldn't initialize error messages");
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: Couldn't initialize error messages");
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
@@ -7747,9 +7816,9 @@ static int rocksdb_init_internal(void *const p) {
   rocksdb_truncation_table_cleanup();
 
   // NO_LINT_DEBUG
-  sql_print_information(
-      "MyRocks storage engine plugin has been successfully "
-      "initialized.");
+  LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                  "MyRocks storage engine plugin has been successfully "
+                  "initialized.");
 
   st_rdb_exec_time.report();
 
@@ -7803,33 +7872,39 @@ static int rocksdb_shutdown(bool minimalShutdown) {
 
     // Wait for the background thread to finish.
     // NO_LINT_DEBUG
-    sql_print_information("Waiting for MyRocks background to finish");
+    LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Waiting for MyRocks background to finish");
     auto err = rdb_bg_thread.join();
     if (err != 0) {
       // We'll log the message and continue because we're shutting down and
       // continuation is the optimal strategy.
       // NO_LINT_DEBUG
-      sql_print_error(
+      LogPluginErrMsg(
+          ERROR_LEVEL, ER_LOG_PRINTF_MSG,
           "RocksDB: Couldn't stop the background thread: (errno=%d)", err);
     }
 
     // Wait for the drop index thread to finish.
     // NO_LINT_DEBUG
-    sql_print_information("Waiting for MyRocks drop index thread to finish");
+    LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Waiting for MyRocks drop index thread to finish");
     err = rdb_drop_idx_thread.join();
     if (err != 0) {
       // NO_LINT_DEBUG
-      sql_print_error("RocksDB: Couldn't stop the index thread: (errno=%d)",
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "RocksDB: Couldn't stop the index thread: (errno=%d)",
                       err);
     }
 
     // Wait for the index stats calculation thread to finish.
     // NO_LINT_DEBUG
-    sql_print_information("Waiting for MyRocks index stats thread to finish");
+    LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Waiting for MyRocks index stats thread to finish");
     err = rdb_is_thread.join();
     if (err != 0) {
       // NO_LINT_DEBUG
-      sql_print_error(
+      LogPluginErrMsg(
+          ERROR_LEVEL, ER_LOG_PRINTF_MSG,
           "RocksDB: Couldn't stop the index stats calculation thread: "
           "(errno=%d)",
           err);
@@ -7837,11 +7912,13 @@ static int rocksdb_shutdown(bool minimalShutdown) {
 
     // Wait for the manual compaction thread to finish.
     // NO_LINT_DEBUG
-    sql_print_information("Waiting for MyRocks compaction thread to finish");
+    LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Waiting for MyRocks compaction thread to finish");
     err = rdb_mc_thread.join();
     if (err != 0) {
       // NO_LINT_DEBUG
-      sql_print_error(
+      LogPluginErrMsg(
+          ERROR_LEVEL, ER_LOG_PRINTF_MSG,
           "RocksDB: Couldn't stop the manual compaction thread: (errno=%d)",
           err);
     }
@@ -7849,7 +7926,8 @@ static int rocksdb_shutdown(bool minimalShutdown) {
     if (rdb_open_tables.count()) {
       // Looks like we are getting unloaded and yet we have some open tables
       // left behind.
-      sql_print_error("RocksDB: there're tables still opened during shutdown");
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "RocksDB: there're tables still opened during shutdown");
       error = 1;
     }
 
@@ -7913,6 +7991,10 @@ static int rocksdb_shutdown(bool minimalShutdown) {
   if (!minimalShutdown) {
     my_error_unregister(HA_ERR_ROCKSDB_FIRST, HA_ERR_ROCKSDB_LAST);
   }
+
+#ifdef MYSQL_DYNAMIC_PLUGIN
+  deinit_logging_service_for_plugin(&reg_srv, &log_bi, &log_bs);
+#endif
 
   return error;
 }
@@ -8325,10 +8407,10 @@ ha_rocksdb::~ha_rocksdb() {
   err = finalize_bulk_load(false);
   if (err != 0) {
     // NO_LINT_DEBUG
-    sql_print_error(
-        "RocksDB: Error %d finalizing bulk load while closing "
-        "handler.",
-        err);
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: Error %d finalizing bulk load while closing "
+                    "handler.",
+                    err);
   }
 }
 
@@ -8429,10 +8511,10 @@ bool rdb_should_hide_ttl_rec(const Rdb_key_def &kd,
                       RDB_MAX_HEXDUMP_LEN);
     const GL_INDEX_ID gl_index_id = kd.get_gl_index_id();
     // NO_LINT_DEBUG
-    sql_print_error(
-        "Decoding ttl from PK value failed, "
-        "for index (%u,%u), val: %s",
-        gl_index_id.cf_id, gl_index_id.index_id, buf.c_str());
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Decoding ttl from PK value failed, "
+                    "for index (%u,%u), val: %s",
+                    gl_index_id.cf_id, gl_index_id.index_id, buf.c_str());
     assert(0);
     return false;
   }
@@ -9188,11 +9270,11 @@ int ha_rocksdb::create_inplace_key_defs(
       if (!dict_manager.get_dict_manager_selector_const(gl_index_id.cf_id)
                ->get_index_info(gl_index_id, &index_info)) {
         // NO_LINT_DEBUG
-        sql_print_error(
-            "RocksDB: Could not get index information "
-            "for Index Number (%u,%u), table %s",
-            gl_index_id.cf_id, gl_index_id.index_id,
-            old_tbl_def_arg->full_tablename().c_str());
+        LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                        "RocksDB: Could not get index information "
+                        "for Index Number (%u,%u), table %s",
+                        gl_index_id.cf_id, gl_index_id.index_id,
+                        old_tbl_def_arg->full_tablename().c_str());
         DBUG_RETURN(HA_EXIT_FAILURE);
       }
 
@@ -9888,10 +9970,10 @@ int ha_rocksdb::truncate_table(Rdb_tbl_def *tbl_def_arg,
       should_remove_old_table = false;
     } else {
       // NO_LINT_DEBUG
-      sql_print_error(
-          "MyRocks: Failure during truncation of table %s "
-          "being renamed from %s",
-          orig_tablename.c_str(), tmp_tablename.c_str());
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "MyRocks: Failure during truncation of table %s "
+                      "being renamed from %s",
+                      orig_tablename.c_str(), tmp_tablename.c_str());
       err = rename_err;
     }
   }
@@ -9906,10 +9988,10 @@ int ha_rocksdb::truncate_table(Rdb_tbl_def *tbl_def_arg,
     m_tbl_def = old_tbl_def;
     if (delete_table(old_tbl_def) != HA_EXIT_SUCCESS) {
       // NO_LINT_DEBUG
-      sql_print_error(
-          "Failure when trying to drop table %s during "
-          "truncation of table %s",
-          tmp_tablename.c_str(), orig_tablename.c_str());
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Failure when trying to drop table %s during "
+                      "truncation of table %s",
+                      tmp_tablename.c_str(), orig_tablename.c_str());
     }
   }
 
@@ -10357,8 +10439,8 @@ int ha_rocksdb::check(THD *const thd MY_ATTRIBUTE((__unused__)),
   m_converter->set_verify_row_debug_checksums(true);
   /* For each secondary index, check that we can get a PK value from it */
   // NO_LINT_DEBUG
-  sql_print_information("CHECKTABLE %s: Checking table %s", table_name,
-                        table_name);
+  LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                  "CHECKTABLE %s: Checking table %s", table_name, table_name);
   ha_rows row_checksums_at_start =
       ha_rows(0);  // set/used iff first_index==true
   ha_rows row_checksums = ha_rows(-1);
@@ -10375,8 +10457,9 @@ int ha_rocksdb::check(THD *const thd MY_ATTRIBUTE((__unused__)),
       }
       int res;
       // NO_LINT_DEBUG
-      sql_print_information("CHECKTABLE %s:   Checking index %s", table_name,
-                            table->key_info[keyno].name);
+      LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                      "CHECKTABLE %s:   Checking index %s", table_name,
+                      table->key_info[keyno].name);
       while (1) {
         if (!rows) {
           res = index_first(table->record[0]);
@@ -10388,7 +10471,8 @@ int ha_rocksdb::check(THD *const thd MY_ATTRIBUTE((__unused__)),
         if (res) {
           // error
           // NO_LINT_DEBUG
-          sql_print_error("CHECKTABLE %s:   .. row %lld: index scan error %d",
+          LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                          "CHECKTABLE %s:   .. row %lld: index scan error %d",
                           table_name, rows, res);
           goto error;
         }
@@ -10401,10 +10485,10 @@ int ha_rocksdb::check(THD *const thd MY_ATTRIBUTE((__unused__)),
                                     rowkey_copy.length(), nullptr, false,
                                     !rdb_is_binlog_ttl_enabled()))) {
           // NO_LINT_DEBUG
-          sql_print_error(
-              "CHECKTABLE %s:   .. row %lld: "
-              "failed to fetch row by rowid",
-              table_name, rows);
+          LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                          "CHECKTABLE %s:   .. row %lld: "
+                          "failed to fetch row by rowid",
+                          table_name, rows);
           goto error;
         }
 
@@ -10420,7 +10504,8 @@ int ha_rocksdb::check(THD *const thd MY_ATTRIBUTE((__unused__)),
         if (packed_size != rowkey_copy.length() ||
             memcmp(m_pk_packed_tuple, rowkey_copy.ptr(), packed_size)) {
           // NO_LINT_DEBUG
-          sql_print_error("CHECKTABLE %s:   .. row %lld: PK value mismatch",
+          LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                          "CHECKTABLE %s:   .. row %lld: PK value mismatch",
                           table_name, rows);
           goto print_and_error;
         }
@@ -10431,10 +10516,10 @@ int ha_rocksdb::check(THD *const thd MY_ATTRIBUTE((__unused__)),
         if (packed_size != sec_key_copy.length() ||
             memcmp(m_sk_packed_tuple, sec_key_copy.ptr(), packed_size)) {
           // NO_LINT_DEBUG
-          sql_print_error(
-              "CHECKTABLE %s:   .. row %lld: "
-              "secondary index value mismatch",
-              table_name, rows);
+          LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                          "CHECKTABLE %s:   .. row %lld: "
+                          "secondary index value mismatch",
+                          table_name, rows);
           goto print_and_error;
         }
         rows++;
@@ -10445,26 +10530,29 @@ int ha_rocksdb::check(THD *const thd MY_ATTRIBUTE((__unused__)),
         buf = rdb_hexdump(rowkey_copy.ptr(), rowkey_copy.length(),
                           RDB_MAX_HEXDUMP_LEN);
         // NO_LINT_DEBUG
-        sql_print_error("CHECKTABLE %s:   rowkey: %s", table_name, buf.c_str());
+        LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                        "CHECKTABLE %s:   rowkey: %s", table_name, buf.c_str());
 
         buf = rdb_hexdump(m_retrieved_record.data(), m_retrieved_record.size(),
                           RDB_MAX_HEXDUMP_LEN);
         // NO_LINT_DEBUG
-        sql_print_error("CHECKTABLE %s:   record: %s", table_name, buf.c_str());
+        LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                        "CHECKTABLE %s:   record: %s", table_name, buf.c_str());
 
         buf = rdb_hexdump(sec_key_copy.ptr(), sec_key_copy.length(),
                           RDB_MAX_HEXDUMP_LEN);
         // NO_LINT_DEBUG
-        sql_print_error("CHECKTABLE %s:   index: %s", table_name, buf.c_str());
+        LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                        "CHECKTABLE %s:   index: %s", table_name, buf.c_str());
 
         goto error;
       }
       }
       // NO_LINT_DEBUG
-      sql_print_information(
-          "CHECKTABLE %s:   ... %lld index entries checked "
-          "(%lld had checksums)",
-          table_name, rows, m_validated_checksums);
+      LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                      "CHECKTABLE %s:   ... %lld index entries checked "
+                      "(%lld had checksums)",
+                      table_name, rows, m_validated_checksums);
 
       if (first_index) {
         row_checksums =
@@ -10476,8 +10564,9 @@ int ha_rocksdb::check(THD *const thd MY_ATTRIBUTE((__unused__)),
   }
   if (row_checksums != ha_rows(-1)) {
     // NO_LINT_DEBUG
-    sql_print_information("CHECKTABLE %s:   %lld table records had checksums",
-                          table_name, row_checksums);
+    LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                    "CHECKTABLE %s:   %lld table records had checksums",
+                    table_name, row_checksums);
   }
   extra(HA_EXTRA_NO_KEYREAD);
 
@@ -11117,7 +11206,8 @@ bool ha_rocksdb::do_intrinsic_table_commit(Rdb_transaction *const tx) {
     res = tx->flush_batch(m_tbl_def->get_table_type());
     if (res) {
       // NO_LINT_DEBUG
-      sql_print_error("flush_batch failed for intrinsic table commit");
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "flush_batch failed for intrinsic table commit");
       return res;
     }
     res = get_ha_data(ha_thd())->refresh_iterator_for_all_handlers(&output);
@@ -11861,7 +11951,8 @@ int ha_rocksdb::finalize_bulk_load(bool print_client_error) {
           }
           res = HA_ERR_ROCKSDB_BULK_LOAD;
           // NO_LINT_DEBUG
-          sql_print_warning(
+          LogPluginErrMsg(
+              WARNING_LEVEL, ER_LOG_PRINTF_MSG,
               "MyRocks: failed to bulk load. "
               "status code = %d, status = %s, IngestExternalFileOptions=%s",
               s.code(), s.ToString().c_str(),
@@ -13385,11 +13476,11 @@ static int delete_range(const std::unordered_set<GL_INDEX_ID> &indices) {
     uint32 cf_flags = 0;
     if (!local_dict_manager->get_cf_flags(d.cf_id, &cf_flags)) {
       // NO_LINT_DEBUG
-      sql_print_error(
-          "RocksDB: Failed to get column family flags "
-          "from cf id %u. MyRocks data dictionary may "
-          "get corrupted.",
-          d.cf_id);
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "RocksDB: Failed to get column family flags "
+                      "from cf id %u. MyRocks data dictionary may "
+                      "get corrupted.",
+                      d.cf_id);
       ret = 1;
       return ret;
     }
@@ -13405,7 +13496,8 @@ static int delete_range(const std::unordered_set<GL_INDEX_ID> &indices) {
                                                 &range.start, &range.limit);
     if (!status.ok()) {
       // NO_LINT_DEBUG
-      sql_print_warning(
+      LogPluginErrMsg(
+          WARNING_LEVEL, ER_LOG_PRINTF_MSG,
           "RocksDB: Failed to call DeleteFilesInRange for [cf_id %u, index_id "
           "%u] with status [%s]",
           d.cf_id, d.index_id, status.ToString().c_str());
@@ -13413,7 +13505,8 @@ static int delete_range(const std::unordered_set<GL_INDEX_ID> &indices) {
     status = batch.DeleteRange(cfh.get(), range.start, range.limit);
     if (!status.ok()) {
       // NO_LINT_DEBUG
-      sql_print_error(
+      LogPluginErrMsg(
+          ERROR_LEVEL, ER_LOG_PRINTF_MSG,
           "RocksDB: Failed to call DeleteRange for [cf_id %u, index_id %u] "
           "with status [%s]",
           d.cf_id, d.index_id, status.ToString().c_str());
@@ -14170,7 +14263,8 @@ static int calculate_cardinality_table_scan(
     for (it->Seek(first_index_key); is_valid_iterator(it.get()); it->Next()) {
       if (killed && *killed) {
         // NO_LINT_DEBUG
-        sql_print_information(
+        LogPluginErrMsg(
+            INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
             "Index stats calculation for index %s with id (%u,%u) is "
             "terminated",
             kd->get_name().c_str(), stat.m_gl_index_id.cf_id,
@@ -15367,7 +15461,8 @@ int ha_rocksdb::inplace_populate_sk(
       if (hidden_pk_exists &&
           (res = read_hidden_pk_id_from_rowkey(&hidden_pk_id))) {
         // NO_LINT_DEBUG
-        sql_print_error("Error retrieving hidden pk id.");
+        LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                        "Error retrieving hidden pk id.");
         ha_rnd_end();
         DBUG_RETURN(res);
       }
@@ -15401,7 +15496,8 @@ int ha_rocksdb::inplace_populate_sk(
 
     if (res != HA_ERR_END_OF_FILE) {
       // NO_LINT_DEBUG
-      sql_print_error("Error retrieving index entry from primary key.");
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Error retrieving index entry from primary key.");
       ha_rnd_end();
       DBUG_RETURN(res);
     }
@@ -15421,7 +15517,8 @@ int ha_rocksdb::inplace_populate_sk(
 
     if (res && is_critical_error) {
       // NO_LINT_DEBUG
-      sql_print_error("Error finishing bulk load.");
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Error finishing bulk load.");
       DBUG_RETURN(res);
     }
   }
@@ -16508,7 +16605,8 @@ int Rdb_index_stats_thread::renice(int nice_val) {
 #endif
   if (ret != 0) {
     // NO_LINT_DEBUG
-    sql_print_error("Set index stats thread priority failed due to %s",
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Set index stats thread priority failed due to %s",
                     strerror(errno));
     RDB_MUTEX_UNLOCK_CHECK(m_is_mutex);
     return HA_EXIT_FAILURE;
@@ -16597,8 +16695,9 @@ void Rdb_manual_compaction_thread::run() {
 
     assert(mcr.state == Manual_compaction_request::RUNNING);
     // NO_LINT_DEBUG
-    sql_print_information("Manual Compaction id %d cf %s started.", mcr.mc_id,
-                          mcr.cf->GetName().c_str());
+    LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Manual Compaction id %d cf %s started.", mcr.mc_id,
+                    mcr.cf->GetName().c_str());
     if (rocksdb_debug_manual_compaction_delay > 0) {
       uint32 delay = rocksdb_debug_manual_compaction_delay;
       for (uint32 i = 0; i < delay; ++i) {
@@ -16633,28 +16732,31 @@ void Rdb_manual_compaction_thread::run() {
     if (s.ok()) {
       rocksdb_manual_compactions_processed++;
       // NO_LINT_DEBUG
-      sql_print_information("Manual Compaction id %d cf %s ended.", mcr.mc_id,
-                            mcr.cf->GetName().c_str());
+      LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Manual Compaction id %d cf %s ended.", mcr.mc_id,
+                      mcr.cf->GetName().c_str());
       set_state(&mcr, Manual_compaction_request::SUCCESS);
     } else {
       if (!cf_manager.get_cf(mcr.cf->GetID())) {
         // NO_LINT_DEBUG
-        sql_print_information("cf %s has been dropped",
-                              mcr.cf->GetName().c_str());
+        LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                        "cf %s has been dropped", mcr.cf->GetName().c_str());
         set_state(&mcr, Manual_compaction_request::SUCCESS);
       } else if (s.IsIncomplete()) {
         // NO_LINT_DEBUG
-        sql_print_information(
-            "Manual Compaction id %d cf %s cancelled. (%d:%d, %s)", mcr.mc_id,
-            mcr.cf->GetName().c_str(), s.code(), s.subcode(), s.getState());
+        LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                        "Manual Compaction id %d cf %s cancelled. (%d:%d, %s)",
+                        mcr.mc_id, mcr.cf->GetName().c_str(), s.code(),
+                        s.subcode(), s.getState());
         // Cancelled
         set_state(&mcr, Manual_compaction_request::CANCEL);
         rocksdb_manual_compactions_cancelled++;
       } else {
         // NO_LINT_DEBUG
-        sql_print_information(
-            "Manual Compaction id %d cf %s aborted. (%d:%d, %s)", mcr.mc_id,
-            mcr.cf->GetName().c_str(), s.code(), s.subcode(), s.getState());
+        LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                        "Manual Compaction id %d cf %s aborted. (%d:%d, %s)",
+                        mcr.mc_id, mcr.cf->GetName().c_str(), s.code(),
+                        s.subcode(), s.getState());
         set_state(&mcr, Manual_compaction_request::FAILURE);
         if (!s.IsShutdownInProgress()) {
           rdb_handle_io_error(s, RDB_IO_ERROR_BG_THREAD);
@@ -17207,10 +17309,10 @@ static void rocksdb_set_delayed_write_rate(
 
     if (!s.ok()) {
       /* NO_LINT_DEBUG */
-      sql_print_warning(
-          "MyRocks: failed to update delayed_write_rate. "
-          "status code = %d, status = %s",
-          s.code(), s.ToString().c_str());
+      LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                      "MyRocks: failed to update delayed_write_rate. "
+                      "status code = %d, status = %s",
+                      s.code(), s.ToString().c_str());
     }
   }
   RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
@@ -17290,10 +17392,10 @@ static int rocksdb_check_bulk_load(
     const int rc = tx->finish_bulk_load(&is_critical_error);
     if (rc != 0 && is_critical_error) {
       // NO_LINT_DEBUG
-      sql_print_error(
-          "RocksDB: Error %d finalizing last SST file while "
-          "setting bulk loading variable",
-          rc);
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "RocksDB: Error %d finalizing last SST file while "
+                      "setting bulk loading variable",
+                      rc);
       THDVAR(thd, bulk_load) = 0;
       return 1;
     }
@@ -17349,10 +17451,10 @@ static void rocksdb_set_max_background_jobs(
 
     if (!s.ok()) {
       /* NO_LINT_DEBUG */
-      sql_print_warning(
-          "MyRocks: failed to update max_background_jobs. "
-          "Status code = %d, status = %s.",
-          s.code(), s.ToString().c_str());
+      LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                      "MyRocks: failed to update max_background_jobs. "
+                      "Status code = %d, status = %s.",
+                      s.code(), s.ToString().c_str());
     }
   }
 
@@ -17378,10 +17480,10 @@ static void rocksdb_set_max_background_compactions(
 
     if (!s.ok()) {
       /* NO_LINT_DEBUG */
-      sql_print_warning(
-          "MyRocks: failed to update max_background_compactions. "
-          "Status code = %d, status = %s.",
-          s.code(), s.ToString().c_str());
+      LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                      "MyRocks: failed to update max_background_compactions. "
+                      "Status code = %d, status = %s.",
+                      s.code(), s.ToString().c_str());
     }
   }
 
@@ -17448,10 +17550,10 @@ static void rocksdb_set_bytes_per_sync(
 
     if (!s.ok()) {
       /* NO_LINT_DEBUG */
-      sql_print_warning(
-          "MyRocks: failed to update max_background_jobs. "
-          "Status code = %d, status = %s.",
-          s.code(), s.ToString().c_str());
+      LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                      "MyRocks: failed to update max_background_jobs. "
+                      "Status code = %d, status = %s.",
+                      s.code(), s.ToString().c_str());
     }
   }
 
@@ -17477,10 +17579,10 @@ static void rocksdb_set_wal_bytes_per_sync(
 
     if (!s.ok()) {
       /* NO_LINT_DEBUG */
-      sql_print_warning(
-          "MyRocks: failed to update max_background_jobs. "
-          "Status code = %d, status = %s.",
-          s.code(), s.ToString().c_str());
+      LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                      "MyRocks: failed to update max_background_jobs. "
+                      "Status code = %d, status = %s.",
+                      s.code(), s.ToString().c_str());
     }
   }
 
@@ -17613,7 +17715,8 @@ static void rocksdb_set_update_cf_options(THD *const /* unused */,
 
     if (!cfh) {
       // NO_LINT_DEBUG
-      sql_print_information(
+      LogPluginErrMsg(
+          INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
           "Skip updating options for cf %s because the cf has been dropped.",
           cf_name.c_str());
       continue;
@@ -17628,10 +17731,10 @@ static void rocksdb_set_update_cf_options(THD *const /* unused */,
 
       if (s != rocksdb::Status::OK()) {
         // NO_LINT_DEBUG
-        sql_print_warning(
-            "MyRocks: failed to convert the options for column "
-            "family '%s' to a map. %s",
-            cf_name.c_str(), s.ToString().c_str());
+        LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                        "MyRocks: failed to convert the options for column "
+                        "family '%s' to a map. %s",
+                        cf_name.c_str(), s.ToString().c_str());
       } else {
         assert(rdb != nullptr);
 
@@ -17643,16 +17746,16 @@ static void rocksdb_set_update_cf_options(THD *const /* unused */,
 
         if (s != rocksdb::Status::OK()) {
           // NO_LINT_DEBUG
-          sql_print_warning(
-              "MyRocks: failed to apply the options for column "
-              "family '%s'. %s",
-              cf_name.c_str(), s.ToString().c_str());
+          LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                          "MyRocks: failed to apply the options for column "
+                          "family '%s'. %s",
+                          cf_name.c_str(), s.ToString().c_str());
         } else {
           // NO_LINT_DEBUG
-          sql_print_information(
-              "MyRocks: options for column family '%s' "
-              "have been successfully updated.",
-              cf_name.c_str());
+          LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                          "MyRocks: options for column family '%s' "
+                          "have been successfully updated.",
+                          cf_name.c_str());
 
           // Make sure that data is internally consistent as well and update
           // the CF options. This is necessary also to make sure that the CF
@@ -18591,10 +18694,11 @@ static bool parse_fault_injection_params(
   rapidjson::ParseResult ok = doc.Parse(opt_rocksdb_fault_injection_options);
   if (!ok) {
     // NO_LINT_DEBUG
-    sql_print_error(
-        "RocksDB: Parse error (errcode=%d offset=%d)  "
-        "rocksdb_fault_injection_options=%s",
-        ok.Code(), ok.Offset(), opt_rocksdb_fault_injection_options);
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: Parse error (errcode=%d offset=%zu)  "
+                    "rocksdb_fault_injection_options=%s",
+                    ok.Code(), ok.Offset(),
+                    opt_rocksdb_fault_injection_options);
     return true;
   }
 
@@ -18605,7 +18709,8 @@ static bool parse_fault_injection_params(
   if (retry_it == doc.MemberEnd() || fr_it == doc.MemberEnd() ||
       ft_it == doc.MemberEnd()) {
     // NO_LINT_DEBUG
-    sql_print_error(
+    LogPluginErrMsg(
+        ERROR_LEVEL, ER_LOG_PRINTF_MSG,
         "RocksDB: rocksdb_fault_injection_options=%s schema not valid",
         opt_rocksdb_fault_injection_options);
     return true;
@@ -18614,7 +18719,8 @@ static bool parse_fault_injection_params(
   if (!retry_it->value.IsBool() || !fr_it->value.IsInt() ||
       !ft_it->value.IsArray()) {
     // NO_LINT_DEBUG
-    sql_print_error(
+    LogPluginErrMsg(
+        ERROR_LEVEL, ER_LOG_PRINTF_MSG,
         "RocksDB: rocksdb_fault_injection_options=%s schema not valid (wrong "
         "types)",
         opt_rocksdb_fault_injection_options);
@@ -18628,12 +18734,12 @@ static bool parse_fault_injection_params(
     if (!ft_it->value[i].IsString() ||
         parse_fault_injection_file_type(ft_it->value[i].GetString(), &type)) {
       // NO_LINT_DEBUG
-      sql_print_error(
-          "RocksDB: Wrong filetype = %s to  "
-          "rocksdb_fault_injection_options=%s",
-          ft_it->value[i].IsString() ? ft_it->value[i].GetString()
-                                     : "(wrong type)",
-          opt_rocksdb_fault_injection_options);
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "RocksDB: Wrong filetype = %s to  "
+                      "rocksdb_fault_injection_options=%s",
+                      ft_it->value[i].IsString() ? ft_it->value[i].GetString()
+                                                 : "(wrong type)",
+                      opt_rocksdb_fault_injection_options);
       return true;
     }
     types->push_back(type);

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -29,7 +29,6 @@
 #include <vector>
 
 /* MySQL header files */
-#include <mysql/components/services/log_builtins.h>
 #include "my_checksum.h"
 #include "my_dbug.h"
 #include "my_icp.h" /* icp_result */

--- a/storage/rocksdb/logger.h
+++ b/storage/rocksdb/logger.h
@@ -18,9 +18,6 @@
 #include <sstream>
 #include <string>
 
-/* MySQL header files */
-#include <sql/log.h>
-
 namespace myrocks {
 
 class Rdb_logger : public rocksdb::Logger {
@@ -60,7 +57,7 @@ class Rdb_logger : public rocksdb::Logger {
     char msg[LOG_BUFF_MAX];
     vsnprintf(msg, sizeof(msg) - 1, f.c_str(), ap);
 
-    log_errlog_formatted(mysql_log_level, msg);
+    LogPluginErrMsg(mysql_log_level, ER_LOG_PRINTF_MSG, "%s", msg);
   }
 
   void Logv(const char *format, va_list ap) override {

--- a/storage/rocksdb/nosql_access.cc
+++ b/storage/rocksdb/nosql_access.cc
@@ -2577,8 +2577,9 @@ bool handle_unsupported_bypass(THD *thd, const char *error_msg) {
     // size equals zero
     if (get_select_bypass_rejected_query_history_size() == 0) {
       // NO_LINT_DEBUG
-      sql_print_information("[REJECTED_BYPASS_QUERY] Query='%s', Reason='%s'\n",
-                            thd->query().str, error_msg);
+      LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                      "[REJECTED_BYPASS_QUERY] Query='%s', Reason='%s'\n",
+                      thd->query().str, error_msg);
     } else {
       // Otherwise, record the rejected query into information_schema
       const std::lock_guard<std::mutex> lock(rejected_bypass_query_lock);
@@ -2645,9 +2646,9 @@ bool rocksdb_handle_single_table_select(THD *thd, Query_block *select_lex) {
     }
     if (should_log_failed_select_bypass()) {
       // NO_LINT_DEBUG
-      sql_print_information("[FAILED_BYPASS_QUERY] Query='%s', Reason='%s'\n",
-                            thd->query().str,
-                            thd->get_stmt_da()->message_text());
+      LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                      "[FAILED_BYPASS_QUERY] Query='%s', Reason='%s'\n",
+                      thd->query().str, thd->get_stmt_da()->message_text());
     }
     rocksdb_select_bypass_failed++;
   } else {

--- a/storage/rocksdb/properties_collector.cc
+++ b/storage/rocksdb/properties_collector.cc
@@ -25,7 +25,6 @@
 
 /* MySQL header files */
 #include "./my_stacktrace.h"
-#include "sql/log.h"
 #include "sql/sql_array.h"
 
 /* MyRocks header files */

--- a/storage/rocksdb/rdb_cf_manager.cc
+++ b/storage/rocksdb/rdb_cf_manager.cc
@@ -66,7 +66,8 @@ bool Rdb_cf_manager::init(rocksdb::DB *const rdb,
     if (std::find(tmp_cfs.begin(), tmp_cfs.end(), cf_name) != tmp_cfs.end()) {
       uint cf_id = cfh_ptr->GetID();
       // NO_LINT_DEBUG
-      sql_print_information(
+      LogPluginErrMsg(
+          INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
           "RocksDB: Dropping column family %s with id %u on RocksDB for temp "
           "table",
           cf_name.c_str(), cf_id);
@@ -76,7 +77,8 @@ bool Rdb_cf_manager::init(rocksdb::DB *const rdb,
         continue;
       }
       // NO_LINT_DEBUG
-      sql_print_error(
+      LogPluginErrMsg(
+          ERROR_LEVEL, ER_LOG_PRINTF_MSG,
           "RocksDB: Dropping column family %s with id %u on RocksDB failed for "
           "temp table",
           cf_name.c_str(), cf_id);
@@ -167,14 +169,16 @@ std::shared_ptr<rocksdb::ColumnFamilyHandle> Rdb_cf_manager::get_or_create_cf(
     m_cf_options->get_cf_options(cf_name, &opts);
 
     // NO_LINT_DEBUG
-    sql_print_information("RocksDB: creating a column family %s",
-                          cf_name.c_str());
+    LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: creating a column family %s", cf_name.c_str());
     // NO_LINT_DEBUG
-    sql_print_information("    write_buffer_size=%ld", opts.write_buffer_size);
+    LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                    "    write_buffer_size=%ld", opts.write_buffer_size);
 
     // NO_LINT_DEBUG
-    sql_print_information("    target_file_size_base=%" PRIu64,
-                          opts.target_file_size_base);
+    LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                    "    target_file_size_base=%" PRIu64,
+                    opts.target_file_size_base);
 
     rocksdb::ColumnFamilyHandle *cf_handle_ptr = nullptr;
     const rocksdb::Status s =
@@ -218,7 +222,8 @@ std::shared_ptr<rocksdb::ColumnFamilyHandle> Rdb_cf_manager::get_cf(
 
   if (!cf_handle) {
     // NO_LINT_DEBUG
-    sql_print_warning("Column family '%s' not found.", cf_name.c_str());
+    LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Column family '%s' not found.", cf_name.c_str());
   }
 
   if (!lock_held_by_caller) {
@@ -283,10 +288,10 @@ int Rdb_cf_manager::remove_dropped_cf(Rdb_dict_manager *const dict_manager,
     RDB_MUTEX_UNLOCK_CHECK(m_mutex);
 
     // NO_LINT_DEBUG
-    sql_print_warning(
-        "RocksDB: Column family with id %u is marked as dropped, "
-        "but doesn't exist in cf manager",
-        cf_id);
+    LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: Column family with id %u is marked as dropped, "
+                    "but doesn't exist in cf manager",
+                    cf_id);
 
     return HA_EXIT_FAILURE;
   }
@@ -297,10 +302,10 @@ int Rdb_cf_manager::remove_dropped_cf(Rdb_dict_manager *const dict_manager,
   if (!dict_manager->get_dropped_cf(cf_id)) {
     RDB_MUTEX_UNLOCK_CHECK(m_mutex);
     // NO_LINT_DEBUG
-    sql_print_warning(
-        "RocksDB: Column family %s with id %u is not in "
-        "the list of cf ids to be dropped",
-        cf_name.c_str(), cf_id);
+    LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: Column family %s with id %u is not in "
+                    "the list of cf ids to be dropped",
+                    cf_name.c_str(), cf_id);
     return HA_EXIT_FAILURE;
   }
 
@@ -312,7 +317,8 @@ int Rdb_cf_manager::remove_dropped_cf(Rdb_dict_manager *const dict_manager,
     RDB_MUTEX_UNLOCK_CHECK(m_mutex);
 
     // NO_LINT_DEBUG
-    sql_print_error(
+    LogPluginErrMsg(
+        ERROR_LEVEL, ER_LOG_PRINTF_MSG,
         "RocksDB: Dropping column family %s with id %u on RocksDB failed",
         cf_name.c_str(), cf_id);
 
@@ -343,7 +349,8 @@ int Rdb_cf_manager::remove_dropped_cf(Rdb_dict_manager *const dict_manager,
   RDB_MUTEX_UNLOCK_CHECK(m_mutex);
 
   // NO_LINT_DEBUG
-  sql_print_information(
+  LogPluginErrMsg(
+      INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
       "RocksDB: Column family %s with id %u has been dropped successfully",
       cf_name.c_str(), cf_id);
 
@@ -392,10 +399,10 @@ int Rdb_cf_manager::drop_cf(Rdb_ddl_manager *const ddl_manager,
   if (cf_handle == nullptr) {
     RDB_MUTEX_UNLOCK_CHECK(m_mutex);
     // NO_LINT_DEBUG
-    sql_print_warning(
-        "RocksDB: Cannot mark Column family %s to be dropped, "
-        "because it doesn't exist in cf manager",
-        cf_name.c_str());
+    LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: Cannot mark Column family %s to be dropped, "
+                    "because it doesn't exist in cf manager",
+                    cf_name.c_str());
 
     return HA_EXIT_FAILURE;
   }
@@ -407,7 +414,8 @@ int Rdb_cf_manager::drop_cf(Rdb_ddl_manager *const ddl_manager,
   if (ret) {
     RDB_MUTEX_UNLOCK_CHECK(m_mutex);
     // NO_LINT_DEBUG
-    sql_print_warning(
+    LogPluginErrMsg(
+        WARNING_LEVEL, ER_LOG_PRINTF_MSG,
         "RocksDB: Cannot mark Column family %s with id %u to be dropped, "
         "because it is in use",
         cf_name.c_str(), cf_id);
@@ -418,7 +426,8 @@ int Rdb_cf_manager::drop_cf(Rdb_ddl_manager *const ddl_manager,
   if (ret) {
     RDB_MUTEX_UNLOCK_CHECK(m_mutex);
     // NO_LINT_DEBUG
-    sql_print_warning(
+    LogPluginErrMsg(
+        WARNING_LEVEL, ER_LOG_PRINTF_MSG,
         "RocksDB: Cannot mark Column family %s with id %u to be dropped, "
         "because it is used by an ongoing add index command",
         cf_name.c_str(), cf_id);
@@ -438,7 +447,8 @@ int Rdb_cf_manager::drop_cf(Rdb_ddl_manager *const ddl_manager,
   RDB_MUTEX_UNLOCK_CHECK(m_mutex);
 
   // NO_LINT_DEBUG
-  sql_print_information(
+  LogPluginErrMsg(
+      INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
       "RocksDB: Column family %s with id %u has been marked to be dropped",
       cf_name.c_str(), cf_id);
 

--- a/storage/rocksdb/rdb_cf_options.cc
+++ b/storage/rocksdb/rdb_cf_options.cc
@@ -25,7 +25,6 @@
 #include <string>
 
 /* MySQL header files */
-#include "sql/log.h"
 
 /* RocksDB header files */
 #include "rocksdb/utilities/convenience.h"
@@ -137,7 +136,8 @@ bool Rdb_cf_options::find_column_family(const std::string &input,
 
   if (end_pos == beg_pos - 1) {
     // NO_LINT_DEBUG
-    sql_print_warning("No column family found (options: %s)", input.c_str());
+    LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                    "No column family found (options: %s)", input.c_str());
     return false;
   }
 
@@ -156,8 +156,9 @@ bool Rdb_cf_options::find_options(const std::string &input, size_t *const pos,
   // Make sure we have an open curly brace at the current position.
   if (*pos < input.size() && input[*pos] != '{') {
     // NO_LINT_DEBUG
-    sql_print_warning("Invalid cf options, '{' expected (options: %s)",
-                      input.c_str());
+    LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Invalid cf options, '{' expected (options: %s)",
+                    input.c_str());
     return false;
   }
 
@@ -200,8 +201,9 @@ bool Rdb_cf_options::find_options(const std::string &input, size_t *const pos,
   // We never found the correct number of closing curly braces.
   // Generate an error.
   // NO_LINT_DEBUG
-  sql_print_warning("Mismatched cf options, '}' expected (options: %s)",
-                    input.c_str());
+  LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                  "Mismatched cf options, '}' expected (options: %s)",
+                  input.c_str());
   return false;
 }
 
@@ -222,8 +224,9 @@ bool Rdb_cf_options::find_cf_options_pair(const std::string &input,
   // If we are at the end of the input then we generate an error.
   if (*pos == input.size()) {
     // NO_LINT_DEBUG
-    sql_print_warning("Invalid cf options, '=' expected (options: %s)",
-                      input.c_str());
+    LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Invalid cf options, '=' expected (options: %s)",
+                    input.c_str());
     return false;
   }
 
@@ -242,8 +245,9 @@ bool Rdb_cf_options::find_cf_options_pair(const std::string &input,
   if (*pos < input.size()) {
     if (input[*pos] != ';') {
       // NO_LINT_DEBUG
-      sql_print_warning("Invalid cf options, ';' expected (options: %s)",
-                        input.c_str());
+      LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Invalid cf options, ';' expected (options: %s)",
+                      input.c_str());
       return false;
     }
 
@@ -280,7 +284,8 @@ bool Rdb_cf_options::parse_cf_options(const std::string &cf_options,
                 << cf_options.c_str() << ")";
       if (print_warnings) {
         // NO_LINT_DEBUG
-        sql_print_warning(output->str().c_str());
+        LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG, "%s",
+                        output->str().c_str());
       }
       return false;
     }
@@ -292,7 +297,8 @@ bool Rdb_cf_options::parse_cf_options(const std::string &cf_options,
                 << ")";
       if (print_warnings) {
         // NO_LINT_DEBUG
-        sql_print_warning(output->str().c_str());
+        LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG, "%s",
+                        output->str().c_str());
       }
       return false;
     }
@@ -306,7 +312,8 @@ bool Rdb_cf_options::parse_cf_options(const std::string &cf_options,
                 << " (options: " << cf_options.c_str() << ")";
       if (print_warnings) {
         // NO_LINT_DEBUG
-        sql_print_warning(output->str().c_str());
+        LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG, "%s",
+                        output->str().c_str());
       }
       return false;
     }

--- a/storage/rocksdb/rdb_converter.cc
+++ b/storage/rocksdb/rdb_converter.cc
@@ -26,7 +26,6 @@
 /* MySQL header files */
 #include "./my_stacktrace.h"
 #include "sql/field.h"
-#include "sql/log.h"
 #include "sql/sql_array.h"
 
 /* MyRocks header files */

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -1745,12 +1745,14 @@ void Rdb_key_def::report_checksum_mismatch(const bool is_key,
                                            const char *const data,
                                            const size_t data_size) const {
   // NO_LINT_DEBUG
-  sql_print_error("Checksum mismatch in %s of key-value pair for index 0x%x",
+  LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                  "Checksum mismatch in %s of key-value pair for index 0x%x",
                   is_key ? "key" : "value", get_index_number());
 
   const std::string buf = rdb_hexdump(data, data_size, RDB_MAX_HEXDUMP_LEN);
   // NO_LINT_DEBUG
-  sql_print_error("Data with incorrect checksum (%" PRIu64 " bytes): %s",
+  LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                  "Data with incorrect checksum (%" PRIu64 " bytes): %s",
                   (uint64_t)data_size, buf.c_str());
 
   my_error(ER_INTERNAL_ERROR, MYF(0), "Record checksum mismatch");
@@ -4008,14 +4010,14 @@ bool Rdb_field_packing::setup(const Rdb_key_def *const key_descr,
                                        &space_mb_len);
         } else {
           //  NO_LINT_DEBUG
-          sql_print_warning(
-              "RocksDB: you're trying to create an index "
-              "with a multi-level collation %s",
-              cs->name);
+          LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                          "RocksDB: you're trying to create an index "
+                          "with a multi-level collation %s",
+                          cs->name);
           //  NO_LINT_DEBUG
-          sql_print_warning(
-              "MyRocks will handle this collation internally "
-              "as if it had a NO_PAD attribute.");
+          LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                          "MyRocks will handle this collation internally "
+                          "as if it had a NO_PAD attribute.");
         }
       }
 
@@ -4377,11 +4379,11 @@ bool Rdb_validate_tbls::validate(void) {
       */
       if (m_list.count(expected_db_name) == 0 ||
           m_list[expected_db_name].erase(expected_tbl_name) == 0) {
-        sql_print_warning(
-            "RocksDB: Schema mismatch - "
-            "A DD table exists for table %s.%s, "
-            "but that table is not registered in RocksDB",
-            dbname.c_str(), tablename.c_str());
+        LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                        "RocksDB: Schema mismatch - "
+                        "A DD table exists for table %s.%s, "
+                        "but that table is not registered in RocksDB",
+                        dbname.c_str(), tablename.c_str());
         result = false;
       }
     }
@@ -4399,10 +4401,10 @@ bool Rdb_validate_tbls::validate(void) {
   */
   for (const auto &db : m_list) {
     for (const auto &table : db.second) {
-      sql_print_warning(
-          "Schema mismatch - Table %s.%s is registered in RocksDB "
-          "but does not have a corresponding DD table",
-          db.first.c_str(), table.c_str());
+      LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Schema mismatch - Table %s.%s is registered in RocksDB "
+                      "but does not have a corresponding DD table",
+                      db.first.c_str(), table.c_str());
       result = false;
     }
   }
@@ -4463,12 +4465,12 @@ bool Rdb_ddl_manager::validate_auto_incr() {
     rdb_netbuf_read_gl_index(&ptr, &gl_index_id);
     if (!dict_user_table->get_index_info(gl_index_id, nullptr)) {
       // NO_LINT_DEBUG
-      sql_print_warning(
-          "RocksDB: AUTOINC mismatch - "
-          "Index number (%u, %u) found in AUTOINC "
-          "but does not exist as a DDL entry for table %s",
-          gl_index_id.cf_id, gl_index_id.index_id,
-          safe_get_table_name(gl_index_id).c_str());
+      LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                      "RocksDB: AUTOINC mismatch - "
+                      "Index number (%u, %u) found in AUTOINC "
+                      "but does not exist as a DDL entry for table %s",
+                      gl_index_id.cf_id, gl_index_id.index_id,
+                      safe_get_table_name(gl_index_id).c_str());
       return false;
     }
 
@@ -4476,12 +4478,12 @@ bool Rdb_ddl_manager::validate_auto_incr() {
     const int version = rdb_netbuf_read_uint16(&ptr);
     if (version > Rdb_key_def::AUTO_INCREMENT_VERSION) {
       // NO_LINT_DEBUG
-      sql_print_warning(
-          "RocksDB: AUTOINC mismatch - "
-          "Index number (%u, %u) found in AUTOINC "
-          "is on unsupported version %d for table %s",
-          gl_index_id.cf_id, gl_index_id.index_id, version,
-          safe_get_table_name(gl_index_id).c_str());
+      LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                      "RocksDB: AUTOINC mismatch - "
+                      "Index number (%u, %u) found in AUTOINC "
+                      "is on unsupported version %d for table %s",
+                      gl_index_id.cf_id, gl_index_id.index_id, version,
+                      safe_get_table_name(gl_index_id).c_str());
       return false;
     }
   }
@@ -4529,7 +4531,8 @@ bool Rdb_ddl_manager::init(Rdb_dict_manager_selector *const dict_arg,
 
     if (key.size() <= Rdb_key_def::INDEX_NUMBER_SIZE) {
       // NO_LINT_DEBUG
-      sql_print_error("RocksDB: Table_store: key has length %d (corruption?)",
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "RocksDB: Table_store: key has length %d (corruption?)",
                       (int)key.size());
       return true;
     }
@@ -4541,7 +4544,8 @@ bool Rdb_ddl_manager::init(Rdb_dict_manager_selector *const dict_arg,
     const int real_val_size = val.size() - Rdb_key_def::VERSION_SIZE;
     if (real_val_size % Rdb_key_def::PACKED_SIZE * 2 > 0) {
       // NO_LINT_DEBUG
-      sql_print_error("RocksDB: Table_store: invalid keylist for table %s",
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "RocksDB: Table_store: invalid keylist for table %s",
                       tdef->full_tablename().c_str());
       return true;
     }
@@ -4553,10 +4557,10 @@ bool Rdb_ddl_manager::init(Rdb_dict_manager_selector *const dict_arg,
     const int version = rdb_netbuf_read_uint16(&ptr);
     if (version != Rdb_key_def::DDL_ENTRY_INDEX_VERSION) {
       // NO_LINT_DEBUG
-      sql_print_error(
-          "RocksDB: DDL ENTRY Version was not expected."
-          "Expected: %d, Actual: %d",
-          Rdb_key_def::DDL_ENTRY_INDEX_VERSION, version);
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "RocksDB: DDL ENTRY Version was not expected."
+                      "Expected: %d, Actual: %d",
+                      Rdb_key_def::DDL_ENTRY_INDEX_VERSION, version);
       return true;
     }
     ptr_end = ptr + real_val_size;
@@ -4567,28 +4571,28 @@ bool Rdb_ddl_manager::init(Rdb_dict_manager_selector *const dict_arg,
       struct Rdb_index_info index_info;
       if (!dict_user_table->get_index_info(gl_index_id, &index_info)) {
         // NO_LINT_DEBUG
-        sql_print_error(
-            "RocksDB: Could not get index information "
-            "for Index Number (%u,%u), table %s",
-            gl_index_id.cf_id, gl_index_id.index_id,
-            tdef->full_tablename().c_str());
+        LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                        "RocksDB: Could not get index information "
+                        "for Index Number (%u,%u), table %s",
+                        gl_index_id.cf_id, gl_index_id.index_id,
+                        tdef->full_tablename().c_str());
         return true;
       }
       if (max_index_id_in_dict < gl_index_id.index_id) {
         // NO_LINT_DEBUG
-        sql_print_error(
-            "RocksDB: Found max index id %u from data dictionary "
-            "but also found larger index id %u from dictionary. "
-            "This should never happen and possibly a bug.",
-            max_index_id_in_dict, gl_index_id.index_id);
+        LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                        "RocksDB: Found max index id %u from data dictionary "
+                        "but also found larger index id %u from dictionary. "
+                        "This should never happen and possibly a bug.",
+                        max_index_id_in_dict, gl_index_id.index_id);
         return true;
       }
       if (!dict_user_table->get_cf_flags(gl_index_id.cf_id, &flags)) {
         // NO_LINT_DEBUG
-        sql_print_error(
-            "RocksDB: Could not get Column Family Flags "
-            "for CF Number %d, table %s",
-            gl_index_id.cf_id, tdef->full_tablename().c_str());
+        LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                        "RocksDB: Could not get Column Family Flags "
+                        "for CF Number %d, table %s",
+                        gl_index_id.cf_id, tdef->full_tablename().c_str());
         return true;
       }
 
@@ -4596,10 +4600,10 @@ bool Rdb_ddl_manager::init(Rdb_dict_manager_selector *const dict_arg,
         // The per-index cf option is deprecated.  Make sure we don't have the
         // flag set in any existing database.   NO_LINT_DEBUG
         // NO_LINT_DEBUG
-        sql_print_error(
-            "RocksDB: The defunct AUTO_CF_FLAG is enabled for CF "
-            "number %d, table %s",
-            gl_index_id.cf_id, tdef->full_tablename().c_str());
+        LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                        "RocksDB: The defunct AUTO_CF_FLAG is enabled for CF "
+                        "number %d, table %s",
+                        gl_index_id.cf_id, tdef->full_tablename().c_str());
       }
 
       std::shared_ptr<rocksdb::ColumnFamilyHandle> cfh =
@@ -4656,7 +4660,8 @@ bool Rdb_ddl_manager::init(Rdb_dict_manager_selector *const dict_arg,
     }
     if (validate_tables == 1 && !msg.empty()) {
       // NO_LINT_DEBUG
-      sql_print_error(
+      LogPluginErrMsg(
+          ERROR_LEVEL, ER_LOG_PRINTF_MSG,
           "%s. Use \"rocksdb_validate_tables=2\" to ignore this error.",
           msg.c_str());
       return true;
@@ -4677,8 +4682,8 @@ bool Rdb_ddl_manager::init(Rdb_dict_manager_selector *const dict_arg,
   }
   delete it;
   // NO_LINT_DEBUG
-  sql_print_information("RocksDB: Table_store: loaded DDL data for %d tables",
-                        i);
+  LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                  "RocksDB: Table_store: loaded DDL data for %d tables", i);
 
   initialized = true;
   return false;
@@ -5682,10 +5687,10 @@ int Rdb_dict_manager::remove_orphaned_dropped_cfs(
   for (const auto cf_id : dropped_cf_ids) {
     if (!cf_manager->get_cf(cf_id)) {
       // NO_LINT_DEBUG
-      sql_print_warning(
-          "RocksDB: Column family with id %u doesn't exist in "
-          "cf manager, but it is listed to be dropped",
-          cf_id);
+      LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                      "RocksDB: Column family with id %u doesn't exist in "
+                      "cf manager, but it is listed to be dropped",
+                      cf_id);
 
       if (enable_remove_orphaned_dropped_cfs) {
         delete_dropped_cf_and_flags(batch, cf_id);
@@ -5807,8 +5812,9 @@ void Rdb_dict_manager::add_create_index(
     rocksdb::WriteBatch *const batch) const {
   for (const auto &gl_index_id : gl_index_ids) {
     // NO_LINT_DEBUG
-    sql_print_information("RocksDB: Begin index creation (%u,%u)",
-                          gl_index_id.cf_id, gl_index_id.index_id);
+    LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: Begin index creation (%u,%u)", gl_index_id.cf_id,
+                    gl_index_id.index_id);
     start_create_index(batch, gl_index_id);
   }
 }
@@ -5891,8 +5897,9 @@ void Rdb_dict_manager::rollback_ongoing_index_creation(
 
   for (const auto &gl_index_id : gl_index_ids) {
     // NO_LINT_DEBUG
-    sql_print_information("RocksDB: Removing incomplete create index (%u,%u)",
-                          gl_index_id.cf_id, gl_index_id.index_id);
+    LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: Removing incomplete create index (%u,%u)",
+                    gl_index_id.cf_id, gl_index_id.index_id);
 
     start_drop_index(batch, gl_index_id);
   }
@@ -5956,11 +5963,11 @@ bool Rdb_dict_manager::update_max_index_id(rocksdb::WriteBatch *const batch,
   if (get_max_index_id(&old_index_id)) {
     if (old_index_id > index_id) {
       // NO_LINT_DEBUG
-      sql_print_error(
-          "RocksDB: Found max index id %u from data dictionary "
-          "but trying to update to older value %u. This should "
-          "never happen and possibly a bug.",
-          old_index_id, index_id);
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "RocksDB: Found max index id %u from data dictionary "
+                      "but trying to update to older value %u. This should "
+                      "never happen and possibly a bug.",
+                      old_index_id, index_id);
       return true;
     }
   }

--- a/storage/rocksdb/rdb_index_merge.cc
+++ b/storage/rocksdb/rdb_index_merge.cc
@@ -53,14 +53,16 @@ Rdb_index_merge::~Rdb_index_merge() {
     for (uint i = 0; i < m_merge_file.m_num_sort_buffers; i++) {
       if (my_chsize(m_merge_file.m_fd, curr_size, 0, MYF(MY_WME))) {
         // NO_LINT_DEBUG
-        sql_print_error("Error truncating file during fast index creation.");
+        LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                        "Error truncating file during fast index creation.");
       }
 
       my_sleep(m_merge_tmp_file_removal_delay * 1000);
       // Not aborting on fsync error since the tmp file is not used anymore
       if (mysql_file_sync(m_merge_file.m_fd, MYF(MY_WME))) {
         // NO_LINT_DEBUG
-        sql_print_error("Error flushing truncated MyRocks merge buffer.");
+        LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                        "Error flushing truncated MyRocks merge buffer.");
       }
       curr_size -= m_merge_buf_size;
     }
@@ -116,7 +118,8 @@ int Rdb_index_merge::merge_file_create() {
 
   if (fd < 0) {
     // NO_LINT_DEBUG
-    sql_print_error("Failed to create temp file during fast index creation.");
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Failed to create temp file during fast index creation.");
     return HA_ERR_ROCKSDB_MERGE_FILE_ERR;
   }
 
@@ -152,16 +155,17 @@ int Rdb_index_merge::add(const rocksdb::Slice &key, const rocksdb::Slice &val) {
     */
     if (m_offset_tree.empty()) {
       // NO_LINT_DEBUG
-      sql_print_error(
-          "Current value of rocksdb_merge_buf_size=%llu is too "
-          "small. At least %u bytes required.",
-          m_rec_buf_unsorted->m_total_size, total_offset);
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Current value of rocksdb_merge_buf_size=%lu is too "
+                      "small. At least %u bytes required.",
+                      m_rec_buf_unsorted->m_total_size, total_offset);
       return HA_ERR_ROCKSDB_MERGE_FILE_ERR;
     }
 
     if (merge_buf_write()) {
       // NO_LINT_DEBUG
-      sql_print_error("Error writing sort buffer to disk.");
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Error writing sort buffer to disk.");
       return HA_ERR_ROCKSDB_MERGE_FILE_ERR;
     }
 
@@ -172,10 +176,10 @@ int Rdb_index_merge::add(const rocksdb::Slice &key, const rocksdb::Slice &val) {
                            RDB_MERGE_VAL_DELIMITER + key.size() + val.size();
     if (data_size > m_rec_buf_unsorted->m_total_size) {
       // NO_LINT_DEBUG
-      sql_print_error(
-          "Current value of rocksdb_merge_buf_size=%llu is too "
-          "small. At least %u bytes required.",
-          m_rec_buf_unsorted->m_total_size, data_size);
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Current value of rocksdb_merge_buf_size=%lu is too "
+                      "small. At least %u bytes required.",
+                      m_rec_buf_unsorted->m_total_size, data_size);
       return HA_ERR_ROCKSDB_MERGE_FILE_ERR;
     }
   }
@@ -244,7 +248,8 @@ int Rdb_index_merge::merge_buf_write() {
               m_merge_file.m_num_sort_buffers * m_merge_buf_size, SEEK_SET,
               MYF(0)) == MY_FILEPOS_ERROR) {
     // NO_LINT_DEBUG
-    sql_print_error("Error seeking to location in merge file on disk.");
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Error seeking to location in merge file on disk.");
     return HA_ERR_ROCKSDB_MERGE_FILE_ERR;
   }
 
@@ -257,7 +262,8 @@ int Rdb_index_merge::merge_buf_write() {
                m_output_buf->m_total_size, MYF(MY_WME | MY_NABP)) ||
       mysql_file_sync(m_merge_file.m_fd, MYF(MY_WME))) {
     // NO_LINT_DEBUG
-    sql_print_error("Error writing sorted merge buffer to disk.");
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Error writing sorted merge buffer to disk.");
     return HA_ERR_ROCKSDB_MERGE_FILE_ERR;
   }
 
@@ -321,7 +327,8 @@ int Rdb_index_merge::merge_heap_prepare() {
     /* Read the first record from each buffer to initially populate the heap */
     if (entry->read_rec(&entry->m_key, &entry->m_val)) {
       // NO_LINT_DEBUG
-      sql_print_error("Chunk size is too small to process merge.");
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Chunk size is too small to process merge.");
       return HA_ERR_ROCKSDB_MERGE_FILE_ERR;
     }
 
@@ -368,7 +375,8 @@ int Rdb_index_merge::next(rocksdb::Slice *const key,
   if (m_merge_min_heap.empty()) {
     if ((res = merge_heap_prepare())) {
       // NO_LINT_DEBUG
-      sql_print_error("Error during preparation of heap.");
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Error during preparation of heap.");
       return res;
     }
 
@@ -469,7 +477,8 @@ int Rdb_index_merge::merge_buf_info::read_next_chunk_from_disk(File fd) {
 
   if (my_seek(fd, m_disk_curr_offset, SEEK_SET, MYF(0)) == MY_FILEPOS_ERROR) {
     // NO_LINT_DEBUG
-    sql_print_error("Error seeking to location in merge file on disk.");
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Error seeking to location in merge file on disk.");
     return HA_EXIT_FAILURE;
   }
 
@@ -478,7 +487,8 @@ int Rdb_index_merge::merge_buf_info::read_next_chunk_from_disk(File fd) {
       my_read(fd, m_block.get(), m_block_len, MYF(MY_WME));
   if (bytes_read == (size_t)-1) {
     // NO_LINT_DEBUG
-    sql_print_error("Error reading merge file from disk.");
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Error reading merge file from disk.");
     return HA_EXIT_FAILURE;
   }
 
@@ -581,7 +591,8 @@ size_t Rdb_index_merge::merge_buf_info::prepare(File fd, ulonglong f_offset) {
   */
   if (my_seek(fd, f_offset, SEEK_SET, MYF(0)) == MY_FILEPOS_ERROR) {
     // NO_LINT_DEBUG
-    sql_print_error("Error seeking to location in merge file on disk.");
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Error seeking to location in merge file on disk.");
     return (size_t)-1;
   }
 
@@ -589,7 +600,8 @@ size_t Rdb_index_merge::merge_buf_info::prepare(File fd, ulonglong f_offset) {
       my_read(fd, m_block.get(), m_total_size, MYF(MY_WME));
   if (bytes_read == (size_t)-1) {
     // NO_LINT_DEBUG
-    sql_print_error("Error reading merge file from disk.");
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Error reading merge file from disk.");
     return (size_t)-1;
   }
 

--- a/storage/rocksdb/rdb_index_merge.h
+++ b/storage/rocksdb/rdb_index_merge.h
@@ -19,7 +19,6 @@
 /* MySQL header files */
 #include "mysql/plugin.h"
 #include "sql/handler.h" /* handler */
-#include "sql/log.h"
 
 /* C++ standard header files */
 #include <queue>

--- a/storage/rocksdb/rdb_io_watchdog.cc
+++ b/storage/rocksdb/rdb_io_watchdog.cc
@@ -65,7 +65,8 @@ void Rdb_io_watchdog::io_check_callback(
 
   if (unlikely(ret)) {
     // NO_LINT_DEBUG
-    sql_print_warning("Creating a watchdog I/O timer failed with %d.", errno);
+    LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Creating a watchdog I/O timer failed with %d.", errno);
     RDB_MUTEX_UNLOCK_CHECK(m_reset_mutex);
     return;
   }
@@ -80,8 +81,9 @@ void Rdb_io_watchdog::io_check_callback(
 
   if (unlikely(ret)) {
     // NO_LINT_DEBUG
-    sql_print_warning("Setting time for a watchdog I/O timer failed with %d.",
-                      errno);
+    LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Setting time for a watchdog I/O timer failed with %d.",
+                    errno);
     RDB_MUTEX_UNLOCK_CHECK(m_reset_mutex);
     return;
   }
@@ -96,8 +98,9 @@ void Rdb_io_watchdog::io_check_callback(
     // in other cases as well.
     if (unlikely(ret != HA_EXIT_SUCCESS)) {
       // NO_LINT_DEBUG
-      sql_print_warning("Unable to verify write access to %s (error code %d).",
-                        directory.c_str(), ret);
+      LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                      "Unable to verify write access to %s (error code %d).",
+                      directory.c_str(), ret);
     }
   }
 
@@ -108,7 +111,8 @@ void Rdb_io_watchdog::io_check_callback(
 
   if (unlikely(ret)) {
     // NO_LINT_DEBUG
-    sql_print_warning("Deleting the watchdog I/O timer failed with %d.", errno);
+    LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Deleting the watchdog I/O timer failed with %d.", errno);
   }
 
   m_io_check_watchdog_timer = nullptr;
@@ -166,7 +170,8 @@ int Rdb_io_watchdog::reset_timeout(const uint32_t write_timeout) {
 
   if (unlikely(ret)) {
     // NO_LINT_DEBUG
-    sql_print_warning("Stopping I/O timers failed with %d.", errno);
+    LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Stopping I/O timers failed with %d.", errno);
     RDB_MUTEX_UNLOCK_CHECK(m_reset_mutex);
     return ret;
   }
@@ -209,7 +214,8 @@ int Rdb_io_watchdog::reset_timeout(const uint32_t write_timeout) {
 
   if (unlikely(ret)) {
     // NO_LINT_DEBUG
-    sql_print_warning("Creating a I/O timer failed with %d.", errno);
+    LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Creating a I/O timer failed with %d.", errno);
     RDB_MUTEX_UNLOCK_CHECK(m_reset_mutex);
     return ret;
   }
@@ -225,8 +231,9 @@ int Rdb_io_watchdog::reset_timeout(const uint32_t write_timeout) {
 
   if (unlikely(ret)) {
     // NO_LINT_DEBUG
-    sql_print_warning("Setting time for a watchdog I/O timer failed with %d.",
-                      errno);
+    LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                    "Setting time for a watchdog I/O timer failed with %d.",
+                    errno);
   }
 
   RDB_MUTEX_UNLOCK_CHECK(m_reset_mutex);

--- a/storage/rocksdb/rdb_sst_info.cc
+++ b/storage/rocksdb/rdb_sst_info.cc
@@ -27,7 +27,6 @@
 /* MySQL header files */
 #include "./my_dir.h"
 #include "mysqld_error.h"
-#include "sql/log.h"
 
 /* RocksDB header files */
 #include "rocksdb/db.h"
@@ -86,8 +85,9 @@ rocksdb::Status Rdb_sst_file_ordered::Rdb_sst_file::open() {
   s = m_sst_file_writer->Open(m_name);
   if (m_tracing) {
     // NO_LINT_DEBUG
-    sql_print_information("SST Tracing: Open(%s) returned %s", m_name.c_str(),
-                          s.ok() ? "ok" : "not ok");
+    LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                    "SST Tracing: Open(%s) returned %s", m_name.c_str(),
+                    s.ok() ? "ok" : "not ok");
   }
 
   if (!s.ok()) {
@@ -136,22 +136,23 @@ rocksdb::Status Rdb_sst_file_ordered::Rdb_sst_file::commit() {
   s = m_sst_file_writer->Finish(&fileinfo);
   if (m_tracing) {
     // NO_LINT_DEBUG
-    sql_print_information("SST Tracing: Finish returned %s",
-                          s.ok() ? "ok" : "not ok");
+    LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                    "SST Tracing: Finish returned %s",
+                    s.ok() ? "ok" : "not ok");
   }
 
   if (s.ok()) {
     if (m_tracing) {
       // NO_LINT_DEBUG
-      sql_print_information(
-          "SST Tracing: Adding file %s, smallest key: %s, "
-          "largest key: %s, file size: %" PRIu64
-          ", "
-          "num_entries: %" PRIu64,
-          fileinfo.file_path.c_str(),
-          generateKey(fileinfo.smallest_key).c_str(),
-          generateKey(fileinfo.largest_key).c_str(), fileinfo.file_size,
-          fileinfo.num_entries);
+      LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                      "SST Tracing: Adding file %s, smallest key: %s, "
+                      "largest key: %s, file size: %" PRIu64
+                      ", "
+                      "num_entries: %" PRIu64,
+                      fileinfo.file_path.c_str(),
+                      generateKey(fileinfo.smallest_key).c_str(),
+                      generateKey(fileinfo.largest_key).c_str(),
+                      fileinfo.file_size, fileinfo.num_entries);
     }
   }
 
@@ -535,8 +536,9 @@ void Rdb_sst_info::init(const rocksdb::DB *const db) {
       fs->GetChildren(dir, rocksdb::IOOptions(), &files_in_dir, nullptr);
   if (!s.ok()) {
     // NO_LINT_DEBUG
-    sql_print_warning("RocksDB: Could not access database directory: %s",
-                      dir.c_str());
+    LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: Could not access database directory: %s",
+                    dir.c_str());
     return;
   }
 

--- a/storage/rocksdb/rdb_threads.h
+++ b/storage/rocksdb/rdb_threads.h
@@ -101,7 +101,8 @@ class Rdb_thread : public Ensure_initialized {
     int err = pthread_setname_np(m_handle.thread, m_name.c_str());
     if (err) {
       // NO_LINT_DEBUG
-      sql_print_warning(
+      LogPluginErrMsg(
+          WARNING_LEVEL, ER_LOG_PRINTF_MSG,
           "MyRocks: Failed to set name (%s) for current thread, errno=%d,%d",
           m_name.c_str(), errno, err);
     }

--- a/storage/rocksdb/rdb_utils.cc
+++ b/storage/rocksdb/rdb_utils.cc
@@ -287,13 +287,15 @@ bool rdb_database_exists(const std::string &db_name) {
 void rdb_log_status_error(const rocksdb::Status &s, const char *msg) {
   if (msg == nullptr) {
     // NO_LINT_DEBUG
-    sql_print_error("RocksDB: status error, code: %d, error message: %s",
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: status error, code: %d, error message: %s",
                     s.code(), s.ToString().c_str());
     return;
   }
 
   // NO_LINT_DEBUG
-  sql_print_error("RocksDB: %s, Status Code: %d, Status: %s", msg, s.code(),
+  LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                  "RocksDB: %s, Status Code: %d, Status: %s", msg, s.code(),
                   s.ToString().c_str());
 }
 
@@ -321,23 +323,24 @@ void rdb_persist_corruption_marker() {
 
   if (!io_s.ok()) {
     // NO_LINT_DEBUG
-    sql_print_error(
-        "RocksDB: Can't create file %s to mark rocksdb as "
-        "corrupted.",
-        fileName.c_str());
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: Can't create file %s to mark rocksdb as "
+                    "corrupted.",
+                    fileName.c_str());
   } else {
     // NO_LINT_DEBUG
-    sql_print_information(
-        "RocksDB: Creating the file %s to abort mysqld "
-        "restarts. Remove this file from the data directory "
-        "after fixing the corruption to recover. ",
-        fileName.c_str());
+    LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: Creating the file %s to abort mysqld "
+                    "restarts. Remove this file from the data directory "
+                    "after fixing the corruption to recover. ",
+                    fileName.c_str());
   }
 
   io_s = file->Close(rocksdb::IOOptions(), nullptr);
   if (!io_s.ok()) {
     // NO_LINT_DEBUG
-    sql_print_error("RocksDB: Error (%s) closing the file %s",
+    LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                    "RocksDB: Error (%s) closing the file %s",
                     io_s.ToString().c_str(), fileName.c_str());
   }
 }

--- a/storage/rocksdb/rdb_utils.h
+++ b/storage/rocksdb/rdb_utils.h
@@ -23,8 +23,10 @@
 /* MySQL header files */
 #include "./my_stacktrace.h"
 #include "./sql_string.h"
-#include "sql/log.h"
 #include "sql/mysqld.h"
+#define LOG_COMPONENT_TAG "rocksdb"
+#include "mysql/components/services/log_builtins.h"
+#include "mysqld_error.h"
 
 /* RocksDB header files */
 #include "rocksdb/slice.h"
@@ -226,7 +228,8 @@ MY_ATTRIBUTE((cold, noreturn,
               noinline)) void rdb_fatal_error(const char *fmt,
                                               Params &&...params) {
   // NO_LINT_DEBUG
-  sql_print_error(fmt, std::forward<Params>(params)...);
+  LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG, fmt,
+                  std::forward<Params>(params)...);
   abort();
 }
 
@@ -377,8 +380,9 @@ class Rdb_exec_time {
     result += "}";
 
     /* NO_LINT_DEBUG */
-    sql_print_information("MyRocks: rdb execution report (microsec): %s",
-                          result.c_str());
+    LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                    "MyRocks: rdb execution report (microsec): %s",
+                    result.c_str());
   }
 };
 


### PR DESCRIPTION
Summary:
Prior to this diff, fb-mysql MyRocks only supported static plugins, and used sql_print_* APIs for logging, which was not available for dynamic plugins.

This diff allows to create either static or dynamic plugins, depending on -DMYSQL_DYNAMIC_PLUGIN. In addition to that, adding another option to skip creating MyRocks plugin by -DWITHOUT_ROCKSDB_STORAGE_ENGINE.

Without -DMYSQL_DYNAMIC_PLUGIN, it creates static plugin, basically the same behavior as before.
With -DMYSQL_DYNAMIC_PLUGIN, it creates dynamic plugin, and using plugin logging functions (LogPluginErr). Linking with other libraries such as jemalloc is adjusted accordingly.

Test Plan: mtr with dynamic builds