### PR TITLE
socket_connection.cc: remove redundant brace

### DIFF
--- a/sql/conn_handler/socket_connection.cc
+++ b/sql/conn_handler/socket_connection.cc
@@ -1342,7 +1342,7 @@ const Listen_socket *Mysqld_socket_listener::get_listen_socket() {
     if (m_poll_info.m_fds[i].revents & POLLIN)
 #else  // HAVE_POLL
     if (FD_ISSET(mysql_socket_getfd(m_socket_vector[i].m_socket),
-                 &m_select_info.m_read_fds)) {
+                 &m_select_info.m_read_fds))
 #endif  // HAVE_POLL
     {
       return &m_socket_vector[i];


### PR DESCRIPTION
The `else` conditional compile branch of `HAVE_POLL` has a redundant `{`.

This PR fix this issue