### PR TITLE
Add SQL-level support for storing the DD schema in MyRocks

### DIFF
--- a/sql/dd/impl/tables/index_column_usage.cc
+++ b/sql/dd/impl/tables/index_column_usage.cc
@@ -39,6 +39,9 @@ const Index_column_usage &Index_column_usage::instance() {
 ///////////////////////////////////////////////////////////////////////////
 
 Index_column_usage::Index_column_usage() {
+  assert(default_dd_storage_engine == DEFAULT_DD_INNODB ||
+         default_dd_storage_engine == DEFAULT_DD_ROCKSDB);
+
   m_target_def.set_table_name("index_column_usage");
 
   m_target_def.add_field(FIELD_INDEX_ID, "FIELD_INDEX_ID",
@@ -58,9 +61,15 @@ Index_column_usage::Index_column_usage() {
                          "NOT NULL");
   m_target_def.add_field(FIELD_HIDDEN, "FIELD_HIDDEN", "hidden BOOL NOT NULL");
 
-  m_target_def.add_index(INDEX_UK_INDEX_ID_ORDINAL_POSITION,
-                         "INDEX_UK_INDEX_ID_ORDINAL_POSITION",
-                         "UNIQUE KEY (index_id, ordinal_position)");
+  if (default_dd_storage_engine == DEFAULT_DD_INNODB) {
+    m_target_def.add_index(INDEX_UK_INDEX_ID_ORDINAL_POSITION,
+                           "INDEX_UK_INDEX_ID_ORDINAL_POSITION",
+                           "UNIQUE KEY (index_id, ordinal_position)");
+  } else {
+    m_target_def.add_index(INDEX_UK_INDEX_ID_ORDINAL_POSITION,
+                           "INDEX_UK_INDEX_ID_ORDINAL_POSITION",
+                           "PRIMARY KEY (index_id, ordinal_position)");
+  }
   m_target_def.add_index(INDEX_UK_INDEX_ID_COLUMN_ID_HIDDEN,
                          "INDEX_UK_INDEX_ID_COLUMN_ID_HIDDEN",
                          "UNIQUE KEY (index_id, column_id, hidden)");

--- a/sql/dd/impl/tables/index_stats.cc
+++ b/sql/dd/impl/tables/index_stats.cc
@@ -32,6 +32,9 @@ namespace tables {
 ///////////////////////////////////////////////////////////////////////////
 
 Index_stats::Index_stats() {
+  assert(default_dd_storage_engine == DEFAULT_DD_INNODB ||
+         default_dd_storage_engine == DEFAULT_DD_ROCKSDB);
+
   m_target_def.set_table_name("index_stats");
 
   m_target_def.add_field(FIELD_SCHEMA_NAME, "FIELD_SCHEMA_NAME",
@@ -47,10 +50,17 @@ Index_stats::Index_stats() {
   m_target_def.add_field(FIELD_CACHED_TIME, "FIELD_CACHED_TIME",
                          "cached_time TIMESTAMP NOT NULL");
 
-  m_target_def.add_index(INDEX_UK_SCHEMA_TABLE_INDEX_COLUMN,
-                         "INDEX_UK_SCHEMA_TABLE_INDEX_COLUMN",
-                         "UNIQUE KEY (schema_name, table_name, "
-                         "index_name, column_name)");
+  if (default_dd_storage_engine == DEFAULT_DD_INNODB) {
+    m_target_def.add_index(INDEX_UK_SCHEMA_TABLE_INDEX_COLUMN,
+                           "INDEX_UK_SCHEMA_TABLE_INDEX_COLUMN",
+                           "UNIQUE KEY (schema_name, table_name, "
+                           "index_name, column_name)");
+  } else {
+    m_target_def.add_index(INDEX_UK_SCHEMA_TABLE_INDEX_COLUMN,
+                           "INDEX_UK_SCHEMA_TABLE_INDEX_COLUMN",
+                           "PRIMARY KEY (schema_name, table_name, "
+                           "index_name, column_name)");
+  }
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/sql/dd/impl/tables/tablespace_files.cc
+++ b/sql/dd/impl/tables/tablespace_files.cc
@@ -39,6 +39,9 @@ const Tablespace_files &Tablespace_files::instance() {
 ///////////////////////////////////////////////////////////////////////////
 
 Tablespace_files::Tablespace_files() {
+  assert(default_dd_storage_engine == DEFAULT_DD_INNODB ||
+         default_dd_storage_engine == DEFAULT_DD_ROCKSDB);
+
   m_target_def.set_table_name("tablespace_files");
 
   m_target_def.add_field(FIELD_TABLESPACE_ID, "FIELD_TABLESPACE_ID",
@@ -50,9 +53,15 @@ Tablespace_files::Tablespace_files() {
   m_target_def.add_field(FIELD_SE_PRIVATE_DATA, "FIELD_SE_PRIVATE_DATA",
                          "se_private_data MEDIUMTEXT");
 
-  m_target_def.add_index(INDEX_UK_TABLESPACE_ID_ORDINAL_POSITION,
-                         "INEDX_UK_TABLESPACE_ID_ORDINAL_POSITION",
-                         "UNIQUE KEY (tablespace_id, ordinal_position)");
+  if (default_dd_storage_engine == DEFAULT_DD_INNODB) {
+    m_target_def.add_index(INDEX_UK_TABLESPACE_ID_ORDINAL_POSITION,
+                           "INEDX_UK_TABLESPACE_ID_ORDINAL_POSITION",
+                           "UNIQUE KEY (tablespace_id, ordinal_position)");
+  } else {
+    m_target_def.add_index(INDEX_UK_TABLESPACE_ID_ORDINAL_POSITION,
+                           "INEDX_UK_TABLESPACE_ID_ORDINAL_POSITION",
+                           "PRIMARY KEY (tablespace_id, ordinal_position)");
+  }
   m_target_def.add_index(INDEX_UK_FILE_NAME, "INEDX_UK_FILE_NAME",
                          "UNIQUE KEY (file_name)");
 

--- a/sql/dd/impl/types/object_table_definition_impl.h
+++ b/sql/dd/impl/types/object_table_definition_impl.h
@@ -227,6 +227,9 @@ class Object_table_definition_impl : public Object_table_definition {
   virtual void add_foreign_key(int foreign_key_number,
                                const String_type &foreign_key_name,
                                const String_type &foreign_key_definition) {
+    // This gets called for DDSE == RocksDB, even though it does not support
+    // foreign keys. They will get filtered from the actual executed CREATE
+    // TABLE statement later.
     add_element(foreign_key_number, foreign_key_name, foreign_key_definition,
                 &m_foreign_key_numbers, &m_foreign_key_definitions);
   }

--- a/sql/dd/impl/types/object_table_impl.cc
+++ b/sql/dd/impl/types/object_table_impl.cc
@@ -36,8 +36,13 @@ Object_table_impl::Object_table_impl()
       m_actual_present(false),
       m_actual_def(),
       m_hidden(true) {
-  m_target_def.add_option(static_cast<int>(Common_option::ENGINE), "ENGINE",
-                          "ENGINE=INNODB");
+  assert(default_dd_storage_engine == DEFAULT_DD_INNODB ||
+         default_dd_storage_engine == DEFAULT_DD_ROCKSDB);
+
+  m_target_def.add_option(
+      static_cast<int>(Common_option::ENGINE), "ENGINE",
+      (default_dd_storage_engine == DEFAULT_DD_INNODB ? "ENGINE=INNODB"
+                                                      : "ENGINE=ROCKSDB"));
   m_target_def.add_option(static_cast<int>(Common_option::CHARSET), "CHARSET",
                           "DEFAULT CHARSET=utf8");
   m_target_def.add_option(static_cast<int>(Common_option::COLLATION),
@@ -46,9 +51,11 @@ Object_table_impl::Object_table_impl()
                           "ROW_FORMAT", "ROW_FORMAT=DYNAMIC");
   m_target_def.add_option(static_cast<int>(Common_option::STATS_PERSISTENT),
                           "STATS_PERSISTENT", "STATS_PERSISTENT=0");
-  m_target_def.add_option(
-      static_cast<int>(Common_option::TABLESPACE), "TABLESPACE",
-      String_type("TABLESPACE=") + String_type(MYSQL_TABLESPACE_NAME.str));
+  if (default_dd_storage_engine == DEFAULT_DD_INNODB) {
+    m_target_def.add_option(
+        static_cast<int>(Common_option::TABLESPACE), "TABLESPACE",
+        String_type("TABLESPACE=") + String_type(MYSQL_TABLESPACE_NAME.str));
+  }
 }
 
 bool Object_table_impl::set_actual_table_definition(


### PR DESCRIPTION
- Iff the DDSE is MyRocks, for the DD tables that have non-NULL UNIQUE keys but no PRIMARY KEY, explicitly pick one of the unique keys and make it primary.
- Output the foreign key declarations iff the DDSE supports them.
- Output "TABLESPACE=mysql" iff the DDSE is InnoDB.

No functional changes if the DDSE is InnoDB.