### PR TITLE
Refactor the acquisition of DDSE handlerton

### DIFF
--- a/sql/dd/dd_table.cc
+++ b/sql/dd/dd_table.cc
@@ -44,6 +44,7 @@
 #include "sql/dd/cache/dictionary_client.h"  // dd::cache::Dictionary_client
 #include "sql/dd/collection.h"               // dd::Collection
 #include "sql/dd/dd.h"                       // dd::get_dictionary
+#include "sql/dd/dd_utility.h"
 #include "sql/dd/dictionary.h"               // dd::Dictionary
 // TODO: Avoid exposing dd/impl headers in public files.
 #include "sql/dd/impl/dictionary_impl.h"       // default_catalog_name
@@ -2331,7 +2332,7 @@ static std::unique_ptr<dd::Table> create_dd_system_table(
   }
 
   // Register the se private id with the DDSE.
-  handlerton *ddse = ha_resolve_by_legacy_type(thd, DB_TYPE_INNODB);
+  handlerton *ddse = get_dd_engine(thd);
   if (ddse->dict_register_dd_table_id == nullptr) return nullptr;
   ddse->dict_register_dd_table_id(tab_obj->se_private_id());
 

--- a/sql/dd/dd_utility.cc
+++ b/sql/dd/dd_utility.cc
@@ -57,12 +57,11 @@ size_t normalize_string(const CHARSET_INFO *cs, const String_type &src,
 
 bool check_if_server_ddse_readonly(THD *thd, const char *schema_name_abbrev) {
   /*
-    We must check if the DDSE is started in a way that makes the DD
-    read only. For now, we only support InnoDB as SE for the DD. The call
-    to retrieve the handlerton for the DDSE should be replaced by a more
-    generic mechanism.
+    We must check if the DDSE is started in a way that makes the DD read only.
+    The call to retrieve the handlerton for the DDSE should be replaced by a
+    more generic mechanism.
   */
-  handlerton *ddse = ha_resolve_by_legacy_type(thd, DB_TYPE_INNODB);
+  handlerton *ddse = get_dd_engine(thd);
   if (ddse->is_dict_readonly && ddse->is_dict_readonly()) {
     LogErr(WARNING_LEVEL, ER_SKIP_UPDATING_METADATA_IN_SE_RO_MODE,
            schema_name_abbrev);

--- a/sql/dd/dd_utility.h
+++ b/sql/dd/dd_utility.h
@@ -73,11 +73,26 @@ bool check_if_server_ddse_readonly(THD *thd, const char *schema_name);
   initialized yet.
   @return isolation level
 */
-inline enum_tx_isolation get_dd_isolation_level() {
+[[nodiscard]] inline enum_tx_isolation get_dd_isolation_level() {
   assert(default_dd_storage_engine == DEFAULT_DD_ROCKSDB ||
          default_dd_storage_engine == DEFAULT_DD_INNODB);
   return default_dd_storage_engine == DEFAULT_DD_ROCKSDB ? ISO_READ_COMMITTED
                                                          : ISO_READ_UNCOMMITTED;
+}
+
+[[nodiscard]] inline handlerton *get_dd_engine(THD *thd) {
+  assert(default_dd_storage_engine == DEFAULT_DD_ROCKSDB ||
+         default_dd_storage_engine == DEFAULT_DD_INNODB);
+  const auto db_type = default_dd_storage_engine == DEFAULT_DD_ROCKSDB
+                           ? DB_TYPE_ROCKSDB
+                           : DB_TYPE_INNODB;
+  return ha_resolve_by_legacy_type(thd, db_type);
+}
+
+[[nodiscard]] inline const char *get_dd_engine_name() {
+  assert(default_dd_storage_engine == DEFAULT_DD_ROCKSDB ||
+         default_dd_storage_engine == DEFAULT_DD_INNODB);
+  return default_dd_storage_engine == DEFAULT_DD_ROCKSDB ? "RocksDB" : "InnoDB";
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/sql/dd/impl/bootstrap/bootstrapper.cc
+++ b/sql/dd/impl/bootstrap/bootstrapper.cc
@@ -41,6 +41,7 @@
 #include "sql/auth/sql_security_ctx.h"
 #include "sql/dd/cache/dictionary_client.h"  // dd::cache::Dictionary_client
 #include "sql/dd/dd.h"                       // dd::create_object
+#include "sql/dd/dd_utility.h"
 #include "sql/dd/impl/bootstrap/bootstrap_ctx.h"        // DD_bootstrap_ctx
 #include "sql/dd/impl/cache/shared_dictionary_cache.h"  // Shared_dictionary_cache
 #include "sql/dd/impl/cache/storage_adapter.h"          // Storage_adapter
@@ -81,7 +82,7 @@ namespace {
 // Initialize recovery in the DDSE.
 bool DDSE_dict_recover(THD *thd, dict_recovery_mode_t dict_recovery_mode,
                        uint version) {
-  handlerton *ddse = ha_resolve_by_legacy_type(thd, DB_TYPE_INNODB);
+  handlerton *ddse = get_dd_engine(thd);
   if (ddse->dict_recover == nullptr) return true;
 
   bool error = ddse->dict_recover(dict_recovery_mode, version);
@@ -616,14 +617,14 @@ bool populate_tables(THD *thd) {
 // Re-populate character sets and collations upon normal restart.
 bool repopulate_charsets_and_collations(THD *thd) {
   /*
-    We must check if the DDSE is started in a way that makes the DD
-    read only. For now, we only support InnoDB as SE for the DD. The call
-    to retrieve the handlerton for the DDSE should be replaced by a more
-    generic mechanism.
+    We must check if the DDSE is started in a way that makes the DD read only.
+    The call to retrieve the handlerton for the DDSE should be replaced by a
+    more generic mechanism.
   */
-  handlerton *ddse = ha_resolve_by_legacy_type(thd, DB_TYPE_INNODB);
+  handlerton *ddse = get_dd_engine(thd);
   if (ddse->is_dict_readonly && ddse->is_dict_readonly()) {
-    LogErr(WARNING_LEVEL, ER_DD_NO_WRITES_NO_REPOPULATION, "InnoDB", " ");
+    LogErr(WARNING_LEVEL, ER_DD_NO_WRITES_NO_REPOPULATION, get_dd_engine_name(),
+           " ");
     return false;
   }
 
@@ -724,7 +725,7 @@ namespace bootstrap {
   predefined tables and tablespaces.
 */
 bool DDSE_dict_init(THD *thd, dict_init_mode_t dict_init_mode, uint version) {
-  handlerton *ddse = ha_resolve_by_legacy_type(thd, DB_TYPE_INNODB);
+  handlerton *ddse = get_dd_engine(thd);
 
   /*
     The lists with element wrappers are mem root allocated. The wrapped
@@ -829,8 +830,8 @@ bool initialize_dictionary(THD *thd, bool is_dd_upgrade_57,
     return true;
 
   if (is_dd_upgrade_57) {
-    // Add status to mark creation of dictionary in InnoDB.
-    // Till this step, no new undo log is created by InnoDB.
+    // Add status to mark creation of dictionary in DDSE. In case it is InnoDB,
+    // till this step, no new undo log is created there.
     if (upgrade_57::Upgrade_status().update(
             upgrade_57::Upgrade_status::enum_stage::DICT_TABLES_CREATED))
       return true;
@@ -1502,7 +1503,7 @@ bool sync_meta_data(THD *thd) {
     return true;
 
   // Reset the DDSE local dictionary cache.
-  handlerton *ddse = ha_resolve_by_legacy_type(thd, DB_TYPE_INNODB);
+  handlerton *ddse = get_dd_engine(thd);
   if (ddse->dict_cache_reset == nullptr) return true;
 
   for (System_tables::Const_iterator it = System_tables::instance()->begin();
@@ -1797,7 +1798,7 @@ bool update_versions(THD *thd, bool is_dd_upgrade_57) {
     back in case of an abort, so this better be the last step we
     do before committing.
   */
-  handlerton *ddse = ha_resolve_by_legacy_type(thd, DB_TYPE_INNODB);
+  handlerton *ddse = get_dd_engine(thd);
   if (bootstrap::DD_bootstrap_ctx::instance().is_server_upgrade()) {
     if (ddse->dict_set_server_version == nullptr ||
         ddse->dict_set_server_version()) {

--- a/sql/dd/impl/bootstrap/bootstrapper.h
+++ b/sql/dd/impl/bootstrap/bootstrapper.h
@@ -236,7 +236,7 @@ bool setup_dd_objects_and_collations(THD *thd);
 /**
   This function is used in case of crash during upgrade.
   It tries to initialize dictionary and calls DDSE_dict_recover.
-  InnoDB should do the recovery and empty undo log. Upgrade
+  The DDSE should do the recovery and, if it is InnoDB, empty undo log. Upgrade
   process will do the cleanup and exit.
 
   @param thd    Thread context.
@@ -244,7 +244,7 @@ bool setup_dd_objects_and_collations(THD *thd);
 void recover_innodb_upon_upgrade(THD *thd);
 
 /**
-  Initialize InnoDB for
+  Initialize DDSE for
   - creating new data directory : InnoDB creates system tablespace and
                                   dictionary tablespace.
   - normal server restart.      : Verifies existence of system and dictionary
@@ -253,7 +253,7 @@ void recover_innodb_upon_upgrade(THD *thd);
                                   create dictionary tablespace.
 
   @param thd             Thread context.
-  @param dict_init_mode  mode to initialize InnoDB
+  @param dict_init_mode  mode to initialize DDSE
   @param version         Dictionary version.
 
   @return       Upon failure, return true, otherwise false.

--- a/sql/dd/impl/dictionary_impl.cc
+++ b/sql/dd/impl/dictionary_impl.cc
@@ -41,6 +41,7 @@
 #include "sql/dd/cache/dictionary_client.h"      // dd::Dictionary_client
 #include "sql/dd/dd.h"                           // enum_dd_init_type
 #include "sql/dd/dd_schema.h"                    // dd::Schema_MDL_locker
+#include "sql/dd/dd_utility.h"
 #include "sql/dd/dd_version.h"                   // dd::DD_VERSION
 #include "sql/dd/impl/bootstrap/bootstrapper.h"  // dd::Bootstrapper
 #include "sql/dd/impl/cache/shared_dictionary_cache.h"  // Shared_dictionary_cache
@@ -694,7 +695,7 @@ bool drop_native_table(THD *thd, const char *schema_name,
 
 bool reset_tables_and_tablespaces() {
   Auto_THD thd;
-  handlerton *ddse = ha_resolve_by_legacy_type(thd.thd, DB_TYPE_INNODB);
+  handlerton *ddse = get_dd_engine(thd.thd);
 
   // Acquire transactional metadata locks and evict all cached objects.
   if (dd::cache::Shared_dictionary_cache::reset_tables_and_tablespaces(thd.thd))

--- a/sql/dd/impl/upgrade/dd.cc
+++ b/sql/dd/impl/upgrade/dd.cc
@@ -31,6 +31,7 @@
 #include "mysql_version.h"  // MYSQL_VERSION_ID
 #include "mysqld_error.h"
 #include "sql/dd/cache/dictionary_client.h"  // dd::cache::Dictionary_client
+#include "sql/dd/dd_utility.h"
 #include "sql/dd/impl/bootstrap/bootstrap_ctx.h"        // DD_bootstrap_ctx
 #include "sql/dd/impl/cache/shared_dictionary_cache.h"  // Shared_dictionary_cache
 #include "sql/dd/impl/system_registry.h"                // dd::System_tables
@@ -1155,7 +1156,7 @@ bool upgrade_tables(THD *thd) {
   Object_table_definition_impl::set_dd_tablespace_encrypted(false);
 
   // Reset the DDSE local dictionary cache.
-  handlerton *ddse = ha_resolve_by_legacy_type(thd, DB_TYPE_INNODB);
+  handlerton *ddse = get_dd_engine(thd);
   if (ddse->dict_cache_reset == nullptr) return true;
 
   for (System_tables::Const_iterator it =

--- a/sql/dd/info_schema/table_stats.cc
+++ b/sql/dd/info_schema/table_stats.cc
@@ -25,6 +25,7 @@
 #include "my_time.h"  // TIME_to_ulonglong_datetime
 #include "sql/dd/cache/dictionary_client.h"
 #include "sql/dd/dd.h"          // dd::create_object
+#include "sql/dd/dd_utility.h"
 #include "sql/dd/impl/utils.h"  // dd::my_time_t_to_ull_datetime()
 #include "sql/dd/properties.h"
 #include "sql/dd/types/index_stat.h"             // dd::Index_stat
@@ -69,7 +70,7 @@ namespace {
 inline bool can_persist_I_S_dynamic_statistics(THD *thd,
                                                const char *schema_name,
                                                const char *partition_name) {
-  handlerton *ddse = ha_resolve_by_legacy_type(thd, DB_TYPE_INNODB);
+  handlerton *ddse = dd::get_dd_engine(thd);
   if (ddse == nullptr || ddse->is_dict_readonly()) return false;
 
   return (thd->variables.information_schema_stats_expiry &&

--- a/sql/dd/upgrade_57/upgrade.h
+++ b/sql/dd/upgrade_57/upgrade.h
@@ -107,8 +107,8 @@ class Upgrade_status {
     STARTED,
 
     /*
-      Started InnoDB in upgrade mode, i.e., undo and redo logs are
-      upgraded and mysql.ibd is created.
+      Started DDSE in upgrade mode, i.e. in the case of InnoDB, undo and redo
+      logs are upgraded and mysql.ibd is created.
     */
     DICT_SPACE_CREATED,
 

--- a/sql/resourcegroups/resource_group_mgr.cc
+++ b/sql/resourcegroups/resource_group_mgr.cc
@@ -49,6 +49,7 @@
 #include "sql/current_thd.h"                 // current_thd
 #include "sql/dd/cache/dictionary_client.h"  // Dictionary_client
 #include "sql/dd/dd_resource_group.h"        // dd::create_resource_group
+#include "sql/dd/dd_utility.h"
 #include "sql/dd/string_type.h"
 #include "sql/dd/types/resource_group.h"
 #include "sql/handler.h"
@@ -119,7 +120,7 @@ Resource_group_mgr *Resource_group_mgr::instance() {
 static inline bool persist_resource_group(
     THD *thd, const resourcegroups::Resource_group &resource_group,
     bool update) {
-  handlerton *ddse = ha_resolve_by_legacy_type(thd, DB_TYPE_INNODB);
+  handlerton *ddse = dd::get_dd_engine(thd);
   if (ddse->is_dict_readonly && ddse->is_dict_readonly()) {
     LogErr(WARNING_LEVEL, ER_RESOURCE_GROUP_METADATA_UPDATE_SKIPPED);
     return false;

--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -52,7 +52,7 @@ ELSE()
   # get a list of rocksdb library source files
   # run with env -i to avoid passing variables
   EXECUTE_PROCESS(
-    COMMAND env -i PATH="/sbin:/usr/sbin:/bin:/usr/bin" ${CMAKE_SOURCE_DIR}/storage/rocksdb/get_rocksdb_files.sh ${ROCKSDB_FOLLY}
+    COMMAND env -i ${CMAKE_SOURCE_DIR}/storage/rocksdb/get_rocksdb_files.sh ${ROCKSDB_FOLLY}
     OUTPUT_VARIABLE SCRIPT_OUTPUT
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   )

--- a/storage/rocksdb/get_rocksdb_files.sh
+++ b/storage/rocksdb/get_rocksdb_files.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+if [ -z "$PATH" ]; then
+    export PATH="/sbin:/usr/sbin:/bin:/usr/bin"
+fi
+
 MKFILE=`mktemp`
 # create and run a simple makefile
 # include rocksdb make file relative to the path of this script


### PR DESCRIPTION
Make it support both InnoDB and MyRocks DDSEs by introducing a helper function
dd::get_dd_engine that returns either based on the default_dd_storage_engine
sysvar setting. To have correct diagnostics in one instance at least, introduce
a get_dd_engine_name utility function too.

No functional changes if default_dd_storage_engine == InnoDB.
