### PR TITLE
implement handler API table_exists_in_engine for myrocks

### DIFF
--- a/sql/dd/impl/bootstrap/bootstrap_ctx.h
+++ b/sql/dd/impl/bootstrap/bootstrap_ctx.h
@@ -30,7 +30,8 @@
 #include "mysql_version.h"                // MYSQL_VERSION_ID
 #include "sql/dd/dd_version.h"            // DD_VERSION
 #include "sql/dd/info_schema/metadata.h"  // IS_DD_VERSION
-#include "sql/mysqld.h"                   // opt_initialize
+#include "sql/handler.h"
+#include "sql/mysqld.h"  // opt_initialize
 
 class THD;
 
@@ -100,7 +101,12 @@ class DD_bootstrap_ctx {
 
   uint m_did_I_S_upgrade_from = 0;
   uint m_actual_I_S_version = 0;
-  uint m_actual_dd_engine = 0;
+  // actual DDSE holds dd tables
+  // its values is indicted by which SE hold mysql.dd_properties table
+  //  Druing boostrap time,  its value is equal to default_dd_storage_engine
+  //  During upgrade time, its value maybe not equal to
+  //  default_dd_storage_engine
+  legacy_db_type m_actual_dd_engine = DB_TYPE_UNKNOWN;
 
  public:
   DD_bootstrap_ctx() = default;
@@ -124,7 +130,8 @@ class DD_bootstrap_ctx {
     m_actual_I_S_version = actual_I_S_version;
   }
 
-  void set_actual_dd_engine(uint actual_dd_engine) {
+  void set_actual_dd_engine(enum legacy_db_type actual_dd_engine) {
+    assert(m_actual_dd_engine == DB_TYPE_UNKNOWN);
     m_actual_dd_engine = actual_dd_engine;
   }
 
@@ -132,7 +139,10 @@ class DD_bootstrap_ctx {
 
   uint get_actual_I_S_version() const { return m_actual_I_S_version; }
 
-  uint get_actual_dd_engine() const { return m_actual_dd_engine; }
+  uint get_actual_dd_engine() const {
+    assert(m_actual_dd_engine != DB_TYPE_UNKNOWN);
+    return m_actual_dd_engine;
+  }
 
   void set_dd_upgrade_done() {
     assert(m_did_dd_upgrade_from == 0);

--- a/sql/dd/impl/bootstrap/bootstrap_ctx.h
+++ b/sql/dd/impl/bootstrap/bootstrap_ctx.h
@@ -139,7 +139,7 @@ class DD_bootstrap_ctx {
 
   uint get_actual_I_S_version() const { return m_actual_I_S_version; }
 
-  uint get_actual_dd_engine() const {
+  legacy_db_type get_actual_dd_engine() const {
     assert(m_actual_dd_engine != DB_TYPE_UNKNOWN);
     return m_actual_dd_engine;
   }

--- a/sql/dd/impl/bootstrap/bootstrap_ctx.h
+++ b/sql/dd/impl/bootstrap/bootstrap_ctx.h
@@ -100,6 +100,7 @@ class DD_bootstrap_ctx {
 
   uint m_did_I_S_upgrade_from = 0;
   uint m_actual_I_S_version = 0;
+  uint m_actual_dd_engine = 0;
 
  public:
   DD_bootstrap_ctx() = default;
@@ -123,9 +124,15 @@ class DD_bootstrap_ctx {
     m_actual_I_S_version = actual_I_S_version;
   }
 
+  void set_actual_dd_engine(uint actual_dd_engine) {
+    m_actual_dd_engine = actual_dd_engine;
+  }
+
   uint get_actual_dd_version() const { return m_actual_dd_version; }
 
   uint get_actual_I_S_version() const { return m_actual_I_S_version; }
+
+  uint get_actual_dd_engine() const { return m_actual_dd_engine; }
 
   void set_dd_upgrade_done() {
     assert(m_did_dd_upgrade_from == 0);

--- a/sql/dd/impl/bootstrap/bootstrapper.cc
+++ b/sql/dd/impl/bootstrap/bootstrapper.cc
@@ -1084,15 +1084,11 @@ bool initialize_dd_properties(THD *thd) {
           rocksdb_hton, thd, MYSQL_SCHEMA_NAME.str,
           dd::tables::DD_properties::instance().name().c_str());
     }
-    if (error == HA_ERR_TABLE_EXIST) {
-      // actual ddse maybe rocksdb
-      bootstrap::DD_bootstrap_ctx::instance().set_actual_dd_engine(
-          DB_TYPE_ROCKSDB);
-    } else {
-      // actual ddse maybe innodb
-      bootstrap::DD_bootstrap_ctx::instance().set_actual_dd_engine(
-          DB_TYPE_INNODB);
-    }
+
+    // HA_ERR_TABLE_EXIST means actual ddse maybe rocksdb
+    // otherwise, actual ddse maybe innodb
+    bootstrap::DD_bootstrap_ctx::instance().set_actual_dd_engine(
+        error == HA_ERR_TABLE_EXIST ? DB_TYPE_ROCKSDB : DB_TYPE_INNODB);
   }
 
   // Create the dd_properties table.

--- a/sql/dd/impl/bootstrap/bootstrapper.cc
+++ b/sql/dd/impl/bootstrap/bootstrapper.cc
@@ -1073,6 +1073,27 @@ bool create_dd_schema(THD *thd) {
 }
 
 bool initialize_dd_properties(THD *thd) {
+  if (!opt_initialize) {
+    // Find out which ddse contains dd_properties table during restart
+    // Try rocksdb first
+    handlerton *rocksdb_ddse = ha_resolve_by_legacy_type(thd, DB_TYPE_ROCKSDB);
+    int error = HA_ERR_NO_SUCH_TABLE;
+    if (rocksdb_ddse != nullptr || rocksdb_ddse->table_exists_in_engine) {
+      error = rocksdb_ddse->table_exists_in_engine(
+          rocksdb_ddse, thd, MYSQL_SCHEMA_NAME.str,
+          dd::tables::DD_properties::instance().name().c_str());
+    }
+    if (error == HA_ERR_TABLE_EXIST) {
+      // actual ddse maybe rocksdb
+      bootstrap::DD_bootstrap_ctx::instance().set_actual_dd_engine(
+          enum_dd_default_engine::DEFAULT_DD_ROCKSDB);
+    } else {
+      // actual ddse maybe innodb
+      bootstrap::DD_bootstrap_ctx::instance().set_actual_dd_engine(
+          enum_dd_default_engine::DEFAULT_DD_INNODB);
+    }
+  }
+
   // Create the dd_properties table.
   const Object_table_definition *dd_properties_def =
       dd::tables::DD_properties::instance().target_table_definition();

--- a/sql/dd/impl/bootstrap/bootstrapper.cc
+++ b/sql/dd/impl/bootstrap/bootstrapper.cc
@@ -1074,23 +1074,24 @@ bool create_dd_schema(THD *thd) {
 
 bool initialize_dd_properties(THD *thd) {
   if (!opt_initialize) {
-    // Find out which ddse contains dd_properties table during restart
+    // Find out which SE contains dd_properties table during restart
     // Try rocksdb first
-    handlerton *rocksdb_ddse = ha_resolve_by_legacy_type(thd, DB_TYPE_ROCKSDB);
+    handlerton *rocksdb_hton = ha_resolve_by_legacy_type(thd, DB_TYPE_ROCKSDB);
     int error = HA_ERR_NO_SUCH_TABLE;
-    if (rocksdb_ddse != nullptr || rocksdb_ddse->table_exists_in_engine) {
-      error = rocksdb_ddse->table_exists_in_engine(
-          rocksdb_ddse, thd, MYSQL_SCHEMA_NAME.str,
+    if (rocksdb_hton != nullptr &&
+        rocksdb_hton->table_exists_in_engine != nullptr) {
+      error = rocksdb_hton->table_exists_in_engine(
+          rocksdb_hton, thd, MYSQL_SCHEMA_NAME.str,
           dd::tables::DD_properties::instance().name().c_str());
     }
     if (error == HA_ERR_TABLE_EXIST) {
       // actual ddse maybe rocksdb
       bootstrap::DD_bootstrap_ctx::instance().set_actual_dd_engine(
-          enum_dd_default_engine::DEFAULT_DD_ROCKSDB);
+          DB_TYPE_ROCKSDB);
     } else {
       // actual ddse maybe innodb
       bootstrap::DD_bootstrap_ctx::instance().set_actual_dd_engine(
-          enum_dd_default_engine::DEFAULT_DD_INNODB);
+          DB_TYPE_INNODB);
     }
   }
 

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -7204,9 +7204,7 @@ static bool rocksdb_get_table_statistics(
     const dd::Properties & /*ts_se_private_data*/,
     const dd::Properties & /*tbl_se_private_data*/, uint /*stat_flags*/,
     ha_statistics *stats) {
-  std::string fullname = db_name;
-  fullname.append(".");
-  fullname.append(table_name);
+  std::string fullname = get_full_tablename(db_name, table_name);
 
   // We are called from within metadata lock MDL_EXPLICIT, so it should be
   // safe to access Rdb_tbl_def here
@@ -7228,24 +7226,18 @@ static bool rocksdb_get_table_statistics(
 
 /**
   Check if a table exists in ROCKSDB during DD upgrade/restart
-  NOTE: Don't call any DD API, due to this function maybe called during
+  NOTE: Don't call any server DD API, due to this function maybe called during
   DD initializing.
 
-  @return HA_ERR_TABLE_EXIST - if table exist in ROCKSDB
-  @return HA_ERR_NO_SUCH_TABLE - if table isn't exists in ROCKSDB.
+  @return HA_ERR_TABLE_EXIST - if table exists in ROCKSDB
+  @return HA_ERR_NO_SUCH_TABLE - if table doesn't exist in ROCKSDB.
 */
 static int rocksdb_table_exists_in_engine(handlerton *, THD *,
                                           const char *db_name,
                                           const char *table_name) {
-  std::string fullname = db_name;
-  fullname.append(".");
-  fullname.append(table_name);
-
-  auto tbl_def = ddl_manager.find(fullname);
-  if (!tbl_def) {
-    return HA_ERR_NO_SUCH_TABLE;
-  }
-  return HA_ERR_TABLE_EXIST;
+  std::string fullname = get_full_tablename(db_name, table_name);
+  const auto *const tbl_def = ddl_manager.find(fullname);
+  return tbl_def ? HA_ERR_TABLE_EXIST : HA_ERR_NO_SUCH_TABLE;
 }
 
 static rocksdb::Status check_rocksdb_options_compatibility(

--- a/storage/rocksdb/nosql_access.cc
+++ b/storage/rocksdb/nosql_access.cc
@@ -14,6 +14,7 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 
+#include "rdb_utils.h"
 #define MYSQL_SERVER 1
 
 /* This C++ file's header */
@@ -2135,10 +2136,9 @@ select_exec_result INLINE_ATTR select_exec::run() {
   }
 
   // Look for the table metadata
-  std::string db_table;
-  db_table.append(m_table_share->db.str);
-  db_table.append(".");
-  db_table.append(m_table_share->table_name.str);
+  std::string db_table =
+      get_full_tablename(m_table_share->db.str, m_table_share->table_name.str);
+
   m_tbl_def = m_ddl_manager->find(db_table);
   if (m_tbl_def == nullptr) {
     m_handler->print_error(HA_ERR_ROCKSDB_INVALID_TABLE, 0);

--- a/storage/rocksdb/nosql_access.cc
+++ b/storage/rocksdb/nosql_access.cc
@@ -14,7 +14,6 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 
-#include "rdb_utils.h"
 #define MYSQL_SERVER 1
 
 /* This C++ file's header */
@@ -51,6 +50,7 @@
 #include "./rdb_converter.h"
 #include "./rdb_datadic.h"
 #include "./rdb_iterator.h"
+#include "./rdb_utils.h"
 
 static const size_t DEFAULT_FIELD_LIST_SIZE = 16;
 static const size_t MAX_NOSQL_COND_COUNT = 16;

--- a/storage/rocksdb/rdb_utils.h
+++ b/storage/rocksdb/rdb_utils.h
@@ -473,4 +473,13 @@ class Ensure_initialized {
   return fn.compare(fn_len - ext_len, ext_len, extension) == 0;
 }
 
+// return <db_name>.<table_name>
+inline std::string get_full_tablename(const char *const db_name,
+                                      const char *const table_name) {
+  std::string fullname = db_name;
+  fullname.append(".");
+  fullname.append(table_name);
+  return fullname;
+}
+
 }  // namespace myrocks

--- a/storage/rocksdb/rdb_utils.h
+++ b/storage/rocksdb/rdb_utils.h
@@ -476,8 +476,11 @@ class Ensure_initialized {
 // return <db_name>.<table_name>
 inline std::string get_full_tablename(const char *const db_name,
                                       const char *const table_name) {
-  std::string fullname = db_name;
-  fullname.append(".");
+  std::string fullname;
+  // + 1 for '.'
+  fullname.reserve(strlen(db_name) + strlen(table_name) + 1);
+  fullname.append(db_name);
+  fullname += '.';
   fullname.append(table_name);
   return fullname;
 }


### PR DESCRIPTION
Summary:
During Data Dictioanry(DD) upgrade or restart, mysql should decide which SE(Storage Engine) contains actual DD tables if multiple SEs can be DDSE. 

Currently MyRocks still have its own private data dictionary, which contains table name->table_def mapping.  also these private data dictionary is initialized during plugin initialization. Thus implements handler API  table_exists_in_engine to check whether a table exists in myrocks internal data dictionary.

 


Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: