### PR TITLE
Add rocksdb_compact_lzero_now global variable

### DIFF
--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -882,6 +882,7 @@ rocksdb_collect_sst_properties	ON
 rocksdb_commit_in_the_middle	OFF
 rocksdb_commit_time_batch_for_recovery	ON
 rocksdb_compact_cf	
+rocksdb_compact_lzero_now	OFF
 rocksdb_compaction_readahead_size	0
 rocksdb_compaction_sequential_deletes	0
 rocksdb_compaction_sequential_deletes_count_sd	OFF

--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_compact_lzero_now_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_compact_lzero_now_basic.result
@@ -1,0 +1,50 @@
+CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(1);
+INSERT INTO valid_values VALUES(0);
+INSERT INTO valid_values VALUES('on');
+CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
+SET @start_global_value = @@global.ROCKSDB_COMPACT_LZERO_NOW;
+SELECT @start_global_value;
+@start_global_value
+0
+'# Setting to valid values in global scope#'
+"Trying to set variable @@global.ROCKSDB_COMPACT_LZERO_NOW to 1"
+SET @@global.ROCKSDB_COMPACT_LZERO_NOW   = 1;
+SELECT @@global.ROCKSDB_COMPACT_LZERO_NOW;
+@@global.ROCKSDB_COMPACT_LZERO_NOW
+0
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_COMPACT_LZERO_NOW = DEFAULT;
+SELECT @@global.ROCKSDB_COMPACT_LZERO_NOW;
+@@global.ROCKSDB_COMPACT_LZERO_NOW
+0
+"Trying to set variable @@global.ROCKSDB_COMPACT_LZERO_NOW to 0"
+SET @@global.ROCKSDB_COMPACT_LZERO_NOW   = 0;
+SELECT @@global.ROCKSDB_COMPACT_LZERO_NOW;
+@@global.ROCKSDB_COMPACT_LZERO_NOW
+0
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_COMPACT_LZERO_NOW = DEFAULT;
+SELECT @@global.ROCKSDB_COMPACT_LZERO_NOW;
+@@global.ROCKSDB_COMPACT_LZERO_NOW
+0
+"Trying to set variable @@global.ROCKSDB_COMPACT_LZERO_NOW to on"
+SET @@global.ROCKSDB_COMPACT_LZERO_NOW   = on;
+SELECT @@global.ROCKSDB_COMPACT_LZERO_NOW;
+@@global.ROCKSDB_COMPACT_LZERO_NOW
+0
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_COMPACT_LZERO_NOW = DEFAULT;
+SELECT @@global.ROCKSDB_COMPACT_LZERO_NOW;
+@@global.ROCKSDB_COMPACT_LZERO_NOW
+0
+"Trying to set variable @@session.ROCKSDB_COMPACT_LZERO_NOW to 444. It should fail because it is not session."
+SET @@session.ROCKSDB_COMPACT_LZERO_NOW   = 444;
+ERROR HY000: Variable 'rocksdb_compact_lzero_now' is a GLOBAL variable and should be set with SET GLOBAL
+'# Testing with invalid values in global scope #'
+SET @@global.ROCKSDB_COMPACT_LZERO_NOW = @start_global_value;
+SELECT @@global.ROCKSDB_COMPACT_LZERO_NOW;
+@@global.ROCKSDB_COMPACT_LZERO_NOW
+0
+DROP TABLE valid_values;
+DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_compact_lzero_now_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_compact_lzero_now_basic.test
@@ -1,0 +1,17 @@
+--source include/have_rocksdb.inc
+
+CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(1);
+INSERT INTO valid_values VALUES(0);
+INSERT INTO valid_values VALUES('on');
+
+CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
+
+--let $sys_var=ROCKSDB_COMPACT_LZERO_NOW
+--let $read_only=0
+--let $session=0
+--let $sticky=1
+--source ../include/rocksdb_sys_var.inc
+
+DROP TABLE valid_values;
+DROP TABLE invalid_values;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -445,17 +445,7 @@ static int rocksdb_force_flush_memtable_now(
   return HA_EXIT_SUCCESS;
 }
 
