### PR TITLE
Handle log archiver archiving past the clone SE sync point

### DIFF
--- a/mysql-test/suite/rocksdb_clone/r/two_se_debug.result
+++ b/mysql-test/suite/rocksdb_clone/r/two_se_debug.result
@@ -1,0 +1,53 @@
+CREATE TABLE t_innodb(col1 INT PRIMARY KEY, col2 CHAR(255)) ENGINE=InnoDB;
+CREATE TABLE t_myrocks(col1 INT PRIMARY KEY, col2 CHAR(255)) ENGINE=RocksDB;
+INSERT INTO t_innodb VALUES(10, 'InnoDB clone row 1');
+INSERT INTO t_innodb VALUES(20, 'InnoDB clone row 2');
+INSERT INTO t_myrocks VALUES(10, 'MyRocks clone row 1');
+INSERT INTO t_myrocks VALUES(20, 'MyRocks clone row 2');
+INSTALL PLUGIN clone SONAME 'CLONE_PLUGIN';
+SET DEBUG_SYNC = 'after_clone_se_sync SIGNAL se_synced WAIT_FOR resume_clone';
+SET GLOBAL clone_autotune_concurrency = OFF;
+SET GLOBAL clone_max_concurrency = 8;
+CLONE LOCAL DATA DIRECTORY = 'CLONE_DATADIR';
+SET DEBUG_SYNC = 'now WAIT_FOR se_synced';
+SET GLOBAL innodb_monitor_enable=module_log;
+INSERT INTO t_innodb VALUES(30, REPEAT('a', 255));
+INSERT INTO t_innodb VALUES(40, REPEAT('b', 255));
+INSERT INTO t_myrocks VALUES(30, 'MyRocks uncloned row');
+SET DEBUG_SYNC = 'now SIGNAL resume_clone';
+SELECT * FROM t_innodb;
+col1	col2
+10	InnoDB clone row 1
+20	InnoDB clone row 2
+30	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+40	bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+SELECT * FROM t_myrocks;
+col1	col2
+10	MyRocks clone row 1
+20	MyRocks clone row 2
+30	MyRocks uncloned row
+# restart: --datadir=CLONE_DATADIR
+SELECT * FROM t_innodb;
+col1	col2
+10	InnoDB clone row 1
+20	InnoDB clone row 2
+INSERT INTO t_innodb VALUES(40, 'InnoDB cloned instance row 4');
+SELECT * FROM t_innodb;
+col1	col2
+10	InnoDB clone row 1
+20	InnoDB clone row 2
+40	InnoDB cloned instance row 4
+SELECT * FROM t_myrocks;
+col1	col2
+10	MyRocks clone row 1
+20	MyRocks clone row 2
+INSERT INTO t_myrocks VALUES(40, 'MyRocks cloned instance row 4');
+SELECT * FROM t_myrocks;
+col1	col2
+10	MyRocks clone row 1
+20	MyRocks clone row 2
+40	MyRocks cloned instance row 4
+# restart
+DROP TABLE t_innodb;
+DROP TABLE t_myrocks;
+UNINSTALL PLUGIN clone;

--- a/mysql-test/suite/rocksdb_clone/t/two_se_debug.test
+++ b/mysql-test/suite/rocksdb_clone/t/two_se_debug.test
@@ -1,0 +1,75 @@
+--source include/have_rocksdb.inc
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+
+--connect(con2,localhost,root,,)
+
+--source ../../clone/include/clone_connection_begin.inc
+
+--let $CLONE_DATADIR = $MYSQL_TMP_DIR/data_new
+
+CREATE TABLE t_innodb(col1 INT PRIMARY KEY, col2 CHAR(255)) ENGINE=InnoDB;
+CREATE TABLE t_myrocks(col1 INT PRIMARY KEY, col2 CHAR(255)) ENGINE=RocksDB;
+
+INSERT INTO t_innodb VALUES(10, 'InnoDB clone row 1');
+INSERT INTO t_innodb VALUES(20, 'InnoDB clone row 2');
+
+INSERT INTO t_myrocks VALUES(10, 'MyRocks clone row 1');
+INSERT INTO t_myrocks VALUES(20, 'MyRocks clone row 2');
+
+--replace_result $CLONE_PLUGIN CLONE_PLUGIN
+--eval INSTALL PLUGIN clone SONAME '$CLONE_PLUGIN'
+
+--connection clone_conn_1
+
+SET DEBUG_SYNC = 'after_clone_se_sync SIGNAL se_synced WAIT_FOR resume_clone';
+
+--source ../../clone/include/clone_command_send.inc
+
+--connection con2
+
+SET DEBUG_SYNC = 'now WAIT_FOR se_synced';
+
+SET GLOBAL innodb_monitor_enable=module_log;
+
+--let $arch_lsn_1=`SELECT COUNT FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE NAME="log_lsn_archived"`
+
+INSERT INTO t_innodb VALUES(30, REPEAT('a', 255));
+INSERT INTO t_innodb VALUES(40, REPEAT('b', 255));
+INSERT INTO t_myrocks VALUES(30, 'MyRocks uncloned row');
+
+--let $wait_condition=SELECT COUNT >= $arch_lsn_1 FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE NAME="log_lsn_archived"
+--source include/wait_condition.inc
+
+SET DEBUG_SYNC = 'now SIGNAL resume_clone';
+
+--connection clone_conn_1
+--reap
+
+SELECT * FROM t_innodb;
+SELECT * FROM t_myrocks;
+
+# Restart server on cloned data directory
+--replace_result $CLONE_DATADIR CLONE_DATADIR
+--let restart_parameters="restart: --datadir=$CLONE_DATADIR"
+--source include/restart_mysqld.inc
+
+SELECT * FROM t_innodb;
+INSERT INTO t_innodb VALUES(40, 'InnoDB cloned instance row 4');
+SELECT * FROM t_innodb;
+
+SELECT * FROM t_myrocks;
+INSERT INTO t_myrocks VALUES(40, 'MyRocks cloned instance row 4');
+SELECT * FROM t_myrocks;
+
+--let restart_parameters=
+--source include/restart_mysqld.inc
+
+DROP TABLE t_innodb;
+DROP TABLE t_myrocks;
+
+--force-rmdir $CLONE_DATADIR
+
+UNINSTALL PLUGIN clone;
+
+--source ../../clone/include/clone_connection_end.inc

