### PR TITLE
add dd_properties table actual table definition

### DIFF
--- a/sql/dd/impl/bootstrap/bootstrapper.cc
+++ b/sql/dd/impl/bootstrap/bootstrapper.cc
@@ -1072,7 +1072,19 @@ bool create_dd_schema(THD *thd) {
                                     dd::String_type(MYSQL_SCHEMA_NAME.str));
 }
 
-bool initialize_dd_properties(THD *thd) {
+/*
+  With multiple DDSE, dd_properties table may exists in other SE instead of
+  default DDSE. thus add two table definition: actual and target
+    - "actual" means existing table definition,
+    - "target" means expected table definition, it should be table definiton
+      using default DDSE.
+  For bootstrap, "actual" doesn't exist.
+  For restart without upgrade, "actual" and "target" should be same.
+  For upgrade, "actual" is gotten by checking table_exists_in_engine and then
+    compute.
+  The only difference between "actual" and "target" is SE.
+*/
+const Object_table_definition *get_dd_properties_table_definition(THD *thd) {
   if (!opt_initialize) {
     // Find out which SE contains dd_properties table during restart
     // Try rocksdb first
@@ -1084,20 +1096,27 @@ bool initialize_dd_properties(THD *thd) {
           rocksdb_hton, thd, MYSQL_SCHEMA_NAME.str,
           dd::tables::DD_properties::instance().name().c_str());
     }
-    if (error == HA_ERR_TABLE_EXIST) {
-      // actual ddse maybe rocksdb
-      bootstrap::DD_bootstrap_ctx::instance().set_actual_dd_engine(
-          DB_TYPE_ROCKSDB);
-    } else {
-      // actual ddse maybe innodb
-      bootstrap::DD_bootstrap_ctx::instance().set_actual_dd_engine(
-          DB_TYPE_INNODB);
-    }
+    dd::tables::DD_properties::instance().set_actual_engine(
+        error == HA_ERR_TABLE_EXIST ? String_type("ROCkSDB"): String_type("INNODB"));
   }
 
   // Create the dd_properties table.
+  const Object_table_definition *dd_properties_def = nullptr;
+  if (opt_initialize) {
+    dd_properties_def =
+        dd::tables::DD_properties::instance().target_table_definition();
+  } else {
+    dd_properties_def =
+        dd::tables::DD_properties::instance().actual_table_definition();
+  }
+  return dd_properties_def;
+}
+
+bool initialize_dd_properties(THD *thd) {
+  // Create the dd_properties table.
   const Object_table_definition *dd_properties_def =
-      dd::tables::DD_properties::instance().target_table_definition();
+      get_dd_properties_table_definition(thd);
+
   if (dd::execute_query(thd, dd_properties_def->get_ddl())) return true;
 
   /*

--- a/sql/dd/impl/bootstrap/bootstrapper.cc
+++ b/sql/dd/impl/bootstrap/bootstrapper.cc
@@ -1084,7 +1084,8 @@ bool create_dd_schema(THD *thd) {
     compute.
   The only difference between "actual" and "target" is SE.
 */
-const Object_table_definition *get_dd_properties_table_definition(THD *thd) {
+[[nodiscard]] const Object_table_definition *get_dd_properties_table_definition(
+    THD *thd) {
   if (!opt_initialize) {
     // Find out which SE contains dd_properties table during restart
     // Try rocksdb first
@@ -1097,7 +1098,8 @@ const Object_table_definition *get_dd_properties_table_definition(THD *thd) {
           dd::tables::DD_properties::instance().name().c_str());
     }
     dd::tables::DD_properties::instance().set_actual_engine(
-        error == HA_ERR_TABLE_EXIST ? String_type("ROCkSDB"): String_type("INNODB"));
+        error == HA_ERR_TABLE_EXIST ? String_type("ROCkSDB")
+                                    : String_type("INNODB"));
   }
 
   // Create the dd_properties table.

--- a/sql/dd/impl/bootstrap/bootstrapper.cc
+++ b/sql/dd/impl/bootstrap/bootstrapper.cc
@@ -1098,7 +1098,7 @@ bool create_dd_schema(THD *thd) {
           dd::tables::DD_properties::instance().name().c_str());
     }
     dd::tables::DD_properties::instance().set_actual_engine(
-        error == HA_ERR_TABLE_EXIST ? String_type("ROCkSDB")
+        error == HA_ERR_TABLE_EXIST ? String_type("ROCKSDB")
                                     : String_type("INNODB"));
   }
 

--- a/sql/dd/impl/tables/dd_properties.cc
+++ b/sql/dd/impl/tables/dd_properties.cc
@@ -299,5 +299,16 @@ bool DD_properties::remove(THD *thd, const String_type &key) {
   return flush_cached_properties(thd);
 }
 
+void DD_properties::set_actual_engine(const String_type &engine) {
+  // clone table definition from target table if actual table isn't constructed
+  if (!m_actual_present) {
+    std::unique_ptr<Properties> definition(Properties::parse_properties(""));
+    target_table_definition()->store_into_properties(definition.get());
+    set_actual_table_definition(*definition);
+  }
+  m_actual_def.update_option(static_cast<int>(Common_option::ENGINE), "ENGINE",
+                             String_type("ENGINE=") + engine);
+}
+
 }  // namespace tables
 }  // namespace dd

--- a/sql/dd/impl/tables/dd_properties.h
+++ b/sql/dd/impl/tables/dd_properties.h
@@ -196,6 +196,15 @@ class DD_properties : public Object_table_impl {
   */
   bool remove(THD *thd, const String_type &key);
 
+  /**
+    Set dd_properties table actual definition with specified SE
+    if actual definition isn't initialized, it will clone target table
+    definition
+
+    @param engine     Table SE
+  */
+  void set_actual_engine(const String_type &engine);
+
  private:
   // A cache of the table contents.
   Properties_impl m_properties;

--- a/sql/dd/impl/types/object_table_definition_impl.h
+++ b/sql/dd/impl/types/object_table_definition_impl.h
@@ -240,6 +240,12 @@ class Object_table_definition_impl : public Object_table_definition {
                 &m_option_numbers, &m_option_definitions);
   }
 
+  virtual void update_option(int option_number, const String_type &option_name,
+                             const String_type &option_definition) {
+    m_option_numbers[option_name] = option_number;
+    m_option_definitions[option_number] = option_definition;
+  }
+
   virtual void add_populate_statement(const String_type &statement) {
     m_dml_statements.push_back(statement);
   }


### PR DESCRIPTION
Summary:
With multiple DDSE, dd_properties table will also have two table definition(similar to other DD tables): 
 - actual table definition: existing SE which store dd_properties table
 - target table definition: same as default DDSE
The only difference between these two table definitions is table storage engine(SE).

