### PR TITLE
use record[0] in Raw_record::drop()

### DIFF
--- a/sql/dd/impl/raw/raw_record.cc
+++ b/sql/dd/impl/raw/raw_record.cc
@@ -97,7 +97,7 @@ bool Raw_record::update() {
 bool Raw_record::drop() {
   DBUG_TRACE;
 
-  int rc = m_table->file->ha_delete_row(m_table->record[1]);
+  int rc = m_table->file->ha_delete_row(m_table->record[0]);
 
   if (rc) {
     m_table->file->print_error(rc, MYF(0));


### PR DESCRIPTION
When ddse fetch data from SE, it always store data into record[0]. see [https://github.com/.../sql/dd/impl/raw/raw_record_set.cc...](https://github.com/mysql/mysql-server/blob/8.0/sql/dd/impl/raw/raw_record_set.cc#L62). From convention, it should also delete data using record[0] in Raw_record::drop().

Although INNODB use prebuilt->pcur instead of record[0]/record[1] during delete_row, other SE may still depend on record[0]/record[1] to delete all index correctly.