### PR TITLE
Run clang-format on storage/rocksdb

### DIFF
--- a/mysql-test/suite/rocksdb/r/error_abort_warning_on_corrupt_data.result
+++ b/mysql-test/suite/rocksdb/r/error_abort_warning_on_corrupt_data.result
@@ -1,4 +1,4 @@
-SET SESSION debug="+d, stimulate_corrupt_data_read";
+SET SESSION debug="+d, simulate_corrupt_data_read";
 CREATE DATABASE a;
 USE a;
 CREATE TABLE t1 (a INT PRIMARY KEY, b CHAR(8)) ENGINE=rocksdB;
@@ -12,14 +12,14 @@ ERROR HY000: Got error 505 'Found data corruption.' from ROCKSDB
 fail server
 SET GLOBAL rocksdb_corrupt_data_action = ABORT_SERVER;
 select * from t1;
-SET SESSION debug="+d, stimulate_corrupt_data_read";
+SET SESSION debug="+d, simulate_corrupt_data_read";
 pass query with warning
 SET GLOBAL rocksdb_corrupt_data_action = WARNING;
 select * from t1;
 a	b
 3	bar
 4	bar
-SET SESSION debug="-d, stimulate_corrupt_data_read";
+SET SESSION debug="-d, simulate_corrupt_data_read";
 write
 USE a;
 CREATE table t2 (
@@ -29,7 +29,7 @@ val int default 0,
 unique(sk)
 ) engine=rocksdb;
 insert into t2 (sk) values (1), (2);
-SET SESSION debug="+d, stimulate_corrupt_data_update";
+SET SESSION debug="+d, simulate_corrupt_data_update";
 fail query
 SET GLOBAL rocksdb_corrupt_data_action = ERROR;
 insert into t2 (sk) values (1), (2) on duplicate key update val = val + 1;
@@ -37,11 +37,11 @@ ERROR HY000: Got error 505 'Found data corruption.' from ROCKSDB
 fail server
 SET GLOBAL rocksdb_corrupt_data_action = ABORT_SERVER;
 insert into t2 (sk) values (1), (2) on duplicate key update val = val + 1;
-SET SESSION debug="+d, stimulate_corrupt_data_update";
+SET SESSION debug="+d, simulate_corrupt_data_update";
 pass query with warning
 SET GLOBAL rocksdb_corrupt_data_action = WARNING;
 insert into t2 (sk) values (1), (2) on duplicate key update val = val + 1;
-SET SESSION debug="-d, stimulate_corrupt_data_update";
+SET SESSION debug="-d, simulate_corrupt_data_update";
 select * from t2;
 pk0	sk	val
 1	1	1

--- a/mysql-test/suite/rocksdb/t/error_abort_warning_on_corrupt_data.test
+++ b/mysql-test/suite/rocksdb/t/error_abort_warning_on_corrupt_data.test
@@ -7,7 +7,7 @@
 
 let DATADIR_LOCATION=$MYSQLTEST_VARDIR/mysqld.1/data;
 
-SET SESSION debug="+d, stimulate_corrupt_data_read";
+SET SESSION debug="+d, simulate_corrupt_data_read";
 	
 CREATE DATABASE a;
 USE a;
@@ -35,13 +35,13 @@ select * from t1;
 let $WAIT_COUNT=6000;
 --source include/wait_time_until_connected_again.inc
 
-SET SESSION debug="+d, stimulate_corrupt_data_read";
+SET SESSION debug="+d, simulate_corrupt_data_read";
 
 --echo pass query with warning
 SET GLOBAL rocksdb_corrupt_data_action = WARNING;
 select * from t1;
 
-SET SESSION debug="-d, stimulate_corrupt_data_read";
+SET SESSION debug="-d, simulate_corrupt_data_read";
 
 --echo write
 
@@ -55,7 +55,7 @@ CREATE table t2 (
 
 insert into t2 (sk) values (1), (2);
 
-SET SESSION debug="+d, stimulate_corrupt_data_update";
+SET SESSION debug="+d, simulate_corrupt_data_update";
 
 --echo fail query
 SET GLOBAL rocksdb_corrupt_data_action = ERROR;
@@ -74,13 +74,13 @@ insert into t2 (sk) values (1), (2) on duplicate key update val = val + 1;
 let $WAIT_COUNT=6000;
 --source include/wait_time_until_connected_again.inc
 
-SET SESSION debug="+d, stimulate_corrupt_data_update";
+SET SESSION debug="+d, simulate_corrupt_data_update";
 
 --echo pass query with warning
 SET GLOBAL rocksdb_corrupt_data_action = WARNING;
 insert into t2 (sk) values (1), (2) on duplicate key update val = val + 1;
 
-SET SESSION debug="-d, stimulate_corrupt_data_update";
+SET SESSION debug="-d, simulate_corrupt_data_update";
 
 select * from t2;
 

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -4797,15 +4797,15 @@ class Rdb_transaction {
       if (!m_thd->is_system_thread() &&
           !m_thd->is_attachable_transaction_active()) {
         THD *thd = new THD();
-      thd->thread_stack = reinterpret_cast<char *>(&(thd));
-      thd->store_globals();
+        thd->thread_stack = reinterpret_cast<char *>(&(thd));
+        thd->store_globals();
 
-      const char act[] =
-          "now signal destructor_started wait_for trx_list_query";
-      assert(!debug_sync_set_action(thd, STRING_WITH_LEN(act)));
+        const char act[] =
+            "now signal destructor_started wait_for trx_list_query";
+        assert(!debug_sync_set_action(thd, STRING_WITH_LEN(act)));
 
-      thd->restore_globals();
-      delete thd;
+        thd->restore_globals();
+        delete thd;
       }
     });
     RDB_MUTEX_LOCK_CHECK(s_tx_list_mutex);
@@ -5421,9 +5421,7 @@ class Rdb_writebatch_impl : public Rdb_transaction {
   }
 
  private:
