### PR TITLE
storage/innobase/dict/dict0dd.cc: fix Apple clang 14 Release build

### DIFF
--- a/storage/innobase/dict/dict0dd.cc
+++ b/storage/innobase/dict/dict0dd.cc
@@ -1739,7 +1739,7 @@ void dd_add_instant_columns(IF_DEBUG(const Alter_inplace_info *ha_alter_info, )
                             const TABLE *altered_table, dd::Table *new_dd_table,
                             const dict_table_t *new_table) {
   DD_instant_col_val_coder coder;
-  uint32_t old_n_stored_cols = 0;
+  uint32_t old_n_stored_cols [[maybe_unused]] = 0;
   uint32_t old_cols = 0;
   uint32_t new_cols = 0;
   ut_d(uint32_t n_stored_checked = 0);


### PR DESCRIPTION
In Release build, there is a write-only variable:

/Users/laurynas/vilniusdb/dict0dd-release-build/storage/innobase/dict/dict0dd.cc:1742:12: error: variable 'old_n_stored_cols' set but not used [-Werror,-Wunused-but-set-variable]
  uint32_t old_n_stored_cols = 0;
           ^

Drop on 8.0.32 rebase.