### PR TITLE
Do not try to access plugin name for unloaded plugins

### DIFF
--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -1441,9 +1441,9 @@ static bool plugin_init_initialize_and_reap() {
   for (st_plugin_int **it = plugin_array->begin(); it != plugin_array->end();
        ++it) {
     plugin_ptr = *it;
-    // Delay initialze raft plugin
-    if (0 == strcmp(plugin_ptr->name.str, raft_plugin_name.str)) continue;
-    if (plugin_ptr->state == PLUGIN_IS_UNINITIALIZED) {
+    // Delay initialization of raft plugin
+    if (plugin_ptr->state == PLUGIN_IS_UNINITIALIZED &&
+        strcmp(plugin_ptr->name.str, raft_plugin_name.str) != 0) {
       if (plugin_initialize(plugin_ptr)) {
         plugin_ptr->state = PLUGIN_IS_DYING;
         *(reap++) = plugin_ptr;


### PR DESCRIPTION
If early plugin initialization fails, the plugin is unloaded with its entry remaining in plugin_array with PLUGIN_IS_FREED. The unloading of plugin will call dlclose, potentially unmapping its memory, including the plugin name constant. This may cause a crash in plugin_init_initialize_and_reap in the code which delays the raft plugin initialization by comparing its name. The crash is seen on macOS, MTR test perfschema.table_plugin_early_load, on a sanitizer-less build (enabling sanitizers disables the dlclose call).

Fix by moving plugin name check after the plugin state check, which excludes the PLUGIN_IS_FREED entries.

Squash with 0cf9341ab0a9751a8895dd073fc6ae9f3aa0bd89