-  bool prepare() override {
-    return true;
-  }
+  bool prepare() override { return true; }
 
   bool commit_no_binlog(TABLE_TYPE table_type) override {
     assert(!is_ac_nl_ro_rc_transaction());
@@ -5465,22 +5463,16 @@ class Rdb_writebatch_impl : public Rdb_transaction {
   }
 
   /* Implementations of do_*savepoint based on rocksdB::WriteBatch savepoints */
-  void do_set_savepoint() override {
-    m_batch->SetSavePoint();
-  }
+  void do_set_savepoint() override { m_batch->SetSavePoint(); }
 
   rocksdb::Status do_pop_savepoint() override {
     return m_batch->PopSavePoint();
   }
 
-  void do_rollback_to_savepoint() override {
-    m_batch->RollbackToSavePoint();
-  }
+  void do_rollback_to_savepoint() override { m_batch->RollbackToSavePoint(); }
 
  public:
-  bool is_writebatch_trx() const override {
-    return true;
-  }
+  bool is_writebatch_trx() const override { return true; }
 
   void set_lock_timeout(int timeout_sec_arg MY_ATTRIBUTE((unused)),
                         TABLE_TYPE /*table_type*/) override {
@@ -5489,9 +5481,7 @@ class Rdb_writebatch_impl : public Rdb_transaction {
     // Nothing to do here.
   }
 
-  void set_sync(bool sync) override {
-    write_opts.sync = sync;
-  }
+  void set_sync(bool sync) override { write_opts.sync = sync; }
 
   void release_lock(const Rdb_key_def &key_descr MY_ATTRIBUTE((unused)),
                     const std::string &rowkey MY_ATTRIBUTE((unused)),
@@ -5593,9 +5583,7 @@ class Rdb_writebatch_impl : public Rdb_transaction {
     return m_batch->GetWriteBatch()->Count() > 0;
   }
 
-  rocksdb::WriteBatchBase *get_write_batch() override {
-    return m_batch;
-  }
+  rocksdb::WriteBatchBase *get_write_batch() override { return m_batch; }
 
   rocksdb::WriteBatchBase *get_indexed_write_batch(
       TABLE_TYPE table_type) override {
@@ -9118,8 +9106,8 @@ int ha_rocksdb::convert_record_from_storage_format(
     uchar *const buf) {
   int rc = m_converter->decode(m_pk_descr, buf, key, value);
 
-  DBUG_EXECUTE_IF("stimulate_corrupt_data_read",
-      if (m_tbl_def->full_tablename() == "a.t1") {
+  DBUG_EXECUTE_IF(
+      "simulate_corrupt_data_read", if (m_tbl_def->full_tablename() == "a.t1") {
         rc = HA_ERR_ROCKSDB_CORRUPT_DATA;
       });
 
@@ -12397,7 +12385,8 @@ int ha_rocksdb::check_and_lock_sk(
     const rocksdb::Slice &rkey = all_parts_used ? new_slice : iter.key();
     uint pk_size =
         kd.get_primary_key_tuple(*m_pk_descr, &rkey, m_pk_packed_tuple);
-    DBUG_EXECUTE_IF("stimulate_corrupt_data_update",
+    DBUG_EXECUTE_IF(
+        "simulate_corrupt_data_update",
         if (m_tbl_def->full_tablename() == "a.t2") {
           pk_size = RDB_INVALID_KEY_LEN;
         });

--- a/storage/rocksdb/nosql_access.h
+++ b/storage/rocksdb/nosql_access.h
@@ -27,9 +27,9 @@
 
 /* MySQL header files */
 #include <mysql/service_rpc_plugin.h>
+#include "./sql_string.h"
 #include "sql/protocol.h"
 #include "sql/sql_class.h"
-#include "./sql_string.h"
 
 #pragma once
 

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -888,8 +888,8 @@ const std::string Rdb_key_def::parse_comment_for_qualifier(
 
   Returns -1 if field was null, 1 if error, 0 otherwise.
 */
-int Rdb_key_def::read_memcmp_key_part(
-    Rdb_string_reader *reader, const uint part_num) const {
+int Rdb_key_def::read_memcmp_key_part(Rdb_string_reader *reader,
+                                      const uint part_num) const {
   /* It is impossible to unpack the column. Skip it. */
   if (m_pack_info[part_num].m_field_is_nullable) {
     const char *nullp;
@@ -1474,7 +1474,7 @@ uint Rdb_key_def::pack_hidden_pk(const longlong hidden_pk_id,
   tuple += INDEX_NUMBER_SIZE;
   assert(m_key_parts == 1);
   assert(is_storage_available(tuple - packed_tuple,
-                                   m_pack_info[0].m_max_image_len));
+                              m_pack_info[0].m_max_image_len));
 
   m_pack_info[0].fill_hidden_pk_val(&tuple, hidden_pk_id);
 
@@ -1644,7 +1644,7 @@ int Rdb_key_def::unpack_record(TABLE *const table, uchar *const buf,
   // the layout there is different. The checksum is verified in
   // ha_rocksdb::convert_record_from_storage_format instead.
   assert_IMP(!(m_index_type == INDEX_TYPE_SECONDARY),
-                  !verify_row_debug_checksums);
+             !verify_row_debug_checksums);
 
   // Skip the index number
   if (unlikely(!reader.read(INDEX_NUMBER_SIZE))) {
@@ -3940,12 +3940,11 @@ bool Rdb_field_packing::setup(const Rdb_key_def *const key_descr,
         // VARCHARs - are compared as if they were space-padded - but are
         // not actually space-padded (reading the value back produces the
         // original value, without the padding)
-        m_unpack_func =
-            (cs == &my_charset_utf8mb4_bin)
-                ? Rdb_key_def::unpack_utf8mb4_varlength_space_pad
-                : (cs == &my_charset_utf8_bin)
-                      ? Rdb_key_def::unpack_utf8_varlength_space_pad
-                      : Rdb_key_def::unpack_binary_varlength_space_pad;
+        m_unpack_func = (cs == &my_charset_utf8mb4_bin)
+                            ? Rdb_key_def::unpack_utf8mb4_varlength_space_pad
+                        : (cs == &my_charset_utf8_bin)
+                            ? Rdb_key_def::unpack_utf8_varlength_space_pad
+                            : Rdb_key_def::unpack_binary_varlength_space_pad;
 
         m_skip_func = Rdb_key_def::skip_variable_space_pad;
         m_pack_func = Rdb_key_def::pack_with_varlength_space_pad;
@@ -3962,11 +3961,10 @@ bool Rdb_field_packing::setup(const Rdb_key_def *const key_descr,
         // We just store that and restore it back.
         assert(m_pack_func == Rdb_key_def::pack_string);
         assert(m_make_unpack_info_func == nullptr);
-        m_unpack_func = (cs == &my_charset_utf8mb4_bin)
-                            ? Rdb_key_def::unpack_utf8mb4_str
-                            : (cs == &my_charset_utf8_bin)
-                                  ? Rdb_key_def::unpack_utf8_str
-                                  : Rdb_key_def::unpack_binary_str;
+        m_unpack_func =
+            (cs == &my_charset_utf8mb4_bin) ? Rdb_key_def::unpack_utf8mb4_str
+            : (cs == &my_charset_utf8_bin)  ? Rdb_key_def::unpack_utf8_str
+                                            : Rdb_key_def::unpack_binary_str;
       }
       m_covered = Rdb_key_def::KEY_COVERED;
     } else {
@@ -4182,8 +4180,7 @@ bool Rdb_key_def::has_index_flag(uint32 index_flags, enum INDEX_FLAG flag) {
 uint32 Rdb_key_def::calculate_index_flag_offset(uint32 index_flags,
                                                 enum INDEX_FLAG flag,
                                                 uint *const length) {
-  assert_IMP(flag != MAX_FLAG,
-                  Rdb_key_def::has_index_flag(index_flags, flag));
+  assert_IMP(flag != MAX_FLAG, Rdb_key_def::has_index_flag(index_flags, flag));
 
   uint offset = 0;
   for (size_t bit = 0; bit < sizeof(index_flags) * CHAR_BIT; ++bit) {
@@ -5137,9 +5134,7 @@ void Rdb_binlog_manager::update(const char *const binlog_name,
                                 const my_off_t binlog_pos,
                                 const char *const binlog_max_gtid,
                                 rocksdb::WriteBatchBase *const batch) {
-  DBUG_EXECUTE_IF("rocksdb_skip_binlog_pos_update", {
-    return;
-  };);
+  DBUG_EXECUTE_IF("rocksdb_skip_binlog_pos_update", { return; };);
 
   if (binlog_name && binlog_pos) {
     // max binlog length (512) + binlog pos (4) + binlog gtid (57) < 1024
@@ -5650,7 +5645,7 @@ void Rdb_dict_manager::get_ongoing_index_operation(
     std::unordered_set<GL_INDEX_ID> *gl_index_ids,
     Rdb_key_def::DATA_DICT_TYPE dd_type) const {
   assert(dd_type == Rdb_key_def::DDL_DROP_INDEX_ONGOING ||
-              dd_type == Rdb_key_def::DDL_CREATE_INDEX_ONGOING);
+         dd_type == Rdb_key_def::DDL_CREATE_INDEX_ONGOING);
 
   Rdb_buf_writer<Rdb_key_def::INDEX_NUMBER_SIZE> index_writer;
   index_writer.write_uint32(dd_type);
@@ -5746,7 +5741,7 @@ int Rdb_dict_manager::remove_orphaned_dropped_cfs(
 bool Rdb_dict_manager::is_index_operation_ongoing(
     const GL_INDEX_ID &gl_index_id, Rdb_key_def::DATA_DICT_TYPE dd_type) const {
   assert(dd_type == Rdb_key_def::DDL_DROP_INDEX_ONGOING ||
-              dd_type == Rdb_key_def::DDL_CREATE_INDEX_ONGOING);
+         dd_type == Rdb_key_def::DDL_CREATE_INDEX_ONGOING);
 
   bool found = false;
   std::string value;
@@ -5768,7 +5763,7 @@ void Rdb_dict_manager::start_ongoing_index_operation(
     rocksdb::WriteBatch *const batch, const GL_INDEX_ID &gl_index_id,
     Rdb_key_def::DATA_DICT_TYPE dd_type) const {
   assert(dd_type == Rdb_key_def::DDL_DROP_INDEX_ONGOING ||
-              dd_type == Rdb_key_def::DDL_CREATE_INDEX_ONGOING);
+         dd_type == Rdb_key_def::DDL_CREATE_INDEX_ONGOING);
 
   Rdb_buf_writer<Rdb_key_def::INDEX_NUMBER_SIZE * 3> key_writer;
   Rdb_buf_writer<Rdb_key_def::VERSION_SIZE> value_writer;
@@ -5793,7 +5788,7 @@ void Rdb_dict_manager::end_ongoing_index_operation(
     rocksdb::WriteBatch *const batch, const GL_INDEX_ID &gl_index_id,
     Rdb_key_def::DATA_DICT_TYPE dd_type) const {
   assert(dd_type == Rdb_key_def::DDL_DROP_INDEX_ONGOING ||
-              dd_type == Rdb_key_def::DDL_CREATE_INDEX_ONGOING);
+         dd_type == Rdb_key_def::DDL_CREATE_INDEX_ONGOING);
 
   delete_with_prefix(batch, dd_type, gl_index_id);
 }
@@ -5863,7 +5858,7 @@ void Rdb_dict_manager::finish_indexes_operation(
     const std::unordered_set<GL_INDEX_ID> &gl_index_ids,
     Rdb_key_def::DATA_DICT_TYPE dd_type) const {
   assert(dd_type == Rdb_key_def::DDL_DROP_INDEX_ONGOING ||
-              dd_type == Rdb_key_def::DDL_CREATE_INDEX_ONGOING);
+         dd_type == Rdb_key_def::DDL_CREATE_INDEX_ONGOING);
 
   const std::unique_ptr<rocksdb::WriteBatch> wb = begin();
   rocksdb::WriteBatch *const batch = wb.get();

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -578,8 +578,8 @@ class Rdb_key_def {
   void setup(const TABLE &table, const Rdb_tbl_def &tbl_def);
 
   [[nodiscard]] static uint extract_ttl_duration(const TABLE &table_arg,
-                                   const Rdb_tbl_def &tbl_def_arg,
-                                   uint64 &ttl_duration);
+                                                 const Rdb_tbl_def &tbl_def_arg,
+                                                 uint64 &ttl_duration);
   [[nodiscard]] static uint extract_ttl_col(const TABLE &table_arg,
                                             const Rdb_tbl_def &tbl_def_arg,
                                             std::string &ttl_column,
@@ -1371,7 +1371,7 @@ class Rdb_seq_generator {
 };
 
 interface Rdb_tables_scanner {
-  virtual int add_table(Rdb_tbl_def * tdef) = 0;
+  virtual int add_table(Rdb_tbl_def *tdef) = 0;
   virtual ~Rdb_tables_scanner(){};
 };
 

--- a/storage/rocksdb/rdb_iterator.cc
+++ b/storage/rocksdb/rdb_iterator.cc
@@ -391,7 +391,8 @@ int Rdb_iterator_base::get(const rocksdb::Slice *key,
                               type == RDB_LOCK_WRITE, skip_wait);
   }
 
-  DBUG_EXECUTE_IF("rocksdb_return_status_corrupted",
+  DBUG_EXECUTE_IF(
+      "rocksdb_return_status_corrupted",
       if (m_tbl_def->full_tablename() == "test.t1") {
         s = rocksdb::Status::Corruption();
       });

--- a/storage/rocksdb/rdb_sst_info.h
+++ b/storage/rocksdb/rdb_sst_info.h
@@ -206,8 +206,7 @@ class Rdb_sst_info {
 
     void init(rocksdb::ColumnFamilyHandle *cf,
               std::vector<std::string> &&files) {
-      assert(m_cf == nullptr && m_committed_files.size() == 0 &&
-                  m_committed);
+      assert(m_cf == nullptr && m_committed_files.size() == 0 && m_committed);
       m_cf = cf;
       m_committed_files = std::move(files);
       m_committed = false;

--- a/storage/rocksdb/rdb_utils.h
+++ b/storage/rocksdb/rdb_utils.h
@@ -403,7 +403,7 @@ class Rdb_exec_time {
    * static cast on overloaded functions passed in as template param.
    */
   template <class Fn, class... Args>
-  auto exec(const std::string &key, const Fn &&fn, Args &&... args)
+  auto exec(const std::string &key, const Fn &&fn, Args &&...args)
       -> decltype(fn(args...)) {
     Auto_timer timer([&](uint64_t &e) { entries_.emplace(key, e); });
     return fn(args...);

--- a/storage/rocksdb/ut0counter.h
+++ b/storage/rocksdb/ut0counter.h
@@ -55,7 +55,7 @@ struct generic_indexer_t {
 };
 
 #ifdef HAVE_SCHED_GETCPU
-//#include <utmpx.h>  // Including this causes problems with EMPTY symbol
+// #include <utmpx.h>  // Including this causes problems with EMPTY symbol
 #include <sched.h>  // Include this instead
 /** Use the cpu id to index into the counter array. If it fails then
 use the thread id. */


### PR DESCRIPTION
Since it touched one of the lines with these debugging sync points, use this opportunity to fix "stimulate/simulate" typo too.