### PR TITLE
Fix clang 15 -Wunused-but-set-variable warnings in MyRocks

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -10392,7 +10392,7 @@ int ha_rocksdb::index_read_intern(uchar *const buf, const uchar *const key,
   check_build_decoder();
 
   DBUG_EXECUTE_IF(
-      "myrocks_busy_loop_on_row_read", int debug_i = 0;
+      "myrocks_busy_loop_on_row_read", volatile int debug_i = 0;
       while (1) { debug_i++; });
 
   int rc = 0;
@@ -14624,7 +14624,6 @@ static int read_stats_from_ssts(
     }
   }
 
-  int num_sst = 0;
   for (const auto &it : props) {
     std::vector<Rdb_index_stats> sst_stats;
     Rdb_tbl_prop_coll::read_stats_from_tbl_props(it.second, &sst_stats);
@@ -14654,7 +14653,6 @@ static int read_stats_from_ssts(
       (*stats)[it1.m_gl_index_id].merge(
           it1, true, it_index->second->max_storage_fmt_length());
     }
-    num_sst++;
   }
 
   DBUG_RETURN(HA_EXIT_SUCCESS);


### PR DESCRIPTION
- Make infinite debug loop counter volatile. Otherwise it's undefined behavior and/or the loop might be optimized away.
- Remove another write-only variable