### PR TITLE
Remove an incorrect assert from MYSQL_BIN_LOG::prepare

### DIFF
--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -10401,12 +10401,6 @@ int MYSQL_BIN_LOG::prepare(THD *thd, bool all) {
   DBUG_TRACE;
 
   assert(opt_bin_log);
-  /*
-    The applier thread explicitly overrides the value of sql_log_bin
-    with the value of log_replica_updates.
-  */
-  assert(thd->slave_thread ? opt_log_replica_updates
-                           : thd->variables.sql_log_bin);
 
   /*
     Set HA_IGNORE_DURABILITY to not flush the prepared record of the


### PR DESCRIPTION
It fires on MyRocks DDSE setup, whenever binlog is enabled globally, but turned off at the moment in one thread.

This is fixed in upstream 8.0.32:  https://github.com/laurynas-biveinis/mysql-5.6/commit/c1401ada9b17ecddbbf71706e886f162cff1a37a