### PR TITLE
client/mysqltest.cc: fix Apple clang 14 Release build

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -3228,7 +3228,7 @@ static void var_set_query_get_value_by_name(struct st_command *command,
   {
     /* Get the value */
     MYSQL_ROW row;
-    long rows = 0;
+    long rows [[maybe_unused]] = 0;
     const char *value = "No such row";
 
     while ((row = mysql_fetch_row_wrapper(res))) {


### PR DESCRIPTION
In Release build, there is a write-only variable:

/Users/laurynas/vilniusdb/fb-mysql/client/mysqltest.cc:3231:10: error: variable 'rows' set but not used [-Werror,-Wunused-but-set-variable]
    long rows = 0;
         ^

Squash with e990f6f13936638b33d0d4429507f5eb31bda7ff