--- a/plugin/clone/src/clone_common.cc
+++ b/plugin/clone/src/clone_common.cc
@@ -103,6 +103,8 @@ int Ha_clone_common_cbk::synchronize_engines() {
 
   assert(json_dom->json_type() == enum_json_type::J_OBJECT);
 
+  DEBUG_SYNC_C("after_clone_se_sync");
+
   const auto *const json_obj = static_cast<const Json_object *>(json_dom);
   for (const auto &json_se_pos : *json_obj) {
     const auto &se_name = json_se_pos.first;

--- a/storage/innobase/arch/arch0log.cc
+++ b/storage/innobase/arch/arch0log.cc
@@ -439,9 +439,11 @@ int Arch_Log_Sys::stop(Arch_Group *group, lsn_t &stop_lsn, byte *log_blk,
                        uint32_t &blk_len) {
   int err = 0;
   blk_len = 0;
-  stop_lsn = m_archived_lsn.load();
+
   auto se_sync_stop_lsn = get_stop_lsn_master_thread();
   ut_ad(se_sync_stop_lsn != LSN_MAX || log_blk == nullptr);
+
+  stop_lsn = std::min(m_archived_lsn.load(), se_sync_stop_lsn);
   ut_ad(stop_lsn <= se_sync_stop_lsn);
 
   if (log_blk != nullptr) {
@@ -595,7 +597,6 @@ Arch_State Arch_Log_Sys::check_set_state(bool is_abort, lsn_t *archived_lsn,
       if (*archived_lsn != LSN_MAX) {
         /* Update system archived LSN from input */
         ut_ad(*archived_lsn >= m_archived_lsn.load());
-        ut_ad(*archived_lsn <= get_stop_lsn_any_thread());
         m_archived_lsn.store(*archived_lsn);
       } else {
         /* If input is not initialized,
@@ -614,11 +615,13 @@ Arch_State Arch_Log_Sys::check_set_state(bool is_abort, lsn_t *archived_lsn,
         const auto local_archived_lsn = m_archived_lsn.load();
         ut_ad(local_write_lsn >= local_archived_lsn);
         const auto stop_lsn = get_stop_lsn_any_thread();
-        ut_ad(stop_lsn >= local_archived_lsn);
         ut_ad(stop_lsn <= local_lsn || stop_lsn == LSN_MAX ||
               DBUG_EVALUATE_IF("clone_arch_log_stop_file_end", true, false));
 
-        lsn_diff = std::min(stop_lsn, local_write_lsn) - local_archived_lsn;
+        const auto archive_up_to_lsn = stop_lsn > local_archived_lsn
+                                           ? std::min(stop_lsn, local_write_lsn)
+                                           : local_archived_lsn;
+        lsn_diff = archive_up_to_lsn - local_archived_lsn;
       }
 
       lsn_diff = ut_uint64_align_down(lsn_diff, OS_FILE_LOG_BLOCK_SIZE);


### PR DESCRIPTION
Under write workload, it is possible for the InnoDB log archiver to archive log data past the clone SE synchronization point LSN, with the following thread interleaving:

1) Clone SE synchronization executes the performance_schema.LOG_STATUS query 
2) User query performs a write to InnoDB, advancing the LSN 
3) InnoDB log archiver archives the log written in the previous step
4) Clone SE synchronization asks the InnoDB log archiver to stop archiving at the clone LSN, which is less than the already-archived LSN.

It was assumed that this scenario cannot happen, thus code hits various asserts, and on the release build may continue archiving indefinitely.

Since the log archiver already has support for providing less log data than archived, fix by setting the log archiver stop LSN correctly to smaller of SE synchronization and already-archived LSN.

Add a DEBUG_SYNC-using testcase.