### PR TITLE
m_auto_incr_map: reduce a redundant search operation

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -4200,14 +4200,15 @@ class Rdb_transaction {
   }
 
   void set_auto_incr(const GL_INDEX_ID &gl_index_id, ulonglong curr_id) {
-    m_auto_incr_map[gl_index_id] =
-        std::max(m_auto_incr_map[gl_index_id], curr_id);
+    auto& existing = m_auto_incr_map[gl_index_id];
+    existing = std::max(existing, curr_id);
   }
 
 #ifndef NDEBUG
   ulonglong get_auto_incr(const GL_INDEX_ID &gl_index_id) {
-    if (m_auto_incr_map.count(gl_index_id) > 0) {
-      return m_auto_incr_map[gl_index_id];
+    auto iter = m_auto_incr_map.find(gl_index_id);
+    if (m_auto_incr_map.end() != iter) {
+      return iter->second;
     }
     return 0;
   }


### PR DESCRIPTION
This PR reduced redundant searchs on `m_auto_incr_map`.