### PR TITLE
Set rocksdb_large_prefix to ON and deprecate this system variable

### DIFF
--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -2148,8 +2148,9 @@ The following options may be given as the first argument:
  --rocksdb-keep-log-file-num=# 
  DBOptions::keep_log_file_num for RocksDB
  --rocksdb-large-prefix 
- Support large index prefix length of 3072 bytes. If off,
- the maximum index prefix length is 767.
+ Deprecated: support large index prefix length of 3072
+ bytes. If off, the maximum index prefix length is 767.
+ (Defaults to on; use --skip-rocksdb-large-prefix to disable.)
  --rocksdb-live-files-metadata[=name] 
  Enable or disable ROCKSDB_LIVE_FILES_METADATA plugin.
  Possible values are ON, OFF, FORCE (don't start if the
@@ -3642,7 +3643,7 @@ rocksdb-info-log-level error_level
 rocksdb-io-write-timeout 0
 rocksdb-is-fd-close-on-exec TRUE
 rocksdb-keep-log-file-num 1000
-rocksdb-large-prefix FALSE
+rocksdb-large-prefix TRUE
 rocksdb-live-files-metadata ON
 rocksdb-lock-scanned-rows FALSE
 rocksdb-lock-wait-timeout 1

--- a/mysql-test/suite/rocksdb/r/dup_key_update.result
+++ b/mysql-test/suite/rocksdb/r/dup_key_update.result
@@ -1,5 +1,3 @@
-DROP TABLE IF EXISTS t1;
-DROP TABLE IF EXISTS t2;
 CREATE TABLE t1 (id1 INT, id2 INT, id3 INT,
 PRIMARY KEY (id1, id2, id3),
 UNIQUE KEY (id3, id1)) ENGINE=ROCKSDB;
@@ -178,7 +176,6 @@ id1	id2	id3
 9	17	9
 DROP TABLE t1;
 DROP TABLE t2;
-set global rocksdb_large_prefix=1;
 CREATE TABLE t1 (id1 varchar(128) CHARACTER SET latin1 COLLATE latin1_bin,
 id2 varchar(256) CHARACTER SET utf8 COLLATE utf8_bin,
 id3 varchar(200) CHARACTER SET latin1 COLLATE latin1_swedish_ci,
@@ -187,8 +184,6 @@ UNIQUE KEY (id3, id1)) ENGINE=ROCKSDB;
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_bin' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-set global rocksdb_large_prefix=DEFAULT;
-set global rocksdb_large_prefix=1;
 CREATE TABLE t2 (id1 varchar(128) CHARACTER SET latin1 COLLATE latin1_bin,
 id2 varchar(256) CHARACTER SET utf8 COLLATE utf8_bin,
 id3 varchar(200) CHARACTER SET latin1 COLLATE latin1_swedish_ci,
@@ -197,7 +192,6 @@ UNIQUE KEY (id3, id1) COMMENT 'rev:cf') ENGINE=ROCKSDB;
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 Warning	3778	'utf8_bin' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
-set global rocksdb_large_prefix=DEFAULT;
 INSERT INTO t1 VALUES (1, 1, 1) ON DUPLICATE KEY UPDATE id2 = 9;
 SELECT * FROM t1 WHERE id1 = 1;
 id1	id2	id3

--- a/mysql-test/suite/rocksdb/r/early_load_rocksdb_plugin.result
+++ b/mysql-test/suite/rocksdb/r/early_load_rocksdb_plugin.result
@@ -3,12 +3,17 @@
 #
 # Try --initialize
 #
+# Try to run the server with --initialize --rocksdb_large_prefix=OFF
 # Run the server with --initialize
 #
 # Cleanup
 #
 # Restarting the server
 # restart
+#
+# Error log checks
+#
 include/assert_grep.inc [Check RocksDB:Init column families]
 include/assert_grep.inc [Check Data dictionary initializing]
+include/assert_grep.inc [disabling rocksdb_large_prefix is not allowed with MySQL data dictionary in MyRocks]
 # Remove data dir and log file.

--- a/mysql-test/suite/rocksdb/r/index.result
+++ b/mysql-test/suite/rocksdb/r/index.result
@@ -41,6 +41,8 @@ t1	1	a	1	a	A	#	NULL	NULL	YES	SE_SPECIFIC		simple index on a	YES	NULL
 ALTER TABLE t1 DROP KEY a;
 DROP TABLE t1;
 set global rocksdb_large_prefix=0;
+Warnings:
+Warning	131	using rocksdb_large_prefix is deprecated and it will be removed in a future release
 CREATE TABLE t1 (
 a BLOB(1024),
 KEY (a(767))
@@ -54,6 +56,8 @@ Warnings:
 Warning	1071	Specified key was too long; max key length is 767 bytes
 DROP TABLE t1;
 set global rocksdb_large_prefix=1;
+Warnings:
+Warning	131	using rocksdb_large_prefix is deprecated and it will be removed in a future release
 CREATE TABLE t1 (
 a BLOB(4096),
 KEY (a(3072))
@@ -67,6 +71,8 @@ Warnings:
 Warning	1071	Specified key was too long; max key length is 3072 bytes
 DROP TABLE t1;
 set global rocksdb_large_prefix=DEFAULT;
+Warnings:
+Warning	131	using rocksdb_large_prefix is deprecated and it will be removed in a future release
 #
 # Issue #376: MyRocks: ORDER BY optimizer is unable to use the index extension
 #

--- a/mysql-test/suite/rocksdb/r/index_primary.result
+++ b/mysql-test/suite/rocksdb/r/index_primary.result
@@ -47,6 +47,8 @@ Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_par
 t1	0	PRIMARY	1	b	A	#	NULL	NULL		SE_SPECIFIC			YES	NULL
 DROP TABLE t1;
 set global rocksdb_large_prefix=0;
+Warnings:
+Warning	131	using rocksdb_large_prefix is deprecated and it will be removed in a future release
 CREATE TABLE t1 (
 a BLOB(1024),
 PRIMARY KEY (a(767))
@@ -58,6 +60,8 @@ PRIMARY KEY (a(768))
 ) ENGINE=rocksdb;
 ERROR 42000: Specified key was too long; max key length is 767 bytes
 set global rocksdb_large_prefix=1;
+Warnings:
+Warning	131	using rocksdb_large_prefix is deprecated and it will be removed in a future release
 CREATE TABLE t1 (
 a BLOB(4096),
 PRIMARY KEY (a(3072))
@@ -69,3 +73,5 @@ PRIMARY KEY (a(3073))
 ) ENGINE=rocksdb;
 ERROR 42000: Specified key was too long; max key length is 3072 bytes
 set global rocksdb_large_prefix=DEFAULT;
+Warnings:
+Warning	131	using rocksdb_large_prefix is deprecated and it will be removed in a future release

--- a/mysql-test/suite/rocksdb/r/index_type_btree.result
+++ b/mysql-test/suite/rocksdb/r/index_type_btree.result
@@ -50,6 +50,8 @@ t1	1	a	1	a	A	#	NULL	NULL	YES	SE_SPECIFIC		simple index on a	YES	NULL
 ALTER TABLE t1 DROP KEY a;
 DROP TABLE t1;
 set global rocksdb_large_prefix=0;
+Warnings:
+Warning	131	using rocksdb_large_prefix is deprecated and it will be removed in a future release
 CREATE TABLE t1 (
 a BLOB(1024),
 KEY (a(767))
@@ -63,6 +65,8 @@ Warnings:
 Warning	1071	Specified key was too long; max key length is 767 bytes
 DROP TABLE t1;
 set global rocksdb_large_prefix=1;
+Warnings:
+Warning	131	using rocksdb_large_prefix is deprecated and it will be removed in a future release
 CREATE TABLE t1 (
 a BLOB(4096),
 KEY (a(3072))
@@ -76,3 +80,5 @@ Warnings:
 Warning	1071	Specified key was too long; max key length is 3072 bytes
 DROP TABLE t1;
 set global rocksdb_large_prefix=DEFAULT;
+Warnings:
+Warning	131	using rocksdb_large_prefix is deprecated and it will be removed in a future release

--- a/mysql-test/suite/rocksdb/r/index_type_hash.result
+++ b/mysql-test/suite/rocksdb/r/index_type_hash.result
@@ -50,6 +50,8 @@ t1	1	a	1	a	A	#	NULL	NULL	YES	SE_SPECIFIC		simple index on a	YES	NULL
 ALTER TABLE t1 DROP KEY a;
 DROP TABLE t1;
 set global rocksdb_large_prefix=0;
+Warnings:
+Warning	131	using rocksdb_large_prefix is deprecated and it will be removed in a future release
 CREATE TABLE t1 (
 a BLOB(1024),
 KEY (a(767))
@@ -63,6 +65,8 @@ Warnings:
 Warning	1071	Specified key was too long; max key length is 767 bytes
 DROP TABLE t1;
 set global rocksdb_large_prefix=1;
+Warnings:
+Warning	131	using rocksdb_large_prefix is deprecated and it will be removed in a future release
 CREATE TABLE t1 (
 a BLOB(4096),
 KEY (a(3072))
@@ -76,3 +80,5 @@ Warnings:
 Warning	1071	Specified key was too long; max key length is 3072 bytes
 DROP TABLE t1;
 set global rocksdb_large_prefix=DEFAULT;
+Warnings:
+Warning	131	using rocksdb_large_prefix is deprecated and it will be removed in a future release

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -992,7 +992,7 @@ rocksdb_index_type	kBinarySearch
 rocksdb_info_log_level	error_level
 rocksdb_is_fd_close_on_exec	ON
 rocksdb_keep_log_file_num	1000
-rocksdb_large_prefix	OFF
+rocksdb_large_prefix	ON
 rocksdb_lock_scanned_rows	OFF
 rocksdb_lock_wait_timeout	1
 rocksdb_log_file_time_to_roll	0
@@ -2515,16 +2515,10 @@ id
 select * from t1 where id=9 for update;
 id
 drop table t1;
-#Index on blob column
-SET @old_mode = @@sql_mode;
-SET sql_mode = 'strict_all_tables';
-Warnings:
-Warning	3135	'NO_ZERO_DATE', 'NO_ZERO_IN_DATE' and 'ERROR_FOR_DIVISION_BY_ZERO' sql modes should be used with strict mode. They will be merged with strict mode in a future release.
+# Index on blob column
 create table t1 (a int, b text, c varchar(400), Primary Key(a), Key(c, b(255))) ENGINE=rocksdb CHARSET=latin1;
 drop table t1;
-set global rocksdb_large_prefix=1;
 create table t1 (a int, b text, c varchar(400), Primary Key(a), Key(b(1255))) ENGINE=rocksdb CHARSET=latin1;
-set global rocksdb_large_prefix=0;
 insert into t1 values (1, '1abcde', '1abcde'), (2, '2abcde', '2abcde'), (3, '3abcde', '3abcde');
 select * from t1;
 a	b	c
@@ -2548,9 +2542,6 @@ a	b	c
 2	12345	2abcde
 3	3abcde	3abcde
 drop table t1;
-create table t1 (a int, b text, c varchar(400), Primary Key(a), Key(b(2255))) ENGINE=rocksdb CHARSET=latin1;
-ERROR 42000: Specified key was too long; max key length is 767 bytes
-SET sql_mode = @old_mode;
 drop table t0;
 #
 # Fix assertion failure (attempt to overrun the key buffer) for prefix indexes

--- a/mysql-test/suite/rocksdb/t/dup_key_update.test
+++ b/mysql-test/suite/rocksdb/t/dup_key_update.test
@@ -2,11 +2,6 @@
 
 # Test insert ... on duplicate key update statements
 
---disable_warnings
-DROP TABLE IF EXISTS t1;
-DROP TABLE IF EXISTS t2;
---enable_warnings
-
 CREATE TABLE t1 (id1 INT, id2 INT, id3 INT,
                  PRIMARY KEY (id1, id2, id3),
                  UNIQUE KEY (id3, id1)) ENGINE=ROCKSDB;
@@ -15,28 +10,23 @@ CREATE TABLE t2 (id1 INT, id2 INT, id3 INT,
                  PRIMARY KEY (id1, id2, id3),
                  UNIQUE KEY (id3, id1) COMMENT 'rev:cf') ENGINE=ROCKSDB;
 
-
 --source suite/rocksdb/include/dup_key_update.inc
 
 # Cleanup
 DROP TABLE t1;
 DROP TABLE t2;
 
-set global rocksdb_large_prefix=1;
 CREATE TABLE t1 (id1 varchar(128) CHARACTER SET latin1 COLLATE latin1_bin,
                  id2 varchar(256) CHARACTER SET utf8 COLLATE utf8_bin,
                  id3 varchar(200) CHARACTER SET latin1 COLLATE latin1_swedish_ci,
                  PRIMARY KEY (id1, id2, id3),
                  UNIQUE KEY (id3, id1)) ENGINE=ROCKSDB;
-set global rocksdb_large_prefix=DEFAULT;
 
-set global rocksdb_large_prefix=1;
 CREATE TABLE t2 (id1 varchar(128) CHARACTER SET latin1 COLLATE latin1_bin,
                  id2 varchar(256) CHARACTER SET utf8 COLLATE utf8_bin,
                  id3 varchar(200) CHARACTER SET latin1 COLLATE latin1_swedish_ci,
                  PRIMARY KEY (id1, id2, id3),
                  UNIQUE KEY (id3, id1) COMMENT 'rev:cf') ENGINE=ROCKSDB;
-set global rocksdb_large_prefix=DEFAULT;
 
 --source suite/rocksdb/include/dup_key_update.inc
 

--- a/mysql-test/suite/rocksdb/t/early_load_rocksdb_plugin.test
+++ b/mysql-test/suite/rocksdb/t/early_load_rocksdb_plugin.test
@@ -7,6 +7,7 @@
 
 let BASEDIR= `select @@basedir`;
 let DDIR=$MYSQL_TMP_DIR/installdb_test;
+let MYSQLD_LPO_LOG=$MYSQL_TMP_DIR/server-lpo.log;
 let MYSQLD_LOG=$MYSQL_TMP_DIR/server.log;
 let extra_args=--no-defaults --basedir=$BASEDIR --debug=+d,ddse_rocksdb;
 
@@ -17,6 +18,12 @@ let extra_args=--no-defaults --basedir=$BASEDIR --debug=+d,ddse_rocksdb;
 --echo #
 --echo # Try --initialize
 --echo #
+
+--echo # Try to run the server with --initialize --rocksdb_large_prefix=OFF
+--error 1
+--exec $MYSQLD $extra_args --initialize --default_dd_storage_engine=RocksDB --rocksdb_large_prefix=OFF --datadir=$DDIR --log-error-verbosity=3 > $MYSQLD_LPO_LOG 2>&1
+
+--force-rmdir $DDIR
 
 --echo # Run the server with --initialize
 --exec $MYSQLD $extra_args --initialize --default_dd_storage_engine=RocksDB --datadir=$DDIR --log-error-verbosity=3 > $MYSQLD_LOG 2>&1
@@ -29,6 +36,9 @@ let extra_args=--no-defaults --basedir=$BASEDIR --debug=+d,ddse_rocksdb;
 --echo # Restarting the server
 --source include/start_mysqld.inc
 
+--echo #
+--echo # Error log checks
+--echo #
 --let $assert_file = $MYSQLD_LOG
 --let $assert_count = 1
 
@@ -39,6 +49,9 @@ let extra_args=--no-defaults --basedir=$BASEDIR --debug=+d,ddse_rocksdb;
 --let $assert_text = Check Data dictionary initializing
 --let $assert_select = Data dictionary initializing
 --let $assert_only_after = Check RocksDB:Init column families
+--source include/assert_grep.inc
+
+--let $assert_text=disabling rocksdb_large_prefix is not allowed with MySQL data dictionary in MyRocks
 --source include/assert_grep.inc
 
 --echo # Remove data dir and log file.

--- a/mysql-test/suite/rocksdb/t/rocksdb.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb.test
@@ -1669,14 +1669,10 @@ select * from t1 where id=9 for update;
 -- disconnect con1
 drop table t1;
 
---echo #Index on blob column
-SET @old_mode = @@sql_mode;
-SET sql_mode = 'strict_all_tables';
+--echo # Index on blob column
 create table t1 (a int, b text, c varchar(400), Primary Key(a), Key(c, b(255))) ENGINE=rocksdb CHARSET=latin1;
 drop table t1;
-set global rocksdb_large_prefix=1;
 create table t1 (a int, b text, c varchar(400), Primary Key(a), Key(b(1255))) ENGINE=rocksdb CHARSET=latin1;
-set global rocksdb_large_prefix=0;
 insert into t1 values (1, '1abcde', '1abcde'), (2, '2abcde', '2abcde'), (3, '3abcde', '3abcde');
 select * from t1;
 --replace_column 10 # 11 #
@@ -1686,9 +1682,6 @@ explain select b, a from t1 where b like '1%';
 update t1 set b= '12345' where b = '2abcde';
 select * from t1;
 drop table t1;
---error ER_TOO_LONG_KEY
-create table t1 (a int, b text, c varchar(400), Primary Key(a), Key(b(2255))) ENGINE=rocksdb CHARSET=latin1;
-SET sql_mode = @old_mode;
 
 drop table t0;
 

--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_large_prefix_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_large_prefix_basic.result
@@ -8,38 +8,50 @@ INSERT INTO invalid_values VALUES('\'bbb\'');
 SET @start_global_value = @@global.ROCKSDB_LARGE_PREFIX;
 SELECT @start_global_value;
 @start_global_value
-0
+1
 '# Setting to valid values in global scope#'
 "Trying to set variable @@global.ROCKSDB_LARGE_PREFIX to 1"
 SET @@global.ROCKSDB_LARGE_PREFIX   = 1;
+Warnings:
+Warning	131	using rocksdb_large_prefix is deprecated and it will be removed in a future release
 SELECT @@global.ROCKSDB_LARGE_PREFIX;
 @@global.ROCKSDB_LARGE_PREFIX
 1
 "Setting the global scope variable back to default"
 SET @@global.ROCKSDB_LARGE_PREFIX = DEFAULT;
+Warnings:
+Warning	131	using rocksdb_large_prefix is deprecated and it will be removed in a future release
 SELECT @@global.ROCKSDB_LARGE_PREFIX;
 @@global.ROCKSDB_LARGE_PREFIX
-0
+1
 "Trying to set variable @@global.ROCKSDB_LARGE_PREFIX to 0"
 SET @@global.ROCKSDB_LARGE_PREFIX   = 0;
+Warnings:
+Warning	131	using rocksdb_large_prefix is deprecated and it will be removed in a future release
 SELECT @@global.ROCKSDB_LARGE_PREFIX;
 @@global.ROCKSDB_LARGE_PREFIX
 0
 "Setting the global scope variable back to default"
 SET @@global.ROCKSDB_LARGE_PREFIX = DEFAULT;
+Warnings:
+Warning	131	using rocksdb_large_prefix is deprecated and it will be removed in a future release
 SELECT @@global.ROCKSDB_LARGE_PREFIX;
 @@global.ROCKSDB_LARGE_PREFIX
-0
+1
 "Trying to set variable @@global.ROCKSDB_LARGE_PREFIX to on"
 SET @@global.ROCKSDB_LARGE_PREFIX   = on;
+Warnings:
+Warning	131	using rocksdb_large_prefix is deprecated and it will be removed in a future release
 SELECT @@global.ROCKSDB_LARGE_PREFIX;
 @@global.ROCKSDB_LARGE_PREFIX
 1
 "Setting the global scope variable back to default"
 SET @@global.ROCKSDB_LARGE_PREFIX = DEFAULT;
+Warnings:
+Warning	131	using rocksdb_large_prefix is deprecated and it will be removed in a future release
 SELECT @@global.ROCKSDB_LARGE_PREFIX;
 @@global.ROCKSDB_LARGE_PREFIX
-0
+1
 "Trying to set variable @@session.ROCKSDB_LARGE_PREFIX to 444. It should fail because it is not session."
 SET @@session.ROCKSDB_LARGE_PREFIX   = 444;
 ERROR HY000: Variable 'rocksdb_large_prefix' is a GLOBAL variable and should be set with SET GLOBAL
@@ -49,16 +61,18 @@ SET @@global.ROCKSDB_LARGE_PREFIX   = 'aaa';
 Got one of the listed errors
 SELECT @@global.ROCKSDB_LARGE_PREFIX;
 @@global.ROCKSDB_LARGE_PREFIX
-0
+1
 "Trying to set variable @@global.ROCKSDB_LARGE_PREFIX to 'bbb'"
 SET @@global.ROCKSDB_LARGE_PREFIX   = 'bbb';
 Got one of the listed errors
 SELECT @@global.ROCKSDB_LARGE_PREFIX;
 @@global.ROCKSDB_LARGE_PREFIX
-0
+1
 SET @@global.ROCKSDB_LARGE_PREFIX = @start_global_value;
+Warnings:
+Warning	131	using rocksdb_large_prefix is deprecated and it will be removed in a future release
 SELECT @@global.ROCKSDB_LARGE_PREFIX;
 @@global.ROCKSDB_LARGE_PREFIX
-0
+1
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/share/messages_to_clients.txt
+++ b/share/messages_to_clients.txt
@@ -10157,6 +10157,9 @@ ER_THRIFT_PLACEHOLDER_50136
 ER_RDB_TTL_WRITES_WITH_STALE_SNAPSHOT
   eng "Can't execute writes with a stale snapshot on a TTL enabled table when rocksdb_binlog_ttl = 1. Retry the transaction to refresh the snapshot."
 
+ER_RDB_DDSE_CANNOT_DISABLE_LARGE_PREFIX
+  eng "Can't disable rocksdb_large_prefix when MyRocks is the MySQL data dictionary engine"
+
 #
 # End of 8.0 FB MySQL error messages.
 # (Please read comments from the header of this section before adding error

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -62,6 +62,7 @@
 #include "sql/sql_partition.h"
 #include "sql/sql_table.h"
 #include "sql/sql_thd_internal_api.h"
+#include "sql/strfunc.h"
 
 /* RocksDB includes */
 #include "env/composite_env_wrapper.h"
@@ -930,7 +931,7 @@ static unsigned long long rocksdb_table_stats_max_num_rows_scanned = 0ul;
 static bool rocksdb_enable_bulk_load_api = 1;
 static bool rocksdb_enable_remove_orphaned_dropped_cfs = 1;
 static bool rocksdb_print_snapshot_conflict_queries = 0;
-static bool rocksdb_large_prefix = 0;
+static bool rocksdb_large_prefix = true;
 static bool rocksdb_allow_to_start_after_corruption = 0;
 static ulong rocksdb_write_policy = rocksdb::TxnDBWritePolicy::WRITE_COMMITTED;
 static char *rocksdb_read_free_rpl_tables;
@@ -1413,6 +1414,63 @@ static constexpr ulong RDB_DEADLOCK_DETECT_DEPTH = 50;
 static constexpr ulonglong RDB_DEFAULT_MAX_COMPACTION_HISTORY = 64;
 static constexpr ulong ROCKSDB_MAX_MRR_BATCH_SIZE = 1000;
 static constexpr uint ROCKSDB_MAX_BOTTOM_PRI_BACKGROUND_COMPACTIONS = 64;
+
+static constexpr char large_prefix_deprecated_msg[] =
+    "using rocksdb_large_prefix is deprecated and it will be removed in a "
+    "future release";
+
+static constexpr char ddse_enforced_large_prefix_msg[] =
+    "disabling rocksdb_large_prefix is not allowed with MySQL data dictionary "
+    "in MyRocks";
+
+// Copied over from InnoDB with minor changes. Returns false on success, true on
+// failure.
+static bool check_func_bool(void *save, st_mysql_value *value) {
+  int result;
+  if (value->value_type(value) == MYSQL_VALUE_TYPE_STRING) {
+    char buff[STRING_BUFFER_USUAL_SIZE];
+    int length = sizeof(buff);
+
+    const auto *const str = value->val_str(value, buff, &length);
+
+    if (str == nullptr) return true;
+
+    result = find_type(&bool_typelib, str, length, true) - 1;
+
+    if (result < 0) return true;
+  } else {
+    long long tmp;
+    if (value->val_int(value, &tmp) < 0) return true;
+    if (tmp > 1 || tmp < 0) return true;
+    result = static_cast<int>(tmp);
+  }
+  *(bool *)save = result != 0;
+  return false;
+}
+
+static int rocksdb_large_prefix_check(THD *, SYS_VAR *, void *save,
+                                      st_mysql_value *value) {
+  if (check_func_bool(save, value)) return HA_EXIT_FAILURE;
+
+  if (default_dd_storage_engine != DEFAULT_DD_ROCKSDB) return HA_EXIT_SUCCESS;
+
+  const auto proposed_value = *static_cast<bool *>(save);
+
+  if (default_dd_storage_engine == DEFAULT_DD_ROCKSDB && !proposed_value) {
+    my_error(ER_RDB_DDSE_CANNOT_DISABLE_LARGE_PREFIX, MYF(0));
+    return HA_EXIT_FAILURE;
+  }
+
+  return HA_EXIT_SUCCESS;
+}
+
+static void rocksdb_large_prefix_update(THD *thd, SYS_VAR *, void *var_ptr,
+                                        const void *save) {
+  push_warning(thd, Sql_condition::SL_WARNING, HA_ERR_WRONG_COMMAND,
+               large_prefix_deprecated_msg);
+
+  *static_cast<bool *>(var_ptr) = *static_cast<const bool *>(save);
+}
 
 // TODO: 0 means don't wait at all, and we don't support it yet?
 static MYSQL_THDVAR_ULONG(lock_wait_timeout, PLUGIN_VAR_RQCMDARG,
@@ -2690,9 +2748,9 @@ static MYSQL_SYSVAR_BOOL(table_stats_use_table_scan,
 
 static MYSQL_SYSVAR_BOOL(
     large_prefix, rocksdb_large_prefix, PLUGIN_VAR_RQCMDARG,
-    "Support large index prefix length of 3072 bytes. If off, the maximum "
-    "index prefix length is 767.",
-    nullptr, nullptr, false);
+    "Deprecated: support large index prefix length of 3072 bytes. If off, the "
+    "maximum index prefix length is 767.",
+    rocksdb_large_prefix_check, rocksdb_large_prefix_update, true);
 
 static MYSQL_SYSVAR_BOOL(
     allow_to_start_after_corruption, rocksdb_allow_to_start_after_corruption,
@@ -7354,6 +7412,16 @@ static int rocksdb_init_internal(void *const p) {
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 #endif
+
+  if (!rocksdb_large_prefix) {
+    if (default_dd_storage_engine == DEFAULT_DD_ROCKSDB) {
+      LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
+                      ddse_enforced_large_prefix_msg);
+      DBUG_RETURN(HA_EXIT_FAILURE);
+    }
+    LogPluginErrMsg(WARNING_LEVEL, ER_LOG_PRINTF_MSG,
+                    large_prefix_deprecated_msg);
+  }
 
   clone::fixup_on_startup();
   move_wals_to_target_dir();


### PR DESCRIPTION
This variable was introduced to mirror innodb_large_prefix, which was deprecated in 5.7 and removed in 8.0, and no longer serves any real purpose, nor there is anything to gain with its 'OFF' setting, which is also incompatible with the data dictionary schema. Thus 1) change the default to 'ON'; 2) deprecate it.

Squash with 749f1dc5ef0327e55616441b399000510db9a54d