### PR TITLE
[MyRocksDD] Disable DESC for mysql.password_history when creating sys…

### DIFF
--- a/mysql-test/suite/rocksdb/t/early_load_rocksdb_plugin.test
+++ b/mysql-test/suite/rocksdb/t/early_load_rocksdb_plugin.test
@@ -1,4 +1,5 @@
 --source include/have_rocksdb.inc
+--source include/have_debug.inc
 
 # Set the default ddse to Rocksdb
 # Bootstrap by starting mysqld with --initialize
@@ -7,8 +8,7 @@
 let BASEDIR= `select @@basedir`;
 let DDIR=$MYSQL_TMP_DIR/installdb_test;
 let MYSQLD_LOG=$MYSQL_TMP_DIR/server.log;
-let extra_args=--no-defaults --basedir=$BASEDIR;
-
+let extra_args=--no-defaults --basedir=$BASEDIR --debug=+d,ddse_rocksdb;
 
 --echo # shut server down
 --source include/shutdown_mysqld.inc

--- a/scripts/mysql_system_tables.sql
+++ b/scripts/mysql_system_tables.sql
@@ -26,6 +26,7 @@
 
 set @have_innodb= (select count(engine) from information_schema.engines where engine='INNODB' and support != 'NO');
 set @is_mysql_encrypted = (select ENCRYPTION from information_schema.INNODB_TABLESPACES where NAME='mysql');
+set @ddse= (select @@default_dd_storage_engine);
 
 -- Tables below are NOT treated as DD tables by MySQL server yet.
 
@@ -183,11 +184,8 @@ SET @cmd = "CREATE TABLE IF NOT EXISTS password_history
   Host CHAR(255) CHARACTER SET ASCII DEFAULT '' NOT NULL,
   User CHAR(80) BINARY DEFAULT '' NOT NULL,
   Password_timestamp TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-  Password TEXT,
-  PRIMARY KEY(Host, User, Password_timestamp DESC)
- ) engine=InnoDB STATS_PERSISTENT=0 CHARACTER SET utf8 COLLATE utf8_bin
- comment='Password history for user accounts' ROW_FORMAT=DYNAMIC TABLESPACE=mysql";
-SET @str = CONCAT(@cmd, " ENCRYPTION='", @is_mysql_encrypted, "'");
+  Password TEXT,";
+SET @str = IF(@ddse = 'ROCKSDB', CONCAT(@cmd, "PRIMARY KEY(Host, User, Password_timestamp))", " engine=ROCKSDB CHARACTER SET utf8 COLLATE utf8_bin comment='Password history for user accounts'"), CONCAT(@cmd, "PRIMARY KEY(Host, User, Password_timestamp DESC))", " engine=InnoDB STATS_PERSISTENT=0 CHARACTER SET utf8 COLLATE utf8_bin comment='Password history for user accounts' ROW_FORMAT=DYNAMIC TABLESPACE=mysql", " ENCRYPTION='", @is_mysql_encrypted, "'"));
 PREPARE stmt FROM @str;
 EXECUTE stmt;
 DROP PREPARE stmt;

--- a/storage/rocksdb/rdb_native_dd.cc
+++ b/storage/rocksdb/rdb_native_dd.cc
@@ -16,6 +16,7 @@
 
 /* This C++ file's header file */
 #include "rdb_native_dd.h"
+#include <cstring>
 
 /* MySQL header files */
 #include "sql/dd/types/table.h"  // dd::Table
@@ -64,7 +65,15 @@ bool rocksdb_dict_set_server_version() {
       ->set_server_version();
 };
 
-bool rocksdb_is_supported_system_table(const char *, const char *, bool) {
+bool rocksdb_is_supported_system_table([[maybe_unused]] const char *db_name,
+                                       [[maybe_unused]] const char *tbl_name,
+                                       bool) {
+  DBUG_EXECUTE_IF("ddse_rocksdb", {
+    if (strcmp(db_name, "mysql") == 0 &&
+        strcmp(tbl_name, "password_history") == 0) {
+      return true;
+    }
+  });
   return false;
 }
 


### PR DESCRIPTION
…tem table

Summary: Myrocks doesn't support DESC. Disable DESC when creating rocksdb system tables.

Test Plan: Don't break current MTR

Reviewers:

Subscribers:

Tasks:

Tags: