### PR TITLE
Add set/get server version api

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -7434,6 +7434,8 @@ static int rocksdb_init_internal(void *const p) {
   rocksdb_hton->clone_interface.clone_apply_end = rocksdb_clone_apply_end;
 
   rocksdb_hton->dict_register_dd_table_id = rocksdb_dict_register_dd_table_id;
+  rocksdb_hton->dict_get_server_version = rocksdb_dict_get_server_version;
+  rocksdb_hton->dict_set_server_version = rocksdb_dict_set_server_version;
 
   rocksdb_hton->flags = HTON_SUPPORTS_EXTENDED_KEYS | HTON_CAN_RECREATE;
 

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -5311,6 +5311,11 @@ bool Rdb_dict_manager::init(rocksdb::TransactionDB *const rdb_dict,
       rocksdb::Slice(reinterpret_cast<char *>(m_key_buf_max_index_id),
                      Rdb_key_def::INDEX_NUMBER_SIZE);
 
+  rdb_netbuf_store_index(m_key_buf_server_version, Rdb_key_def::SERVER_VERSION);
+  m_key_slice_server_version =
+      rocksdb::Slice(reinterpret_cast<char *>(m_key_buf_server_version),
+                     Rdb_key_def::INDEX_NUMBER_SIZE);
+
   resume_drop_indexes();
   rollback_ongoing_index_creation();
 
@@ -6031,6 +6036,39 @@ bool Rdb_dict_manager::update_max_index_id(rocksdb::WriteBatch *const batch,
   }
 
   return false;
+}
+
+bool Rdb_dict_manager::get_server_version(uint *const ser_version) const {
+  std::string value;
+
+  const rocksdb::Status status = get_value(m_key_slice_server_version, &value);
+  if (status.ok()) {
+    Rdb_string_reader reader(value);
+    uint version = 0;
+    reader.read_uint16(&version);
+    if (version == Rdb_key_def::SERVER_VERSION_VERSION) {
+      return reader.read_uint32(ser_version);
+    }
+  }
+
+  return true;
+}
+
+bool Rdb_dict_manager::set_server_version() const {
+  const std::unique_ptr<rocksdb::WriteBatch> batch = begin();
+
+  Rdb_buf_writer<Rdb_key_def::VERSION_SIZE + Rdb_key_def::SERVER_VERSION_SIZE>
+      value_writer;
+
+  uint32 server_ver = MYSQL_VERSION_ID;
+  value_writer.write_uint16(Rdb_key_def::SERVER_VERSION_VERSION);
+  value_writer.write_uint32(server_ver);
+  const rocksdb::Status status = batch.get()->Put(
+      m_system_cfh, m_key_slice_server_version, value_writer.to_slice());
+
+  commit(batch.get());
+
+  return !status.ok();
 }
 
 void Rdb_dict_manager::add_stats(

--- a/storage/rocksdb/rdb_native_dd.cc
+++ b/storage/rocksdb/rdb_native_dd.cc
@@ -22,6 +22,8 @@
 
 /* MyRocks header files */
 #include "ha_rocksdb.h"
+#include "storage/rocksdb/ha_rocksdb_proto.h"
+#include "storage/rocksdb/rdb_datadic.h"
 
 namespace myrocks {
 std::unordered_set<dd::Object_id> native_dd::s_dd_table_ids = {};
@@ -48,6 +50,18 @@ void native_dd::clear_dd_table_ids() { s_dd_table_ids.clear(); }
 
 void rocksdb_dict_register_dd_table_id(dd::Object_id dd_table_id) {
   native_dd::insert_dd_table_ids(dd_table_id);
+};
+
+bool rocksdb_dict_get_server_version(uint *version) {
+  return rdb_get_dict_manager()
+      ->get_dict_manager_selector_non_const(false /*is_tmp_table*/)
+      ->get_server_version(version);
+};
+
+bool rocksdb_dict_set_server_version() {
+  return rdb_get_dict_manager()
+      ->get_dict_manager_selector_non_const(false /*is_tmp_table*/)
+      ->set_server_version();
 };
 
 }  // namespace myrocks

--- a/storage/rocksdb/rdb_native_dd.h
+++ b/storage/rocksdb/rdb_native_dd.h
@@ -16,6 +16,7 @@
 #pragma once
 
 /* C++ standard header files */
+#include <sys/types.h>
 #include <unordered_set>
 
 /* MySQL header files */
@@ -28,6 +29,8 @@ class Table;
 namespace myrocks {
 
 void rocksdb_dict_register_dd_table_id(dd::Object_id dd_table_id);
+bool rocksdb_dict_get_server_version(uint *version);
+bool rocksdb_dict_set_server_version();
 
 class native_dd {
  private:


### PR DESCRIPTION
Summary: This diff added support for set/get server version api in rocksdb

Test Plan: Test it locally

Reviewers:

Subscribers:

Tasks:

Tags: