### PR TITLE
Do not use THR_LOCK for MyRocks

### DIFF
--- a/mysql-test/suite/rocksdb/r/table_locks.result
+++ b/mysql-test/suite/rocksdb/r/table_locks.result
@@ -1,0 +1,524 @@
+SET SESSION default_storage_engine = RocksDB;
+create table t1 (c1 int);
+create table t2 (c1 int);
+create table t3 (c1 int);
+lock tables t1 write, t2 write, t3 write;
+drop table t2, t3, t1;
+create table t1 (c1 int);
+create table t2 (c1 int);
+create table t3 (c1 int);
+lock tables t1 write, t2 write, t3 write, t1 as t4 read;
+alter table t2 add column c2 int;
+drop table t1, t2, t3;
+create table t1 ( a int(11) not null auto_increment, primary key(a));
+Warnings:
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+create table t2 ( a int(11) not null auto_increment, primary key(a));
+Warnings:
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+lock tables t1 write, t2 read;
+delete from t1 using t1,t2 where t1.a=t2.a;
+delete t1 from t1,t2 where t1.a=t2.a;
+delete from t2 using t1,t2 where t1.a=t2.a;
+ERROR HY000: Table 't2' was locked with a READ lock and can't be updated
+delete t2 from t1,t2 where t1.a=t2.a;
+ERROR HY000: Table 't2' was locked with a READ lock and can't be updated
+drop table t1,t2;
+ERROR HY000: Table 't2' was locked with a READ lock and can't be updated
+unlock tables;
+drop table t2,t1;
+End of 4.1 tests.
+create table t1 (a int);
+lock table t1 write;
+flush tables with read lock;
+ERROR HY000: Can't execute the given command because you have active locked tables or an active transaction
+unlock tables;
+drop table t1;
+CREATE TABLE t1 (i INT);
+LOCK TABLES mysql.time_zone READ, mysql.time_zone_name READ, t1 READ;
+UNLOCK TABLES;
+LOCK TABLES mysql.time_zone READ, mysql.time_zone_name READ, t1 WRITE;
+UNLOCK TABLES;
+LOCK TABLES mysql.time_zone READ, mysql.time_zone_name READ;
+UNLOCK TABLES;
+LOCK TABLES mysql.time_zone WRITE, mysql.time_zone_name WRITE;
+UNLOCK TABLES;
+LOCK TABLES mysql.time_zone READ, mysql.time_zone_name WRITE, t1 READ;
+ERROR HY000: You can't combine write-locking of system tables with other tables or lock types
+LOCK TABLES mysql.time_zone WRITE, mysql.time_zone_name WRITE, t1 READ;
+ERROR HY000: You can't combine write-locking of system tables with other tables or lock types
+LOCK TABLES mysql.time_zone WRITE, mysql.time_zone_name WRITE, t1 WRITE;
+ERROR HY000: You can't combine write-locking of system tables with other tables or lock types
+LOCK TABLES mysql.time_zone READ, mysql.time_zone_name WRITE;
+ERROR HY000: You can't combine write-locking of system tables with other tables or lock types
+DROP TABLE t1;
+
+Bug#5719 impossible to lock VIEW
+
+Just covering existing behaviour with tests. 
+Consistency has not been found here.
+
+drop view if exists v_bug5719;
+drop table if exists t1, t2, t3;
+create table t1 (a int);
+create temporary table t2 (a int);
+create table t3 (a int);
+create view v_bug5719 as select 1;
+lock table v_bug5719 write;
+select * from t1;
+ERROR HY000: Table 't1' was not locked with LOCK TABLES
+
+Allowed to select from a temporary talbe under LOCK TABLES
+
+select * from t2;
+a
+select * from t3;
+ERROR HY000: Table 't3' was not locked with LOCK TABLES
+select * from v_bug5719;
+1
+1
+drop view v_bug5719;
+ERROR HY000: Can't execute the given command because you have active locked tables or an active transaction
+
+sic: did not left LOCK TABLES mode automatically
+
+select * from t1;
+ERROR HY000: Table 't1' was not locked with LOCK TABLES
+unlock tables;
+create or replace view v_bug5719 as select * from t1;
+lock tables v_bug5719 write;
+select * from v_bug5719;
+a
+
+Allowed to use an underlying table under LOCK TABLES <view>
+
+select * from t1;
+a
+
+Allowed to select from a temporary table under LOCK TABLES
+
+select * from t2;
+a
+select * from t3;
+ERROR HY000: Table 't3' was not locked with LOCK TABLES
+Dropping of implicitly locked table is allowed.
+drop table t1;
+View becomes invalid.
+select * from v_bug5719;
+ERROR HY000: View 'test.v_bug5719' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them
+unlock tables;
+create table t1 (a int);
+Now let us also lock table explicitly and drop it.
+lock tables t1 write, v_bug5719 write;
+drop table t1;
+
+sic: left LOCK TABLES mode
+
+select * from t3;
+a
+select * from v_bug5719;
+ERROR HY000: View 'test.v_bug5719' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them
+unlock tables;
+drop view v_bug5719;
+
+When limitation to use temporary tables in views is removed, please
+add a test that shows what happens under LOCK TABLES when a view
+references a temporary table, is locked, and the underlying table
+is dropped.
+
+create view v_bug5719 as select * from t2;
+ERROR HY000: View's SELECT refers to a temporary table 't2'
+
+Cleanup.
+
+drop table t2, t3;
+#
+# Bug#39843 DELETE requires write access to table in subquery in where clause
+#
+CREATE TABLE t1 (
+table1_rowid SMALLINT NOT NULL
+);
+CREATE TABLE t2 (
+table2_rowid SMALLINT NOT NULL
+);
+INSERT INTO t1 VALUES (1);
+INSERT INTO t2 VALUES (1);
+LOCK TABLES t1 WRITE, t2 READ;
+# Sub-select should not try to aquire a write lock.
+DELETE FROM t1 
+WHERE EXISTS 
+( 
+SELECT 'x' 
+FROM t2
+WHERE t1.table1_rowid = t2.table2_rowid
+) ;
+# While implementing the patch we didn't break old behavior;
+# The following sub-select should still requires a write lock:
+SELECT * FROM t1 WHERE 1 IN (SELECT * FROM t2 FOR UPDATE);
+ERROR HY000: Table 't2' was locked with a READ lock and can't be updated
+UNLOCK TABLES;
+DROP TABLE t1,t2;
+End of 5.1 tests.
+#
+# Ensure that FLUSH TABLES doesn't substitute a base locked table
+# with a temporary one.
+#
+create table t1 (a int);
+create table t2 (a int);
+lock table t1 write, t2 write;
+create temporary table t1 (a int);
+flush table t1;
+drop temporary table t1;
+select * from t1;
+a
+unlock tables;
+drop table t1, t2;
+#
+# Ensure that mi_copy_status is called for two instances
+# of the same table when it is reopened after a flush.
+# 
+drop table if exists t1;
+drop view if exists v1;
+create table t1 (c1 int);
+create view v1 as select * from t1;
+lock tables t1 write, v1 write;
+flush table t1;
+insert into t1 values (33);
+flush table t1;
+select * from t1;
+c1
+33
+unlock tables;
+drop table t1;
+drop view v1;
+#
+# WL#4284: Transactional DDL locking
+#
+create table t1 (a int);
+set autocommit= 0;
+insert into t1 values (1);
+lock table t1 write;
+# Disconnect
+# Ensure that metadata locks will be released if there is an open
+# transaction (autocommit=off) in conjunction with lock tables.
+drop table t1;
+# Same problem but now for BEGIN
+create table t1 (a int);
+begin;
+insert into t1 values (1);
+# Disconnect
+# Ensure that metadata locks held by the transaction are released.
+drop table t1;
+#
+# Coverage for situations when we try to execute DDL on tables
+# which are locked by LOCK TABLES only implicitly.
+#
+drop tables if exists t1, t2;
+drop view if exists v1;
+drop function if exists f1;
+create table t1 (i int);
+create table t2 (j int);
+#
+# Try to perform DDL on table which is locked through view.
+create view v1 as select * from t2;
+lock tables t1 write, v1 write;
+flush table t2;
+alter table t2 add column k int;
+create trigger t2_bi before insert on t2 for each row set @a:=1;
+repair table t2;
+Table	Op	Msg_type	Msg_text
+test.t2	repair	note	The storage engine for the table doesn't support repair
+drop table t2;
+unlock tables;
+drop view v1;
+#
+# Now, try  DDL on table which is locked through routine.
+create function f1 () returns int
+begin
+insert into t2 values (1);
+return 0;
+end|
+create table t2 (j int);
+create view v1 as select f1() from t1;
+lock tables v1 read;
+flush table t2;
+alter table t2 add column k int;
+create trigger t2_bi before insert on t2 for each row set @a:=1;
+repair table t2;
+Table	Op	Msg_type	Msg_text
+test.t2	repair	note	The storage engine for the table doesn't support repair
+drop table t2;
+unlock tables;
+drop view v1;
+drop function f1;
+#
+# Finally, try DDL on table which is locked thanks to trigger.
+create trigger t1_ai after insert on t1 for each row insert into t2 values (1);
+create table t2 (j int);
+lock tables t1 write;
+alter table t2 add column k int;
+create trigger t2_bi before insert on t2 for each row set @a:=1;
+repair table t2;
+Table	Op	Msg_type	Msg_text
+test.t2	repair	note	The storage engine for the table doesn't support repair
+flush table t2;
+drop table t2;
+unlock tables;
+drop trigger t1_ai;
+drop tables t1;
+#
+# Bug#45035 " Altering table under LOCK TABLES results in 
+# "Error 1213 Deadlock found..."
+#
+# When reopening tables under LOCK TABLES after ALTER TABLE,
+# 6.0 used to be taking thr_lock locks one by one, and
+# that would lead to a lock conflict. 
+# Check that taking all locks at once works.
+#
+create table t1 (i int);
+lock tables t1 write, t1 as a read, t1 as b read;
+alter table t1 add column j int;
+unlock tables;
+drop table t1;
+create temporary table t1 (i int);
+#
+# This is just for test coverage purposes, 
+# when this is allowed, remove the --error.
+#
+lock tables t1 write, t1 as a read, t1 as b read;
+ERROR HY000: Can't reopen table: 't1'
+alter table t1 add column j int;
+unlock tables;
+drop table t1;
+# Moved case for partitioned tables to partition.test
+#
+# Bug #43272 HANDLER SQL command does not work under LOCK TABLES
+#
+CREATE TABLE t1 (a INT);
+LOCK TABLE t1 WRITE;
+# HANDLER commands are not allowed in LOCK TABLES mode
+HANDLER t1 OPEN;
+ERROR HY000: Can't execute the given command because you have active locked tables or an active transaction
+HANDLER t1 READ FIRST;
+ERROR HY000: Can't execute the given command because you have active locked tables or an active transaction
+HANDLER t1 CLOSE;
+ERROR HY000: Can't execute the given command because you have active locked tables or an active transaction
+UNLOCK TABLES;
+DROP TABLE t1;
+#
+# Bug#45066 FLUSH TABLES WITH READ LOCK deadlocks against 
+#           LOCK TABLE 
+#
+CREATE TABLE t1(a INT);
+LOCK TABLE t1 READ;
+FLUSH TABLES;
+ERROR HY000: Table 't1' was locked with a READ lock and can't be updated
+LOCK TABLE t1 WRITE;
+FLUSH TABLES;
+#
+# If you allow the next combination, you reintroduce bug Bug#45066
+# 
+LOCK TABLE t1 READ;
+FLUSH TABLES WITH READ LOCK;
+ERROR HY000: Can't execute the given command because you have active locked tables or an active transaction
+LOCK TABLE t1 WRITE;
+FLUSH TABLES WITH READ LOCK;
+ERROR HY000: Can't execute the given command because you have active locked tables or an active transaction
+UNLOCK TABLES;
+DROP TABLE t1;
+#
+# Simplified test for bug #48538 "Assertion in thr_lock() on LOAD DATA
+# CONCURRENT INFILE".
+#
+CREATE TABLE t1 (f1 INT, f2 INT) ENGINE = MEMORY;
+CREATE TRIGGER t1_ai AFTER INSERT ON t1 FOR EACH ROW 
+UPDATE LOW_PRIORITY t1 SET f2 = 7;
+# Statement below should fail with ER_CANT_UPDATE_USED_TABLE_IN_SF_OR_TRG
+# error instead of failing on assertion in table-level locking subsystem.
+INSERT INTO t1(f1) VALUES(0);
+ERROR HY000: Can't update table 't1' in stored function/trigger because it is already used by statement which invoked this stored function/trigger.
+DROP TABLE t1;
+#
+# Bug#43685 Lock table affects other non-related tables
+#
+CREATE TABLE t1 (id INT);
+CREATE TABLE t2 (id INT);
+# Connection default
+LOCK TABLE t1 WRITE;
+ANALYZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
+# Connection con2
+LOCK TABLE t2 WRITE;
+# This used to hang until the first connection
+# unlocked t1.
+FLUSH TABLE t2;
+UNLOCK TABLES;
+# Connection default
+UNLOCK TABLES;
+DROP TABLE t1, t2;
+#
+# Bug#13586314 - RUNTIME - HIBISCUS: ISSUE DEPRECATION
+# WARNING FOR LOW_PRIORITY MODIFIER
+#
+DROP TABLE IF EXISTS t1;
+CREATE TABLE t1 (a INT);
+# Below statement should return a deprecation warning
+LOCK TABLES t1 LOW_PRIORITY WRITE;
+Warnings:
+Warning	1287	'LOW_PRIORITY WRITE' is deprecated and will be removed in a future release. Please use WRITE instead
+UNLOCK TABLES;
+DROP TABLE t1;
+# End of Bug#13586314
+#
+# End of 6.0 tests.
+#
+call mtr.add_suppression("Can't open and lock privilege tables: Table 'user' was not locked with LOCK TABLES");
+#
+# WL#4284: Transactional DDL locking
+#
+# FLUSH PRIVILEGES should not implicitly unlock locked tables.
+#
+DROP TABLE IF EXISTS t1;
+CREATE TABLE t1 (c1 INT);
+LOCK TABLES t1 READ;
+FLUSH PRIVILEGES;
+ERROR HY000: Table 'user' was not locked with LOCK TABLES
+UNLOCK TABLES;
+FLUSH PRIVILEGES;
+DROP TABLE t1;
+drop table if exists t1;
+create table t1 (id integer, x integer) engine=ROCKSDB;
+insert into t1 values(0, 0);
+set autocommit=0;
+SELECT * from t1 where id = 0 FOR UPDATE;
+id	x
+0	0
+set autocommit=0;
+lock table t1 write;
+update t1 set x=1 where id = 0;
+select * from t1;
+id	x
+0	1
+commit;
+update t1 set x=2 where id = 0;
+commit;
+unlock tables;
+select * from t1;
+id	x
+0	2
+commit;
+drop table t1;
+Bug#19803418   ASSERTION: TABLE->QUIESCE == QUIESCE_NONE
+IN ROW0QUIESCE.CC LINE 683
+CREATE TABLE t1(C TEXT CHARACTER SET UJIS) ENGINE=ROCKSDB;
+LOCK TABLES t1 WRITE,t1 AS t0 READ,t1 AS t2 READ;
+FLUSH TABLE t1;
+LOCK TABLES t1 READ,t1 AS t0 WRITE,t1 AS t2 READ;
+FLUSH TABLE t1;
+LOCK TABLES t1 READ,t1 AS t0 READ,t1 AS t2 READ;
+FLUSH TABLE t1;
+ERROR HY000: Table 't1' was locked with a READ lock and can't be updated
+UNLOCK TABLES;
+FLUSH TABLE t1;
+DROP TABLE t1;
+#
+# Test for bug #11764618 "DEADLOCK WHEN DDL UNDER LOCK TABLES
+#                         WRITE, READ + PREPARE".
+#
+connect  con1,localhost,root,,test,,;
+connect  con2,localhost,root,,test,,;
+connect  con3,localhost,root,,test,,;
+connection default;
+create table t1(i int);
+create table t2(i int);
+create table t3(i int);
+create table t4(i int);
+lock tables t1 write, t3 read;
+connection con1;
+begin;
+select count(*) from t4;
+count(*)
+0
+# Sending:
+insert into t3 values (1);;
+connection con2;
+# Wait until 'con1' acquires SR metadata lock on 't4'
+# and blocks on 't3'. Before WL#6671 waiting has happened
+# on THR_LOCK lock which led to deadlock.
+# Sending:
+rename table t2 to t0, t4 to t2, t0 to t4;;
+connection con3;
+# Wait until RENAME acquires X metadata lock on 't2'
+# and blocks on 't4'.
+# Sending:
+prepare stmt1 from 'select * from t1, t2';;
+connection default;
+# Wait until PREPARE acquires S metadata lock on 't1'
+# and blocks on 't2'.
+# This ALTER TABLE upgrades SNRW lock on t1 to X lock.
+# In the past this caused deadlock.
+alter table t1 add column j int;
+unlock tables;
+connection con1;
+# Reap INSERT
+commit;
+connection con2;
+# Reap RENAME
+connection con3;
+# Reap PREPARE
+connection default;
+disconnect con1;
+disconnect con2;
+disconnect con3;
+drop tables t1, t2, t3, t4;
+#
+# Test for bug #11764618 "DEADLOCK WHEN DDL UNDER LOCK TABLES
+#                         WRITE, READ + PREPARE".
+#
+connect  con1,localhost,root,,test,,;
+connect  con2,localhost,root,,test,,;
+connect  con3,localhost,root,,test,,;
+connection default;
+create table t1(i int);
+create table t2(i int);
+create table t3(i int);
+create table t4(i int);
+lock tables t1 write, t3 read;
+connection con1;
+begin;
+select count(*) from t4;
+count(*)
+0
+# Sending:
+insert into t3 values (1);;
+connection con2;
+# Wait until 'con1' acquires SR metadata lock on 't4'
+# and blocks on 't3'. Before WL#6671 waiting has happened
+# on THR_LOCK lock which led to deadlock.
+# Sending:
+rename table t2 to t0, t4 to t2, t0 to t4;;
+connection con3;
+# Wait until RENAME acquires X metadata lock on 't2'
+# and blocks on 't4'.
+# Sending:
+prepare stmt1 from 'select * from t1, t2';;
+connection default;
+# Wait until PREPARE acquires S metadata lock on 't1'
+# and blocks on 't2'.
+# This ALTER TABLE upgrades SNRW lock on t1 to X lock.
+# In the past this caused deadlock.
+alter table t1 add column j int;
+unlock tables;
+connection con1;
+# Reap INSERT
+commit;
+connection con2;
+# Reap RENAME
+connection con3;
+# Reap PREPARE
+connection default;
+disconnect con1;
+disconnect con2;
+disconnect con3;
+drop tables t1, t2, t3, t4;

--- a/mysql-test/suite/rocksdb/r/table_locks_debug.result
+++ b/mysql-test/suite/rocksdb/r/table_locks_debug.result
@@ -1,0 +1,40 @@
+#
+# Additional test coverage for LOCK TABLES ... READ LOCAL
+# for ROCKSDB tables.
+#
+# Check that we correctly handle deadlocks which can occur
+# during metadata lock upgrade which happens when one tries
+# to use LOCK TABLES ... READ LOCAL for ROCKSDB tables.
+CREATE TABLE t1 (i INT) ENGINE=ROCKSDB;
+CREATE TABLE t2 (j INT) ENGINE=ROCKSDB;
+# Execute LOCK TABLE READ LOCK which will pause after acquiring
+# SR metadata lock and before upgrading it to SRO lock.
+SET DEBUG_SYNC="after_open_table_mdl_shared SIGNAL locked WAIT_FOR go";
+# Sending:
+LOCK TABLE t1 READ LOCAL;
+connect  con1, localhost, root;
+SET DEBUG_SYNC="now WAIT_FOR locked";
+# Execute RENAME TABLE which will try to acquire X lock.
+# Sending:
+RENAME TABLE t1 TO t3, t2 TO t1, t3 TO t2;
+connect  con2, localhost, root;
+# Wait until RENAME TABLE is blocked.
+# Resume LOCK TABLE statement. It should try to
+# upgrade SR lock to SRO lock which will create
+# deadlock due to presence of pending X lock.
+# Deadlock should be detected and LOCK TABLES should
+# release its MDL and retry opening of tables.
+SET DEBUG_SYNC="now SIGNAL go";
+connection con1;
+# RENAME TABLE should be able to complete. Reap it.
+connection default;
+# Reap LOCK TABLES.
+# Check that we see new version of table.
+SELECT * FROM t1;
+j
+UNLOCK TABLES;
+# Clean-up.
+SET DEBUG_SYNC="RESET";
+disconnect con1;
+disconnect con2;
+DROP TABLES t1, t2;

