### PR TITLE
Enable engine specific DD tables

### DIFF
--- a/sql/dd/dd_utility.h
+++ b/sql/dd/dd_utility.h
@@ -92,7 +92,7 @@ bool check_if_server_ddse_readonly(THD *thd, const char *schema_name);
 [[nodiscard]] inline const char *get_dd_engine_name() {
   assert(default_dd_storage_engine == DEFAULT_DD_ROCKSDB ||
          default_dd_storage_engine == DEFAULT_DD_INNODB);
-  return default_dd_storage_engine == DEFAULT_DD_ROCKSDB ? "RocksDB" : "InnoDB";
+  return default_dd_storage_engine == DEFAULT_DD_ROCKSDB ? "ROCKSDB" : "INNODB";
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/sql/dd/impl/types/object_table_impl.cc
+++ b/sql/dd/impl/types/object_table_impl.cc
@@ -22,6 +22,7 @@
 
 #include <mysqld_error.h>
 
+#include "sql/dd/dd_utility.h"                    // get_dd_engine_name
 #include "sql/dd/impl/bootstrap/bootstrap_ctx.h"  // DD_bootstrap_ctx
 #include "sql/dd/impl/types/object_table_impl.h"  // Object_table_impl
 #include "sql/table.h"
@@ -31,18 +32,21 @@ namespace dd {
 ///////////////////////////////////////////////////////////////////////////
 
 Object_table_impl::Object_table_impl()
+    : Object_table_impl(get_dd_engine_name()) {
+  assert(default_dd_storage_engine == DEFAULT_DD_INNODB ||
+         default_dd_storage_engine == DEFAULT_DD_ROCKSDB);
+}
+
+Object_table_impl::Object_table_impl(const String_type &engine)
     : m_last_dd_version(0),
       m_target_def(),
       m_actual_present(false),
       m_actual_def(),
       m_hidden(true) {
-  assert(default_dd_storage_engine == DEFAULT_DD_INNODB ||
-         default_dd_storage_engine == DEFAULT_DD_ROCKSDB);
+  assert(engine == "INNODB" || engine == "ROCKSDB");
 
-  m_target_def.add_option(
-      static_cast<int>(Common_option::ENGINE), "ENGINE",
-      (default_dd_storage_engine == DEFAULT_DD_INNODB ? "ENGINE=INNODB"
-                                                      : "ENGINE=ROCKSDB"));
+  m_target_def.add_option(static_cast<int>(Common_option::ENGINE), "ENGINE",
+                          String_type("ENGINE=") + engine);
   m_target_def.add_option(static_cast<int>(Common_option::CHARSET), "CHARSET",
                           "DEFAULT CHARSET=utf8");
   m_target_def.add_option(static_cast<int>(Common_option::COLLATION),
@@ -51,7 +55,7 @@ Object_table_impl::Object_table_impl()
                           "ROW_FORMAT", "ROW_FORMAT=DYNAMIC");
   m_target_def.add_option(static_cast<int>(Common_option::STATS_PERSISTENT),
                           "STATS_PERSISTENT", "STATS_PERSISTENT=0");
-  if (default_dd_storage_engine == DEFAULT_DD_INNODB) {
+  if (engine == "INNODB") {
     m_target_def.add_option(
         static_cast<int>(Common_option::TABLESPACE), "TABLESPACE",
         String_type("TABLESPACE=") + String_type(MYSQL_TABLESPACE_NAME.str));
@@ -90,8 +94,8 @@ int Object_table_impl::field_number(const String_type &field_label) const {
 
 ///////////////////////////////////////////////////////////////////////////
 
-Object_table *Object_table::create_object_table() {
-  return new (std::nothrow) Object_table_impl();
+Object_table *Object_table::create_object_table(const String_type &engine) {
+  return new (std::nothrow) Object_table_impl(engine);
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/sql/dd/impl/types/object_table_impl.h
+++ b/sql/dd/impl/types/object_table_impl.h
@@ -85,6 +85,7 @@ class Object_table_impl : virtual public Object_table {
     common options.
   */
   Object_table_impl();
+  Object_table_impl(const String_type &engine);
 
   const String_type &name() const override {
     return m_target_def.get_table_name();

--- a/sql/dd/impl/types/object_table_impl.h
+++ b/sql/dd/impl/types/object_table_impl.h
@@ -85,7 +85,7 @@ class Object_table_impl : virtual public Object_table {
     common options.
   */
   Object_table_impl();
-  Object_table_impl(const String_type &engine);
+  explicit Object_table_impl(const String_type &engine);
 
   const String_type &name() const override {
     return m_target_def.get_table_name();

--- a/sql/dd/types/object_table.h
+++ b/sql/dd/types/object_table.h
@@ -86,7 +86,7 @@ class Object_table {
 
     @returns pointer to new Object_table instance.
   */
-  static Object_table *create_object_table();
+  static Object_table *create_object_table(const String_type &engine);
 
   /**
     Get the table name used by the target definition for the dictionary table.

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -12924,7 +12924,7 @@ static bool innobase_ddse_dict_init(
 
   /* Instantiate table defs only if we are successful so far. */
   dd::Object_table *innodb_dynamic_metadata =
-      dd::Object_table::create_object_table();
+      dd::Object_table::create_object_table("INNODB");
   innodb_dynamic_metadata->set_hidden(true);
   dd::Object_table_definition *def =
       innodb_dynamic_metadata->target_table_definition();
@@ -12959,7 +12959,7 @@ static bool innobase_ddse_dict_init(
   std::string table_field = table_name_field.str();
 
   dd::Object_table *innodb_table_stats =
-      dd::Object_table::create_object_table();
+      dd::Object_table::create_object_table("INNODB");
   innodb_table_stats->set_hidden(false);
   def = innodb_table_stats->target_table_definition();
   def->set_table_name("innodb_table_stats");
@@ -12978,7 +12978,7 @@ static bool innobase_ddse_dict_init(
   /* Options and tablespace are set at the SQL layer. */
 
   dd::Object_table *innodb_index_stats =
-      dd::Object_table::create_object_table();
+      dd::Object_table::create_object_table("INNODB");
   innodb_index_stats->set_hidden(false);
   def = innodb_index_stats->target_table_definition();
   def->set_table_name("innodb_index_stats");
@@ -13004,7 +13004,8 @@ static bool innobase_ddse_dict_init(
                  "index_name, stat_name)");
   /* Options and tablespace are set at the SQL layer. */
 
-  dd::Object_table *innodb_ddl_log = dd::Object_table::create_object_table();
+  dd::Object_table *innodb_ddl_log =
+      dd::Object_table::create_object_table("INNODB");
   innodb_ddl_log->set_hidden(true);
   def = innodb_ddl_log->target_table_definition();
   def->set_table_name("innodb_ddl_log");


### PR DESCRIPTION
During ddse upgrade/downgrade, these DDSE_PRIVATE and  DDSE_PROTECTED dd tables(such as innodb_table_stats , innodb_index_stats and  innodb_ddl_log) should stay at its original SE. 

Changes:
- add an overload constructor Object_table_impl() to allow pass engine specific tables
- For innodb DD tables, always add tablespaces (not matter whether default_dd_storage_engine)


The change shouldn't break anything if current DDSE is innodb.
