### PR TITLE
sql/sql_plugin.cc: fix Apple clang 14 Release build

### DIFF
--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -1535,7 +1535,7 @@ bool plugin_register_builtin_and_init_core_se(int *argc, char **argv) {
 
   mysql_mutex_lock(&LOCK_plugin);
   initialized = true;
-  bool rocksdb_loaded = false;
+  bool rocksdb_loaded [[maybe_unused]] = false;
 
   const char *ROCKSDB = "ROCKSDB";
   const size_t rocksdb_len = strlen(ROCKSDB);


### PR DESCRIPTION
In Release build, there is a write-only variable:

/Users/laurynas/vilniusdb/sql_plugin-release-build/sql/sql_plugin.cc:1538:8: error: variable 'rocksdb_loaded' set but not used [-Werror,-Wunused-but-set-variable]
  bool rocksdb_loaded = false;
       ^