-static void rocksdb_force_flush_memtable_and_lzero_now_stub(
-    THD *const thd, struct st_mysql_sys_var *const var, void *const var_ptr,
-    const void *const save) {}
-
-static int rocksdb_force_flush_memtable_and_lzero_now(
-    THD *const thd, struct st_mysql_sys_var *const var, void *const var_ptr,
-    struct st_mysql_value *const value) {
-  // NO_LINT_DEBUG
-  sql_print_information("RocksDB: Manual memtable and L0 flush.");
-  rocksdb_flush_all_memtables();
-
+static int rocksdb_compact_lzero() {
   const Rdb_cf_manager &cf_manager = rdb_get_cf_manager();
   rocksdb::CompactionOptions c_options = rocksdb::CompactionOptions();
   rocksdb::ColumnFamilyMetaData metadata;
@@ -469,6 +459,23 @@ static int rocksdb_force_flush_memtable_and_lzero_now(
       cf_handle->GetDescriptor(&cf_descr);
       c_options.output_file_size_limit = cf_descr.options.target_file_size_base;
 
+      // Lets RocksDB use the configured compression for this level
+      c_options.compression = rocksdb::kDisableCompressionOption;
+
+      uint64_t base_level;
+      if (!rdb->GetIntProperty(cf_handle.get(),
+                               rocksdb::DB::Properties::kBaseLevel,
+                               &base_level)) {
+        sql_print_information("RocksDB: compact L0 cannot get base level");
+        break;
+      }
+
+      if (base_level == 0) {
+        sql_print_information(
+            "RocksDB: compact L0 cannot flush to base level when 0");
+        break;
+      }
+
       DBUG_ASSERT(metadata.levels[0].level == 0);
       std::vector<std::string> file_names;
       for (auto &file : metadata.levels[0].files) {
@@ -476,11 +483,12 @@ static int rocksdb_force_flush_memtable_and_lzero_now(
       }
 
       if (file_names.empty()) {
+        sql_print_information("RocksDB: compact L0 no files in L0");
         break;
       }
 
       rocksdb::Status s;
-      s = rdb->CompactFiles(c_options, cf_handle.get(), file_names, 1);
+      s = rdb->CompactFiles(c_options, cf_handle.get(), file_names, base_level);
 
       if (!s.ok()) {
         std::shared_ptr<rocksdb::ColumnFamilyHandle> cfh =
@@ -490,8 +498,9 @@ static int rocksdb_force_flush_memtable_and_lzero_now(
         // error. We are done with this CF and proceed to the next CF.
         if (!cfh) {
           // NO_LINT_DEBUG
-          sql_print_information("cf %s has been dropped during CompactFiles.",
-                                cf_handle->GetName().c_str());
+          sql_print_information(
+              "RocksDB: cf %s has been dropped during compact L0.",
+              cf_handle->GetName().c_str());
           break;
         }
 
@@ -515,6 +524,34 @@ static int rocksdb_force_flush_memtable_and_lzero_now(
   }
 
   return num_errors == 0 ? HA_EXIT_SUCCESS : HA_EXIT_FAILURE;
+}
+
+static void rocksdb_compact_lzero_now_stub(
+    THD *const thd, struct st_mysql_sys_var *const var, void *const var_ptr,
+    const void *const save) {}
+
+static int rocksdb_compact_lzero_now(
+    THD *const thd, struct st_mysql_sys_var *const var, void *const var_ptr,
+    struct st_mysql_value *const value) {
+  sql_print_information("RocksDB: Manual compact L0.");
+  return rocksdb_compact_lzero();
+}
+
+static void rocksdb_force_flush_memtable_and_lzero_now_stub(
+    THD *const thd, struct st_mysql_sys_var *const var, void *const var_ptr,
+    const void *const save) {}
+
+static int rocksdb_force_flush_memtable_and_lzero_now(
+    THD *const thd, struct st_mysql_sys_var *const var, void *const var_ptr,
+    struct st_mysql_value *const value) {
+  // NO_LINT_DEBUG
+  sql_print_information("RocksDB: Manual memtable and L0 flush.");
+  rocksdb_flush_all_memtables();
+
+  // Try to avoid https://github.com/facebook/mysql-5.6/issues/1200
+  my_sleep(1000000);
+
+  return rocksdb_compact_lzero();
 }
 
 static void rocksdb_cancel_manual_compactions_stub(
@@ -695,6 +732,7 @@ static char *rocksdb_strict_collation_exceptions;
 static my_bool rocksdb_collect_sst_properties = 1;
 static my_bool rocksdb_force_flush_memtable_now_var = 0;
 static my_bool rocksdb_force_flush_memtable_and_lzero_now_var = 0;
+static my_bool rocksdb_compact_lzero_now_var = 0;
 static my_bool rocksdb_cancel_manual_compactions_var = 0;
 static my_bool rocksdb_enable_ttl = 1;
 static my_bool rocksdb_enable_ttl_read_filtering = 1;
@@ -2102,6 +2140,13 @@ static MYSQL_SYSVAR_BOOL(
     rocksdb_force_flush_memtable_and_lzero_now,
     rocksdb_force_flush_memtable_and_lzero_now_stub, FALSE);
 
+static MYSQL_SYSVAR_BOOL(
+    compact_lzero_now,
+    rocksdb_compact_lzero_now_var, PLUGIN_VAR_RQCMDARG,
+    "Compacts all L0 files.",
+    rocksdb_compact_lzero_now,
+    rocksdb_compact_lzero_now_stub, FALSE);
+
 static MYSQL_SYSVAR_BOOL(cancel_manual_compactions,
                          rocksdb_cancel_manual_compactions_var,
                          PLUGIN_VAR_RQCMDARG,
@@ -2515,6 +2560,7 @@ static struct st_mysql_sys_var *rocksdb_system_variables[] = {
     MYSQL_SYSVAR(collect_sst_properties),
     MYSQL_SYSVAR(force_flush_memtable_now),
     MYSQL_SYSVAR(force_flush_memtable_and_lzero_now),
+    MYSQL_SYSVAR(compact_lzero_now),
     MYSQL_SYSVAR(cancel_manual_compactions),
     MYSQL_SYSVAR(enable_ttl),
     MYSQL_SYSVAR(enable_ttl_read_filtering),


### PR DESCRIPTION
This fixes issues 1200 and 1295 for 5.6.35 similar to how the were fixed for 8.0.28 by: https://github.com/facebook/mysql-5.6/commit/3ba4f39d4ef9a7389a92938997ae02de953de718

The fix for issue 1295 is to get the value of the base level from RocksDB rather than assuming that L0 compacts into L1 because L1 might not be the base level when dynamic leveled compaction is used -- in that case the base level can be Ln where n > 1 because L1 isn't needed yet.

There are two workarounds for issue 1200. The hacky one is to sleep for 1 second between requesting memtable flush and L0 -> base_level compaction.

The alternative is to add a new global variable, rocksdb_compact_lzero_now, that when set will request L0 -> base_level compaction. This allows a client to first set rocksdb_force_flush_memtable_now, wait for that to finish, then set rocksdb_compact_lzero_now.

Note: these variables are triggers, an action is taken when this is done: set global var = ON | true | 1