### PR TITLE
Fix -Wformat-security warning for variadic templates

### DIFF
--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -181,9 +181,6 @@ SET(ROCKSDB_SOURCES
   ${ROCKSDB_LIB_SOURCES}
 )
 
-# To avoid compiler error on rdb_fatal_error() in rdb_util.h
-add_compile_flags(${ROCKSDB_SOURCES} COMPILE_FLAGS "-Wno-format-security")
-
 IF(WITH_FB_TSAN OR ROCKSDB_DYNAMIC_PLUGIN)
   SET(PIC_EXT "_pic")
 ELSE()

--- a/storage/rocksdb/rdb_utils.cc
+++ b/storage/rocksdb/rdb_utils.cc
@@ -284,6 +284,12 @@ bool rdb_database_exists(const std::string &db_name) {
   return true;
 }
 
+void rdb_fatal_error(const char *msg) {
+  // NO_LINT_DEBUG
+  LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG, "%s", msg);
+  abort();
+}
+
 void rdb_log_status_error(const rocksdb::Status &s, const char *msg) {
   if (msg == nullptr) {
     // NO_LINT_DEBUG


### PR DESCRIPTION
If -Wformat-security is enabled,
rdb_fatal_error(... "not a printf format string")
gives
rdb_utils.h:254:27: error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
  myrocks_sql_print_error(fmt, std::forward<Params>(params)...);

Fix by introducing an rdb_fatal_error overload for messages without format strings, i.e. the ones which could serve as a parameter for a "%s" format string.

At the same time at a format function attribute for rdb_fatal_error for supported compilers, which at the moment are clang >= 15.