### PR TITLE
Move default PATH setting from CMake to get_rocksdb_files.sh

### DIFF
--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -52,7 +52,7 @@ ELSE()
   # get a list of rocksdb library source files
   # run with env -i to avoid passing variables
   EXECUTE_PROCESS(
-    COMMAND env -i PATH="/sbin:/usr/sbin:/bin:/usr/bin" ${CMAKE_SOURCE_DIR}/storage/rocksdb/get_rocksdb_files.sh ${ROCKSDB_FOLLY}
+    COMMAND env -i ${CMAKE_SOURCE_DIR}/storage/rocksdb/get_rocksdb_files.sh ${ROCKSDB_FOLLY}
     OUTPUT_VARIABLE SCRIPT_OUTPUT
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   )

--- a/storage/rocksdb/get_rocksdb_files.sh
+++ b/storage/rocksdb/get_rocksdb_files.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+if [ -z "$PATH" ]; then
+    export PATH="/sbin:/usr/sbin:/bin:/usr/bin"
+fi
+
 MKFILE=`mktemp`
 # create and run a simple makefile
 # include rocksdb make file relative to the path of this script


### PR DESCRIPTION
In c3f1703231d7fec34de1479b8913a06cd9c4cd79, get_rocksdb_files.sh invocation got PATH setting. The public discussion is incomplete but b739eac1760c2451200246c5d7fe3233787053b8 suggests that there is a problem with CentOS 9 and make 4.3 that undefined PATH does not get a default fallback, thus a PATH value is provided for the invocation.

The provided PATH value is however incompatible with building on macOS. Fix by setting the fallback PATH value in the get_rocksdb_files.sh script itself.