### PR TITLE
Mark main.mysqldump-lra as a Linux-only test

### DIFF
--- a/mysql-test/t/mysqldump-lra.test
+++ b/mysql-test/t/mysqldump-lra.test
@@ -1,3 +1,5 @@
+--source include/linux.inc
+
 # A simple test to verify the interface of mysqldump with
 # logical read ahead options
 


### PR DESCRIPTION
This fixes, on macOS:

[ 33%] main.mysqldump-lra 'innodb_intrinsic_table'  [ fail ]  Found warnings/errors in error log file!
        Test ended at 2023-09-04 14:10:02
include/load_error_log.inc
line
2023-09-04T11:10:01.772900Z 10 [Warning] [MY-011825] [InnoDB] Logical read ahead is supported only on linux. .... repeated 1211 times: [Warning] [MY-011825] [InnoDB] Logical read ahead is supported only on linux.

Squash with 41be2e0ee060be4326be1b2798bdc3dc8fa713f2