### PR TITLE
Remove redundant static constexpr declaration

### DIFF
--- a/sql/session_tracker.cc
+++ b/sql/session_tracker.cc
@@ -60,8 +60,6 @@
 #include "sql_string.h"
 #include "template_utils.h"
 
-constexpr size_t Session_resp_attr_tracker::MAX_RESP_ATTR_LEN;
-
 static void store_lenenc_string(String &to, const char *from, size_t length);
 
 /**


### PR DESCRIPTION
This fixes "Out-of-line definition of constexpr static data member is redundant in C++17 and is deprecated" under XCode 15.

Squash with 02d95c4b50fca5fbb5be486f92d872635a098e7b