### PR TITLE
Fix/skip some tests in MTR main suite for MyRocks DDSE

### DIFF
--- a/mysql-test/suite/innodb/t/innodb_no_rocksdb_block_user_table-master.opt
+++ b/mysql-test/suite/innodb/t/innodb_no_rocksdb_block_user_table-master.opt
@@ -1,3 +1,3 @@
---initialize 
+--initialize
 --enable_user_tables_engine_check=ON
---skip-rocksdb
+--loose-skip-rocksdb

--- a/mysql-test/suite/innodb/t/innodb_no_rocksdb_block_user_table.test
+++ b/mysql-test/suite/innodb/t/innodb_no_rocksdb_block_user_table.test
@@ -1,3 +1,4 @@
+--source include/have_innodb_ddse.inc
 #
 # MyRocks-specific tests for enable_user_tables_engine_check
 #

--- a/mysql-test/t/dd_is_concurrency.test
+++ b/mysql-test/t/dd_is_concurrency.test
@@ -1,3 +1,5 @@
+# READ UNCOMMITTED reads from MyRocks DD tables will work as READ COMMITTED
+--source include/have_innodb_ddse.inc
 --source include/have_debug_sync.inc
 
 # Allow system table access.

--- a/mysql-test/t/foreign_key.test
+++ b/mysql-test/t/foreign_key.test
@@ -1,3 +1,6 @@
+# Multiple FK operations in a single SQL statement depend on the READ
+# UNCOMMITTED support
+--source include/have_innodb_ddse.inc
 #
 # Test syntax of foreign keys
 #

--- a/mysql-test/t/foreign_key_debug.test
+++ b/mysql-test/t/foreign_key_debug.test
@@ -1,3 +1,6 @@
+# Multiple FK operations in a single SQL statement depend on the READ
+# UNCOMMITTED support
+--source include/have_innodb_ddse.inc
 #
 # Tests of foreign keys that need a debug build or debug_sync feature.
 #

--- a/mysql-test/t/mysqld_cmdline_warnings.test
+++ b/mysql-test/t/mysqld_cmdline_warnings.test
@@ -50,5 +50,4 @@
 --source include/search_pattern.inc
 
 # Cleanup
---remove_files_wildcard $WL11109_DATADIR *
---rmdir $WL11109_DATADIR
+--force-rmdir $WL11109_DATADIR

--- a/mysql-test/t/populate_collations_read_only.test
+++ b/mysql-test/t/populate_collations_read_only.test
@@ -1,3 +1,5 @@
+# --innodb-read-only will not prevent updates to the data dictionary in MyRocks
+--source include/have_innodb_ddse.inc
 --echo # Verify that restarting the server in --read-only mode skips
 --echo # re-populating character sets and collations. Also verify the
 --echo # same for --innodb-read-only.


### PR DESCRIPTION
- Fix main.mysqld_cmdline_warnings: The test uses remove_files_wildcard/rmdir commands, where the former ignores the hidden .rocksdb directory, making the latter fail. Replace with a single force-rmdir.
- Skip MTR tests that require InnoDB DDSE:
  - main.dd_is_concurrency due to unsupported MyRocks transaction isolation levels.
  - main.foreign_key, main.foreign_key_debug due to multiple operations in a single SQL statement depending on READ UNCOMMITTED support available for DD transactions.
  - main.populate_collations_read_only because --innodb-read-only will not disable updates for the data dictionary being in MyRocks.
  - innodb.innodb_no_rocksdb_block_user_table because it requires MyRocks being absent at all.