### PR TITLE
Bug#34776172 MacOS: silence deprecated use warnings from XCode >= 14

### DIFF
--- a/cmake/maintainer.cmake
+++ b/cmake/maintainer.cmake
@@ -94,7 +94,7 @@ IF(MY_COMPILER_IS_CLANG)
   MY_ADD_C_WARNING_FLAG("Wunreachable-code-break")
   MY_ADD_C_WARNING_FLAG("Wunreachable-code-return")
 ENDIF()
-  
+
 # Extra warning flags for Clang++
 IF(MY_COMPILER_IS_CLANG)
   # Disable a few default Clang++ warnings
@@ -104,6 +104,17 @@ IF(MY_COMPILER_IS_CLANG)
 
   STRING_APPEND(MY_CXX_WARNING_FLAGS " -Wconditional-uninitialized")
   STRING_APPEND(MY_CXX_WARNING_FLAGS " -Wdeprecated")
+
+  # Xcode >= 14 makes noise about sprintf, and loss of precision when
+  # assigning integers from 64 bits to 32 bits, so silence. We can't
+  # put these two deprecation exceptions in Darwin.cmake because the
+  # previous line adding -Wdeprecated would be added later and
+  # override them, so do it here instead:
+  IF(APPLE)
+     STRING_APPEND(MY_CXX_WARNING_FLAGS " -Wno-deprecated-declarations")
+     STRING_APPEND(MY_CXX_WARNING_FLAGS " -Wno-shorten-64-to-32")
+  ENDIF()
+
   STRING_APPEND(MY_CXX_WARNING_FLAGS " -Wextra-semi")
   STRING_APPEND(MY_CXX_WARNING_FLAGS " -Wheader-hygiene")
   STRING_APPEND(MY_CXX_WARNING_FLAGS " -Wnon-virtual-dtor")


### PR DESCRIPTION
- We have much use of sprintf, which is now flagged by clang as unsafe. Silence this, since we have too many uses to rewrite easily.

- This version if Xcode also flags loss of precision from 64 to 32 bits integer, silence this also. Typically when x of type size_t is assigned to an int.

Change-Id: I3e5f829c7fdb8ddb08c56149bc0db1a5dc277f34