### PR TITLE
Fix MYSQL_BIN_LOG::update_prev_gtid_and_opid declaration

### DIFF
--- a/sql/binlog.h
+++ b/sql/binlog.h
@@ -586,8 +586,8 @@ class MYSQL_BIN_LOG : public TC_LOG {
 
   inline uint get_sync_period() { return *sync_period_ptr; }
 
-  void update_prev_gtid_and_opid(Gtid_set *prev_gtid, long raft_term,
-                                 long raft_index);
+  void update_prev_gtid_and_opid(Gtid_set *prev_gtid, int64_t raft_term,
+                                 int64_t raft_index);
 
  public:
   /*


### PR DESCRIPTION
It was declared with long and defined with int64_t, causing

fb-mysql/sql/binlog.cc:6305:21: error: out-of-line definition of 'update_prev_gtid_and_opid' does not match any declaration in 'MYSQL_BIN_LOG' void MYSQL_BIN_LOG::update_prev_gtid_and_opid(Gtid_set *prev_gtid,

on macOS, where long != int64_t.

Squash with 10f0fe819b417767857146c0a6c5fa152f8e0238