### PR TITLE
Index read fixes

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -11037,6 +11037,7 @@ int ha_rocksdb::index_next_same(uchar *const buf,
 
   if (m_full_key_lookup) {
 #ifndef NDEBUG
+    assert(active_index != MAX_KEY);
     uint len = calculate_key_len(table, active_index, HA_WHOLE_KEY);
     assert(len == keylen);
 #endif
@@ -12763,9 +12764,6 @@ void ha_rocksdb::check_build_decoder() {
 int ha_rocksdb::index_init(uint idx, bool sorted MY_ATTRIBUTE((__unused__))) {
   DBUG_ENTER_FUNC();
 
-  m_need_build_decoder = true;
-  active_index = idx;
-
   THD *thd = ha_thd();
   if (thd && thd->killed) {
     DBUG_RETURN(HA_ERR_QUERY_INTERRUPTED);
@@ -12774,6 +12772,8 @@ int ha_rocksdb::index_init(uint idx, bool sorted MY_ATTRIBUTE((__unused__))) {
   Rdb_transaction *const tx =
       get_or_create_tx(thd, m_tbl_def->get_table_type());
   assert(tx != nullptr);
+
+  m_need_build_decoder = true;
 
   active_index = idx;
   if (idx != table->s->primary_key &&


### PR DESCRIPTION
Minor index access cleanups for MyRocks:
- `ha_rocksdb::index_init`: remove duplicate `active_index` assignment. Move
  `m_need_build_decoder` assignment past the error exit so that taking it does not
  result in any state changes.
- `ha_rocksdb::index_next_same`: add an assert for `active_index` value to prevent
  out-of-bound accesses in the next line.