### PR TITLE
Fix MyRocks compilation under XCode 15

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -14054,9 +14054,8 @@ int ha_rocksdb::start_stmt(THD *const thd,
   DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
-rocksdb::Range get_range(uint32_t i,
-                         uchar buf[Rdb_key_def::INDEX_NUMBER_SIZE * 2],
-                         int offset1, int offset2) {
+[[nodiscard]] static rocksdb::Range get_range(uint32_t i, uchar *buf,
+                                              int offset1, int offset2) {
   uchar *buf_begin = buf;
   uchar *buf_end = buf + Rdb_key_def::INDEX_NUMBER_SIZE;
   rdb_netbuf_store_index(buf_begin, i + offset1);
@@ -14067,14 +14066,12 @@ rocksdb::Range get_range(uint32_t i,
       rocksdb::Slice((const char *)buf_end, Rdb_key_def::INDEX_NUMBER_SIZE));
 }
 
-static rocksdb::Range get_range(const Rdb_key_def &kd,
-                                uchar buf[Rdb_key_def::INDEX_NUMBER_SIZE * 2],
-                                int offset1, int offset2) {
+[[nodiscard]] static rocksdb::Range get_range(const Rdb_key_def &kd, uchar *buf,
+                                              int offset1, int offset2) {
   return get_range(kd.get_index_number(), buf, offset1, offset2);
 }
 
-rocksdb::Range ha_rocksdb::get_range(
-    const Rdb_key_def &kd, uchar buf[Rdb_key_def::INDEX_NUMBER_SIZE * 2]) {
+rocksdb::Range ha_rocksdb::get_range(const Rdb_key_def &kd, uchar *buf) {
   if (kd.m_is_reverse_cf) {
     return myrocks::get_range(kd, buf, 1, 0);
   } else {
@@ -14082,8 +14079,7 @@ rocksdb::Range ha_rocksdb::get_range(
   }
 }
 
-rocksdb::Range ha_rocksdb::get_range(
-    const int i, uchar buf[Rdb_key_def::INDEX_NUMBER_SIZE * 2]) const {
+rocksdb::Range ha_rocksdb::get_range(int i, uchar *buf) const {
   return get_range(*m_key_descr_arr[i], buf);
 }
 

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -388,7 +388,7 @@ class ha_rocksdb : public my_core::handler, public blob_buffer {
   void free_key_buffers();
 
   // the buffer size should be at least 2*Rdb_key_def::INDEX_NUMBER_SIZE
-  rocksdb::Range get_range(const int i, uchar buf[]) const;
+  [[nodiscard]] rocksdb::Range get_range(int i, uchar *buf) const;
 
   void records_in_range_internal(uint inx, key_range *const min_key,
                                  key_range *const max_key, int64 disk_size,
@@ -403,7 +403,8 @@ class ha_rocksdb : public my_core::handler, public blob_buffer {
  public:
   bool refresh_tmp_table_iterator(const std::string &key);
   void extract_snapshot_keys(std::string *key);
-  static rocksdb::Range get_range(const Rdb_key_def &kd, uchar buf[]);
+  [[nodiscard]] static rocksdb::Range get_range(const Rdb_key_def &kd,
+                                                uchar *buf);
 
   /*
     Update stats

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -26,6 +26,7 @@
 /* C++ standard header files */
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <limits>
 #include <map>
 #include <set>
@@ -5521,12 +5522,12 @@ bool Rdb_dict_manager::get_index_info(
   }
 
   if (error) {
-    rdb_fatal_error(
-        "RocksDB: Found invalid key version number (%u, %u, %u, %llu) "
-        "from data dictionary. This should never happen "
-        "and it may be a bug.",
-        index_info->m_index_dict_version, index_info->m_index_type,
-        index_info->m_kv_version, index_info->m_ttl_duration);
+    rdb_fatal_error("RocksDB: Found invalid key version number (%" PRIu16
+                    ", %hhu, %" PRIu16
+                    ", %llu) from data dictionary. This should never happen "
+                    "and it may be a bug.",
+                    index_info->m_index_dict_version, index_info->m_index_type,
+                    index_info->m_kv_version, index_info->m_ttl_duration);
   }
 
   return found;


### PR DESCRIPTION
This fixes the errors listed below. For the array argument, fix by converting the arrays to pointers as this is what gets passed around anyway.

/Users/laurynas/vilniusdb/xcode-15-fixes/storage/rocksdb/rdb_datadic.cc:5528:9: error: format specifies type 'unsigned int' but the argument has type 'uint16_t' (aka 'unsigned short') [-Werror,-Wformat]
        index_info->m_index_dict_version, index_info->m_index_type,
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/laurynas/vilniusdb/xcode-15-fixes/storage/rocksdb/rdb_datadic.cc:5528:43: error: format specifies type 'unsigned int' but the argument has type 'uchar' (aka 'unsigned char') [-Werror,-Wformat]
        index_info->m_index_dict_version, index_info->m_index_type,
                                          ^~~~~~~~~~~~~~~~~~~~~~~~
/Users/laurynas/vilniusdb/xcode-15-fixes/storage/rocksdb/rdb_datadic.cc:5529:9: error: format specifies type 'unsigned int' but the argument has type 'uint16_t' (aka 'unsigned short') [-Werror,-Wformat]
        index_info->m_kv_version, index_info->m_ttl_duration);
        ^~~~~~~~~~~~~~~~~~~~~~~~
3 errors generated.

/Users/laurynas/vilniusdb/xcode-15-fixes/storage/rocksdb/ha_rocksdb.cc:14077:34: error: argument 'buf' of type 'uchar[8]' (aka 'unsigned char[8]') with mismatched bound [-Werror,-Warray-parameter]
    const Rdb_key_def &kd, uchar buf[Rdb_key_def::INDEX_NUMBER_SIZE * 2]) {
                                 ^
/Users/laurynas/vilniusdb/xcode-15-fixes/storage/rocksdb/./ha_rocksdb.h:406:64: note: previously declared as 'uchar[]' (aka 'unsigned char[]') here
  static rocksdb::Range get_range(const Rdb_key_def &kd, uchar buf[]);
                                                               ^
/Users/laurynas/vilniusdb/xcode-15-fixes/storage/rocksdb/ha_rocksdb.cc:14086:24: error: argument 'buf' of type 'uchar[8]' (aka 'unsigned char[8]') with mismatched bound [-Werror,-Warray-parameter]
    const int i, uchar buf[Rdb_key_def::INDEX_NUMBER_SIZE * 2]) const {
                       ^
/Users/laurynas/vilniusdb/xcode-15-fixes/storage/rocksdb/./ha_rocksdb.h:391:47: note: previously declared as 'uchar[]' (aka 'unsigned char[]') here
  rocksdb::Range get_range(const int i, uchar buf[]) const;
                                              ^