### PR TITLE
Add dd default engine

### DIFF
--- a/mysql-test/suite/sys_vars/r/default_dd_storage_engine_basic.result
+++ b/mysql-test/suite/sys_vars/r/default_dd_storage_engine_basic.result
@@ -1,0 +1,11 @@
+SET @start_global_value = @@global.default_dd_storage_engine;
+SELECT @start_global_value;
+@start_global_value
+InnoDB
+select @@global.default_dd_storage_engine;
+@@global.default_dd_storage_engine
+InnoDB
+select @@session.default_dd_storage_engine;
+ERROR HY000: Variable 'default_dd_storage_engine' is a GLOBAL variable
+SET @@global.default_dd_storage_engine = @start_global_value;
+ERROR HY000: Variable 'default_dd_storage_engine' is a read only variable

--- a/mysql-test/suite/sys_vars/t/default_dd_storage_engine_basic.test
+++ b/mysql-test/suite/sys_vars/t/default_dd_storage_engine_basic.test
@@ -1,0 +1,14 @@
+--source include/load_sysvars.inc
+
+SET @start_global_value = @@global.default_dd_storage_engine;
+SELECT @start_global_value;
+
+select @@global.default_dd_storage_engine;
+
+# Global variable
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+select @@session.default_dd_storage_engine;
+
+# Read only variable
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SET @@global.default_dd_storage_engine = @start_global_value;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1158,6 +1158,7 @@ bool listen_admin_interface_in_separate_thread;
 static const char *default_collation_name;
 const char *default_storage_engine;
 const char *default_tmp_storage_engine;
+ulong default_dd_storage_engine;
 ulonglong temptable_max_ram;
 ulonglong temptable_max_mmap;
 bool temptable_track_shared_block_ram = false;

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -272,6 +272,11 @@ extern char *default_tz_name;
 extern Time_zone *default_tz;
 extern const char *default_storage_engine;
 extern const char *default_tmp_storage_engine;
+enum enum_dd_default_engine {
+  DEFAULT_DD_INNODB,
+  DEFAULT_DD_ROCKSDB,
+};
+extern ulong default_dd_storage_engine;
 extern ulonglong temptable_max_ram;
 extern ulonglong temptable_max_mmap;
 extern bool temptable_track_shared_block_ram;

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -6071,6 +6071,14 @@ static Sys_var_plugin Sys_default_tmp_storage_engine(
     MYSQL_STORAGE_ENGINE_PLUGIN, DEFAULT(&default_tmp_storage_engine),
     NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(check_storage_engine));
 
+static const char *dd_storage_engine[] = {"InnoDB", "RocksDB", NullS};
+static Sys_var_enum Sys_default_dd_storage_engine(
+    "default_dd_storage_engine",
+    "The default storage engine for data dictionary",
+    READ_ONLY GLOBAL_VAR(default_dd_storage_engine), NO_CMD_LINE,
+    dd_storage_engine, DEFAULT(DEFAULT_DD_INNODB), NO_MUTEX_GUARD,
+    NOT_IN_BINLOG, ON_CHECK(0), ON_UPDATE(0));
+
 #if defined(ENABLED_DEBUG_SYNC)
 /*
   Variable can be set for the session only.


### PR DESCRIPTION
Summary: Add global read only variable for dd default storage engine

Test Plan: MTR test

Reviewers:

Subscribers:

Tasks:

Tags: