### PR TITLE
[DD] add DD_ENGINE property into dd_properties table

### DIFF
--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -11596,6 +11596,12 @@ ER_IB_SLOWRM_CREATE_DIR
 ER_IB_SLOWRM_MOVE_FILE
   eng "%s"
 
+ER_DDSE_CHANGE
+  eng "MySQL DDSE is changing from '%s' to '%s'."
+
+ER_DD_ENGINE_NOT_FOUND
+  eng "The DD_ENGINE setting for the data dictionary was not found. Starting the server using DD_ENGINE= '%u'."
+
 # DO NOT add server-to-client messages here;
 # they go in messages_to_clients.txt
 # in the same directory as this file.

--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -11602,6 +11602,9 @@ ER_DDSE_CHANGE
 ER_DD_ENGINE_NOT_FOUND
   eng "The DD_ENGINE setting for the data dictionary was not found. Starting the server using DD_ENGINE= '%u'."
 
+ER_UNSUPPORTED_DD_ENGINE
+  eng "The DD_ENGINE value '%u' found in dd_properties isn't supported DDSE."
+
 # DO NOT add server-to-client messages here;
 # they go in messages_to_clients.txt
 # in the same directory as this file.

--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -11600,10 +11600,10 @@ ER_DDSE_CHANGE
   eng "MySQL DDSE is changing from '%s' to '%s'."
 
 ER_DD_ENGINE_NOT_FOUND
-  eng "The DD_ENGINE setting for the data dictionary was not found. Starting the server using DD_ENGINE= '%u'."
+  eng "The DD_ENGINE property for the data dictionary was not found. Starting the server using DD_ENGINE='%s'."
 
 ER_UNSUPPORTED_DD_ENGINE
-  eng "The DD_ENGINE value '%u' found in dd_properties isn't supported DDSE."
+  eng "The DD_ENGINE value '%u' found in dd_properties isn't supported DDSE. Currently supported DDSE are '%s'"
 
 # DO NOT add server-to-client messages here;
 # they go in messages_to_clients.txt

--- a/sql/dd/dd_utility.h
+++ b/sql/dd/dd_utility.h
@@ -80,12 +80,17 @@ bool check_if_server_ddse_readonly(THD *thd, const char *schema_name);
                                                          : ISO_READ_UNCOMMITTED;
 }
 
-[[nodiscard]] inline handlerton *get_dd_engine(THD *thd) {
+[[nodiscard]] inline legacy_db_type get_dd_engine_type() {
   assert(default_dd_storage_engine == DEFAULT_DD_ROCKSDB ||
          default_dd_storage_engine == DEFAULT_DD_INNODB);
   const auto db_type = default_dd_storage_engine == DEFAULT_DD_ROCKSDB
                            ? DB_TYPE_ROCKSDB
                            : DB_TYPE_INNODB;
+  return db_type;
+}
+
+[[nodiscard]] inline handlerton *get_dd_engine(THD *thd) {
+  const auto db_type = get_dd_engine_type();
   return ha_resolve_by_legacy_type(thd, db_type);
 }
 

--- a/sql/dd/dd_utility.h
+++ b/sql/dd/dd_utility.h
@@ -100,6 +100,10 @@ bool check_if_server_ddse_readonly(THD *thd, const char *schema_name);
   return default_dd_storage_engine == DEFAULT_DD_ROCKSDB ? "ROCKSDB" : "INNODB";
 }
 
+[[nodiscard]] inline const char *get_dd_engine_name(legacy_db_type db_type) {
+  assert(db_type == DB_TYPE_INNODB || db_type == DB_TYPE_ROCKSDB);
+  return db_type == DB_TYPE_ROCKSDB ? "ROCKSDB" : "INNODB";
+}
 ///////////////////////////////////////////////////////////////////////////
 
 }  // namespace dd

--- a/sql/dd/impl/bootstrap/bootstrap_ctx.h
+++ b/sql/dd/impl/bootstrap/bootstrap_ctx.h
@@ -107,6 +107,7 @@ class DD_bootstrap_ctx {
   //  During upgrade time, its value maybe not equal to
   //  default_dd_storage_engine
   legacy_db_type m_actual_dd_engine = DB_TYPE_UNKNOWN;
+  legacy_db_type m_did_dd_engine_upgrade_from = DB_TYPE_UNKNOWN;
 
  public:
   DD_bootstrap_ctx() = default;
@@ -131,8 +132,6 @@ class DD_bootstrap_ctx {
   }
 
   void set_actual_dd_engine(enum legacy_db_type actual_dd_engine) {
-    assert(m_actual_dd_engine == DB_TYPE_UNKNOWN ||
-           m_actual_dd_engine == actual_dd_engine);
     m_actual_dd_engine = actual_dd_engine;
   }
 
@@ -140,7 +139,7 @@ class DD_bootstrap_ctx {
 
   uint get_actual_I_S_version() const { return m_actual_I_S_version; }
 
-  uint get_actual_dd_engine() const {
+  legacy_db_type get_actual_dd_engine() const {
     assert(m_actual_dd_engine != DB_TYPE_UNKNOWN);
     return m_actual_dd_engine;
   }
@@ -149,9 +148,13 @@ class DD_bootstrap_ctx {
     assert(m_did_dd_upgrade_from == 0);
     assert(is_dd_upgrade());
     m_did_dd_upgrade_from = m_actual_dd_version;
+    m_did_dd_engine_upgrade_from = m_actual_dd_engine;
   }
 
-  bool dd_upgrade_done() const { return m_did_dd_upgrade_from != 0; }
+  bool dd_upgrade_done() const {
+    return m_did_dd_upgrade_from != 0 &&
+           m_did_dd_engine_upgrade_from != DB_TYPE_UNKNOWN;
+  }
 
   void set_I_S_upgrade_done() {
     assert(m_did_I_S_upgrade_from == 0);
@@ -186,11 +189,14 @@ class DD_bootstrap_ctx {
 
   bool is_restart() const {
     return !opt_initialize && (m_actual_dd_version == dd::DD_VERSION) &&
-           (m_upgraded_server_version == MYSQL_VERSION_ID);
+           (m_upgraded_server_version == MYSQL_VERSION_ID) &&
+           !is_dd_engine_change();
   }
 
+  // Return True if dd version upgrade or dd engine upgrade
   bool is_dd_upgrade() const {
-    return !opt_initialize && (m_actual_dd_version < dd::DD_VERSION);
+    return (!opt_initialize && (m_actual_dd_version < dd::DD_VERSION)) ||
+           is_dd_engine_change();
   }
 
   bool is_server_upgrade() const {
@@ -223,6 +229,13 @@ class DD_bootstrap_ctx {
 
   bool is_initialize() const {
     return opt_initialize && (m_actual_dd_version == dd::DD_VERSION);
+  }
+
+  bool is_dd_engine_change() const {
+    return !opt_initialize &&
+           (m_actual_dd_engine !=
+            (default_dd_storage_engine == DEFAULT_DD_INNODB ? DB_TYPE_INNODB
+                                                            : DB_TYPE_ROCKSDB));
   }
 };
 

--- a/sql/dd/impl/bootstrap/bootstrap_ctx.h
+++ b/sql/dd/impl/bootstrap/bootstrap_ctx.h
@@ -28,6 +28,7 @@
 
 #include "my_inttypes.h"                  // uint
 #include "mysql_version.h"                // MYSQL_VERSION_ID
+#include "sql/dd/dd_utility.h"            // get_dd_engine_type
 #include "sql/dd/dd_version.h"            // DD_VERSION
 #include "sql/dd/info_schema/metadata.h"  // IS_DD_VERSION
 #include "sql/handler.h"
@@ -232,10 +233,7 @@ class DD_bootstrap_ctx {
   }
 
   bool is_dd_engine_change() const {
-    return !opt_initialize &&
-           (m_actual_dd_engine !=
-            (default_dd_storage_engine == DEFAULT_DD_INNODB ? DB_TYPE_INNODB
-                                                            : DB_TYPE_ROCKSDB));
+    return !opt_initialize && (m_actual_dd_engine != get_dd_engine_type());
   }
 };
 

--- a/sql/dd/impl/tables/dd_properties.cc
+++ b/sql/dd/impl/tables/dd_properties.cc
@@ -95,6 +95,7 @@ DD_properties::DD_properties() : m_properties() {
                                 upgrade.
       MYSQLD_VERSION_UPGRADED   The server version of the last
                                 completed successful upgrade.
+      DD_ENGINE                 Actual DD engine
   */
   m_property_desc = {
       {"DD_VERSION", Property_type::UNSIGNED_INT_32},
@@ -110,7 +111,8 @@ DD_properties::DD_properties() : m_properties() {
       {"SYSTEM_TABLES", Property_type::PROPERTIES},
       {"UPGRADE_TARGET_SCHEMA", Property_type::CHARACTER_STRING},
       {"UPGRADE_ACTUAL_SCHEMA", Property_type::CHARACTER_STRING},
-      {"MYSQLD_VERSION_UPGRADED", Property_type::UNSIGNED_INT_32}};
+      {"MYSQLD_VERSION_UPGRADED", Property_type::UNSIGNED_INT_32},
+      {"DD_ENGINE", Property_type::UNSIGNED_INT_32}};
 }
 
 // Read all properties from disk and populate the cache.


### PR DESCRIPTION
Summary:
With multiple DDSE support, DD tables can be stored in different DDSE. 

During upgrade, it is possible that some of DD table is upgrade to target engine but others DD tables isn't. To skip check all of these tables SE, store DD_ENGINE value into dd_properties and the value is stored/updated at the end of upgrade.
-  if DD_ENGINE value is same as default ddse, upgrade has been finished. 
-  if DD_ENGINE value isn't same as default ddse, continue upgrade from start.


Changes:
- Add more diagnostic info, such as DDSE changes into mysqld log
- is_dd_upgrade() will return true if either version upgrade or ddse upgrade(change)
- DD_ENGINE value is stored at the end of upgrade, similar to mysqld_version 