--- a/mysql-test/suite/rocksdb/t/table_locks.test
+++ b/mysql-test/suite/rocksdb/t/table_locks.test
@@ -1,0 +1,250 @@
+--source include/have_rocksdb.inc
+
+SET SESSION default_storage_engine = RocksDB;
+
+--source t/lock.test
+
+--source include/count_sessions.inc
+
+# Taken from innodb.innodb-lock test
+
+#
+# Testing of explicit table locks with enforced table locks
+#
+
+connect (con1,localhost,root,,);
+connect (con2,localhost,root,,);
+
+--disable_warnings
+drop table if exists t1;
+--enable_warnings
+
+#
+# Testing of explicit table locks with enforced table locks
+#
+
+connection con1;
+create table t1 (id integer, x integer) engine=ROCKSDB;
+insert into t1 values(0, 0);
+set autocommit=0;
+SELECT * from t1 where id = 0 FOR UPDATE;
+
+connection con2;
+set autocommit=0;
+
+# The following statement should hang because con1 is locking the page
+--send
+lock table t1 write;
+--sleep 2
+
+connection con1;
+update t1 set x=1 where id = 0;
+select * from t1;
+commit;
+
+connection con2;
+reap;
+update t1 set x=2 where id = 0;
+commit;
+unlock tables;
+
+connection con1;
+select * from t1;
+commit;
+
+drop table t1;
+
+# End of 4.1 tests
+
+--echo Bug#19803418   ASSERTION: TABLE->QUIESCE == QUIESCE_NONE
+--echo		      IN ROW0QUIESCE.CC LINE 683
+
+CREATE TABLE t1(C TEXT CHARACTER SET UJIS) ENGINE=ROCKSDB;
+LOCK TABLES t1 WRITE,t1 AS t0 READ,t1 AS t2 READ;
+FLUSH TABLE t1;
+
+LOCK TABLES t1 READ,t1 AS t0 WRITE,t1 AS t2 READ;
+FLUSH TABLE t1;
+
+LOCK TABLES t1 READ,t1 AS t0 READ,t1 AS t2 READ;
+--error ER_TABLE_NOT_LOCKED_FOR_WRITE
+FLUSH TABLE t1;
+UNLOCK TABLES;
+FLUSH TABLE t1;
+
+DROP TABLE t1;
+disconnect con1;
+disconnect con2;
+
+# Taken from main.lock_multi
+
+--echo #
+--echo # Test for bug #11764618 "DEADLOCK WHEN DDL UNDER LOCK TABLES
+--echo #                         WRITE, READ + PREPARE".
+--echo #
+--enable_connect_log
+connect (con1,localhost,root,,test,,);
+connect (con2,localhost,root,,test,,);
+connect (con3,localhost,root,,test,,);
+connection default;
+
+create table t1(i int);
+create table t2(i int);
+create table t3(i int);
+create table t4(i int);
+
+lock tables t1 write, t3 read;
+
+connection con1;
+begin;
+select count(*) from t4;
+--echo # Sending:
+--send insert into t3 values (1);
+
+connection con2;
+--echo # Wait until 'con1' acquires SR metadata lock on 't4'
+--echo # and blocks on 't3'. Before WL#6671 waiting has happened
+--echo # on THR_LOCK lock which led to deadlock.
+let $wait_condition=
+select count(*) = 1 from information_schema.processlist
+where state = "Waiting for table metadata lock" and
+info = "insert into t3 values (1)";
+--source include/wait_condition.inc
+
+--echo # Sending:
+--send rename table t2 to t0, t4 to t2, t0 to t4;
+
+connection con3;
+--echo # Wait until RENAME acquires X metadata lock on 't2'
+--echo # and blocks on 't4'.
+let $wait_condition=
+select count(*) = 1 from information_schema.processlist
+where state = "Waiting for table metadata lock" and
+info = "rename table t2 to t0, t4 to t2, t0 to t4";
+--source include/wait_condition.inc
+
+--echo # Sending:
+--send prepare stmt1 from 'select * from t1, t2';
+
+connection default;
+--echo # Wait until PREPARE acquires S metadata lock on 't1'
+--echo # and blocks on 't2'.
+let $wait_condition=
+select count(*) = 1 from information_schema.processlist
+where state = "Waiting for table metadata lock" and
+info = "PREPARE stmt1 FROM ...";
+--source include/wait_condition.inc
+
+--echo # This ALTER TABLE upgrades SNRW lock on t1 to X lock.
+--echo # In the past this caused deadlock.
+alter table t1 add column j int;
+
+unlock tables;
+
+connection con1;
+--echo # Reap INSERT
+--reap
+commit;
+
+connection con2;
+--echo # Reap RENAME
+--reap
+
+connection con3;
+--echo # Reap PREPARE
+--reap
+
+connection default;
+disconnect con1;
+disconnect con2;
+disconnect con3;
+drop tables t1, t2, t3, t4;
+
+--disable_connect_log
+
+--echo #
+--echo # Test for bug #11764618 "DEADLOCK WHEN DDL UNDER LOCK TABLES
+--echo #                         WRITE, READ + PREPARE".
+--echo #
+--enable_connect_log
+connect (con1,localhost,root,,test,,);
+connect (con2,localhost,root,,test,,);
+connect (con3,localhost,root,,test,,);
+connection default;
+
+create table t1(i int);
+create table t2(i int);
+create table t3(i int);
+create table t4(i int);
+
+lock tables t1 write, t3 read;
+
+connection con1;
+begin;
+select count(*) from t4;
+--echo # Sending:
+--send insert into t3 values (1);
+
+connection con2;
+--echo # Wait until 'con1' acquires SR metadata lock on 't4'
+--echo # and blocks on 't3'. Before WL#6671 waiting has happened
+--echo # on THR_LOCK lock which led to deadlock.
+let $wait_condition=
+select count(*) = 1 from information_schema.processlist
+where state = "Waiting for table metadata lock" and
+info = "insert into t3 values (1)";
+--source include/wait_condition.inc
+
+--echo # Sending:
+--send rename table t2 to t0, t4 to t2, t0 to t4;
+
+connection con3;
+--echo # Wait until RENAME acquires X metadata lock on 't2'
+--echo # and blocks on 't4'.
+let $wait_condition=
+select count(*) = 1 from information_schema.processlist
+where state = "Waiting for table metadata lock" and
+info = "rename table t2 to t0, t4 to t2, t0 to t4";
+--source include/wait_condition.inc
+
+--echo # Sending:
+--send prepare stmt1 from 'select * from t1, t2';
+
+connection default;
+--echo # Wait until PREPARE acquires S metadata lock on 't1'
+--echo # and blocks on 't2'.
+let $wait_condition=
+select count(*) = 1 from information_schema.processlist
+where state = "Waiting for table metadata lock" and
+info = "PREPARE stmt1 FROM ...";
+--source include/wait_condition.inc
+
+--echo # This ALTER TABLE upgrades SNRW lock on t1 to X lock.
+--echo # In the past this caused deadlock.
+alter table t1 add column j int;
+
+unlock tables;
+
+connection con1;
+--echo # Reap INSERT
+--reap
+commit;
+
+connection con2;
+--echo # Reap RENAME
+--reap
+
+connection con3;
+--echo # Reap PREPARE
+--reap
+
+connection default;
+disconnect con1;
+disconnect con2;
+disconnect con3;
+drop tables t1, t2, t3, t4;
+
+--disable_connect_log
+
+# Wait till all disconnects are completed
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/rocksdb/t/table_locks_debug.test
+++ b/mysql-test/suite/rocksdb/t/table_locks_debug.test
@@ -1,0 +1,66 @@
+--source include/have_debug_sync.inc
+--source include/have_rocksdb.inc
+
+# Taken from main.lock_sync test
+
+--echo #
+--echo # Additional test coverage for LOCK TABLES ... READ LOCAL
+--echo # for ROCKSDB tables.
+--echo #
+--echo # Check that we correctly handle deadlocks which can occur
+--echo # during metadata lock upgrade which happens when one tries
+--echo # to use LOCK TABLES ... READ LOCAL for ROCKSDB tables.
+
+--source include/count_sessions.inc
+
+--enable_connect_log
+CREATE TABLE t1 (i INT) ENGINE=ROCKSDB;
+CREATE TABLE t2 (j INT) ENGINE=ROCKSDB;
+
+--echo # Execute LOCK TABLE READ LOCK which will pause after acquiring
+--echo # SR metadata lock and before upgrading it to SRO lock.
+SET DEBUG_SYNC="after_open_table_mdl_shared SIGNAL locked WAIT_FOR go";
+--echo # Sending:
+--send LOCK TABLE t1 READ LOCAL
+
+connect (con1, localhost, root);
+SET DEBUG_SYNC="now WAIT_FOR locked";
+--echo # Execute RENAME TABLE which will try to acquire X lock.
+--echo # Sending:
+--send RENAME TABLE t1 TO t3, t2 TO t1, t3 TO t2
+
+connect (con2, localhost, root);
+--echo # Wait until RENAME TABLE is blocked.
+let $wait_condition=
+select count(*) = 1 from information_schema.processlist
+where state = "Waiting for table metadata lock" and
+info = "RENAME TABLE t1 TO t3, t2 TO t1, t3 TO t2";
+--source include/wait_condition.inc
+--echo # Resume LOCK TABLE statement. It should try to
+--echo # upgrade SR lock to SRO lock which will create
+--echo # deadlock due to presence of pending X lock.
+--echo # Deadlock should be detected and LOCK TABLES should
+--echo # release its MDL and retry opening of tables.
+SET DEBUG_SYNC="now SIGNAL go";
+
+connection con1;
+--echo # RENAME TABLE should be able to complete. Reap it.
+--reap
+
+connection default;
+--echo # Reap LOCK TABLES.
+--reap
+--echo # Check that we see new version of table.
+SELECT * FROM t1;
+UNLOCK TABLES;
+
+--echo # Clean-up.
+SET DEBUG_SYNC="RESET";
+disconnect con1;
+disconnect con2;
+DROP TABLES t1, t2;
+--disable_connect_log
+
+# Check that all connections opened by test cases in this file are really
+# gone so execution of other tests won't be affected by their presence.
+--source include/wait_until_count_sessions.inc

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -8608,7 +8608,6 @@ Rdb_table_handler *Rdb_open_tables_map::get_table_handler(
 
     m_table_map.emplace(table_name_str, table_handler);
 
-    thr_lock_init(&table_handler->m_thr_lock);
     table_handler->m_io_perf_read.init();
     table_handler->m_io_perf_write.init();
   }
@@ -8867,7 +8866,6 @@ void Rdb_open_tables_map::release_table_handler(
     const auto ret MY_ATTRIBUTE((__unused__)) =
         m_table_map.erase(std::string(table_handler->m_table_name));
     assert(ret == 1);  // the hash entry must actually be found and deleted
-    my_core::thr_lock_delete(&table_handler->m_thr_lock);
     my_free(table_handler);
   }
 
@@ -9228,8 +9226,6 @@ int ha_rocksdb::open(const char *const name,
     DBUG_RETURN(HA_ERR_OUT_OF_MEM);
   }
 
-  my_core::thr_lock_data_init(&m_table_handler->m_thr_lock, &m_db_lock,
-                              nullptr);
   m_io_perf.init(&m_table_handler->m_table_perf_context,
                  &m_table_handler->m_io_perf_read,
                  &m_table_handler->m_io_perf_write, &stats);
@@ -13851,17 +13847,21 @@ void ha_rocksdb::update_table_stats_if_needed() {
   DBUG_VOID_RETURN;
 }
 
-/* The following function was copied from ha_blackhole::store_lock: */
+/** Inform the storage engine about the THR_LOCK that server would have acquired
+for this statement for this table, so that the storage engine could decide on
+its internal locking.
+@param[in]      thd     user thread handle
+@param[in]      to      pointer to the current element in an array of pointers
+                        to THR_LOCK structs. Returned without modifications.
+@param[in]      lock_type       requested lock type
+@return 'to' parameter. */
 THR_LOCK_DATA **ha_rocksdb::store_lock(THD *const thd, THR_LOCK_DATA **to,
                                        enum thr_lock_type lock_type) {
   DBUG_ENTER_FUNC();
 
   assert(thd != nullptr);
-  assert(to != nullptr);
 
-  bool in_lock_tables = my_core::thd_in_lock_tables(thd);
-
-  /* First, make a decision about MyRocks's internal locking */
+  /* Make a decision about MyRocks's internal locking */
   if (lock_type >= TL_WRITE_ALLOW_WRITE) {
     m_lock_rows = RDB_LOCK_WRITE;
   } else if (lock_type == TL_READ_WITH_SHARED_LOCKS) {
@@ -13876,6 +13876,7 @@ THR_LOCK_DATA **ha_rocksdb::store_lock(THD *const thd, THR_LOCK_DATA **to,
         locks in place on rows that are in a table that is not being updated.
       */
       const uint sql_command = my_core::thd_sql_command(thd);
+      bool in_lock_tables = my_core::thd_in_lock_tables(thd);
       if ((lock_type == TL_READ && in_lock_tables) ||
           (lock_type == TL_READ_HIGH_PRIORITY && in_lock_tables) ||
           can_hold_read_locks_on_select(thd, lock_type)) {
@@ -13895,35 +13896,6 @@ THR_LOCK_DATA **ha_rocksdb::store_lock(THD *const thd, THR_LOCK_DATA **to,
     }
   }
 
-  /* Then, tell the SQL layer what kind of locking it should use: */
-  if (lock_type != TL_IGNORE && m_db_lock.type == TL_UNLOCK) {
-    /*
-      Here is where we get into the guts of a row level lock.
-      If TL_UNLOCK is set
-      If we are not doing a LOCK TABLE or DISCARD/IMPORT
-      TABLESPACE, then allow multiple writers
-    */
-
-    if ((lock_type >= TL_WRITE_CONCURRENT_INSERT && lock_type <= TL_WRITE) &&
-        !in_lock_tables && !my_core::thd_tablespace_op(thd)) {
-      lock_type = TL_WRITE_ALLOW_WRITE;
-    }
-
-    /*
-      In queries of type INSERT INTO t1 SELECT ... FROM t2 ...
-      MySQL would use the lock TL_READ_NO_INSERT on t2, and that
-      would conflict with TL_WRITE_ALLOW_WRITE, blocking all inserts
-      to t2. Convert the lock to a normal read lock to allow
-      concurrent inserts to t2.
-    */
-
-    if (lock_type == TL_READ_NO_INSERT && !in_lock_tables) {
-      lock_type = TL_READ;
-    }
-
-    m_db_lock.type = lock_type;
-  }
-
   m_locked_row_action = THR_WAIT;
   if (lock_type != TL_IGNORE) {
     auto action = table->pos_in_table_list->lock_descriptor().action;
@@ -13938,8 +13910,6 @@ THR_LOCK_DATA **ha_rocksdb::store_lock(THD *const thd, THR_LOCK_DATA **to,
         break;
     }
   }
-
-  *to++ = &m_db_lock;
 
 #ifndef NDEBUG
   const auto *ha_data = get_ha_data_or_null(thd);


### PR DESCRIPTION
Since 5.7, all the THR_LOCK uses cases for InnoDB are fully covered by MDL locking and thus InnoDB removed THR_LOCK-based locking. The same MDL lock coverage applies to MyRocks as well, thus remove THR_LOCK-based locking there too.
- Remove fields Rdb_table_handler::m_thr_lock and ha_rocksdb::m_db_lock
- Add HA_NO_READ_LOCAL_LOCK to ha_rocksdb::table_flags to indicate that the SE does not have any specific support for LOCK TABLE READ LOCAL
- New overridden method ha_rocksdb::lock_count that always returns zero
- Remove all code in ha_rocksdb::store_lock that created THR_LOCK objects. Leave only the code that decides on the internal RocksDB locking.

References:
- https://dev.mysql.com/worklog/task/?id=6671
- https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-5.html
- 5c6171e2536b3274044354471e1ace9c878b8aa4