### PR TITLE
Always assume existence of persisted autoincrement values for MyRocks…

### DIFF
--- a/mysql-test/suite/rocksdb/r/autoinc_debug.result
+++ b/mysql-test/suite/rocksdb/r/autoinc_debug.result
@@ -2,55 +2,10 @@
 # Testing upgrading from server without merges for auto_increment
 # to new server with such support.
 #
-set debug='+d,myrocks_autoinc_upgrade';
-create table t (i int primary key auto_increment);
-insert into t values ();
-insert into t values ();
-insert into t values ();
-select * from t;
-i
-1
-2
-3
-delete from t where i > 1;
-select * from t;
-i
-1
-select table_name, index_name, auto_increment
-from information_schema.rocksdb_ddl where table_name = 't';
-table_name	index_name	auto_increment
-t	PRIMARY	NULL
-set debug='-d,myrocks_autoinc_upgrade';
-# restart
-insert into t values ();
-insert into t values ();
-insert into t values ();
-select * from t;
-i
-1
-2
-3
-4
-select table_name, index_name, auto_increment
-from information_schema.rocksdb_ddl where table_name = 't';
-table_name	index_name	auto_increment
-t	PRIMARY	5
-delete from t where i > 1;
-# restart
-insert into t values ();
-insert into t values ();
-insert into t values ();
-select * from t;
-i
-1
-5
-6
-7
-drop table t;
 #
 # Testing crash safety of transactions.
 #
-create table t (i int primary key auto_increment);
+create table t (i int primary key auto_increment) engine=rocksdb;
 insert into t values ();
 insert into t values ();
 insert into t values ();

--- a/mysql-test/suite/rocksdb/t/autoinc_debug.test
+++ b/mysql-test/suite/rocksdb/t/autoinc_debug.test
@@ -8,46 +8,10 @@
 --echo # to new server with such support.
 --echo #
 
-set debug='+d,myrocks_autoinc_upgrade';
-create table t (i int primary key auto_increment);
-insert into t values ();
-insert into t values ();
-insert into t values ();
-select * from t;
-
-delete from t where i > 1;
-select * from t;
-
-select table_name, index_name, auto_increment
-  from information_schema.rocksdb_ddl where table_name = 't';
-
-set debug='-d,myrocks_autoinc_upgrade';
-
---source include/restart_mysqld.inc
-
-insert into t values ();
-insert into t values ();
-insert into t values ();
-select * from t;
-
-select table_name, index_name, auto_increment
-  from information_schema.rocksdb_ddl where table_name = 't';
-
-delete from t where i > 1;
-
---source include/restart_mysqld.inc
-
-insert into t values ();
-insert into t values ();
-insert into t values ();
-select * from t;
-
-drop table t;
-
 --echo #
 --echo # Testing crash safety of transactions.
 --echo #
-create table t (i int primary key auto_increment);
+create table t (i int primary key auto_increment) engine=rocksdb;
 insert into t values ();
 insert into t values ();
 insert into t values ();

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -3487,8 +3487,6 @@ class Rdb_transaction {
     @param wb
    */
   rocksdb::Status merge_auto_incr_map(rocksdb::WriteBatchBase *const wb) {
-    DBUG_EXECUTE_IF("myrocks_autoinc_upgrade", return rocksdb::Status::OK(););
-
     // Iterate through the merge map merging all keys into data dictionary.
     rocksdb::Status s;
     for (auto &it : m_auto_incr_map) {
@@ -8466,14 +8464,8 @@ std::vector<std::string> Rdb_open_tables_map::get_table_names(void) const {
 
 void ha_rocksdb::load_auto_incr_value() {
   ulonglong auto_incr = 0;
-  bool validate_last = false, use_datadic = true;
-#ifndef NDEBUG
-  DBUG_EXECUTE_IF("myrocks_autoinc_upgrade", use_datadic = false;);
-  validate_last = true;
-#endif
 
-  if (use_datadic &&
-      dict_manager
+  if (dict_manager
           .get_dict_manager_selector_const(
               m_tbl_def->get_autoincr_gl_index_id().cf_id)
           ->get_auto_incr_val(m_tbl_def->get_autoincr_gl_index_id(),
@@ -8481,21 +8473,14 @@ void ha_rocksdb::load_auto_incr_value() {
     update_auto_incr_val(auto_incr);
   }
 
-  // If we find nothing in the data dictionary, or if we are in debug mode,
-  // then call index_last to get the last value.
-  //
-  // This is needed when upgrading from a server that did not support
-  // persistent auto_increment, of if the table is empty.
-  //
-  // For debug mode, we are just verifying that the data dictionary value is
-  // greater than or equal to the maximum value in the table.
-  if (auto_incr == 0 || validate_last) {
-    auto_incr = load_auto_incr_value_from_index();
-    update_auto_incr_val(auto_incr);
-  }
+#ifndef NDEBUG
+  // For debug mode, verify the value against the last value in the index.
+  const auto index_auto_incr = load_auto_incr_value_from_index();
+  assert(auto_incr >= index_auto_incr);
+#endif
 
-  // If we failed to find anything from the data dictionary and index, then
-  // initialize auto_increment to 1.
+  // If the table is empty, thus does not have the autoinc value in the data
+  // dictionary, initialize it to 1.
   if (m_tbl_def->m_auto_incr_val == 0) {
     update_auto_incr_val(1);
   }
@@ -10126,16 +10111,12 @@ int ha_rocksdb::create_table(const std::string &table_name,
   m_pk_descr = m_key_descr_arr[pk_index(table_arg, *m_tbl_def)];
 
   if (auto_increment_value) {
-    bool autoinc_upgrade_test = false;
     m_tbl_def->m_auto_incr_val = auto_increment_value;
-    DBUG_EXECUTE_IF("myrocks_autoinc_upgrade", autoinc_upgrade_test = true;);
-    if (!autoinc_upgrade_test) {
-      auto s = local_dict_manager->put_auto_incr_val(
-          batch, m_tbl_def->get_autoincr_gl_index_id(),
-          m_tbl_def->m_auto_incr_val);
-      if (!s.ok()) {
-        goto error;
-      }
+    const auto s = local_dict_manager->put_auto_incr_val(
+        batch, m_tbl_def->get_autoincr_gl_index_id(),
+        m_tbl_def->m_auto_incr_val);
+    if (!s.ok()) {
+      goto error;
     }
   }
 


### PR DESCRIPTION
… table

The non-persistent autoincrement values upgrade to persistent ones was implemented in 2017, in 5.6. Thus no 8.0 instance should encounter non-persistent values, ever. If this assumption is incorrect, the upgrade is still possible by going through the latest 5.6 release first.

Thus remove myrocks_autoinc_upgrade debug code injection point, simplify the surrounding code, remove the tests that use it.