### PR TITLE
Fix ROCKSDB_PLUGIN typo in get_rocksdb_files.sh

### DIFF
--- a/storage/rocksdb/get_rocksdb_files.sh
+++ b/storage/rocksdb/get_rocksdb_files.sh
@@ -37,7 +37,7 @@ then
 sed -e s/@GIT_SHA@/$git_sha/ -e s:@GIT_TAG@:"$git_tag":  \
     -e s/@GIT_MOD@/"$git_mod"/ -e s/@BUILD_DATE@/"$build_date"/  \
     -e s/@GIT_DATE@/"$git_date"/ \
-    -e s/@ROCKSDB_PLUGIN_BUILTINS@/"$(ROCKSDB_PLUGIN_BUILTINS)"/ \
-    -e s/@ROCKSDB_PLUGIN_EXTERNS@/"$(ROCKSDB_PLUGIN_EXTERNS)"/ \
+    -e s/@ROCKSDB_PLUGIN_BUILTINS@/"$ROCKSDB_PLUGIN_BUILTINS"/ \
+    -e s/@ROCKSDB_PLUGIN_EXTERNS@/"$ROCKSDB_PLUGIN_EXTERNS"/ \
     rocksdb/util/build_version.cc.in > $bv
 fi


### PR DESCRIPTION
I'm guessing this was copy/pasted from a Makefile sort of syntax, whereas it meant to include the contents of these environment variables in this bash script.  When I tried to build mysqld from this it was crashing here saying things like `ROCKSDB_PLUGIN_BUILTINS: command not found` because this syntax in bash means to execute a subcommand.