### PR TITLE
[DD] use actual DDSE during ddse upgrade scenario

### DIFF
--- a/sql/dd/dd_table.cc
+++ b/sql/dd/dd_table.cc
@@ -2339,8 +2339,7 @@ static std::unique_ptr<dd::Table> create_dd_system_table(
   } else {
     assert(file->ht->db_type == DB_TYPE_INNODB ||
            file->ht->db_type == DB_TYPE_ROCKSDB);
-    if (file->ht == nullptr || file->ht->dict_register_dd_table_id == nullptr)
-      return nullptr;
+    if (file->ht->dict_register_dd_table_id == nullptr) return nullptr;
     file->ht->dict_register_dd_table_id(tab_obj->se_private_id());
   }
   return tab_obj;

--- a/sql/dd/dd_table.cc
+++ b/sql/dd/dd_table.cc
@@ -2332,10 +2332,17 @@ static std::unique_ptr<dd::Table> create_dd_system_table(
   }
 
   // Register the se private id with the DDSE.
-  handlerton *ddse = get_dd_engine(thd);
-  if (ddse->dict_register_dd_table_id == nullptr) return nullptr;
-  ddse->dict_register_dd_table_id(tab_obj->se_private_id());
-
+  if (opt_initialize) {
+    handlerton *ddse = get_dd_engine(thd);
+    if (ddse->dict_register_dd_table_id == nullptr) return nullptr;
+    ddse->dict_register_dd_table_id(tab_obj->se_private_id());
+  } else {
+    assert(file->ht->db_type == DB_TYPE_INNODB ||
+           file->ht->db_type == DB_TYPE_ROCKSDB);
+    if (file->ht == nullptr || file->ht->dict_register_dd_table_id == nullptr)
+      return nullptr;
+    file->ht->dict_register_dd_table_id(tab_obj->se_private_id());
+  }
   return tab_obj;
 }
 

--- a/sql/dd/impl/bootstrap/bootstrap_ctx.h
+++ b/sql/dd/impl/bootstrap/bootstrap_ctx.h
@@ -140,7 +140,7 @@ class DD_bootstrap_ctx {
 
   uint get_actual_I_S_version() const { return m_actual_I_S_version; }
 
-  legacy_db_type get_actual_dd_engine() const {
+  [[nodiscard]] legacy_db_type get_actual_dd_engine() const {
     assert(m_actual_dd_engine != DB_TYPE_UNKNOWN);
     return m_actual_dd_engine;
   }

--- a/sql/dd/impl/bootstrap/bootstrap_ctx.h
+++ b/sql/dd/impl/bootstrap/bootstrap_ctx.h
@@ -140,7 +140,7 @@ class DD_bootstrap_ctx {
 
   uint get_actual_I_S_version() const { return m_actual_I_S_version; }
 
-  uint get_actual_dd_engine() const {
+  legacy_db_type get_actual_dd_engine() const {
     assert(m_actual_dd_engine != DB_TYPE_UNKNOWN);
     return m_actual_dd_engine;
   }

--- a/sql/dd/impl/upgrade/dd.cc
+++ b/sql/dd/impl/upgrade/dd.cc
@@ -1156,8 +1156,13 @@ bool upgrade_tables(THD *thd) {
   Object_table_definition_impl::set_dd_tablespace_encrypted(false);
 
   // Reset the DDSE local dictionary cache.
-  handlerton *ddse = get_dd_engine(thd);
-  if (ddse->dict_cache_reset == nullptr) return true;
+  assert(!opt_initialize);
+  handlerton *ddse = ha_resolve_by_legacy_type(
+      thd, bootstrap::DD_bootstrap_ctx::instance().get_actual_dd_engine());
+  if (ddse->dict_cache_reset == nullptr) {
+    assert(false);
+    return true;
+  }
 
   for (System_tables::Const_iterator it =
            System_tables::instance()->begin(System_tables::Types::CORE);


### PR DESCRIPTION
Summary:

- During boostrap, default_dd_storage_engine and actual DDSE is same;
- During DDSE change(innodb->rocksdb or rocksdb->innodb), default_dd_storage_engine and actual DDSE aren't same. default_dd_storage_engine is the target(or expected) DDSE, actual DDSE is existing DDSE and was fetched from dd_properties tables.

The change:
- use actual DDSE during upgrade(! opt_initialize) scenario.
- always call INNODB handler API for innobase_dict_recover and innobase_dict_init unless INNODB is disabled. This is required for DDSE change --- need to access data in INNODB
- call dict_set_server_version to store server version info
- etc

