### PR TITLE
Create rocksdb_datadir if not exist

### DIFF
--- a/mysql-test/suite/rocksdb/r/check_datadir_existence.result
+++ b/mysql-test/suite/rocksdb/r/check_datadir_existence.result
@@ -1,0 +1,12 @@
+# shut server down
+# Server is down
+#
+# Try --initialize
+#
+# Run the server with --initialize
+# Remove data dir and log file.
+#
+# Cleanup
+#
+# Restarting the server
+# restart

--- a/mysql-test/suite/rocksdb/t/check_datadir_existence.test
+++ b/mysql-test/suite/rocksdb/t/check_datadir_existence.test
@@ -1,0 +1,32 @@
+--source include/have_rocksdb.inc
+# Make sure mysqld will not crash when creating a new db instance,
+# if rocksdb_wal_dir and rocksdb_datadir both exist and are different
+
+let BASEDIR= `select @@basedir`;
+let DDIR=$MYSQL_TMP_DIR/installdb_test;
+let WDIR=$MYSQL_TMP_DIR/waltest;
+let MYSQLD_LOG=$MYSQL_TMP_DIR/server.log;
+let extra_args=--no-defaults --basedir=$BASEDIR;
+
+--echo # shut server down
+--source include/shutdown_mysqld.inc
+--echo # Server is down
+
+--echo #
+--echo # Try --initialize
+--echo #
+
+--echo # Run the server with --initialize
+--exec $MYSQLD $extra_args --initialize --datadir=$DDIR --rocksdb_wal_dir=$WDIR --log-error-verbosity=1 > $MYSQLD_LOG 2>&1
+
+--echo # Remove data dir and log file.
+--remove_file $MYSQLD_LOG
+--force-rmdir $DDIR
+--error 1,0
+--force-rmdir $WDIR
+
+--echo #
+--echo # Cleanup
+--echo #
+--echo # Restarting the server
+--source include/start_mysqld.inc

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -7193,6 +7193,10 @@ static void move_wals_to_target_dir() {
         (my_errno() != EEXIST))
       rdb_fatal_error("Failed to create %s", rocksdb_wal_dir);
 
+    if ((my_mkdir(rocksdb_datadir, S_IRWXU, MYF(0)) == -1) &&
+        (my_errno() != EEXIST))
+      rdb_fatal_error("Failed to create %s", rocksdb_datadir);
+
     for_each_in_dir(
         rocksdb_datadir, MY_WANT_STAT | MY_FAE, [](const fileinfo &f_info) {
           if (!S_ISREG(f_info.mystat->st_mode) ||


### PR DESCRIPTION
Summary: When rebuilding a db, mysqld fails because it can not find rocksdb_datadir in move_wals_to_target_dir(). rocksdb_datadir has not been created at the time, but move_wals_to_target_dir() assumes it has. 

Add a check about rocksdb_datadir, if it doesn't exist, create the path.

The reason why we never hit this before is, when we test the clone, the db has already been built and the rocksdb_datadir has been created. 

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: