### PR TITLE
dont bulk load for table metadata change

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -12548,17 +12548,8 @@ int ha_rocksdb::update_write_pk(const Rdb_key_def &kd,
     get_ha_data(ha_thd())->total_tmp_table_size += row_size;
   }
 
-  /*
-    DDL trx update table metadata(DD table) and raw data,
-    For table metadata(thd_is_dd_update_stmt()==True), always skip bulk loading
-    due to DD will read/restore latest metadata after updating metadata
-    For raw data(thd_is_dd_update_stmt()==False), use bulk-load if requested
-  */
-  bool is_dd_operation = default_dd_storage_engine == DEFAULT_DD_ROCKSDB &&
-                         thd_is_dd_update_stmt(ha_thd());
-
   if (rocksdb_enable_bulk_load_api && THDVAR(table->in_use, bulk_load) &&
-      !hidden_pk && !is_dd_operation) {
+      !hidden_pk && !is_dd_operation()) {
     /*
       Write the primary key directly to an SST file using an SstFileWriter
      */
@@ -12830,20 +12821,11 @@ int ha_rocksdb::update_write_indexes(const struct update_row_info &row_info,
     return rc;
   }
 
-  /*
-    DDL trx update table metadata(DD table) and raw data,
-    For table metadata(thd_is_dd_update_stmt()==True), always skip bulk loading
-    due to DD will read/restore latest metadata after updating metadata
-    For raw data(thd_is_dd_update_stmt()==False), use bulk-load if requested
-  */
-  bool is_dd_operation = default_dd_storage_engine == DEFAULT_DD_ROCKSDB &&
-                         thd_is_dd_update_stmt(ha_thd());
-
   // Update the remaining indexes. Allow bulk loading only if
-  // allow_sk is enabled
-  bulk_load_sk = rocksdb_enable_bulk_load_api &&
-                 THDVAR(table->in_use, bulk_load) &&
-                 THDVAR(table->in_use, bulk_load_allow_sk) && !is_dd_operation;
+  // allow_sk is enabled and isn't dd operation(change table metadata)
+  bulk_load_sk =
+      rocksdb_enable_bulk_load_api && THDVAR(table->in_use, bulk_load) &&
+      THDVAR(table->in_use, bulk_load_allow_sk) && !is_dd_operation();
   for (uint key_id = 0; key_id < m_tbl_def->m_key_count; key_id++) {
     if (is_pk(key_id, table, m_tbl_def)) {
       continue;
@@ -16429,6 +16411,19 @@ after check_if_supported_inplace_alter()
 inline bool ha_rocksdb::is_instant(const Alter_inplace_info *ha_alter_info) {
   return (ha_alter_info->handler_trivial_ctx !=
           static_cast<uint8_t>(Instant_Type::INSTANT_IMPOSSIBLE));
+}
+
+/*
+  DDL trx update both table metadata(DD table) and raw data,
+  - For table metadata(thd_is_dd_update_stmt()==True), always skip bulk loading
+  due to DD will read/restore latest metadata after updating metadata and bulk
+  loading doesn't suppose read before commit
+  - For raw data(thd_is_dd_update_stmt()==False), use bulk-load if requested
+  @return True if DDSE is rocksdb and it is updating table metadata
+*/
+inline bool ha_rocksdb::is_dd_operation() {
+  return default_dd_storage_engine == DEFAULT_DD_ROCKSDB &&
+         thd_is_dd_update_stmt(ha_thd());
 }
 
 #define SHOW_FNAME(name) rocksdb_show_##name

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -12549,7 +12549,7 @@ int ha_rocksdb::update_write_pk(const Rdb_key_def &kd,
   }
 
   if (rocksdb_enable_bulk_load_api && THDVAR(table->in_use, bulk_load) &&
-      !hidden_pk && !is_dd_operation()) {
+      !hidden_pk && !is_dd_update()) {
     /*
       Write the primary key directly to an SST file using an SstFileWriter
      */
@@ -12823,9 +12823,9 @@ int ha_rocksdb::update_write_indexes(const struct update_row_info &row_info,
 
   // Update the remaining indexes. Allow bulk loading only if
   // allow_sk is enabled and isn't dd operation(change table metadata)
-  bulk_load_sk =
-      rocksdb_enable_bulk_load_api && THDVAR(table->in_use, bulk_load) &&
-      THDVAR(table->in_use, bulk_load_allow_sk) && !is_dd_operation();
+  bulk_load_sk = rocksdb_enable_bulk_load_api &&
+                 THDVAR(table->in_use, bulk_load) &&
+                 THDVAR(table->in_use, bulk_load_allow_sk) && !is_dd_update();
   for (uint key_id = 0; key_id < m_tbl_def->m_key_count; key_id++) {
     if (is_pk(key_id, table, m_tbl_def)) {
       continue;
@@ -16421,7 +16421,7 @@ inline bool ha_rocksdb::is_instant(const Alter_inplace_info *ha_alter_info) {
   - For raw data(thd_is_dd_update_stmt()==False), use bulk-load if requested
   @return True if DDSE is rocksdb and it is updating table metadata
 */
-inline bool ha_rocksdb::is_dd_operation() {
+inline bool ha_rocksdb::is_dd_update() {
   return default_dd_storage_engine == DEFAULT_DD_ROCKSDB &&
          thd_is_dd_update_stmt(ha_thd());
 }

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -16421,7 +16421,7 @@ inline bool ha_rocksdb::is_instant(const Alter_inplace_info *ha_alter_info) {
   - For raw data(thd_is_dd_update_stmt()==False), use bulk-load if requested
   @return True if DDSE is rocksdb and it is updating table metadata
 */
-inline bool ha_rocksdb::is_dd_update() {
+bool ha_rocksdb::is_dd_update() {
   return default_dd_storage_engine == DEFAULT_DD_ROCKSDB &&
          thd_is_dd_update_stmt(ha_thd());
 }

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -1000,7 +1000,7 @@ class ha_rocksdb : public my_core::handler, public blob_buffer {
   void build_decoder();
   void check_build_decoder();
 
-  inline bool is_dd_operation();
+  inline bool is_dd_update() const;
 
  protected:
   int records(ha_rows *num_rows) override;

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -1000,6 +1000,8 @@ class ha_rocksdb : public my_core::handler, public blob_buffer {
   void build_decoder();
   void check_build_decoder();
 
+  inline bool is_dd_operation();
+
  protected:
   int records(ha_rows *num_rows) override;
   int records_from_index(ha_rows *num_rows, uint index) override;

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -1000,7 +1000,7 @@ class ha_rocksdb : public my_core::handler, public blob_buffer {
   void build_decoder();
   void check_build_decoder();
 
-  inline bool is_dd_update() const;
+  bool is_dd_update() const;
 
  protected:
   int records(ha_rows *num_rows) override;


### PR DESCRIPTION
Summary:

When customer issue a DDL statement, it will change a table's metadata(whose data is stored in DD) and a tables' raw data.

- during table metadata change, DD will enable OPTION_DD_UPDATE_CONTEXT flag(https://github.com/facebook/mysql-5.6/blob/fb-mysql-8.0.28/sql/dd/impl/transaction_impl.cc#L169).

- during table raw data change, OPTION_DD_UPDATE_CONTEXT flag isn't enabled.

if current DD is myrocks and customer try to run a DDL with bulk loading enabled,

- before this change, myrocks write table metadata using bulk loading when DD save new schema(such as dd::Table_impl::store_children). Later, DD will try to read new schema(such as  dd::Table_impl::restore_children), then it fail to find new schema due myrocks bulk load doesn't support read your own data.

- after this change, table metadata won't use bulk loading(its change data is small) and current trx can read its own data.


Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: