### PR TITLE
Mark INFORMATION_SCHEMA.SOCKET_DIAG_SLAVES tests as Linux-only

### DIFF
--- a/mysql-test/t/socket_diag_slaves.test
+++ b/mysql-test/t/socket_diag_slaves.test
@@ -1,3 +1,4 @@
+--source include/linux.inc
 --source include/master-slave.inc
 
 --source include/rpl_connection_master.inc

--- a/mysql-test/t/socket_diag_slaves_list.test
+++ b/mysql-test/t/socket_diag_slaves_list.test
@@ -1,5 +1,6 @@
---source include/master-slave.inc
+--source include/linux.inc
 --source include/have_debug.inc
+--source include/master-slave.inc
 
 --source include/rpl_connection_master.inc
 

--- a/mysql-test/t/socket_diag_slaves_ssl.test
+++ b/mysql-test/t/socket_diag_slaves_ssl.test
@@ -1,3 +1,4 @@
+--source include/linux.inc
 --source include/master-slave.inc
 
 # create a user for replication that requires ssl encryption


### PR DESCRIPTION
Because the table is present only on Linux, i.e. on macOS:

[ 85%] main.socket_diag_slaves_ssl 'innodb_intrinsic_table' w6  [ fail ]
        Test ended at 2023-09-04 14:24:58

CURRENT_TEST: main.socket_diag_slaves_ssl
mysqltest: At line 13: Query 'SELECT * FROM information_schema.socket_diag_slaves' failed.
ERROR 1109 (42S02): Unknown table 'SOCKET_DIAG_SLAVES' in information_schema

At the same time swap have_debug.inc with master-slave.inc in socket_diag_slaves_list so that a cheap check comes before expensive setup.

Squash with accb01cc760345cba3f01776c997780935b6546b