### PR TITLE
Add ddst_dict_init api support for rocksdb dd

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -7511,6 +7511,7 @@ static int rocksdb_init_internal(void *const p) {
   rocksdb_hton->dict_get_server_version = rocksdb_dict_get_server_version;
   rocksdb_hton->dict_set_server_version = rocksdb_dict_set_server_version;
   rocksdb_hton->is_supported_system_table = rocksdb_is_supported_system_table;
+  rocksdb_hton->ddse_dict_init = rocksdb_ddse_dict_init;
 
   rocksdb_hton->flags = HTON_SUPPORTS_EXTENDED_KEYS | HTON_CAN_RECREATE;
 
@@ -19170,7 +19171,6 @@ bool ha_rocksdb::get_se_private_data(dd::Table *, bool reset) {
   if (reset) {
     native_dd::clear_dd_table_ids();
   }
-
   return false;
 }
 

--- a/storage/rocksdb/rdb_native_dd.cc
+++ b/storage/rocksdb/rdb_native_dd.cc
@@ -25,6 +25,7 @@
 #include "ha_rocksdb.h"
 #include "storage/rocksdb/ha_rocksdb_proto.h"
 #include "storage/rocksdb/rdb_datadic.h"
+#include "sql/plugin_table.h"
 
 namespace myrocks {
 std::unordered_set<dd::Object_id> native_dd::s_dd_table_ids = {};
@@ -77,4 +78,22 @@ bool rocksdb_is_supported_system_table([[maybe_unused]] const char *db_name,
   return false;
 }
 
+bool rocksdb_ddse_dict_init(
+    [[maybe_unused]] dict_init_mode_t dict_init_mode, uint,
+    [[maybe_unused]] List<const dd::Object_table> *tables,
+    List<const Plugin_tablespace> *tablespaces) {
+  assert(tables);
+  assert(tables->is_empty());
+  assert(tablespaces);
+  assert(tablespaces->is_empty());
+
+  assert(dict_init_mode == DICT_INIT_CREATE_FILES ||
+         dict_init_mode == DICT_INIT_CHECK_FILES);
+
+  static Plugin_tablespace dd_space(rocksdb_dd_space_name, "", "", "",
+                                    rocksdb_hton_name);
+  tablespaces->push_back(&dd_space);
+
+  return false;
+}
 }  // namespace myrocks

--- a/storage/rocksdb/rdb_native_dd.h
+++ b/storage/rocksdb/rdb_native_dd.h
@@ -21,6 +21,7 @@
 
 /* MySQL header files */
 #include "sql/dd/object_id.h"
+#include "sql/handler.h"
 
 namespace dd {
 class Table;
@@ -28,10 +29,15 @@ class Table;
 
 namespace myrocks {
 
+constexpr const char rocksdb_dd_space_name[] = "mysql";
+
 void rocksdb_dict_register_dd_table_id(dd::Object_id dd_table_id);
 bool rocksdb_dict_get_server_version(uint *version);
 bool rocksdb_dict_set_server_version();
 bool rocksdb_is_supported_system_table(const char *, const char *, bool);
+bool rocksdb_ddse_dict_init(dict_init_mode_t dict_init_mode, uint version,
+                            List<const dd::Object_table> *tables,
+                            List<const Plugin_tablespace> *tablespaces);
 
 class native_dd {
  private:


### PR DESCRIPTION
Summary: Add ddst_dict_init api support for rocksdb dd

Test Plan: Test locally, not crush....

Reviewers:

Subscribers:

Tasks:

Tags: