### PR TITLE
Use PRIu64 instead of %lu to format std::uint64_t values

### DIFF
--- a/sql/rpc_plugin.cc
+++ b/sql/rpc_plugin.cc
@@ -302,13 +302,13 @@ bypass_rpc_exception bypass_select(const myrocks_select_from_rpc *param) {
 
   if (check_hlc_bound(current_thd, param)) {
     char error_msg[180];
-    snprintf(
-        error_msg, sizeof(error_msg) / sizeof(char),
-        "Requested HLC timestamp %lu is higher than current engine HLC of %lu "
-        "for database %s",
-        param->hlc_lower_bound_ts,
-        mysql_bin_log.get_selected_database_hlc(param->db_name),
-        param->db_name.c_str());
+    snprintf(error_msg, sizeof(error_msg) / sizeof(char),
+             "Requested HLC timestamp %" PRIu64
+             " is higher than current engine HLC of %" PRIu64
+             " for database %s",
+             param->hlc_lower_bound_ts,
+             mysql_bin_log.get_selected_database_hlc(param->db_name),
+             param->db_name.c_str());
 
     bypass_rpc_exception ret{ER_STALE_HLC_READ, "MYF(0)", error_msg};
     return ret;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -1055,13 +1055,13 @@ static int rocksdb_tracing(THD *const thd MY_ATTRIBUTE((__unused__)),
     return HA_EXIT_FAILURE;
   }
   // NO_LINT_DEBUG
-  LogPluginErrMsg(
-      INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
-      "RocksDB: Start tracing block cache accesses or queries. Sampling "
-      "frequency: %lu, "
-      "Maximum trace file size: %lu, Trace file path %s.\n",
-      trace_opt.sampling_frequency, trace_opt.max_trace_file_size,
-      trace_file_path.c_str());
+  LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
+                  "RocksDB: Start tracing block cache accesses or queries. "
+                  "Sampling frequency: %" PRIu64
+                  ", Maximum trace file size: %" PRIu64
+                  ", Trace file path %s.\n",
+                  trace_opt.sampling_frequency, trace_opt.max_trace_file_size,
+                  trace_file_path.c_str());
   // Save the trace option.
   *static_cast<const char **>(save) = trace_opt_str_raw;
   return HA_EXIT_SUCCESS;

--- a/storage/rocksdb/rdb_index_merge.cc
+++ b/storage/rocksdb/rdb_index_merge.cc
@@ -156,8 +156,8 @@ int Rdb_index_merge::add(const rocksdb::Slice &key, const rocksdb::Slice &val) {
     if (m_offset_tree.empty()) {
       // NO_LINT_DEBUG
       LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                      "Current value of rocksdb_merge_buf_size=%lu is too "
-                      "small. At least %u bytes required.",
+                      "Current value of rocksdb_merge_buf_size=%" PRIu64
+                      " is too small. At least %u bytes required.",
                       m_rec_buf_unsorted->m_total_size, total_offset);
       return HA_ERR_ROCKSDB_MERGE_FILE_ERR;
     }
@@ -177,8 +177,8 @@ int Rdb_index_merge::add(const rocksdb::Slice &key, const rocksdb::Slice &val) {
     if (data_size > m_rec_buf_unsorted->m_total_size) {
       // NO_LINT_DEBUG
       LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                      "Current value of rocksdb_merge_buf_size=%lu is too "
-                      "small. At least %u bytes required.",
+                      "Current value of rocksdb_merge_buf_size=%" PRIu64
+                      " is too small. At least %u bytes required.",
                       m_rec_buf_unsorted->m_total_size, data_size);
       return HA_ERR_ROCKSDB_MERGE_FILE_ERR;
     }


### PR DESCRIPTION
This fixes the macOS build, where std::uint64_t is unsigned long long.