### PR TITLE
Explicitly specify char signedness for the underlying enum type

### DIFF
--- a/client/mysqlbinlog.cc
+++ b/client/mysqlbinlog.cc
@@ -792,7 +792,7 @@ static const std::string binlog_server_finish_err_msg =
     "The binlog server has finished sending all available binlogs from the "
     "HDFS and has no more binlogs to send.";
 
-enum class Check_database_decision : char {
+enum class Check_database_decision {
   EMPTY_EVENT_DATABASE = 2,
   CHANGED = 1,
   OK = 0,


### PR DESCRIPTION
A plain 'char' without 'signed' or 'unsigned' may default to either one, depending on the platform. On x86_64 Linux it is signed, while on ARM Linux it is unsigned, resulting in a build error. Fix by explicitly marking it signed.

Squash with 295ba21bc021c0758ac4f6bb7c35b54ac5093012