### PR TITLE
Disable rocksdb_clone.remote_kill_donor test until 8.0.30 merge

### DIFF
--- a/mysql-test/collections/disabled.def
+++ b/mysql-test/collections/disabled.def
@@ -90,6 +90,9 @@ rpl_gtid.rpl_gtid_perfschema_applier_xa_status           : BUG#27914287 Disabled
 rpl_gtid.rpl_gtid_mts_spco_deadlock_other_locks          : Bug#32499883 RPL_GTID.RPL_GTID_MTS_SPCO_DEADLOCK_OTHER_LOCKS FAILS ON PB2
 rpl_gtid.rpl_start_replica_until_pos_with_gtid_only      : Bug#33119241 START REPLICA UNTIL SOURCE_LOG_POS SHOULD NOT STOP ON REPLICA EVENTS
 
+# rocksdb_clone suite tests
+rocksdb_clone.remote_kill_donor : BUG#00000000 : re-enable after 8.0.30 rebase with better OpenSSL 3 support
+
 # rpl_nogtid suite tests
 rpl_nogtid.rpl_perfschema_applier_xa_status_check : BUG#27914287 Disabled until the WL#9075 (Performance Schema, XA Transactions) be implemented
 rpl_nogtid.rpl_binlog_format_errors               : BUG#29776083 EXPLICIT BINLOG INJECTION WITH SELF LOGGING ENGINES IS BROKEN


### PR DESCRIPTION
It crashes intermittently with

mysqld: /home/laurynas/vilniusdb/fb-clone-8.0.28-staging/vio/viossl.cc:322: size_t vio_ssl_write(Vio *, const uchar *, size_t): Assertion `ERR_peek_error() == 0' failed.

The assertion is not clone-specific. It may happen whenever one of the SSL-connected servers is killed. The assertion happens up to MySQL 8.0.29, and stops happening with 8.0.30, with the OpenSSL 3.0 support patch (a0132f53d93). It is too much effort to backport that patch, thus disable the testcase until the 8.0.30 rebase.