### PR TITLE
Add multiple checks for clone

### DIFF
--- a/mysql-test/suite/rocksdb_clone/r/remote_se_check.result
+++ b/mysql-test/suite/rocksdb_clone/r/remote_se_check.result
@@ -1,0 +1,27 @@
+INSTALL PLUGIN clone SONAME 'CLONE_PLUGIN';
+SET global debug="+d,client_has_less_se";
+SET GLOBAL clone_autotune_concurrency = OFF;
+SET GLOBAL clone_max_concurrency = 8;
+SET GLOBAL clone_valid_donor_list = 'HOST:PORT';
+CLONE INSTANCE FROM USER@HOST:PORT IDENTIFIED BY '' DATA DIRECTORY = 'CLONE_DATADIR';
+ERROR 08S01: Got an error reading communication packets
+select ID, STATE, ERROR_NO from performance_schema.clone_status;
+ID	STATE	ERROR_NO
+1	Failed	1158
+select ID, STAGE, STATE from performance_schema.clone_progress;
+ID	STAGE	STATE
+SET global debug="-d,client_has_less_se";
+SET global debug="+d,client_has_more_se";
+SET GLOBAL clone_autotune_concurrency = OFF;
+SET GLOBAL clone_max_concurrency = 8;
+SET GLOBAL clone_valid_donor_list = 'HOST:PORT';
+CLONE INSTANCE FROM USER@HOST:PORT IDENTIFIED BY '' DATA DIRECTORY = 'CLONE_DATADIR';
+ERROR 08S01: Got an error reading communication packets
+select ID, STATE, ERROR_NO from performance_schema.clone_status;
+ID	STATE	ERROR_NO
+1	Failed	1158
+select ID, STAGE, STATE from performance_schema.clone_progress;
+ID	STAGE	STATE
+SET global debug="-d,client_has_more_se";
+# restart
+UNINSTALL PLUGIN clone;

--- a/mysql-test/suite/rocksdb_clone/t/remote_se_check.test
+++ b/mysql-test/suite/rocksdb_clone/t/remote_se_check.test
@@ -1,0 +1,35 @@
+--source include/have_debug.inc
+--source include/have_rocksdb.inc
+
+--let $HOST = 127.0.0.1
+--let $PORT =`select @@port`
+--let $USER = root
+--let remote_clone = 1
+
+--source ../../clone/include/clone_connection_begin.inc
+--let $CLONE_DATADIR = $MYSQL_TMP_DIR/data_new
+
+# Install Clone Plugin
+--replace_result $CLONE_PLUGIN CLONE_PLUGIN
+--eval INSTALL PLUGIN clone SONAME '$CLONE_PLUGIN'
+
+# Clone
+--connection clone_conn_1
+SET global debug="+d,client_has_less_se";
+--let $clone_remote_err = 1158
+--source ../../clone/include/clone_command.inc
+SET global debug="-d,client_has_less_se";
+--let $clone_remote_err = 0
+
+SET global debug="+d,client_has_more_se";
+--let $clone_remote_err = 1158
+--source ../../clone/include/clone_command.inc
+SET global debug="-d,client_has_more_se";
+--let $clone_remote_err = 0
+
+--let restart_parameters=
+--source include/restart_mysqld.inc
+
+# Clean up
+UNINSTALL PLUGIN clone;
+--source ../../clone/include/clone_connection_end.inc

--- a/plugin/clone/include/clone_hton.h
+++ b/plugin/clone/include/clone_hton.h
@@ -75,6 +75,9 @@ struct Locator {
       /* Should not lock plugin for auxiliary threads */
       assert(thd != nullptr);
 
+      DBUG_EXECUTE_IF("client_has_more_se", if (db_type == DB_TYPE_ROCKSDB)
+                                                db_type = DB_TYPE_UNKNOWN;);
+
       m_hton = ha_resolve_by_legacy_type(thd, db_type);
 
     } else {

--- a/plugin/clone/src/clone_server.cc
+++ b/plugin/clone/src/clone_server.cc
@@ -381,6 +381,12 @@ int Server::deserialize_init_buffer(const uchar *init_buf, size_t init_len) {
       goto err_end;
     }
 
+    if (!loc.m_hton) {
+      my_error(ER_CLONE_PROTOCOL, MYF(0),
+               "storage engine plugin set mismatch between donor and client");
+      return (ER_CLONE_PROTOCOL);
+    }
+
     m_storage_vec.push_back(loc);
 
     init_len -= serialized_length;


### PR DESCRIPTION
Summary: 

This diff add two checks:
1. mysqld version check will change from major version check to strict version check. Need to change the config name to version_comment to achieve this.
2. Check the client and donor have the same default storage engine plugin.

Test Plan: Test by running clone

Reviewers:

Subscribers:

Tasks:

Tags: