### PR TITLE
Make InnoDB work when it's not the DDSE

### DIFF
--- a/mysql-test/suite/rocksdb_dd_innodb/r/create_select_foreign_key.result
+++ b/mysql-test/suite/rocksdb_dd_innodb/r/create_select_foreign_key.result
@@ -1,0 +1,94 @@
+SET @saved_sql_log_bin = @@SESSION.sql_log_bin;
+#
+# CREATE TABLE AS SELECT (CTAS) and foreign key (FK).
+#
+CREATE TABLE t0 (f1 INT PRIMARY KEY);
+INSERT INTO t0 VALUES (1),(2),(3),(4);
+#
+# CASE 1 The behavior of non-atomic CTAS remains the same
+# with request to create FK. There is no engine which do
+# not support atomic DDL, but supports foreign keys.
+# MyISAM does not support foreign keys, so there is no error
+# as it ignore FK constraints silently.
+CREATE TABLE myisam_table1 (m INT, n INT, FOREIGN KEY (n) REFERENCES t0(f1))
+ENGINE=MyISAM AS SELECT 101 as m, 5 as n;
+SHOW CREATE TABLE myisam_table1;
+Table	Create Table
+myisam_table1	CREATE TABLE `myisam_table1` (
+  `m` int DEFAULT NULL,
+  `n` int DEFAULT NULL,
+  KEY `n` (`n`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+CREATE TABLE myisam_table2 (m INT, n INT, FOREIGN KEY (n) REFERENCES t0(f1))
+ENGINE=MyISAM AS SELECT 101 as m, 2 as n;
+SHOW CREATE TABLE myisam_table2;
+Table	Create Table
+myisam_table2	CREATE TABLE `myisam_table2` (
+  `m` int DEFAULT NULL,
+  `n` int DEFAULT NULL,
+  KEY `n` (`n`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE myisam_table1;
+DROP TABLE myisam_table2;
+#
+# CASE 2 The behavior of atomic CTAS, with sql_log_bin OFF.
+#
+SET sql_log_bin = OFF;
+CREATE TABLE innodb_table1 (m INT, n INT, FOREIGN KEY (n) REFERENCES t0(f1))
+AS SELECT 101 as m, 5 as n;
+ERROR 23000: Cannot add or update a child row: a foreign key constraint fails (`test`.`innodb_table1`, CONSTRAINT `innodb_table1_ibfk_1` FOREIGN KEY (`n`) REFERENCES `t0` (`f1`))
+CREATE TABLE innodb_table1 (m INT, n INT, FOREIGN KEY (n) REFERENCES t0(f1))
+AS SELECT 101 as m, 2 as n;
+CREATE TABLE innodb_table2 as SELECT m, 4 FROM innodb_table1;
+SHOW CREATE TABLE innodb_table1;
+Table	Create Table
+innodb_table1	CREATE TABLE `innodb_table1` (
+  `m` int DEFAULT NULL,
+  `n` int DEFAULT NULL,
+  KEY `n` (`n`),
+  CONSTRAINT `innodb_table1_ibfk_1` FOREIGN KEY (`n`) REFERENCES `t0` (`f1`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SHOW CREATE TABLE innodb_table2;
+Table	Create Table
+innodb_table2	CREATE TABLE `innodb_table2` (
+  `m` int DEFAULT NULL,
+  `4` int NOT NULL DEFAULT '0'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE innodb_table1;
+DROP TABLE innodb_table2;
+#
+# CASE 3 The behavior of CTAS, with sql_log_bin ON and format STATEMENT.
+#
+SET sql_log_bin = ON;
+SET @@SESSION.binlog_format=STATEMENT;
+CREATE TABLE innodb_table1 (m INT, n INT, FOREIGN KEY (n) REFERENCES t0(f1))
+AS SELECT 101 as m, 5 as n;
+ERROR 23000: Cannot add or update a child row: a foreign key constraint fails (`test`.`innodb_table1`, CONSTRAINT `innodb_table1_ibfk_1` FOREIGN KEY (`n`) REFERENCES `t0` (`f1`))
+CREATE TABLE innodb_table1 (m INT, n INT, FOREIGN KEY (n) REFERENCES t0(f1))
+AS SELECT 101 as m, 2 as n;
+DROP TABLE innodb_table1;
+#
+# CASE 4 The behavior of CTAS, with sql_log_bin ON and format MIXED.
+# The behavior would be same as case 3 above.
+SET @@SESSION.binlog_format=MIXED;
+CREATE TABLE innodb_table1 (m INT, n INT, FOREIGN KEY (n) REFERENCES t0(f1))
+AS SELECT 101 as m, 5 as n;
+ERROR 23000: Cannot add or update a child row: a foreign key constraint fails (`test`.`innodb_table1`, CONSTRAINT `innodb_table1_ibfk_1` FOREIGN KEY (`n`) REFERENCES `t0` (`f1`))
+CREATE TABLE innodb_table1 (m INT, n INT, FOREIGN KEY (n) REFERENCES t0(f1))
+AS SELECT 101 as m, 2 as n;
+DROP TABLE innodb_table1;
+#
+# CASE 5 The behavior of CTAS, with sql_log_bin ON and format ROW.
+#
+SET @@SESSION.binlog_format=ROW;
+CREATE TABLE innodb_table1 (m INT, n INT, FOREIGN KEY (n) REFERENCES t0(f1))
+AS SELECT 101 as m, 5 as n;
+ERROR HY000: Foreign key creation is not allowed with CREATE TABLE as SELECT and CREATE TABLE with START TRANSACTION statement.
+CREATE TABLE innodb_table1 (m INT, n INT, FOREIGN KEY (n) REFERENCES t0(f1))
+AS SELECT 101 as m, 2 as n;
+ERROR HY000: Foreign key creation is not allowed with CREATE TABLE as SELECT and CREATE TABLE with START TRANSACTION statement.
+CREATE TABLE innodb_table1 (m INT, n INT,
+FOREIGN KEY (n) REFERENCES t0(f1)) START TRANSACTION;
+ERROR HY000: Foreign key creation is not allowed with CREATE TABLE as SELECT and CREATE TABLE with START TRANSACTION statement.
+SET sql_log_bin = @saved_sql_log_bin;
+DROP TABLE t0;

--- a/mysql-test/suite/rocksdb_dd_innodb/r/create_tablespace_32k.result
+++ b/mysql-test/suite/rocksdb_dd_innodb/r/create_tablespace_32k.result
@@ -1,0 +1,179 @@
+#
+# CREATE TABLESPACE related tests for 32k page sizes.
+#
+SET DEFAULT_STORAGE_ENGINE=InnoDB;
+# Strict-mode has no effect on CREATE TABLESPACE. But it does affect
+# whether an invalid KEY_BLOCK_SIZE is rejected or adjusted.
+SHOW VARIABLES LIKE 'innodb_strict_mode';
+Variable_name	Value
+innodb_strict_mode	ON
+SHOW VARIABLES LIKE 'innodb_file_per_table';
+Variable_name	Value
+innodb_file_per_table	ON
+#
+# Create a tablespace with compressed page sizes that can match
+# innodb-page-size.
+#
+CREATE TABLESPACE s_1k ADD DATAFILE 's_1k.ibd' FILE_BLOCK_SIZE=1k;
+ERROR HY000: InnoDB: Cannot create a COMPRESSED tablespace when innodb_page_size > 16k.
+SHOW WARNINGS;
+Level	Code	Message
+Error	1478	InnoDB: Cannot create a COMPRESSED tablespace when innodb_page_size > 16k.
+Error	1528	Failed to create TABLESPACE s_1k
+Error	1031	Table storage engine for 's_1k' doesn't have this option
+CREATE TABLESPACE s_2k ADD DATAFILE 's_2k.ibd' FILE_BLOCK_SIZE=2k;
+ERROR HY000: InnoDB: Cannot create a COMPRESSED tablespace when innodb_page_size > 16k.
+SHOW WARNINGS;
+Level	Code	Message
+Error	1478	InnoDB: Cannot create a COMPRESSED tablespace when innodb_page_size > 16k.
+Error	1528	Failed to create TABLESPACE s_2k
+Error	1031	Table storage engine for 's_2k' doesn't have this option
+CREATE TABLESPACE s_4k ADD DATAFILE 's_4k.ibd' FILE_BLOCK_SIZE=4k;
+ERROR HY000: InnoDB: Cannot create a COMPRESSED tablespace when innodb_page_size > 16k.
+SHOW WARNINGS;
+Level	Code	Message
+Error	1478	InnoDB: Cannot create a COMPRESSED tablespace when innodb_page_size > 16k.
+Error	1528	Failed to create TABLESPACE s_4k
+Error	1031	Table storage engine for 's_4k' doesn't have this option
+CREATE TABLESPACE s_8k ADD DATAFILE 's_8k.ibd' FILE_BLOCK_SIZE=8k;
+ERROR HY000: InnoDB: Cannot create a COMPRESSED tablespace when innodb_page_size > 16k.
+SHOW WARNINGS;
+Level	Code	Message
+Error	1478	InnoDB: Cannot create a COMPRESSED tablespace when innodb_page_size > 16k.
+Error	1528	Failed to create TABLESPACE s_8k
+Error	1031	Table storage engine for 's_8k' doesn't have this option
+CREATE TABLESPACE s_16k ADD DATAFILE 's_16k.ibd' FILE_BLOCK_SIZE=16k;
+ERROR HY000: InnoDB: Cannot create a COMPRESSED tablespace when innodb_page_size > 16k.
+SHOW WARNINGS;
+Level	Code	Message
+Error	1478	InnoDB: Cannot create a COMPRESSED tablespace when innodb_page_size > 16k.
+Error	1528	Failed to create TABLESPACE s_16k
+Error	1031	Table storage engine for 's_16k' doesn't have this option
+CREATE TABLESPACE s_32k ADD DATAFILE 's_32k.ibd' FILE_BLOCK_SIZE=32k;
+CREATE TABLESPACE s_64k ADD DATAFILE 's_64k.ibd' FILE_BLOCK_SIZE=64k;
+ERROR HY000: InnoDB: Cannot create a tablespace with FILE_BLOCK_SIZE=65536 because INNODB_PAGE_SIZE=32768.
+SHOW WARNINGS;
+Level	Code	Message
+Error	1478	InnoDB: Cannot create a tablespace with FILE_BLOCK_SIZE=65536 because INNODB_PAGE_SIZE=32768.
+Error	1528	Failed to create TABLESPACE s_64k
+Error	1031	Table storage engine for 's_64k' doesn't have this option
+=== information_schema.innodb_tablespaces and innodb_datafiles ===
+Space_Name	Space_Type	Page_Size	Zip_Size	BlockSize!=0	FileSize!=0	Formats_Permitted	Path
+mtr/asserted_test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/asserted_test_suppressions.ibd
+mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_suppressions.ibd
+mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
+mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
+s_32k	General	DEFAULT	0	1	1	Any	s_32k.ibd
+=== information_schema.files ===
+Space_Name	File_Type	Engine	Status	Tablespace_Name	Path
+mtr/asserted_test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/asserted_test_suppressions	MYSQLD_DATADIR/mtr/asserted_test_suppressions.ibd
+mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_DATADIR/mtr/global_suppressions.ibd
+mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
+mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
+s_32k	TABLESPACE	InnoDB	NORMAL	s_32k	MYSQLD_DATADIR/s_32k.ibd
+#
+# Add tables to the tablespaces.
+#
+CREATE TABLE t_zip1k_in_321k (a int, b text) ROW_FORMAT=Compressed KEY_BLOCK_SIZE=1 TABLESPACE s_32k;
+ERROR HY000: InnoDB: Tablespace `s_32k` cannot contain a COMPRESSED table
+SHOW WARNINGS;
+Level	Code	Message
+Error	1478	InnoDB: Tablespace `s_32k` cannot contain a COMPRESSED table
+Error	1031	Table storage engine for 't_zip1k_in_321k' doesn't have this option
+CREATE TABLE t_zip2k_in_32k (a int, b text) ROW_FORMAT=Compressed KEY_BLOCK_SIZE=2 TABLESPACE s_32k;
+ERROR HY000: InnoDB: Tablespace `s_32k` cannot contain a COMPRESSED table
+SHOW WARNINGS;
+Level	Code	Message
+Error	1478	InnoDB: Tablespace `s_32k` cannot contain a COMPRESSED table
+Error	1031	Table storage engine for 't_zip2k_in_32k' doesn't have this option
+CREATE TABLE t_zip4k_in_32k (a int, b text) ROW_FORMAT=Compressed KEY_BLOCK_SIZE=4 TABLESPACE s_32k;
+ERROR HY000: InnoDB: Tablespace `s_32k` cannot contain a COMPRESSED table
+SHOW WARNINGS;
+Level	Code	Message
+Error	1478	InnoDB: Tablespace `s_32k` cannot contain a COMPRESSED table
+Error	1031	Table storage engine for 't_zip4k_in_32k' doesn't have this option
+CREATE TABLE t_zip8k_in_32k (a int, b text) ROW_FORMAT=Compressed KEY_BLOCK_SIZE=8 TABLESPACE s_32k;
+ERROR HY000: InnoDB: Tablespace `s_32k` cannot contain a COMPRESSED table
+SHOW WARNINGS;
+Level	Code	Message
+Error	1478	InnoDB: Tablespace `s_32k` cannot contain a COMPRESSED table
+Error	1031	Table storage engine for 't_zip8k_in_32k' doesn't have this option
+CREATE TABLE t_zip16k_in_32k (a int, b text) ROW_FORMAT=Compressed KEY_BLOCK_SIZE=16 TABLESPACE s_32k;
+ERROR HY000: InnoDB: Tablespace `s_32k` cannot contain a COMPRESSED table
+SHOW WARNINGS;
+Level	Code	Message
+Error	1478	InnoDB: Tablespace `s_32k` cannot contain a COMPRESSED table
+Error	1031	Table storage engine for 't_zip16k_in_32k' doesn't have this option
+CREATE TABLE t_zip32k_in_32k (a int, b text) ROW_FORMAT=Compressed KEY_BLOCK_SIZE=32 TABLESPACE s_32k;
+ERROR HY000: InnoDB: Tablespace `s_32k` cannot contain a COMPRESSED table
+SHOW WARNINGS;
+Level	Code	Message
+Error	1478	InnoDB: Tablespace `s_32k` cannot contain a COMPRESSED table
+Error	1031	Table storage engine for 't_zip32k_in_32k' doesn't have this option
+CREATE TABLE t_red_in_32k (a int, b text) ROW_FORMAT=redundant TABLESPACE s_32k;
+CREATE TABLE t_com_in_32k (a int, b text) ROW_FORMAT=compact TABLESPACE s_32k;
+CREATE TABLE t_dyn_in_32k (a int, b text) ROW_FORMAT=dynamic TABLESPACE s_32k;
+# Add data to the existing Tables
+INSERT INTO t_red_in_32k VALUES (1,'a'),(2,'b'),(3,'c');
+INSERT INTO t_com_in_32k VALUES (1,'a'),(2,'b'),(3,'c');
+INSERT INTO t_dyn_in_32k VALUES (1,'a'),(2,'b'),(3,'c');
+# Restart mysqld
+# restart
+#
+# Try to drop a tablespace which is not empty
+#
+DROP TABLESPACE s_32k;
+ERROR HY000: Tablespace `s_32k` is not empty.
+#
+# Add more data to the existing Tables
+#
+INSERT INTO t_red_in_32k VALUES (4,'d');
+INSERT INTO t_com_in_32k VALUES (4,'d');
+INSERT INTO t_dyn_in_32k VALUES (4,'d');
+#
+# Restart the server and make sure that everything is OK.
+#
+# restart
+=== information_schema.innodb_tablespaces and innodb_datafiles ===
+Space_Name	Space_Type	Page_Size	Zip_Size	BlockSize!=0	FileSize!=0	Formats_Permitted	Path
+mtr/asserted_test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/asserted_test_suppressions.ibd
+mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_suppressions.ibd
+mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
+mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
+s_32k	General	DEFAULT	0	1	1	Any	s_32k.ibd
+=== information_schema.files ===
+Space_Name	File_Type	Engine	Status	Tablespace_Name	Path
+mtr/asserted_test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/asserted_test_suppressions	MYSQLD_DATADIR/mtr/asserted_test_suppressions.ibd
+mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_DATADIR/mtr/global_suppressions.ibd
+mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
+mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
+s_32k	TABLESPACE	InnoDB	NORMAL	s_32k	MYSQLD_DATADIR/s_32k.ibd
+=== information_schema.innodb_tables  and innodb_tablespaces ===
+Table Name	Tablespace	Table Flags	Columns	Row Format	Zip Size	Space Type
+mtr/asserted_test_suppressions	mtr/asserted_test_suppressions	33	4	Dynamic	0	Single
+mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
+mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
+mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
+test/t_com_in_32k	s_32k	129	5	Compact	0	General
+test/t_dyn_in_32k	s_32k	161	5	Dynamic	0	General
+test/t_red_in_32k	s_32k	128	5	Redundant	0	General
+# Directory of MYSQLD_DATADIR/
+mysql.ibd
+s_32k.ibd
+# Directory of MYSQLD_DATADIR/test/
+#
+# Clean-up.
+#
+CHECK TABLE t_red_in_32k;
+Table	Op	Msg_type	Msg_text
+test.t_red_in_32k	check	status	OK
+CHECK TABLE t_com_in_32k;
+Table	Op	Msg_type	Msg_text
+test.t_com_in_32k	check	status	OK
+CHECK TABLE t_dyn_in_32k;
+Table	Op	Msg_type	Msg_text
+test.t_dyn_in_32k	check	status	OK
+DROP TABLE t_red_in_32k;
+DROP TABLE t_com_in_32k;
+DROP TABLE t_dyn_in_32k;
+DROP TABLESPACE s_32k;

--- a/mysql-test/suite/rocksdb_dd_innodb/r/create_tablespace_64k.result
+++ b/mysql-test/suite/rocksdb_dd_innodb/r/create_tablespace_64k.result
@@ -1,0 +1,185 @@
+#
+# CREATE TABLESPACE related tests for 32k page sizes.
+#
+SET DEFAULT_STORAGE_ENGINE=InnoDB;
+# Strict-mode has no effect on CREATE TABLESPACE. But it does affect
+# whether an invalid KEY_BLOCK_SIZE is rejected or adjusted.
+SHOW VARIABLES LIKE 'innodb_strict_mode';
+Variable_name	Value
+innodb_strict_mode	ON
+SHOW VARIABLES LIKE 'innodb_file_per_table';
+Variable_name	Value
+innodb_file_per_table	ON
+#
+# Create a tablespace with compressed page sizes that can match
+# innodb-page-size.
+#
+CREATE TABLESPACE s_1k ADD DATAFILE 's_1k.ibd' FILE_BLOCK_SIZE=1k;
+ERROR HY000: InnoDB: Cannot create a COMPRESSED tablespace when innodb_page_size > 16k.
+SHOW WARNINGS;
+Level	Code	Message
+Error	1478	InnoDB: Cannot create a COMPRESSED tablespace when innodb_page_size > 16k.
+Error	1528	Failed to create TABLESPACE s_1k
+Error	1031	Table storage engine for 's_1k' doesn't have this option
+CREATE TABLESPACE s_2k ADD DATAFILE 's_2k.ibd' FILE_BLOCK_SIZE=2k;
+ERROR HY000: InnoDB: Cannot create a COMPRESSED tablespace when innodb_page_size > 16k.
+SHOW WARNINGS;
+Level	Code	Message
+Error	1478	InnoDB: Cannot create a COMPRESSED tablespace when innodb_page_size > 16k.
+Error	1528	Failed to create TABLESPACE s_2k
+Error	1031	Table storage engine for 's_2k' doesn't have this option
+CREATE TABLESPACE s_4k ADD DATAFILE 's_4k.ibd' FILE_BLOCK_SIZE=4k;
+ERROR HY000: InnoDB: Cannot create a COMPRESSED tablespace when innodb_page_size > 16k.
+SHOW WARNINGS;
+Level	Code	Message
+Error	1478	InnoDB: Cannot create a COMPRESSED tablespace when innodb_page_size > 16k.
+Error	1528	Failed to create TABLESPACE s_4k
+Error	1031	Table storage engine for 's_4k' doesn't have this option
+CREATE TABLESPACE s_8k ADD DATAFILE 's_8k.ibd' FILE_BLOCK_SIZE=8k;
+ERROR HY000: InnoDB: Cannot create a COMPRESSED tablespace when innodb_page_size > 16k.
+SHOW WARNINGS;
+Level	Code	Message
+Error	1478	InnoDB: Cannot create a COMPRESSED tablespace when innodb_page_size > 16k.
+Error	1528	Failed to create TABLESPACE s_8k
+Error	1031	Table storage engine for 's_8k' doesn't have this option
+CREATE TABLESPACE s_16k ADD DATAFILE 's_16k.ibd' FILE_BLOCK_SIZE=16k;
+ERROR HY000: InnoDB: Cannot create a COMPRESSED tablespace when innodb_page_size > 16k.
+SHOW WARNINGS;
+Level	Code	Message
+Error	1478	InnoDB: Cannot create a COMPRESSED tablespace when innodb_page_size > 16k.
+Error	1528	Failed to create TABLESPACE s_16k
+Error	1031	Table storage engine for 's_16k' doesn't have this option
+CREATE TABLESPACE s_32k ADD DATAFILE 's_32k.ibd' FILE_BLOCK_SIZE=32k;
+ERROR HY000: InnoDB: Cannot create a COMPRESSED tablespace when innodb_page_size > 16k.
+SHOW WARNINGS;
+Level	Code	Message
+Error	1478	InnoDB: Cannot create a COMPRESSED tablespace when innodb_page_size > 16k.
+Error	1528	Failed to create TABLESPACE s_32k
+Error	1031	Table storage engine for 's_32k' doesn't have this option
+CREATE TABLESPACE s_64k ADD DATAFILE 's_64k.ibd' FILE_BLOCK_SIZE=64k;
+=== information_schema.innodb_tablespaces and innodb_datafiles ===
+Space_Name	Space_Type	Page_Size	Zip_Size	BlockSize!=0	FileSize!=0	Formats_Permitted	Path
+mtr/asserted_test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/asserted_test_suppressions.ibd
+mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_suppressions.ibd
+mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
+mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
+s_64k	General	DEFAULT	0	1	1	Any	s_64k.ibd
+=== information_schema.files ===
+Space_Name	File_Type	Engine	Status	Tablespace_Name	Path
+mtr/asserted_test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/asserted_test_suppressions	MYSQLD_DATADIR/mtr/asserted_test_suppressions.ibd
+mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_DATADIR/mtr/global_suppressions.ibd
+mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
+mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
+s_64k	TABLESPACE	InnoDB	NORMAL	s_64k	MYSQLD_DATADIR/s_64k.ibd
+#
+# Add tables to the tablespaces.
+#
+CREATE TABLE t_zip1k_in_64k (a int, b text) ROW_FORMAT=Compressed KEY_BLOCK_SIZE=1 TABLESPACE s_64k;
+ERROR HY000: InnoDB: Tablespace `s_64k` cannot contain a COMPRESSED table
+SHOW WARNINGS;
+Level	Code	Message
+Error	1478	InnoDB: Tablespace `s_64k` cannot contain a COMPRESSED table
+Error	1031	Table storage engine for 't_zip1k_in_64k' doesn't have this option
+CREATE TABLE t_zip2k_in_64k (a int, b text) ROW_FORMAT=Compressed KEY_BLOCK_SIZE=2 TABLESPACE s_64k;
+ERROR HY000: InnoDB: Tablespace `s_64k` cannot contain a COMPRESSED table
+SHOW WARNINGS;
+Level	Code	Message
+Error	1478	InnoDB: Tablespace `s_64k` cannot contain a COMPRESSED table
+Error	1031	Table storage engine for 't_zip2k_in_64k' doesn't have this option
+CREATE TABLE t_zip4k_in_64k (a int, b text) ROW_FORMAT=Compressed KEY_BLOCK_SIZE=4 TABLESPACE s_64k;
+ERROR HY000: InnoDB: Tablespace `s_64k` cannot contain a COMPRESSED table
+SHOW WARNINGS;
+Level	Code	Message
+Error	1478	InnoDB: Tablespace `s_64k` cannot contain a COMPRESSED table
+Error	1031	Table storage engine for 't_zip4k_in_64k' doesn't have this option
+CREATE TABLE t_zip8k_in_64k (a int, b text) ROW_FORMAT=Compressed KEY_BLOCK_SIZE=8 TABLESPACE s_64k;
+ERROR HY000: InnoDB: Tablespace `s_64k` cannot contain a COMPRESSED table
+SHOW WARNINGS;
+Level	Code	Message
+Error	1478	InnoDB: Tablespace `s_64k` cannot contain a COMPRESSED table
+Error	1031	Table storage engine for 't_zip8k_in_64k' doesn't have this option
+CREATE TABLE t_zip16k_in_64k (a int, b text) ROW_FORMAT=Compressed KEY_BLOCK_SIZE=16 TABLESPACE s_64k;
+ERROR HY000: InnoDB: Tablespace `s_64k` cannot contain a COMPRESSED table
+SHOW WARNINGS;
+Level	Code	Message
+Error	1478	InnoDB: Tablespace `s_64k` cannot contain a COMPRESSED table
+Error	1031	Table storage engine for 't_zip16k_in_64k' doesn't have this option
+CREATE TABLE t_zip32k_in_64k (a int, b text) ROW_FORMAT=Compressed KEY_BLOCK_SIZE=32 TABLESPACE s_64k;
+ERROR HY000: InnoDB: Tablespace `s_64k` cannot contain a COMPRESSED table
+SHOW WARNINGS;
+Level	Code	Message
+Error	1478	InnoDB: Tablespace `s_64k` cannot contain a COMPRESSED table
+Error	1031	Table storage engine for 't_zip32k_in_64k' doesn't have this option
+CREATE TABLE t_zip64k_in_64k (a int, b text) ROW_FORMAT=Compressed KEY_BLOCK_SIZE=32 TABLESPACE s_64k;
+ERROR HY000: InnoDB: Tablespace `s_64k` cannot contain a COMPRESSED table
+SHOW WARNINGS;
+Level	Code	Message
+Error	1478	InnoDB: Tablespace `s_64k` cannot contain a COMPRESSED table
+Error	1031	Table storage engine for 't_zip64k_in_64k' doesn't have this option
+CREATE TABLE t_red_in_64k (a int, b text) ROW_FORMAT=redundant TABLESPACE s_64k;
+CREATE TABLE t_com_in_64k (a int, b text) ROW_FORMAT=compact TABLESPACE s_64k;
+CREATE TABLE t_dyn_in_64k (a int, b text) ROW_FORMAT=dynamic TABLESPACE s_64k;
+# Add data to the existing Tables
+INSERT INTO t_red_in_64k VALUES (1,'a'),(2,'b'),(3,'c');
+INSERT INTO t_com_in_64k VALUES (1,'a'),(2,'b'),(3,'c');
+INSERT INTO t_dyn_in_64k VALUES (1,'a'),(2,'b'),(3,'c');
+# Restart mysqld
+# restart
+#
+# Try to drop a tablespace which is not empty
+#
+DROP TABLESPACE s_64k;
+ERROR HY000: Tablespace `s_64k` is not empty.
+#
+# Add more data to the existing Tables
+#
+INSERT INTO t_red_in_64k VALUES (4,'d');
+INSERT INTO t_com_in_64k VALUES (4,'d');
+INSERT INTO t_dyn_in_64k VALUES (4,'d');
+#
+# Restart the server and make sure that everything is OK.
+#
+# restart
+=== information_schema.innodb_tablespaces and innodb_datafiles ===
+Space_Name	Space_Type	Page_Size	Zip_Size	BlockSize!=0	FileSize!=0	Formats_Permitted	Path
+mtr/asserted_test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/asserted_test_suppressions.ibd
+mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_suppressions.ibd
+mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
+mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
+s_64k	General	DEFAULT	0	1	1	Any	s_64k.ibd
+=== information_schema.files ===
+Space_Name	File_Type	Engine	Status	Tablespace_Name	Path
+mtr/asserted_test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/asserted_test_suppressions	MYSQLD_DATADIR/mtr/asserted_test_suppressions.ibd
+mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_DATADIR/mtr/global_suppressions.ibd
+mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
+mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
+s_64k	TABLESPACE	InnoDB	NORMAL	s_64k	MYSQLD_DATADIR/s_64k.ibd
+=== information_schema.innodb_tables  and innodb_tablespaces ===
+Table Name	Tablespace	Table Flags	Columns	Row Format	Zip Size	Space Type
+mtr/asserted_test_suppressions	mtr/asserted_test_suppressions	33	4	Dynamic	0	Single
+mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
+mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
+mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
+test/t_com_in_64k	s_64k	129	5	Compact	0	General
+test/t_dyn_in_64k	s_64k	161	5	Dynamic	0	General
+test/t_red_in_64k	s_64k	128	5	Redundant	0	General
+# Directory of MYSQLD_DATADIR/
+mysql.ibd
+s_64k.ibd
+# Directory of MYSQLD_DATADIR/test/
+#
+# Clean-up.
+#
+CHECK TABLE t_red_in_64k;
+Table	Op	Msg_type	Msg_text
+test.t_red_in_64k	check	status	OK
+CHECK TABLE t_com_in_64k;
+Table	Op	Msg_type	Msg_text
+test.t_com_in_64k	check	status	OK
+CHECK TABLE t_dyn_in_64k;
+Table	Op	Msg_type	Msg_text
+test.t_dyn_in_64k	check	status	OK
+DROP TABLE t_red_in_64k;
+DROP TABLE t_com_in_64k;
+DROP TABLE t_dyn_in_64k;
+DROP TABLESPACE s_64k;

--- a/mysql-test/suite/rocksdb_dd_innodb/r/index_large_prefix_4k.result
+++ b/mysql-test/suite/rocksdb_dd_innodb/r/index_large_prefix_4k.result
@@ -1,0 +1,387 @@
+SET default_storage_engine=InnoDB;
+set global innodb_file_per_table=1;
+### Test 1 ###
+create table worklog5743(a TEXT not null, primary key (a(768))) charset latin1 ROW_FORMAT=DYNAMIC;
+show warnings;
+Level	Code	Message
+insert into worklog5743 values(repeat("a", 20000));
+update worklog5743 set a = (repeat("b", 16000));
+SET sql_mode= '';
+create index idx on worklog5743(a(900));
+Warnings:
+Warning	1071	Specified key was too long; max key length is 768 bytes
+show warnings;
+Level	Code	Message
+Warning	1071	Specified key was too long; max key length is 768 bytes
+SET sql_mode= default;
+begin;
+update worklog5743 set a = (repeat("x", 17000));
+select @@session.transaction_isolation;
+@@session.transaction_isolation
+REPEATABLE-READ
+select a = repeat("x", 17000) from worklog5743;
+a = repeat("x", 17000)
+0
+select a = repeat("b", 16000) from worklog5743;
+a = repeat("b", 16000)
+1
+SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+select @@session.transaction_isolation;
+@@session.transaction_isolation
+READ-UNCOMMITTED
+select a = repeat("x", 17000) from worklog5743;
+a = repeat("x", 17000)
+1
+rollback;
+drop table worklog5743;
+### Test 2 ###
+create table worklog5743(a1 int, a2 TEXT not null) charset latin1 ROW_FORMAT=DYNAMIC;
+show warnings;
+Level	Code	Message
+create index idx on worklog5743(a1, a2(750));
+show warnings;
+Level	Code	Message
+insert into worklog5743 values(9, repeat("a", 10000));
+begin;
+update worklog5743 set a1 = 1111;
+select @@session.transaction_isolation;
+@@session.transaction_isolation
+REPEATABLE-READ
+explain select a1, a2 = repeat("a", 10000) from worklog5743 where a1 = 9;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	worklog5743	NULL	ref	idx	idx	5	const	1	100.00	NULL
+Warnings:
+Note	1003	/* select#1 */ select `test`.`worklog5743`.`a1` AS `a1`,(`test`.`worklog5743`.`a2` = convert(repeat('a',10000) using latin1)) AS `a2 = repeat("a", 10000)` from `test`.`worklog5743` where (`test`.`worklog5743`.`a1` = 9)
+select a1, a2 = repeat("a", 10000) from worklog5743 where a1 = 9;
+a1	a2 = repeat("a", 10000)
+9	1
+SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+select @@session.transaction_isolation;
+@@session.transaction_isolation
+READ-UNCOMMITTED
+select a1, a2 = repeat("a", 10000) from worklog5743 where a1 = 9;
+a1	a2 = repeat("a", 10000)
+rollback;
+drop table worklog5743;
+### Test 3 ###
+create table worklog5743(a1 int, a2 TEXT not null) ROW_FORMAT=DYNAMIC;
+create index idx on worklog5743(a1, a2(50));
+insert into worklog5743 values(9, repeat("a", 10000));
+begin;
+update worklog5743 set a1 = 2222;
+select @@session.transaction_isolation;
+@@session.transaction_isolation
+REPEATABLE-READ
+explain select a1, a2 = repeat("a", 10000) from worklog5743 where a1 = 9;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	worklog5743	NULL	ref	idx	idx	5	const	1	100.00	NULL
+Warnings:
+Note	1003	/* select#1 */ select `test`.`worklog5743`.`a1` AS `a1`,(`test`.`worklog5743`.`a2` = repeat('a',10000)) AS `a2 = repeat("a", 10000)` from `test`.`worklog5743` where (`test`.`worklog5743`.`a1` = 9)
+select a1, a2 = repeat("a", 10000) from worklog5743 where a1 = 9;
+a1	a2 = repeat("a", 10000)
+9	1
+SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+select @@session.transaction_isolation;
+@@session.transaction_isolation
+READ-UNCOMMITTED
+select a1, a2 = repeat("a", 10000) from worklog5743 where a1 = 9;
+a1	a2 = repeat("a", 10000)
+rollback;
+drop table worklog5743;
+### Test 4 ###
+create table worklog5743_1(a1 int, a2 TEXT not null) charset latin1 KEY_BLOCK_SIZE=1;
+create table worklog5743_2(a1 int, a2 TEXT not null) charset latin1 KEY_BLOCK_SIZE=2;
+create table worklog5743_4(a1 int, a2 TEXT not null) charset latin1 KEY_BLOCK_SIZE=4;
+create index idx1 on worklog5743_1(a2(4000));
+ERROR 42000: Specified key was too long; max key length is 768 bytes
+show warnings;
+Level	Code	Message
+Error	1071	Specified key was too long; max key length is 768 bytes
+create index idx3 on worklog5743_1(a2(436));
+ERROR 42000: Row size too large. The maximum row size for the used table type, not counting BLOBs, is 1982. This includes storage overhead, check the manual. You have to change some columns to TEXT or BLOBs
+show warnings;
+Level	Code	Message
+Error	1118	Row size too large. The maximum row size for the used table type, not counting BLOBs, is 1982. This includes storage overhead, check the manual. You have to change some columns to TEXT or BLOBs
+create index idx4 on worklog5743_1(a2(434));
+show warnings;
+Level	Code	Message
+create index idx5 on worklog5743_1(a1, a2(430));
+ERROR 42000: Row size too large. The maximum row size for the used table type, not counting BLOBs, is 1982. This includes storage overhead, check the manual. You have to change some columns to TEXT or BLOBs
+show warnings;
+Level	Code	Message
+Error	1118	Row size too large. The maximum row size for the used table type, not counting BLOBs, is 1982. This includes storage overhead, check the manual. You have to change some columns to TEXT or BLOBs
+create index idx6 on worklog5743_1(a1, a2(428));
+show warnings;
+Level	Code	Message
+SET sql_mode= '';
+create index idx1 on worklog5743_2(a2(4000));
+Warnings:
+Warning	1071	Specified key was too long; max key length is 768 bytes
+show warnings;
+Level	Code	Message
+Warning	1071	Specified key was too long; max key length is 768 bytes
+show create table worklog5743_2;
+Table	Create Table
+worklog5743_2	CREATE TABLE `worklog5743_2` (
+  `a1` int DEFAULT NULL,
+  `a2` text NOT NULL,
+  KEY `idx1` (`a2`(768))
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 KEY_BLOCK_SIZE=2
+create index idx3 on worklog5743_2(a2(769));
+Warnings:
+Warning	1071	Specified key was too long; max key length is 768 bytes
+Warning	1831	Duplicate index 'idx3' defined on the table 'test.worklog5743_2'. This is deprecated and will be disallowed in a future release.
+show warnings;
+Level	Code	Message
+Warning	1071	Specified key was too long; max key length is 768 bytes
+Warning	1831	Duplicate index 'idx3' defined on the table 'test.worklog5743_2'. This is deprecated and will be disallowed in a future release.
+create index idx4 on worklog5743_2(a2(768));
+Warnings:
+Warning	1831	Duplicate index 'idx4' defined on the table 'test.worklog5743_2'. This is deprecated and will be disallowed in a future release.
+show warnings;
+Level	Code	Message
+Warning	1831	Duplicate index 'idx4' defined on the table 'test.worklog5743_2'. This is deprecated and will be disallowed in a future release.
+create index idx5 on worklog5743_2(a1, a2(765));
+ERROR 42000: Specified key was too long; max key length is 768 bytes
+show warnings;
+Level	Code	Message
+Error	1071	Specified key was too long; max key length is 768 bytes
+create index idx6 on worklog5743_2(a1, a2(764));
+show warnings;
+Level	Code	Message
+create index idx1 on worklog5743_4(a2(4000));
+Warnings:
+Warning	1071	Specified key was too long; max key length is 768 bytes
+show warnings;
+Level	Code	Message
+Warning	1071	Specified key was too long; max key length is 768 bytes
+show create table worklog5743_4;
+Table	Create Table
+worklog5743_4	CREATE TABLE `worklog5743_4` (
+  `a1` int DEFAULT NULL,
+  `a2` text NOT NULL,
+  KEY `idx1` (`a2`(768))
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 KEY_BLOCK_SIZE=4
+create index idx3 on worklog5743_4(a2(769));
+Warnings:
+Warning	1071	Specified key was too long; max key length is 768 bytes
+Warning	1831	Duplicate index 'idx3' defined on the table 'test.worklog5743_4'. This is deprecated and will be disallowed in a future release.
+show warnings;
+Level	Code	Message
+Warning	1071	Specified key was too long; max key length is 768 bytes
+Warning	1831	Duplicate index 'idx3' defined on the table 'test.worklog5743_4'. This is deprecated and will be disallowed in a future release.
+create index idx4 on worklog5743_4(a2(768));
+Warnings:
+Warning	1831	Duplicate index 'idx4' defined on the table 'test.worklog5743_4'. This is deprecated and will be disallowed in a future release.
+show warnings;
+Level	Code	Message
+Warning	1831	Duplicate index 'idx4' defined on the table 'test.worklog5743_4'. This is deprecated and will be disallowed in a future release.
+create index idx5 on worklog5743_4(a1, a2(765));
+ERROR 42000: Specified key was too long; max key length is 768 bytes
+show warnings;
+Level	Code	Message
+Error	1071	Specified key was too long; max key length is 768 bytes
+create index idx6 on worklog5743_4(a1, a2(764));
+show warnings;
+Level	Code	Message
+SET sql_mode= default;
+insert into worklog5743_1 values(9, repeat("a", 10000));
+insert into worklog5743_2 values(9, repeat("a", 10000));
+insert into worklog5743_4 values(9, repeat("a", 10000));
+insert into worklog5743_1 values(2, repeat("b", 10000));
+insert into worklog5743_2 values(2, repeat("b", 10000));
+insert into worklog5743_4 values(2, repeat("b", 10000));
+select a1, left(a2, 20) from worklog5743_1;
+a1	left(a2, 20)
+9	aaaaaaaaaaaaaaaaaaaa
+2	bbbbbbbbbbbbbbbbbbbb
+select a1, left(a2, 20) from worklog5743_2;
+a1	left(a2, 20)
+9	aaaaaaaaaaaaaaaaaaaa
+2	bbbbbbbbbbbbbbbbbbbb
+select a1, left(a2, 20) from worklog5743_4;
+a1	left(a2, 20)
+9	aaaaaaaaaaaaaaaaaaaa
+2	bbbbbbbbbbbbbbbbbbbb
+begin;
+update worklog5743_1 set a1 = 1000;
+update worklog5743_2 set a1 = 1000;
+update worklog5743_4 set a1 = 1000;
+select a1, left(a2, 20) from worklog5743_1;
+a1	left(a2, 20)
+1000	aaaaaaaaaaaaaaaaaaaa
+1000	bbbbbbbbbbbbbbbbbbbb
+select a1, left(a2, 20) from worklog5743_2;
+a1	left(a2, 20)
+1000	aaaaaaaaaaaaaaaaaaaa
+1000	bbbbbbbbbbbbbbbbbbbb
+select a1, left(a2, 20) from worklog5743_4;
+a1	left(a2, 20)
+1000	aaaaaaaaaaaaaaaaaaaa
+1000	bbbbbbbbbbbbbbbbbbbb
+select @@session.transaction_isolation;
+@@session.transaction_isolation
+REPEATABLE-READ
+explain select a1, left(a2, 20) from worklog5743_1 where a1 = 9;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	worklog5743_1	NULL	ref	idx6	idx6	5	const	1	100.00	NULL
+Warnings:
+Note	1003	/* select#1 */ select `test`.`worklog5743_1`.`a1` AS `a1`,left(`test`.`worklog5743_1`.`a2`,20) AS `left(a2, 20)` from `test`.`worklog5743_1` where (`test`.`worklog5743_1`.`a1` = 9)
+explain select a1, left(a2, 20) from worklog5743_2 where a1 = 9;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	worklog5743_2	NULL	ref	idx6	idx6	5	const	1	100.00	NULL
+Warnings:
+Note	1003	/* select#1 */ select `test`.`worklog5743_2`.`a1` AS `a1`,left(`test`.`worklog5743_2`.`a2`,20) AS `left(a2, 20)` from `test`.`worklog5743_2` where (`test`.`worklog5743_2`.`a1` = 9)
+explain select a1, left(a2, 20) from worklog5743_4 where a1 = 9;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	worklog5743_4	NULL	ref	idx6	idx6	5	const	1	100.00	NULL
+Warnings:
+Note	1003	/* select#1 */ select `test`.`worklog5743_4`.`a1` AS `a1`,left(`test`.`worklog5743_4`.`a2`,20) AS `left(a2, 20)` from `test`.`worklog5743_4` where (`test`.`worklog5743_4`.`a1` = 9)
+select a1, left(a2, 20) from worklog5743_1 where a1 = 9;
+a1	left(a2, 20)
+9	aaaaaaaaaaaaaaaaaaaa
+select a1, left(a2, 20) from worklog5743_2 where a1 = 9;
+a1	left(a2, 20)
+9	aaaaaaaaaaaaaaaaaaaa
+select a1, left(a2, 20) from worklog5743_4 where a1 = 9;
+a1	left(a2, 20)
+9	aaaaaaaaaaaaaaaaaaaa
+SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+select @@session.transaction_isolation;
+@@session.transaction_isolation
+READ-UNCOMMITTED
+select a1, left(a2, 20) from worklog5743_1 where a1 = 9;
+a1	left(a2, 20)
+select a1, left(a2, 20) from worklog5743_2 where a1 = 9;
+a1	left(a2, 20)
+select a1, left(a2, 20) from worklog5743_4 where a1 = 9;
+a1	left(a2, 20)
+rollback;
+drop table worklog5743_1;
+drop table worklog5743_2;
+drop table worklog5743_4;
+### Test 5 ###
+create table worklog5743(a1 int, a2 varchar(20000)) charset latin1 ROW_FORMAT=DYNAMIC;
+create index idx1 on worklog5743(a2);
+ERROR 42000: Specified key was too long; max key length is 3072 bytes
+show warnings;
+Level	Code	Message
+Error	1071	Specified key was too long; max key length is 3072 bytes
+drop table worklog5743;
+create table worklog5743(a1 int, a2 varchar(3072)) charset latin1 ROW_FORMAT=DYNAMIC;
+create index idx1 on worklog5743(a2);
+ERROR 42000: Specified key was too long; max key length is 768 bytes
+show warnings;
+Level	Code	Message
+Error	1071	Specified key was too long; max key length is 768 bytes
+drop table worklog5743;
+create table worklog5743(a1 int, a2 varchar(769)) charset latin1 ROW_FORMAT=DYNAMIC;
+create index idx1 on worklog5743(a2);
+ERROR 42000: Specified key was too long; max key length is 768 bytes
+show warnings;
+Level	Code	Message
+Error	1071	Specified key was too long; max key length is 768 bytes
+drop table worklog5743;
+create table worklog5743(a1 int, a2 varchar(768)) charset latin1 ROW_FORMAT=DYNAMIC;
+create index idx1 on worklog5743(a2);
+show warnings;
+Level	Code	Message
+insert into worklog5743 values(9, repeat("a", 768));
+update worklog5743 set a1 = 3333;
+drop table worklog5743;
+create table worklog5743(a1 int, a2 varchar(765)) charset latin1 ROW_FORMAT=DYNAMIC;
+create index idx1 on worklog5743(a1, a2);
+ERROR 42000: Specified key was too long; max key length is 768 bytes
+show warnings;
+Level	Code	Message
+Error	1071	Specified key was too long; max key length is 768 bytes
+drop table worklog5743;
+create table worklog5743(a1 int, a2 varchar(764)) charset latin1 ROW_FORMAT=DYNAMIC;
+create index idx1 on worklog5743(a1, a2);
+show warnings;
+Level	Code	Message
+insert into worklog5743 values(9, repeat("a", 764));
+begin;
+update worklog5743 set a1 = 4444;
+select @@session.transaction_isolation;
+@@session.transaction_isolation
+REPEATABLE-READ
+explain select a1 from worklog5743 where a1 = 9;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	worklog5743	NULL	ref	idx1	idx1	5	const	1	100.00	Using index
+Warnings:
+Note	1003	/* select#1 */ select `test`.`worklog5743`.`a1` AS `a1` from `test`.`worklog5743` where (`test`.`worklog5743`.`a1` = 9)
+select a1 from worklog5743 where a1 = 9;
+a1
+9
+SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+select @@session.transaction_isolation;
+@@session.transaction_isolation
+READ-UNCOMMITTED
+select a1 from worklog5743 where a1 = 9;
+a1
+rollback;
+drop table worklog5743;
+### Test 6 ###
+create table worklog5743(a TEXT not null, primary key (a(1000)));
+ERROR 42000: Specified key was too long; max key length is 768 bytes
+create table worklog5743(a TEXT) charset latin1 ROW_FORMAT=COMPACT;
+create index idx on worklog5743(a(768));
+ERROR 42000: Specified key was too long; max key length is 767 bytes
+create index idx on worklog5743(a(767));
+insert into worklog5743 values(repeat("a", 20000));
+begin;
+insert into worklog5743 values(repeat("b", 20000));
+update worklog5743 set a = (repeat("x", 25000));
+select @@session.transaction_isolation;
+@@session.transaction_isolation
+REPEATABLE-READ
+select a = repeat("a", 20000) from worklog5743;
+a = repeat("a", 20000)
+1
+SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+select @@session.transaction_isolation;
+@@session.transaction_isolation
+READ-UNCOMMITTED
+select a = repeat("x", 25000) from worklog5743;
+a = repeat("x", 25000)
+1
+1
+rollback;
+drop table worklog5743;
+### Test 7 ###
+create table worklog5743(a TEXT not null) charset latin1 ROW_FORMAT=DYNAMIC;
+SET sql_mode= '';
+create index idx1 on worklog5743(a(769));
+Warnings:
+Warning	1071	Specified key was too long; max key length is 768 bytes
+show warnings;
+Level	Code	Message
+Warning	1071	Specified key was too long; max key length is 768 bytes
+SET sql_mode= default;
+create index idx2 on worklog5743(a(768));
+Warnings:
+Warning	1831	Duplicate index 'idx2' defined on the table 'test.worklog5743'. This is deprecated and will be disallowed in a future release.
+show warnings;
+Level	Code	Message
+Warning	1831	Duplicate index 'idx2' defined on the table 'test.worklog5743'. This is deprecated and will be disallowed in a future release.
+show create table worklog5743;
+Table	Create Table
+worklog5743	CREATE TABLE `worklog5743` (
+  `a` text NOT NULL,
+  KEY `idx1` (`a`(768)),
+  KEY `idx2` (`a`(768))
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC
+insert into worklog5743 values(repeat("a", 768));
+drop table worklog5743;
+create table worklog5743(a TEXT not null) charset latin1 ROW_FORMAT=REDUNDANT;
+create index idx on worklog5743(a(768));
+ERROR 42000: Specified key was too long; max key length is 767 bytes
+create index idx2 on worklog5743(a(767));
+drop table worklog5743;
+create table worklog5743(a TEXT not null) charset latin1 ROW_FORMAT=COMPACT;
+create index idx on worklog5743(a(768));
+ERROR 42000: Specified key was too long; max key length is 767 bytes
+create index idx2 on worklog5743(a(767));
+drop table worklog5743;
+SET GLOBAL innodb_file_per_table=1;

--- a/mysql-test/suite/rocksdb_dd_innodb/r/innodb-table-online.result
+++ b/mysql-test/suite/rocksdb_dd_innodb/r/innodb-table-online.result
@@ -1,0 +1,364 @@
+SET @global_innodb_file_per_table_orig = @@global.innodb_file_per_table;
+SET GLOBAL innodb_file_per_table = on;
+CREATE TABLE t1 (c1 INT PRIMARY KEY, c2 INT NOT NULL, c3 TEXT NOT NULL)
+ENGINE = InnoDB;
+INSERT INTO t1 VALUES (1,1,''), (2,2,''), (3,3,''), (4,4,''), (5,5,'');
+SET GLOBAL innodb_monitor_enable = module_ddl;
+SELECT name, count FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE
+subsystem = 'ddl' and name not in
+('ddl_sort_file_alter_table','ddl_log_file_alter_table') and count > 0;
+name	count
+SET DEBUG_SYNC = 'RESET';
+SET DEBUG_SYNC = 'write_row_noreplace SIGNAL have_handle WAIT_FOR go_ahead';
+INSERT INTO t1 VALUES(1,2,3);
+# Establish session con1 (user=root)
+SET DEBUG_SYNC = 'now WAIT_FOR have_handle';
+SET lock_wait_timeout = 1;
+ALTER TABLE t1 ROW_FORMAT=REDUNDANT;
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on table metadata: test.t1
+SET DEBUG_SYNC = 'now SIGNAL go_ahead';
+# session default
+ERROR 23000: Duplicate entry '1' for key 't1.PRIMARY'
+SELECT name, count FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE
+subsystem = 'ddl' and name not in
+('ddl_sort_file_alter_table','ddl_log_file_alter_table') and count > 0;
+name	count
+# session con1
+SET SESSION DEBUG = '+d,innodb_OOM_prepare_inplace_alter';
+ALTER TABLE t1 ROW_FORMAT=REDUNDANT, ALGORITHM=INPLACE, LOCK=NONE;
+ERROR HY000: Out of memory; check if mysqld or some other process uses all available memory; if not, you may have to use 'ulimit' to allow mysqld to use more memory or you can add more swap space
+SET SESSION DEBUG = '-d,innodb_OOM_prepare_inplace_alter';
+SET SESSION DEBUG = '+d,innodb_OOM_inplace_alter';
+ALTER TABLE t1 ROW_FORMAT=REDUNDANT, ALGORITHM=INPLACE, LOCK=NONE;
+ERROR HY000: Out of memory; check if mysqld or some other process uses all available memory; if not, you may have to use 'ulimit' to allow mysqld to use more memory or you can add more swap space
+SET SESSION DEBUG = '-d,innodb_OOM_inplace_alter';
+ALTER TABLE t1 ROW_FORMAT=REDUNDANT, ALGORITHM=INPLACE, LOCK=NONE;
+# session default
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `c1` int NOT NULL,
+  `c2` int NOT NULL,
+  `c3` text NOT NULL,
+  PRIMARY KEY (`c1`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ROW_FORMAT=REDUNDANT
+BEGIN;
+INSERT INTO t1 VALUES(7,4,2);
+# session con1
+SET DEBUG_SYNC = 'row_log_table_apply1_before SIGNAL scanned WAIT_FOR insert_done';
+ALTER TABLE t1 DROP PRIMARY KEY, ADD UNIQUE INDEX(c2);
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on table metadata: test.t1
+# session default
+COMMIT;
+# session con1
+ALTER TABLE t1 DROP PRIMARY KEY, ADD UNIQUE INDEX(c2);
+ERROR 23000: Duplicate entry '4' for key 't1.c2'
+# session default
+DELETE FROM t1 WHERE c1 = 7;
+# session con1
+ALTER TABLE t1 DROP PRIMARY KEY, ADD UNIQUE INDEX(c2), ROW_FORMAT=COMPACT,
+LOCK = SHARED, ALGORITHM = INPLACE;
+ALTER TABLE t1 ADD UNIQUE INDEX(c2),
+LOCK = EXCLUSIVE, ALGORITHM = INPLACE;
+Warnings:
+Warning	1831	Duplicate index 'c2_2' defined on the table 'test.t1'. This is deprecated and will be disallowed in a future release.
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `c1` int NOT NULL,
+  `c2` int NOT NULL,
+  `c3` text NOT NULL,
+  UNIQUE KEY `c2` (`c2`),
+  UNIQUE KEY `c2_2` (`c2`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ROW_FORMAT=COMPACT
+ALTER TABLE t1 DROP INDEX c2, ALGORITHM = INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Dropping a primary key is not allowed without also adding a new primary key. Try ALGORITHM=COPY.
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `c1` int NOT NULL,
+  `c2` int NOT NULL,
+  `c3` text NOT NULL,
+  UNIQUE KEY `c2` (`c2`),
+  UNIQUE KEY `c2_2` (`c2`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ROW_FORMAT=COMPACT
+ALTER TABLE t1 DROP INDEX c2, ADD PRIMARY KEY(c1);
+# session default
+SET DEBUG_SYNC = 'now WAIT_FOR scanned';
+SELECT name, count FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE
+subsystem = 'ddl' and name not in
+('ddl_sort_file_alter_table','ddl_log_file_alter_table') and count > 0;
+name	count
+ddl_online_create_index	1
+ddl_pending_alter_table	1
+BEGIN;
+INSERT INTO t1 VALUES(4,7,2);
+SET DEBUG_SYNC = 'now SIGNAL insert_done';
+# session con1
+ERROR 23000: Duplicate entry '4' for key 't1.PRIMARY'
+# session default
+ROLLBACK;
+# session con1
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `c1` int NOT NULL,
+  `c2` int NOT NULL,
+  `c3` text NOT NULL,
+  UNIQUE KEY `c2` (`c2`),
+  UNIQUE KEY `c2_2` (`c2`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ROW_FORMAT=COMPACT
+ALTER TABLE t1 DROP PRIMARY KEY, ADD UNIQUE INDEX(c2), ALGORITHM = INPLACE;
+ERROR 42000: Can't DROP 'PRIMARY'; check that column/key exists
+ALTER TABLE t1 DROP INDEX c2, ADD PRIMARY KEY(c1), ALGORITHM = INPLACE;
+SELECT name, count FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE
+subsystem = 'ddl' and name not in
+('ddl_sort_file_alter_table','ddl_log_file_alter_table') and count > 0;
+name	count
+# session default
+INSERT INTO t1 VALUES(6,3,1);
+ERROR 23000: Duplicate entry '3' for key 't1.c2_2'
+INSERT INTO t1 VALUES(7,4,2);
+ERROR 23000: Duplicate entry '4' for key 't1.c2_2'
+DROP INDEX c2_2 ON t1;
+BEGIN;
+INSERT INTO t1 VALUES(7,4,2);
+ROLLBACK;
+# session con1
+KILL QUERY @id;
+ERROR 70100: Query execution was interrupted
+SET DEBUG_SYNC = 'row_log_table_apply1_before SIGNAL rebuilt WAIT_FOR kill_done';
+ALTER TABLE t1 ROW_FORMAT=REDUNDANT;
+# session default
+SET DEBUG_SYNC = 'now WAIT_FOR rebuilt';
+SELECT name, count FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE
+subsystem = 'ddl' and name not in
+('ddl_sort_file_alter_table','ddl_log_file_alter_table') and count > 0;
+name	count
+ddl_online_create_index	1
+ddl_pending_alter_table	1
+KILL QUERY @id;
+SET DEBUG_SYNC = 'now SIGNAL kill_done';
+# session con1
+ERROR 70100: Query execution was interrupted
+SELECT name, count FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE
+subsystem = 'ddl' and name not in
+('ddl_sort_file_alter_table','ddl_log_file_alter_table') and count > 0;
+name	count
+# session default
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+INSERT INTO t1 SELECT  5 + c1, c2, c3 FROM t1;
+INSERT INTO t1 SELECT 10 + c1, c2, c3 FROM t1;
+INSERT INTO t1 SELECT 20 + c1, c2, c3 FROM t1;
+INSERT INTO t1 SELECT 40 + c1, c2, c3 FROM t1;
+EXPLAIN SELECT COUNT(*) FROM t1 WHERE c2 > 3;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	80	33.33	Using where
+Warnings:
+Note	1003	/* select#1 */ select count(0) AS `COUNT(*)` from `test`.`t1` where (`test`.`t1`.`c2` > 3)
+ANALYZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
+# session con1
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `c1` int NOT NULL,
+  `c2` int NOT NULL,
+  `c3` text NOT NULL,
+  PRIMARY KEY (`c1`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ROW_FORMAT=COMPACT
+SET DEBUG_SYNC = 'row_log_table_apply1_before SIGNAL rebuilt2 WAIT_FOR dml2_done';
+SET lock_wait_timeout = 10;
+ALTER TABLE t1 ROW_FORMAT=COMPACT, ALGORITHM = INPLACE;
+# session default
+INSERT INTO t1 SELECT  80 + c1, c2, c3 FROM t1;
+INSERT INTO t1 SELECT 160 + c1, c2, c3 FROM t1;
+UPDATE t1 SET c2 = c2 + 1;
+SET DEBUG_SYNC = 'now WAIT_FOR rebuilt2';
+SELECT name, count FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE
+subsystem = 'ddl' and name not in
+('ddl_sort_file_alter_table','ddl_log_file_alter_table') and count > 0;
+name	count
+ddl_online_create_index	1
+ddl_pending_alter_table	1
+BEGIN;
+DELETE FROM t1;
+ROLLBACK;
+UPDATE t1 SET c2 = c2 + 1;
+BEGIN;
+UPDATE t1 SET c2 = c2 + 1;
+DELETE FROM t1;
+ROLLBACK;
+BEGIN;
+DELETE FROM t1;
+ROLLBACK;
+UPDATE t1 SET c2 = c2 + 1;
+BEGIN;
+UPDATE t1 SET c2 = c2 + 1;
+DELETE FROM t1;
+ROLLBACK;
+BEGIN;
+DELETE FROM t1;
+ROLLBACK;
+UPDATE t1 SET c2 = c2 + 1;
+BEGIN;
+UPDATE t1 SET c2 = c2 + 1;
+DELETE FROM t1;
+ROLLBACK;
+SELECT name, count FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE
+subsystem = 'ddl' and name not in
+('ddl_sort_file_alter_table','ddl_log_file_alter_table') and count > 0;
+name	count
+ddl_online_create_index	1
+ddl_pending_alter_table	1
+SET DEBUG_SYNC = 'now SIGNAL dml2_done';
+# session con1
+ERROR HY000: Creating index 'PRIMARY' required more than 'innodb_online_alter_log_max_size' bytes of modification log. Please try again.
+SELECT name, count FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE
+subsystem = 'ddl' and name not in
+('ddl_sort_file_alter_table','ddl_log_file_alter_table') and count > 0;
+name	count
+SET DEBUG_SYNC = 'row_log_table_apply1_before SIGNAL rebuilt3 WAIT_FOR dml3_done';
+ALTER TABLE t1 ADD PRIMARY KEY(c22f), CHANGE c2 c22f INT;
+ERROR 42000: Multiple primary key defined
+ALTER TABLE t1 DROP PRIMARY KEY, ADD PRIMARY KEY(c22f), CHANGE c2 c22f INT;
+ERROR 23000: Duplicate entry 'N' for key 't1.PRIMARY'
+ALTER TABLE t1 DROP PRIMARY KEY, ADD PRIMARY KEY(c1,c22f,c4(5)),
+CHANGE c2 c22f INT, CHANGE c3 c3 TEXT NULL, CHANGE c1 c1 INT AFTER c22f,
+ADD COLUMN c4 VARCHAR(6) DEFAULT 'Online';
+# session default
+SET DEBUG_SYNC = 'now WAIT_FOR rebuilt3';
+SELECT name, count FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE
+subsystem = 'ddl' and name not in
+('ddl_sort_file_alter_table','ddl_log_file_alter_table') and count > 0;
+name	count
+ddl_online_create_index	1
+ddl_pending_alter_table	1
+BEGIN;
+INSERT INTO t1 SELECT 320 + c1, c2, c3 FROM t1 WHERE c1 > 240;
+DELETE FROM t1 WHERE c1 > 320;
+ROLLBACK;
+BEGIN;
+UPDATE t1 SET c2 = c2 + 1;
+DELETE FROM t1;
+ROLLBACK;
+SELECT name, count FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE
+subsystem = 'ddl' and name not in
+('ddl_sort_file_alter_table','ddl_log_file_alter_table') and count > 0;
+name	count
+ddl_online_create_index	1
+ddl_pending_alter_table	1
+SET DEBUG_SYNC = 'now SIGNAL dml3_done';
+# session con1
+SELECT name, count FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE
+subsystem = 'ddl' and name not in
+('ddl_sort_file_alter_table','ddl_log_file_alter_table') and count > 0;
+name	count
+SELECT COUNT(c22f) FROM t1;
+COUNT(c22f)
+320
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+ALTER TABLE t1 DROP PRIMARY KEY, ADD PRIMARY KEY c3p5(c3(5));
+ERROR 23000: Duplicate entry '' for key 't1.PRIMARY'
+UPDATE t1 SET c3 = NULL WHERE c3 = '';
+SET lock_wait_timeout = 1;
+ALTER TABLE t1 DROP COLUMN c22f, ADD PRIMARY KEY c3p5(c3(5));
+ERROR 42000: Multiple primary key defined
+ALTER TABLE t1 DROP COLUMN c22f, DROP PRIMARY KEY, ADD PRIMARY KEY c3p5(c3(5)),
+ALGORITHM = INPLACE;
+ERROR 22004: Invalid use of NULL value
+ALTER TABLE t1 MODIFY c3 TEXT NOT NULL;
+ERROR 22004: Invalid use of NULL value
+UPDATE t1 SET c3=CONCAT(c1,REPEAT('foo',c1)) WHERE c3 IS NULL;
+SET DEBUG_SYNC = 'row_log_table_apply1_before SIGNAL c3p5_created0 WAIT_FOR ins_done0';
+ALTER TABLE t1 MODIFY c3 TEXT NOT NULL, DROP COLUMN c22f,
+ADD COLUMN c5 CHAR(5) DEFAULT 'tired' FIRST;
+# session default
+SET DEBUG_SYNC = 'now WAIT_FOR c3p5_created0';
+BEGIN;
+INSERT INTO t1 VALUES(347,33101,'Pikku kakkosen posti','YLETV2');
+INSERT INTO t1 VALUES(33101,347,NULL,'');
+SET DEBUG_SYNC = 'now SIGNAL ins_done0';
+# session con1
+ERROR 22004: Invalid use of NULL value
+# session default
+ROLLBACK;
+# session con1
+ALTER TABLE t1 MODIFY c3 TEXT NOT NULL;
+SET DEBUG_SYNC = 'row_log_table_apply1_before SIGNAL c3p5_created WAIT_FOR ins_done';
+ALTER TABLE t1 DROP PRIMARY KEY, DROP COLUMN c22f,
+ADD COLUMN c6 VARCHAR(1000) DEFAULT
+'I love tracking down hard-to-reproduce bugs.',
+ADD PRIMARY KEY c3p5(c3(5), c6(2));
+# session default
+SET DEBUG_SYNC = 'now WAIT_FOR c3p5_created';
+SET DEBUG_SYNC = 'ib_after_row_insert SIGNAL ins_done WAIT_FOR ddl_timed_out';
+INSERT INTO t1 VALUES(347,33101,NULL,'');
+ERROR 23000: Column 'c3' cannot be null
+INSERT INTO t1 VALUES(347,33101,'Pikku kakkosen posti','');
+# session con1
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on table metadata: test.t1
+SET DEBUG_SYNC = 'now SIGNAL ddl_timed_out';
+SELECT name, count FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE
+subsystem = 'ddl' and name not in
+('ddl_sort_file_alter_table','ddl_log_file_alter_table') and count > 0;
+name	count
+# session default
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+321
+ALTER TABLE t1 ROW_FORMAT=REDUNDANT;
+SELECT * FROM t1 LIMIT 10;
+c22f	c1	c3	c4
+5	1	1foo	Online
+6	2	2foofoo	Online
+7	3	3foofoofoo	Online
+8	4	4foofoofoofoo	Online
+9	5	5foofoofoofoofoo	Online
+5	6	6foofoofoofoofoofoo	Online
+6	7	7foofoofoofoofoofoofoo	Online
+7	8	8foofoofoofoofoofoofoofoo	Online
+8	9	9foofoofoofoofoofoofoofoofoo	Online
+9	10	10foofoofoofoofoofoofoofoofoofoo	Online
+# session con1
+ALTER TABLE t1 DISCARD TABLESPACE;
+# session default
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `c22f` int NOT NULL,
+  `c1` int NOT NULL,
+  `c3` text NOT NULL,
+  `c4` varchar(6) NOT NULL DEFAULT 'Online',
+  PRIMARY KEY (`c1`,`c22f`,`c4`(5))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ROW_FORMAT=REDUNDANT
+DROP TABLE t1;
+#
+# Bug#18894337 ONLINE ALTER TABLE LOG APPLY FAILS TO SKIP LOCKING
+#
+# session con1
+CREATE TABLE t1 (a SERIAL, c64 VARCHAR(64) UNIQUE) ENGINE=InnoDB;
+INSERT INTO t1 VALUES(0, NULL);
+SET DEBUG='+d,innodb_trx_duplicates';
+SET DEBUG_SYNC='row_log_table_apply1_before SIGNAL t1_ddl WAIT_FOR t1_dml';
+ALTER TABLE t1 ENGINE=InnoDB;
+# session default
+SET DEBUG_SYNC='now WAIT_FOR t1_ddl';
+INSERT INTO t1 VALUES(0, NULL), (0, NULL);
+SET DEBUG_SYNC='now SIGNAL t1_dml';
+# session con1
+# Disconnect session con1
+# session default
+DROP TABLE t1;
+SET DEBUG_SYNC = 'RESET';
+SET DEBUG = '';
+SET GLOBAL innodb_monitor_disable = module_ddl;
+SET GLOBAL DEBUG = '';
+SET GLOBAL innodb_file_per_table = @global_innodb_file_per_table_orig;
+SET GLOBAL innodb_monitor_enable  = default;
+SET GLOBAL innodb_monitor_disable = default;

--- a/mysql-test/suite/rocksdb_dd_innodb/r/innodb_zip_8k.result
+++ b/mysql-test/suite/rocksdb_dd_innodb/r/innodb_zip_8k.result
@@ -1,0 +1,468 @@
+SET default_storage_engine=InnoDB;
+# Test 1) Show the page size from Information Schema
+SELECT variable_value FROM performance_schema.global_status
+WHERE LOWER(variable_name) = 'innodb_page_size';
+variable_value
+8192
+# Test 2) The number of buffer pool pages is dependent upon the page size.
+SELECT variable_value FROM performance_schema.global_status
+WHERE LOWER(variable_name) = 'innodb_buffer_pool_pages_total';
+variable_value
+{checked_valid}
+# Test 3) Query some information_shema tables that are dependent upon
+#         the page size.
+SELECT	t.name table_name, t.n_cols, t.flag table_flags,
+i.name index_name, i.page_no root_page, i.type,
+i.n_fields, i.merge_threshold
+FROM	INFORMATION_SCHEMA.INNODB_TABLES  t,
+INFORMATION_SCHEMA.INNODB_INDEXES i
+WHERE	t.table_id = i.table_id
+AND	t.name LIKE 'mysql%'
+        AND     t.name NOT LIKE 'mysql/ndb_binlog_index'
+	ORDER BY t.name, i.index_id;
+table_name	n_cols	table_flags	index_name	root_page	type	n_fields	merge_threshold
+CREATE TABLE t1 (a INT KEY, b TEXT) ROW_FORMAT=REDUNDANT ENGINE=innodb;
+CREATE TABLE t2 (a INT KEY, b TEXT) ROW_FORMAT=COMPACT ENGINE=innodb;
+CREATE TABLE t3 (a INT KEY, b TEXT) ROW_FORMAT=COMPRESSED ENGINE=innodb;
+CREATE TABLE t4 (a INT KEY, b TEXT) ROW_FORMAT=DYNAMIC ENGINE=innodb;
+SELECT	t.name table_name, t.n_cols, t.flag table_flags,
+i.name index_name, i.page_no root_page, i.type,
+i.n_fields, i.merge_threshold
+FROM	INFORMATION_SCHEMA.INNODB_TABLES  t,
+INFORMATION_SCHEMA.INNODB_INDEXES i
+WHERE	t.table_id = i.table_id
+AND	t.name LIKE 'test%'
+	ORDER BY t.name, i.name;
+table_name	n_cols	table_flags	index_name	root_page	type	n_fields	merge_threshold
+test/t1	5	0	PRIMARY	4	3	4	50
+test/t2	5	1	PRIMARY	4	3	4	50
+test/t3	5	39	PRIMARY	4	3	4	50
+test/t4	5	33	PRIMARY	4	3	4	50
+=== information_schema.innodb_tablespaces and innodb_datafiles ===
+Space_Name	Space_Type	Page_Size	Zip_Size	BlockSize!=0	FileSize!=0	Formats_Permitted	Path
+mtr/asserted_test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/asserted_test_suppressions.ibd
+mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_suppressions.ibd
+mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
+mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
+test/t1	Single	DEFAULT	0	1	1	Compact or Redundant	MYSQLD_DATADIR/test/t1.ibd
+test/t2	Single	DEFAULT	0	1	1	Compact or Redundant	MYSQLD_DATADIR/test/t2.ibd
+test/t3	Single	DEFAULT	4096	1	1	Compressed	MYSQLD_DATADIR/test/t3.ibd
+test/t4	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/test/t4.ibd
+=== information_schema.files ===
+Space_Name	File_Type	Engine	Status	Tablespace_Name	Path
+mtr/asserted_test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/asserted_test_suppressions	MYSQLD_DATADIR/mtr/asserted_test_suppressions.ibd
+mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_DATADIR/mtr/global_suppressions.ibd
+mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
+mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
+test/t1	TABLESPACE	InnoDB	NORMAL	test/t1	MYSQLD_DATADIR/test/t1.ibd
+test/t2	TABLESPACE	InnoDB	NORMAL	test/t2	MYSQLD_DATADIR/test/t2.ibd
+test/t3	TABLESPACE	InnoDB	NORMAL	test/t3	MYSQLD_DATADIR/test/t3.ibd
+test/t4	TABLESPACE	InnoDB	NORMAL	test/t4	MYSQLD_DATADIR/test/t4.ibd
+DROP TABLE t1, t2, t3, t4;
+# Test 4) The maximum row size is dependent upon the page size.
+#         Redundant: 4027, Compact: 4030.
+#         Compressed: 4030, Dynamic: 4030.
+#         Each row format has its own amount of overhead that
+#         varies depending on number of fields and other overhead.
+SET SESSION innodb_strict_mode = ON;
+CREATE TABLE t1 (
+c01 char(200), c02 char(200), c03 char(200), c04 char(200), c05 char(200),
+c06 char(200), c07 char(200), c08 char(200), c09 char(200), c10 char(200),
+c11 char(200), c12 char(200), c13 char(200), c14 char(200), c15 char(200),
+c16 char(200), c17 char(200), c18 char(200), c19 char(200), c20 char(155)
+) ROW_FORMAT=redundant;
+DROP TABLE t1;
+CREATE TABLE t1 (
+c01 char(200), c02 char(200), c03 char(200), c04 char(200), c05 char(200),
+c06 char(200), c07 char(200), c08 char(200), c09 char(200), c10 char(200),
+c11 char(200), c12 char(200), c13 char(200), c14 char(200), c15 char(200),
+c16 char(200), c17 char(200), c18 char(200), c19 char(200), c20 char(156)
+) charset latin1 ROW_FORMAT=redundant;
+ERROR 42000: Row size too large (> max_row_size). Changing some columns to TEXT or BLOB or using ROW_FORMAT=DYNAMIC or ROW_FORMAT=COMPRESSED may help. In current row format, BLOB prefix of 768 bytes is stored inline.
+CREATE TABLE t1 (
+c01 char(200), c02 char(200), c03 char(200), c04 char(200), c05 char(200),
+c06 char(200), c07 char(200), c08 char(200), c09 char(200), c10 char(200),
+c11 char(200), c12 char(200), c13 char(200), c14 char(200), c15 char(200),
+c16 char(200), c17 char(200), c18 char(200), c19 char(200), c20 char(202)
+) ROW_FORMAT=compact;
+DROP TABLE t1;
+CREATE TABLE t1 (
+c01 char(200), c02 char(200), c03 char(200), c04 char(200), c05 char(200),
+c06 char(200), c07 char(200), c08 char(200), c09 char(200), c10 char(200),
+c11 char(200), c12 char(200), c13 char(200), c14 char(200), c15 char(200),
+c16 char(200), c17 char(200), c18 char(200), c19 char(200), c20 char(203)
+) charset latin1 ROW_FORMAT=compact;
+ERROR 42000: Row size too large (> max_row_size). Changing some columns to TEXT or BLOB or using ROW_FORMAT=DYNAMIC or ROW_FORMAT=COMPRESSED may help. In current row format, BLOB prefix of 768 bytes is stored inline.
+CREATE TABLE t1 (
+c01 char(200), c02 char(200), c03 char(200), c04 char(200), c05 char(200),
+c06 char(200), c07 char(200), c08 char(200), c09 char(200), c10 char(200),
+c11 char(200), c12 char(200), c13 char(200), c14 char(200), c15 char(200),
+c16 char(200), c17 char(200), c18 char(200), c19 char(200), c20 char(103)
+) ROW_FORMAT=compressed;
+DROP TABLE t1;
+CREATE TABLE t1 (
+c01 char(200), c02 char(200), c03 char(200), c04 char(200), c05 char(200),
+c06 char(200), c07 char(200), c08 char(200), c09 char(200), c10 char(200),
+c11 char(200), c12 char(200), c13 char(200), c14 char(200), c15 char(200),
+c16 char(200), c17 char(200), c18 char(200), c19 char(200), c20 char(106)
+) charset latin1 ROW_FORMAT=compressed;
+ERROR 42000: Row size too large (> max_row_size). Changing some columns to TEXT or BLOB may help. In current row format, BLOB prefix of 0 bytes is stored inline.
+CREATE TABLE t1 (
+c01 char(200), c02 char(200), c03 char(200), c04 char(200), c05 char(200),
+c06 char(200), c07 char(200), c08 char(200), c09 char(200), c10 char(200),
+c11 char(200), c12 char(200), c13 char(200), c14 char(200), c15 char(200),
+c16 char(200), c17 char(200), c18 char(200), c19 char(200), c20 char(202)
+) ROW_FORMAT=dynamic;
+DROP TABLE t1;
+CREATE TABLE t1 (
+c01 char(200), c02 char(200), c03 char(200), c04 char(200), c05 char(200),
+c06 char(200), c07 char(200), c08 char(200), c09 char(200), c10 char(200),
+c11 char(200), c12 char(200), c13 char(200), c14 char(200), c15 char(200),
+c16 char(200), c17 char(200), c18 char(200), c19 char(200), c20 char(203)
+) charset latin1 ROW_FORMAT=dynamic;
+ERROR 42000: Row size too large (> max_row_size). Changing some columns to TEXT or BLOB may help. In current row format, BLOB prefix of 0 bytes is stored inline.
+CREATE TABLE t1 (a varchar(128) character set utf8,
+b varchar(128) character set utf8,
+c varchar(128) character set utf8,
+d varchar(128) character set utf8,
+PRIMARY KEY (a,b,c,d))
+charset latin1
+ENGINE=innodb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+DROP TABLE t1;
+CREATE TABLE t1 (a varchar(128) character set utf8,
+b varchar(128) character set utf8,
+c varchar(128) character set utf8,
+d varchar(129) character set utf8,
+PRIMARY KEY (a,b,c,d))
+charset latin1
+ENGINE=innodb;
+ERROR 42000: Specified key was too long; max key length is 1536 bytes
+CREATE TABLE t1 (a varchar(128) character set utf8,
+b varchar(128) character set utf8,
+c varchar(128) character set utf8,
+d varchar(128) character set utf8,
+e varchar(128) character set utf8,
+PRIMARY KEY (a), KEY (b,c,d,e))
+charset latin1
+ENGINE=innodb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+DROP TABLE t1;
+CREATE TABLE t1 (a varchar(128) character set utf8,
+b varchar(128) character set utf8,
+c varchar(128) character set utf8,
+d varchar(128) character set utf8,
+e varchar(129) character set utf8,
+PRIMARY KEY (a), KEY (b,c,d,e))
+charset latin1
+ENGINE=innodb;
+ERROR 42000: Specified key was too long; max key length is 1536 bytes
+# Test 5) Make sure that KEY_BLOCK_SIZE=8, 4, 2 & 1 are all
+#         accepted and that KEY_BLOCK_SIZE=16 is rejected in
+#         strict mode and converted to 8 in non-strict mode.
+SET SESSION innodb_strict_mode = ON;
+CREATE TABLE t1 (i int) ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=16;
+ERROR HY000: Table storage engine for 't1' doesn't have this option
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1478	InnoDB: KEY_BLOCK_SIZE=16 cannot be larger than 8.
+Error	1031	Table storage engine for 't1' doesn't have this option
+CREATE TABLE t1 ( i INT ) ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8;
+SHOW WARNINGS;
+Level	Code	Message
+SELECT table_name, row_format, create_options
+FROM information_schema.tables WHERE table_name = 't1';
+TABLE_NAME	ROW_FORMAT	CREATE_OPTIONS
+t1	Compressed	row_format=COMPRESSED KEY_BLOCK_SIZE=8
+ALTER TABLE t1 KEY_BLOCK_SIZE=4;
+SHOW WARNINGS;
+Level	Code	Message
+SELECT table_name, row_format, create_options
+FROM information_schema.tables WHERE table_name = 't1';
+TABLE_NAME	ROW_FORMAT	CREATE_OPTIONS
+t1	Compressed	row_format=COMPRESSED KEY_BLOCK_SIZE=4
+ALTER TABLE t1 KEY_BLOCK_SIZE=2;
+SHOW WARNINGS;
+Level	Code	Message
+SELECT table_name, row_format, create_options
+FROM information_schema.tables WHERE table_name = 't1';
+TABLE_NAME	ROW_FORMAT	CREATE_OPTIONS
+t1	Compressed	row_format=COMPRESSED KEY_BLOCK_SIZE=2
+ALTER TABLE t1 KEY_BLOCK_SIZE=1;
+SHOW WARNINGS;
+Level	Code	Message
+SELECT table_name, row_format, create_options
+FROM information_schema.tables WHERE table_name = 't1';
+TABLE_NAME	ROW_FORMAT	CREATE_OPTIONS
+t1	Compressed	row_format=COMPRESSED KEY_BLOCK_SIZE=1
+ALTER TABLE t1 KEY_BLOCK_SIZE=0;
+SHOW WARNINGS;
+Level	Code	Message
+SELECT table_name, row_format, create_options
+FROM information_schema.tables WHERE table_name = 't1';
+TABLE_NAME	ROW_FORMAT	CREATE_OPTIONS
+t1	Compressed	row_format=COMPRESSED
+DROP TABLE t1;
+SET SESSION innodb_strict_mode = OFF;
+CREATE TABLE t1 (i int) ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=16;
+Warnings:
+Warning	1478	InnoDB: ignoring KEY_BLOCK_SIZE=16.
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1478	InnoDB: ignoring KEY_BLOCK_SIZE=16.
+SELECT table_name, row_format, create_options
+FROM information_schema.tables WHERE table_name = 't1';
+TABLE_NAME	ROW_FORMAT	CREATE_OPTIONS
+t1	Compressed	row_format=COMPRESSED KEY_BLOCK_SIZE=4
+DROP TABLE t1;
+CREATE TABLE t1 ( i INT ) ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8;
+SHOW WARNINGS;
+Level	Code	Message
+SELECT table_name, row_format, create_options
+FROM information_schema.tables WHERE table_name = 't1';
+TABLE_NAME	ROW_FORMAT	CREATE_OPTIONS
+t1	Compressed	row_format=COMPRESSED KEY_BLOCK_SIZE=8
+DROP TABLE t1;
+CREATE TABLE t1 ( i INT ) ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=4;
+SHOW WARNINGS;
+Level	Code	Message
+SELECT table_name, row_format, create_options
+FROM information_schema.tables WHERE table_name = 't1';
+TABLE_NAME	ROW_FORMAT	CREATE_OPTIONS
+t1	Compressed	row_format=COMPRESSED KEY_BLOCK_SIZE=4
+ALTER TABLE t1 KEY_BLOCK_SIZE=2;
+SHOW WARNINGS;
+Level	Code	Message
+SELECT table_name, row_format, create_options
+FROM information_schema.tables WHERE table_name = 't1';
+TABLE_NAME	ROW_FORMAT	CREATE_OPTIONS
+t1	Compressed	row_format=COMPRESSED KEY_BLOCK_SIZE=2
+ALTER TABLE t1 KEY_BLOCK_SIZE=1;
+SHOW WARNINGS;
+Level	Code	Message
+SELECT table_name, row_format, create_options
+FROM information_schema.tables WHERE table_name = 't1';
+TABLE_NAME	ROW_FORMAT	CREATE_OPTIONS
+t1	Compressed	row_format=COMPRESSED KEY_BLOCK_SIZE=1
+ALTER TABLE t1 KEY_BLOCK_SIZE=0;
+SHOW WARNINGS;
+Level	Code	Message
+SELECT table_name, row_format, create_options
+FROM information_schema.tables WHERE table_name = 't1';
+TABLE_NAME	ROW_FORMAT	CREATE_OPTIONS
+t1	Compressed	row_format=COMPRESSED
+DROP TABLE t1;
+# Test 6) Make sure that KEY_BLOCK_SIZE = 8 and 16
+# are rejected when innodb_file_per_table=OFF
+SET SESSION innodb_strict_mode = ON;
+SET GLOBAL innodb_file_per_table = OFF;
+SHOW VARIABLES LIKE 'innodb_file_per_table';
+Variable_name	Value
+innodb_file_per_table	OFF
+CREATE TABLE t4 (id int PRIMARY KEY) ENGINE=innodb KEY_BLOCK_SIZE=8;
+ERROR HY000: Table storage engine for 't4' doesn't have this option
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1478	InnoDB: KEY_BLOCK_SIZE requires innodb_file_per_table.
+Error	1031	Table storage engine for 't4' doesn't have this option
+CREATE TABLE t5 (id int PRIMARY KEY) ENGINE=innodb KEY_BLOCK_SIZE=16;
+ERROR HY000: Table storage engine for 't5' doesn't have this option
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1478	InnoDB: KEY_BLOCK_SIZE=16 cannot be larger than 8.
+Warning	1478	InnoDB: KEY_BLOCK_SIZE requires innodb_file_per_table.
+Error	1031	Table storage engine for 't5' doesn't have this option
+SET GLOBAL innodb_file_per_table = ON;
+CREATE TABLE t4 (id int PRIMARY KEY) ENGINE=innodb KEY_BLOCK_SIZE=8;
+SHOW WARNINGS;
+Level	Code	Message
+DROP TABLE t4;
+CREATE TABLE t5 (id int PRIMARY KEY) ENGINE=innodb KEY_BLOCK_SIZE=16;
+ERROR HY000: Table storage engine for 't5' doesn't have this option
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1478	InnoDB: KEY_BLOCK_SIZE=16 cannot be larger than 8.
+Error	1031	Table storage engine for 't5' doesn't have this option
+# Test 7) Not included here; 16k only
+# Test 8) Test creating a table that could lead to undo log overflow.
+CREATE TABLE t1(a blob,b blob,c blob,d blob,e blob,f blob,g blob,
+h blob,i blob,j blob,k blob,l blob,m blob,n blob,
+o blob,p blob,q blob,r blob,s blob,t blob,u blob)
+ENGINE=InnoDB ROW_FORMAT=dynamic;
+SET @a = repeat('a', 767);
+SET @b = repeat('b', 767);
+SET @c = repeat('c', 767);
+SET @d = repeat('d', 767);
+SET @e = repeat('e', 767);
+INSERT INTO t1 VALUES (@a,@a,@a,@a,@a,@a,@a,@a,@a,@a,@a,@a,@a,@a,@a,@a,@a,@a,@a,@a,@a);
+UPDATE t1 SET a=@b,b=@b,c=@b,d=@b,e=@b,f=@b,g=@b,h=@b,i=@b,j=@b,
+k=@b,l=@b,m=@b,n=@b,o=@b,p=@b,q=@b,r=@b,s=@b,t=@b,u=@b;
+CREATE INDEX t1a ON t1 (a(767));
+CREATE INDEX t1b ON t1 (b(767));
+UPDATE t1 SET a=@c,b=@c,c=@c,d=@c,e=@c,f=@c,g=@c,h=@c,i=@c,j=@c,
+k=@c,l=@c,m=@c,n=@c,o=@c,p=@c,q=@c,r=@c,s=@c,t=@c,u=@c;
+CREATE INDEX t1c ON t1 (c(767));
+UPDATE t1 SET a=@d,b=@d,c=@d,d=@d,e=@d,f=@d,g=@d,h=@d,i=@d,j=@d,
+k=@d,l=@d,m=@d,n=@d,o=@d,p=@d,q=@d,r=@d,s=@d,t=@d,u=@d;
+ERROR HY000: Undo log record is too big.
+BEGIN;
+UPDATE t1 SET a=@d,b=@d,c=@d,d=@d,e=@d;
+UPDATE t1 SET f=@d,g=@d,h=@d,i=@d,j=@d,k=@d,l=@d,m=@d,
+n=@d,o=@d,p=@d,q=@d,r=@d,s=@d,t=@d,u=@d;
+COMMIT;
+CREATE INDEX t1d ON t1 (d(767));
+UPDATE t1 SET d=@e;
+CREATE INDEX t1e ON t1 (e(767));
+UPDATE t1 SET e=@e;
+CREATE INDEX t1f ON t1 (f(767));
+UPDATE t1 SET f=@e;
+CREATE INDEX t1g ON t1 (g(767));
+UPDATE t1 SET g=@e;
+CREATE INDEX t1h ON t1 (h(767));
+UPDATE t1 SET h=@e;
+CREATE INDEX t1i ON t1 (i(767));
+UPDATE t1 SET i=@e;
+CREATE INDEX t1k ON t1 (j(767));
+CREATE INDEX t1j ON t1 (j(500));
+UPDATE t1 SET j=@e;
+ERROR HY000: Undo log record is too big.
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` blob,
+  `b` blob,
+  `c` blob,
+  `d` blob,
+  `e` blob,
+  `f` blob,
+  `g` blob,
+  `h` blob,
+  `i` blob,
+  `j` blob,
+  `k` blob,
+  `l` blob,
+  `m` blob,
+  `n` blob,
+  `o` blob,
+  `p` blob,
+  `q` blob,
+  `r` blob,
+  `s` blob,
+  `t` blob,
+  `u` blob,
+  KEY `t1a` (`a`(767)),
+  KEY `t1b` (`b`(767)),
+  KEY `t1c` (`c`(767)),
+  KEY `t1d` (`d`(767)),
+  KEY `t1e` (`e`(767)),
+  KEY `t1f` (`f`(767)),
+  KEY `t1g` (`g`(767)),
+  KEY `t1h` (`h`(767)),
+  KEY `t1i` (`i`(767)),
+  KEY `t1k` (`j`(767)),
+  KEY `t1j` (`j`(500))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ROW_FORMAT=DYNAMIC
+DROP TABLE t1;
+SET SESSION innodb_strict_mode = OFF;
+CREATE TABLE t1(
+pk01 varchar(96), pk02 varchar(96), pk03 varchar(96), pk04 varchar(96),
+pk05 varchar(96), pk06 varchar(96), pk07 varchar(96), pk08 varchar(96),
+pk09 varchar(96), pk10 varchar(96), pk11 varchar(96), pk12 varchar(96),
+pk13 varchar(96), pk14 varchar(96), pk15 varchar(96), pk16 varchar(96),
+sk01 varchar(96), sk02 varchar(96), sk03 varchar(96), sk04 varchar(96),
+sk05 varchar(96), sk06 varchar(96), sk07 varchar(96), sk08 varchar(96),
+sk09 varchar(96), sk10 varchar(96), sk11 varchar(96), sk12 varchar(96),
+sk13 varchar(96), sk14 varchar(96), sk15 varchar(96), sk16 varchar(96),
+PRIMARY KEY pk(pk01,pk02,pk03,pk04,pk05,pk06,pk07,pk08,
+pk09,pk10,pk11,pk12,pk13,pk14,pk15,pk16),
+KEY pk(sk01,sk02,sk03,sk04,sk05,sk06,sk07,sk08,
+sk09,sk10,sk11,sk12,sk13,sk14,sk15,sk16))
+charset latin1
+ROW_FORMAT=Redundant ENGINE=InnoDB;
+SET @r = repeat('a', 96);
+INSERT INTO t1 VALUES(@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,
+@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r);
+SET @r = repeat('b', 96);
+INSERT INTO t1 VALUES(@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,
+@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r);
+SET @r = repeat('c', 96);
+INSERT INTO t1 VALUES(@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,
+@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r);
+SET @r = repeat('d', 96);
+INSERT INTO t1 VALUES(@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,
+@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r);
+SET @r = repeat('e', 96);
+INSERT INTO t1 VALUES(@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,
+@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r);
+DELETE from t1;
+DROP TABLE t1;
+CREATE TABLE t1(
+pk01 varchar(96), pk02 varchar(96), pk03 varchar(96), pk04 varchar(96),
+pk05 varchar(96), pk06 varchar(96), pk07 varchar(96), pk08 varchar(96),
+pk09 varchar(96), pk10 varchar(96), pk11 varchar(96), pk12 varchar(96),
+pk13 varchar(96), pk14 varchar(96), pk15 varchar(96), pk16 varchar(96),
+sk01 varchar(96), sk02 varchar(96), sk03 varchar(96), sk04 varchar(96),
+sk05 varchar(96), sk06 varchar(96), sk07 varchar(96), sk08 varchar(96),
+sk09 varchar(96), sk10 varchar(96), sk11 varchar(96), sk12 varchar(96),
+sk13 varchar(96), sk14 varchar(96), sk15 varchar(96), sk16 varchar(96),
+PRIMARY KEY pk(pk01,pk02,pk03,pk04,pk05,pk06,pk07,pk08,
+pk09,pk10,pk11,pk12,pk13,pk14,pk15,pk16),
+KEY pk(sk01,sk02,sk03,sk04,sk05,sk06,sk07,sk08,
+sk09,sk10,sk11,sk12,sk13,sk14,sk15,sk16))
+charset latin1
+ROW_FORMAT=Compressed KEY_BLOCK_SIZE=8 ENGINE=InnoDB;
+SET @r = repeat('a', 96);
+INSERT INTO t1 VALUES(@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,
+@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r);
+SET @r = repeat('b', 96);
+INSERT INTO t1 VALUES(@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,
+@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r);
+SET @r = repeat('c', 96);
+INSERT INTO t1 VALUES(@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,
+@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r);
+SET @r = repeat('d', 96);
+INSERT INTO t1 VALUES(@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,
+@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r);
+SET @r = repeat('e', 96);
+INSERT INTO t1 VALUES(@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,
+@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r,@r);
+DELETE from t1;
+DROP TABLE t1;
+SET SESSION innodb_strict_mode = off;
+CREATE TABLE t1(
+c text NOT NULL, d text NOT NULL,
+PRIMARY KEY (c(767),d(767)))
+ENGINE=InnoDB ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=1 CHARSET=ASCII;
+Warnings:
+Warning	139	Row size too large (> max_row_size). Changing some columns to TEXT or BLOB may help. In current row format, BLOB prefix of 0 bytes is stored inline.
+DROP TABLE t1;
+CREATE TABLE t1(
+c text NOT NULL, d text NOT NULL,
+PRIMARY KEY (c(767),d(767)))
+ENGINE=InnoDB ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=2 CHARSET=ASCII;
+Warnings:
+Warning	139	Row size too large (> max_row_size). Changing some columns to TEXT or BLOB may help. In current row format, BLOB prefix of 0 bytes is stored inline.
+DROP TABLE t1;
+CREATE TABLE t1(
+c text NOT NULL, d text NOT NULL,
+PRIMARY KEY (c(767),d(767)))
+ENGINE=InnoDB ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=4 CHARSET=ASCII;
+drop table t1;
+CREATE TABLE t1(c text, PRIMARY KEY (c(440)))
+ENGINE=InnoDB ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=1 CHARSET=ASCII;
+Warnings:
+Warning	139	Row size too large (> max_row_size). Changing some columns to TEXT or BLOB may help. In current row format, BLOB prefix of 0 bytes is stored inline.
+DROP TABLE t1;
+CREATE TABLE t1(c text, PRIMARY KEY (c(438)))
+ENGINE=InnoDB ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=1 CHARSET=ASCII;
+INSERT INTO t1 VALUES(REPEAT('A',512)),(REPEAT('B',512));
+DROP TABLE t1;

--- a/mysql-test/suite/rocksdb_dd_innodb/r/rpl_mts_spco_alter_table_analyze_partition_nobinlog.result
+++ b/mysql-test/suite/rocksdb_dd_innodb/r/rpl_mts_spco_alter_table_analyze_partition_nobinlog.result
@@ -1,0 +1,78 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+[connection slave]
+include/gtid_utils.inc
+[connection master]
+
+# Setup
+
+[connection slave]
+CALL mtr.add_suppression("You need to use --log-bin to make --binlog-format work");
+SET @save_replica_parallel_workers= @@global.replica_parallel_workers;
+SET @save_replica_parallel_type= @@global.replica_parallel_type;
+SET @save_replica_preserve_commit_order= @@global.replica_preserve_commit_order;
+SET GLOBAL replica_parallel_type = 'LOGICAL_CLOCK';
+SET GLOBAL replica_parallel_workers= 8;
+SET GLOBAL replica_preserve_commit_order= ON;
+include/start_slave.inc
+[connection master]
+SET @save_binlog_transaction_dependency_tracking= @@global.binlog_transaction_dependency_tracking;
+SET @@global.binlog_transaction_dependency_tracking = COMMIT_ORDER;
+[connection master]
+CREATE TABLE t1(a INT PRIMARY KEY); CREATE TABLE t2 (i INTEGER) PARTITION BY RANGE(i) PARTITIONS 2 SUBPARTITION BY HASH(i) (PARTITION p0 VALUES LESS THAN(100) (SUBPARTITION sp00, SUBPARTITION sp01), PARTITION p1 VALUES LESS THAN(200) (SUBPARTITION sp10, SUBPARTITION sp11));;
+include/sync_slave_sql_with_master.inc
+
+# Block slave sql applier threads
+
+[connection slave]
+BEGIN; INSERT INTO t1 VALUES (1);;
+[connection slave]
+[connection slave]
+
+# Generate the transactions which can be applied in parallel on slave
+
+[connection master]
+# Adding debug point 'set_commit_parent_100' to @@GLOBAL.debug
+BEGIN; INSERT INTO t1 VALUES (1); COMMIT; BEGIN; INSERT INTO t1 VALUES (2); COMMIT; ALTER TABLE t2 ANALYZE PARTITION p0; BEGIN; INSERT INTO t1 VALUES (4); COMMIT;;
+Table	Op	Msg_type	Msg_text
+test.t2	analyze	status	OK
+[connection server_1]
+BEGIN; INSERT INTO t1 VALUES (5); COMMIT; BEGIN; INSERT INTO t1 VALUES (6); COMMIT; BEGIN; INSERT INTO t1 VALUES (7); COMMIT;;
+# Removing debug point 'set_commit_parent_100' from @@GLOBAL.debug
+
+# Verify the transactions are ordered correctly on slave
+
+[connection server_2]
+include/assert.inc [Verify table t1 is empty]
+[connection slave]
+include/assert.inc [Exactly 0 GTIDs should have been committed since last invocation]
+
+# Rollback the first insert so that slave applier threads can
+# unblock and proceed. Verify the transactions are applied.
+
+[connection slave]
+ROLLBACK;;
+
+# On slave, verify no additional transaction is added after first
+# insert was blocked i.e. ALTER TABLE .. ANALYZE PARTITION is not
+# bypassing commit order.
+
+include/assert.inc [No additional transaction is added on slave after first insert was blocked]
+
+# Cleanup
+
+[connection master]
+DROP TABLE t1;
+DROP TABLE t2;
+SET GLOBAL binlog_transaction_dependency_tracking=@save_binlog_transaction_dependency_tracking;
+include/sync_slave_sql_with_master.inc
+include/stop_slave.inc
+SET GLOBAL replica_parallel_type= @save_replica_parallel_type;
+SET GLOBAL replica_parallel_workers= @save_replica_parallel_workers;
+SET GLOBAL replica_preserve_commit_order= @save_replica_preserve_commit_order;
+include/start_slave.inc
+include/gtid_utils_end.inc
+include/rpl_end.inc

--- a/mysql-test/suite/rocksdb_dd_innodb/r/undo_tablespace.result
+++ b/mysql-test/suite/rocksdb_dd_innodb/r/undo_tablespace.result
@@ -1,0 +1,392 @@
+#
+# InnoDB supports CREATE/ALTER/DROP UNDO TABLESPACE
+#
+SET GLOBAL innodb_fast_shutdown = 0;
+# restart
+SET GLOBAL innodb_undo_log_truncate = OFF;
+CREATE UNDO TABLESPACE undo_003 ADD DATAFILE 'undo_003.ibu';
+CREATE UNDO TABLESPACE undo_004 ADD DATAFILE 'undo_004.ibu';
+CREATE UNDO TABLESPACE undo_005 ADD DATAFILE '5.ibu';
+SELECT NAME, SPACE_TYPE, STATE FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+WHERE SPACE_TYPE = 'Undo' ORDER BY NAME;
+NAME	SPACE_TYPE	STATE
+innodb_undo_001	Undo	active
+innodb_undo_002	Undo	active
+undo_003	Undo	active
+undo_004	Undo	active
+undo_005	Undo	active
+SELECT TABLESPACE_NAME, FILE_TYPE, FILE_NAME FROM INFORMATION_SCHEMA.FILES
+WHERE FILE_NAME LIKE '%.ibu' ORDER BY TABLESPACE_NAME;
+TABLESPACE_NAME	FILE_TYPE	FILE_NAME
+undo_003	UNDO LOG	./undo_003.ibu
+undo_004	UNDO LOG	./undo_004.ibu
+undo_005	UNDO LOG	./5.ibu
+CREATE TABLESPACE ts1 ADD DATAFILE 'ts1.ibd';
+CREATE TABLE t1 (a int primary key) TABLESPACE ts1;
+#
+# Populate t1 with separate INSERTs so that all rsegs are used.
+#
+CREATE PROCEDURE populate_t1(IN BASE INT, IN SIZE INT)
+BEGIN
+DECLARE i INT DEFAULT BASE;
+WHILE (i <= SIZE) DO
+INSERT INTO t1 values (i);
+SET i = i + 1;
+END WHILE;
+END|
+CALL populate_t1(1, 1000);
+#
+# Show that the implicit undo tablespaces may be set inactive
+# and that a minimum of 2 undo tablespaces must remain active.
+#
+ALTER UNDO TABLESPACE innodb_undo_001 SET INACTIVE;
+ALTER UNDO TABLESPACE innodb_undo_002 SET INACTIVE;
+ALTER UNDO TABLESPACE undo_003 SET INACTIVE;
+ALTER UNDO TABLESPACE undo_004 SET INACTIVE;
+ERROR HY000: Cannot set undo_004 inactive since there would be less than 2 undo tablespaces left active.
+SHOW WARNINGS;
+Level	Code	Message
+Error	3655	Cannot set undo_004 inactive since there would be less than 2 undo tablespaces left active.
+Error	1533	Failed to alter: UNDO TABLESPACE undo_004
+Error	3655	ALTER UNDO TABLEPSPACE operation is disallowed on undo_004
+ALTER UNDO TABLESPACE undo_005 SET INACTIVE;
+ERROR HY000: Cannot set undo_005 inactive since there would be less than 2 undo tablespaces left active.
+SHOW WARNINGS;
+Level	Code	Message
+Error	3655	Cannot set undo_005 inactive since there would be less than 2 undo tablespaces left active.
+Error	1533	Failed to alter: UNDO TABLESPACE undo_005
+Error	3655	ALTER UNDO TABLEPSPACE operation is disallowed on undo_005
+SELECT NAME, SPACE_TYPE, STATE FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+WHERE SPACE_TYPE = 'Undo' ORDER BY NAME;
+NAME	SPACE_TYPE	STATE
+innodb_undo_001	Undo	empty
+innodb_undo_002	Undo	empty
+undo_003	Undo	empty
+undo_004	Undo	active
+undo_005	Undo	active
+SELECT TABLESPACE_NAME, FILE_TYPE, FILE_NAME FROM INFORMATION_SCHEMA.FILES
+WHERE FILE_NAME LIKE '%.ibu' ORDER BY TABLESPACE_NAME;
+TABLESPACE_NAME	FILE_TYPE	FILE_NAME
+undo_003	UNDO LOG	./undo_003.ibu
+undo_004	UNDO LOG	./undo_004.ibu
+undo_005	UNDO LOG	./5.ibu
+ALTER UNDO TABLESPACE innodb_undo_001 SET ACTIVE;
+ALTER UNDO TABLESPACE innodb_undo_002 SET ACTIVE;
+SELECT NAME, SPACE_TYPE, STATE FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+WHERE SPACE_TYPE = 'Undo' ORDER BY NAME;
+NAME	SPACE_TYPE	STATE
+innodb_undo_001	Undo	active
+innodb_undo_002	Undo	active
+undo_003	Undo	empty
+undo_004	Undo	active
+undo_005	Undo	active
+#
+# Show that SET ACTIVE and SET INACTIVE are indempotent.
+#
+ALTER UNDO TABLESPACE undo_003 SET ACTIVE;
+ALTER UNDO TABLESPACE undo_003 SET ACTIVE;
+ALTER UNDO TABLESPACE undo_003 SET INACTIVE;
+ALTER UNDO TABLESPACE undo_003 SET INACTIVE;
+ALTER UNDO TABLESPACE undo_003 SET INACTIVE;
+#
+# SET the explicit tablespaces INACTIVE.
+#
+ALTER UNDO TABLESPACE undo_004 SET INACTIVE;
+ALTER UNDO TABLESPACE undo_005 SET INACTIVE;
+SHOW GLOBAL STATUS LIKE '%undo%';
+Variable_name	Value
+Innodb_undo_tablespaces_total	5
+Innodb_undo_tablespaces_implicit	2
+Innodb_undo_tablespaces_explicit	3
+Innodb_undo_tablespaces_active	2
+SELECT NAME, SPACE_TYPE, STATE FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+WHERE SPACE_TYPE = 'Undo' ORDER BY NAME;
+NAME	SPACE_TYPE	STATE
+innodb_undo_001	Undo	active
+innodb_undo_002	Undo	active
+undo_003	Undo	empty
+undo_004	Undo	empty
+undo_005	Undo	empty
+SELECT TABLESPACE_NAME, FILE_TYPE, FILE_NAME FROM INFORMATION_SCHEMA.FILES
+WHERE FILE_NAME LIKE '%.ibu' ORDER BY TABLESPACE_NAME;
+TABLESPACE_NAME	FILE_TYPE	FILE_NAME
+undo_003	UNDO LOG	./undo_003.ibu
+undo_004	UNDO LOG	./undo_004.ibu
+undo_005	UNDO LOG	./5.ibu
+#
+# Drop undo_003
+#
+DROP UNDO TABLESPACE undo_003;
+SELECT NAME, SPACE_TYPE, STATE FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+WHERE SPACE_TYPE = 'Undo' ORDER BY NAME;
+NAME	SPACE_TYPE	STATE
+innodb_undo_001	Undo	active
+innodb_undo_002	Undo	active
+undo_004	Undo	empty
+undo_005	Undo	empty
+SELECT TABLESPACE_NAME, FILE_TYPE, FILE_NAME FROM INFORMATION_SCHEMA.FILES
+WHERE FILE_NAME LIKE '%.ibu' ORDER BY TABLESPACE_NAME;
+TABLESPACE_NAME	FILE_TYPE	FILE_NAME
+undo_004	UNDO LOG	./undo_004.ibu
+undo_005	UNDO LOG	./5.ibu
+ALTER UNDO TABLESPACE undo_005 SET ACTIVE;
+SELECT NAME, SPACE_TYPE, STATE FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+WHERE SPACE_TYPE = 'Undo' ORDER BY NAME;
+NAME	SPACE_TYPE	STATE
+innodb_undo_001	Undo	active
+innodb_undo_002	Undo	active
+undo_004	Undo	empty
+undo_005	Undo	active
+#
+# Try various bad CREATE UNDO TABLESPACE commands
+#
+CREATE UNDO TABLESPACE innodb_undo_001 ADD DATAFILE 'undo_001.ibu';
+ERROR 42000: InnoDB: Tablespace names starting with `innodb_` are reserved.
+SHOW WARNINGS;
+Level	Code	Message
+Error	3119	InnoDB: Tablespace names starting with `innodb_` are reserved.
+Error	3119	Incorrect tablespace name `innodb_undo_001`
+CREATE UNDO TABLESPACE undo_5 ADD DATAFILE '5.ibu';
+ERROR HY000: Duplicate file name for tablespace 'undo_5'
+SHOW WARNINGS;
+Level	Code	Message
+Error	3606	Duplicate file name for tablespace 'undo_5'
+CREATE UNDO TABLESPACE undo_99 ADD DATAFILE 'undo_99.ibu';
+ERROR HY000: The ADD DATAFILE filepath already exists.
+SHOW WARNINGS;
+Level	Code	Message
+Error	3121	The ADD DATAFILE filepath already exists.
+Error	1528	Failed to create UNDO TABLESPACE undo_99
+Error	3121	Incorrect File Name 'undo_99.ibu'.
+CREATE UNDO TABLESPACE 'undo_99' ADD DATAFILE 'undo_001.ibu';
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ''undo_99' ADD DATAFILE 'undo_001.ibu'' at line 1
+CREATE UNDO TABLESPACE `undo_99`;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '' at line 1
+CREATE UNDO TABLESPACE undo_99 ADD DATAFILE 'undo_99';
+ERROR HY000: The ADD DATAFILE filepath must end with '.ibu'.
+SHOW WARNINGS;
+Level	Code	Message
+Error	3121	The ADD DATAFILE filepath must end with '.ibu'.
+Error	1528	Failed to create UNDO TABLESPACE undo_99
+Error	3121	Incorrect File Name 'undo_99'.
+CREATE UNDO TABLESPACE undo_99 ADD DATAFILE 'undo_99.ibd';
+ERROR HY000: The ADD DATAFILE filepath must end with '.ibu'.
+SHOW WARNINGS;
+Level	Code	Message
+Error	3121	The ADD DATAFILE filepath must end with '.ibu'.
+Error	1528	Failed to create UNDO TABLESPACE undo_99
+Error	3121	Incorrect File Name 'undo_99.ibd'.
+CREATE UNDO TABLESPACE undo_99 ADD DATAFILE '/dir_does_not_exist/undo_99.ibu';
+ERROR HY000: The directory does not exist or is incorrect.
+SHOW WARNINGS;
+Level	Code	Message
+Error	3121	The directory does not exist or is incorrect.
+Error	3121	The UNDO DATAFILE location must be in a known directory.
+Error	1528	Failed to create UNDO TABLESPACE undo_99
+Error	3121	Incorrect File Name '/dir_does_not_exist/undo_99.ibu'.
+CREATE UNDO TABLESPACE undo_99 ADD DATAFILE '../undo_99.ibu';
+ERROR HY000: The ADD DATAFILE filepath for an UNDO TABLESPACE cannot be a relative path.
+SHOW WARNINGS;
+Level	Code	Message
+Error	3121	The ADD DATAFILE filepath for an UNDO TABLESPACE cannot be a relative path.
+Error	3121	The UNDO DATAFILE location must be in a known directory.
+Error	1528	Failed to create UNDO TABLESPACE undo_99
+Error	3121	Incorrect File Name '../undo_99.ibu'.
+#
+# Try various bad ALTER UNDO TABLESPACE commands
+#
+ALTER UNDO TABLESPACE `undo_99`;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '' at line 1
+ALTER UNDO TABLESPACE `undo_99` SET INACTIVE;
+ERROR HY000: Tablespace undo_99 doesn't exist.
+SHOW WARNINGS;
+Level	Code	Message
+Error	3510	Tablespace undo_99 doesn't exist.
+ALTER UNDO TABLESPACE `undo_99` SET ACTIVE;
+ERROR HY000: Tablespace undo_99 doesn't exist.
+SHOW WARNINGS;
+Level	Code	Message
+Error	3510	Tablespace undo_99 doesn't exist.
+ALTER UNDO TABLESPACE `ts1` SET INACTIVE;
+ERROR 42000: Cannot ALTER UNDO TABLESPACE `ts1` because it is a general tablespace.  Please use ALTER TABLESPACE.
+SHOW WARNINGS;
+Level	Code	Message
+Error	3119	Cannot ALTER UNDO TABLESPACE `ts1` because it is a general tablespace.  Please use ALTER TABLESPACE.
+Error	1533	Failed to alter: UNDO TABLESPACE ts1
+Error	3655	ALTER UNDO TABLEPSPACE operation is disallowed on ts1
+ALTER UNDO TABLESPACE `ts1` SET ACTIVE;
+ERROR 42000: Cannot ALTER UNDO TABLESPACE `ts1` because it is a general tablespace.  Please use ALTER TABLESPACE.
+SHOW WARNINGS;
+Level	Code	Message
+Error	3119	Cannot ALTER UNDO TABLESPACE `ts1` because it is a general tablespace.  Please use ALTER TABLESPACE.
+Error	1533	Failed to alter: UNDO TABLESPACE ts1
+Error	3655	ALTER UNDO TABLEPSPACE operation is disallowed on ts1
+ALTER TABLESPACE undo_005 RENAME TO undo_5;
+ERROR 42000: Cannot ALTER TABLESPACE `undo_005` because it is an undo tablespace.  Please use ALTER UNDO TABLESPACE.
+SHOW WARNINGS;
+Level	Code	Message
+Error	3119	Cannot ALTER TABLESPACE `undo_005` because it is an undo tablespace.  Please use ALTER UNDO TABLESPACE.
+Error	1533	Failed to alter: TABLESPACE undo_005
+Error	3655	ALTER TABLESPACE ... RENAME TO operation is disallowed on undo_005
+ALTER UNDO TABLESPACE undo_005 SET EMPTY;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'EMPTY' at line 1
+#
+# Try various bad DROP UNDO TABLESPACE commands
+#
+DROP UNDO TABLESPACE innodb_undo_001;
+ERROR 42000: InnoDB: Tablespace names starting with `innodb_` are reserved.
+SHOW WARNINGS;
+Level	Code	Message
+Error	3119	InnoDB: Tablespace names starting with `innodb_` are reserved.
+Error	3119	Incorrect tablespace name `innodb_undo_001`
+DROP UNDO TABLESPACE undo_99;
+ERROR HY000: Tablespace undo_99 doesn't exist.
+SHOW WARNINGS;
+Level	Code	Message
+Error	3510	Tablespace undo_99 doesn't exist.
+DROP UNDO TABLESPACE undo_005;
+ERROR HY000: Failed to drop UNDO TABLESPACE undo_005
+SHOW WARNINGS;
+Level	Code	Message
+Error	1529	Failed to drop UNDO TABLESPACE undo_005
+Error	3120	Tablespace `undo_005` is not empty.
+DROP TABLESPACE undo_005;
+ERROR 42000: Cannot DROP TABLESPACE `undo_005` because it is an undo tablespace.  Please use DROP UNDO TABLESPACE.
+SHOW WARNINGS;
+Level	Code	Message
+Error	3119	Cannot DROP TABLESPACE `undo_005` because it is an undo tablespace.  Please use DROP UNDO TABLESPACE.
+Error	1529	Failed to drop TABLESPACE undo_005
+Error	3655	DROP TABLEPSPACE operation is disallowed on undo_005
+DROP UNDO TABLESPACE ts1;
+ERROR 42000: Cannot DROP UNDO TABLESPACE `ts1` because it is a general tablespace.  Please use DROP TABLESPACE.
+SHOW WARNINGS;
+Level	Code	Message
+Error	3119	Cannot DROP UNDO TABLESPACE `ts1` because it is a general tablespace.  Please use DROP TABLESPACE.
+Error	1529	Failed to drop UNDO TABLESPACE ts1
+Error	3655	DROP UNDO TABLEPSPACE operation is disallowed on ts1
+#
+# Show that tables cannot be added to an undo tablespace.
+#
+CREATE TABLE t2 (a int primary key) TABLESPACE undo_004;
+ERROR 42000: InnoDB: An undo tablespace cannot contain tables.
+SHOW WARNINGS;
+Level	Code	Message
+Error	3119	InnoDB: An undo tablespace cannot contain tables.
+Error	1031	Table storage engine for 't2' doesn't have this option
+ALTER TABLE t1 TABLESPACE undo_004;
+ERROR 42000: InnoDB: An undo tablespace cannot contain tables.
+SHOW WARNINGS;
+Level	Code	Message
+Error	3119	InnoDB: An undo tablespace cannot contain tables.
+Error	1478	Table storage engine 'InnoDB' does not support the create option 'TABLESPACE'
+#
+# Show that a missing undo tablespace can be dropped
+#
+# restart
+SELECT NAME, SPACE_TYPE, STATE FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+WHERE SPACE_TYPE = 'Undo' ORDER BY NAME;
+NAME	SPACE_TYPE	STATE
+innodb_undo_001	Undo	active
+innodb_undo_002	Undo	active
+undo_004	Undo	empty
+undo_005	Undo	active
+SELECT TABLESPACE_NAME, FILE_TYPE, FILE_NAME FROM INFORMATION_SCHEMA.FILES
+WHERE FILE_NAME LIKE '%.ibu' ORDER BY TABLESPACE_NAME;
+TABLESPACE_NAME	FILE_TYPE	FILE_NAME
+undo_004	NULL	./undo_004.ibu
+undo_005	UNDO LOG	./5.ibu
+Warnings:
+Warning	1812	Tablespace is missing for table undo_004.
+DROP UNDO TABLESPACE undo_004;
+#
+# Show that the setting innodb_validate_tablespace_paths does not affect undo tablespaces.
+#
+CREATE UNDO TABLESPACE undo_006 ADD DATAFILE 'undo_006.ibu';
+SHOW GLOBAL STATUS LIKE '%undo%';
+Variable_name	Value
+Innodb_undo_tablespaces_total	4
+Innodb_undo_tablespaces_implicit	2
+Innodb_undo_tablespaces_explicit	2
+Innodb_undo_tablespaces_active	4
+SELECT NAME, SPACE_TYPE, STATE FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+WHERE SPACE_TYPE = 'Undo' ORDER BY NAME;
+NAME	SPACE_TYPE	STATE
+innodb_undo_001	Undo	active
+innodb_undo_002	Undo	active
+undo_005	Undo	active
+undo_006	Undo	active
+SELECT TABLESPACE_NAME, FILE_TYPE, FILE_NAME FROM INFORMATION_SCHEMA.FILES
+WHERE FILE_NAME LIKE '%.ibu' ORDER BY TABLESPACE_NAME;
+TABLESPACE_NAME	FILE_TYPE	FILE_NAME
+undo_005	UNDO LOG	./5.ibu
+undo_006	UNDO LOG	./undo_006.ibu
+# Restart with validation turned OFF
+# restart: --innodb_validate_tablespace_paths=0
+SHOW GLOBAL STATUS LIKE '%undo%';
+Variable_name	Value
+Innodb_undo_tablespaces_total	4
+Innodb_undo_tablespaces_implicit	2
+Innodb_undo_tablespaces_explicit	2
+Innodb_undo_tablespaces_active	4
+SELECT NAME, SPACE_TYPE, STATE FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+WHERE SPACE_TYPE = 'Undo' ORDER BY NAME;
+NAME	SPACE_TYPE	STATE
+innodb_undo_001	Undo	active
+innodb_undo_002	Undo	active
+undo_005	Undo	active
+undo_006	Undo	active
+SELECT TABLESPACE_NAME, FILE_TYPE, FILE_NAME FROM INFORMATION_SCHEMA.FILES
+WHERE FILE_NAME LIKE '%.ibu' ORDER BY TABLESPACE_NAME;
+TABLESPACE_NAME	FILE_TYPE	FILE_NAME
+undo_005	UNDO LOG	./5.ibu
+undo_006	UNDO LOG	./undo_006.ibu
+# Kill and restart mysqld with validation turned OFF
+# Kill and restart: --innodb_validate_tablespace_paths=0
+SHOW GLOBAL STATUS LIKE '%undo%';
+Variable_name	Value
+Innodb_undo_tablespaces_total	4
+Innodb_undo_tablespaces_implicit	2
+Innodb_undo_tablespaces_explicit	2
+Innodb_undo_tablespaces_active	4
+SELECT NAME, SPACE_TYPE, STATE FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+WHERE SPACE_TYPE = 'Undo' ORDER BY NAME;
+NAME	SPACE_TYPE	STATE
+innodb_undo_001	Undo	active
+innodb_undo_002	Undo	active
+undo_005	Undo	active
+undo_006	Undo	active
+SELECT TABLESPACE_NAME, FILE_TYPE, FILE_NAME FROM INFORMATION_SCHEMA.FILES
+WHERE FILE_NAME LIKE '%.ibu' ORDER BY TABLESPACE_NAME;
+TABLESPACE_NAME	FILE_TYPE	FILE_NAME
+undo_005	UNDO LOG	./5.ibu
+undo_006	UNDO LOG	./undo_006.ibu
+# Restart mysqld with validation turned ON
+# restart:
+SHOW GLOBAL STATUS LIKE '%undo%';
+Variable_name	Value
+Innodb_undo_tablespaces_total	4
+Innodb_undo_tablespaces_implicit	2
+Innodb_undo_tablespaces_explicit	2
+Innodb_undo_tablespaces_active	4
+SELECT NAME, SPACE_TYPE, STATE FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+WHERE SPACE_TYPE = 'Undo' ORDER BY NAME;
+NAME	SPACE_TYPE	STATE
+innodb_undo_001	Undo	active
+innodb_undo_002	Undo	active
+undo_005	Undo	active
+undo_006	Undo	active
+SELECT TABLESPACE_NAME, FILE_TYPE, FILE_NAME FROM INFORMATION_SCHEMA.FILES
+WHERE FILE_NAME LIKE '%.ibu' ORDER BY TABLESPACE_NAME;
+TABLESPACE_NAME	FILE_TYPE	FILE_NAME
+undo_005	UNDO LOG	./5.ibu
+undo_006	UNDO LOG	./undo_006.ibu
+#
+# Cleanup
+#
+DROP TABLE t1;
+DROP TABLESPACE ts1;
+DROP PROCEDURE populate_t1;
+ALTER UNDO TABLESPACE undo_005 SET INACTIVE;
+DROP UNDO TABLESPACE undo_005;
+ALTER UNDO TABLESPACE undo_006 SET INACTIVE;
+DROP UNDO TABLESPACE undo_006;

--- a/mysql-test/suite/rocksdb_dd_innodb/t/create_select_foreign_key.test
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/create_select_foreign_key.test
@@ -1,0 +1,1 @@
+--source ../../../t/create_select_foreign_key.test

--- a/mysql-test/suite/rocksdb_dd_innodb/t/create_tablespace_32k-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/create_tablespace_32k-master.opt
@@ -1,0 +1,2 @@
+--initialize --innodb_page_size=32k
+--innodb_directories=$MYSQL_TMP_DIR

--- a/mysql-test/suite/rocksdb_dd_innodb/t/create_tablespace_32k.test
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/create_tablespace_32k.test
@@ -1,0 +1,1 @@
+--source ../../innodb/t/create_tablespace_32k.test

--- a/mysql-test/suite/rocksdb_dd_innodb/t/create_tablespace_64k-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/create_tablespace_64k-master.opt
@@ -1,0 +1,2 @@
+--initialize --innodb_page_size=64k
+--innodb_directories=$MYSQL_TMP_DIR

--- a/mysql-test/suite/rocksdb_dd_innodb/t/create_tablespace_64k.test
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/create_tablespace_64k.test
@@ -1,0 +1,1 @@
+--source ../../innodb/t/create_tablespace_64k.test

--- a/mysql-test/suite/rocksdb_dd_innodb/t/index_large_prefix_4k-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/index_large_prefix_4k-master.opt
@@ -1,0 +1,1 @@
+--initialize --innodb_page_size=4k

--- a/mysql-test/suite/rocksdb_dd_innodb/t/index_large_prefix_4k.test
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/index_large_prefix_4k.test
@@ -1,0 +1,1 @@
+--source ../../innodb_zip/t/index_large_prefix_4k.test

--- a/mysql-test/suite/rocksdb_dd_innodb/t/innodb-table-online-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/innodb-table-online-master.opt
@@ -1,0 +1,1 @@
+--innodb-sort-buffer-size=64k --innodb-online-alter-log-max-size=64k --innodb-buffer-pool-size=8M --innodb-log-buffer-size=1M

--- a/mysql-test/suite/rocksdb_dd_innodb/t/innodb-table-online.test
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/innodb-table-online.test
@@ -1,0 +1,1 @@
+--source ../../innodb/t/innodb-table-online.test

--- a/mysql-test/suite/rocksdb_dd_innodb/t/innodb_zip_8k-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/innodb_zip_8k-master.opt
@@ -1,0 +1,1 @@
+--initialize --innodb_page_size=8k

--- a/mysql-test/suite/rocksdb_dd_innodb/t/innodb_zip_8k.test
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/innodb_zip_8k.test
@@ -1,0 +1,1 @@
+--source ../../innodb_zip/t/8k.test

--- a/mysql-test/suite/rocksdb_dd_innodb/t/rpl_mts_spco_alter_table_analyze_partition_nobinlog.cnf
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/rpl_mts_spco_alter_table_analyze_partition_nobinlog.cnf
@@ -1,0 +1,12 @@
+# Use settings from rpl_1slave_base.cnf
+# add setting to connect the slave to the master by default
+!include ../../rpl_gtid/rpl_1slave_base.cnf
+!include include/default_client.cnf
+
+[mysqld]
+gtid-mode=on
+enforce-gtid-consistency
+
+[mysqld.2]
+skip-log-bin
+log-replica-updates=0

--- a/mysql-test/suite/rocksdb_dd_innodb/t/rpl_mts_spco_alter_table_analyze_partition_nobinlog.test
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/rpl_mts_spco_alter_table_analyze_partition_nobinlog.test
@@ -1,0 +1,1 @@
+--source ../../rpl_gtid/t/rpl_mts_spco_alter_table_analyze_partition_nobinlog.test

--- a/mysql-test/suite/rocksdb_dd_innodb/t/undo_tablespace.test
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/undo_tablespace.test
@@ -1,0 +1,1 @@
+--source ../../innodb_undo/t/undo_tablespace.test

--- a/storage/innobase/btr/btr0btr.cc
+++ b/storage/innobase/btr/btr0btr.cc
@@ -877,6 +877,52 @@ ulint btr_create(ulint type, space_id_t space, const page_size_t &page_size,
   }
 
   page_no = block->page.id.page_no();
+
+#ifdef UNIV_DEBUG
+  if (space == dict_sys_t::s_dict_space_id && !innobase_is_ddse()) {
+    if (strcmp(index->table_name, "mysql/innodb_dynamic_metadata") == 0) {
+      assert(page_no == 5);
+      assert(index_id == 2);
+    } else if (strcmp(index->table_name, "mysql/innodb_table_stats") == 0) {
+      assert(page_no == 6);
+      assert(index_id == 3);
+    } else if (strcmp(index->table_name, "mysql/innodb_index_stats") == 0) {
+      switch (srv_page_size) {
+      case 4096:
+        assert(page_no == 8);
+        break;
+      case 8192:
+      case 16384:
+      case 32768:
+      case 65536:
+        assert(page_no == 7);
+        break;
+      default:
+        assert(false);
+      }
+      assert(index_id == 4);
+    } else if (strcmp(index->table_name, "mysql/innodb_ddl_log") == 0) {
+      if (index_id == 5) {  // The primary index
+        switch (srv_page_size) {
+        case 4096:
+          assert(page_no == 9);
+          break;
+        case 8192:
+        case 16384:
+        case 32768:
+        case 65536:
+          assert(page_no == 8);
+          break;
+        default:
+          assert(false);
+        }
+      } else {
+        assert(index_id == 6);
+      }
+    }
+  }
+#endif
+
   frame = buf_block_get_frame(block);
 
   if (type & DICT_IBUF) {

--- a/storage/innobase/dict/dict0crea.cc
+++ b/storage/innobase/dict/dict0crea.cc
@@ -72,10 +72,27 @@ dberr_t dict_build_table_def(dict_table_t *table,
   static uint32_t dd_table_id = 1;
 
   if (is_dd_table) {
-    table->id = dd_table_id++;
     table->is_dd_table = true;
+    if (!innobase_is_ddse()) {
+      if (tbl_name == "dd_properties_placeholder") {
+        table->id = 1;
+      } else if (tbl_name == "innodb_dynamic_metadata") {
+        table->id = 2;
+      } else if (tbl_name == "innodb_table_stats") {
+        table->id = 3;
+      } else if (tbl_name == "innodb_index_stats") {
+        table->id = 4;
+      } else {
+        assert(tbl_name == "innodb_ddl_log");
+        table->id = 5;
+      }
+    } else {
+      table->id = dd_table_id++;
+    }
 
-    ut_ad(strcmp(tbl_name.c_str(), innodb_dd_table[table->id - 1].name) == 0);
+    ut_ad(strcmp(tbl_name.c_str(), innodb_dd_table[table->id - 1].name) == 0 ||
+          (!innobase_is_ddse() && tbl_name == "dd_properties_placeholder" &&
+           strcmp(innodb_dd_table[table->id - 1].name, "dd_properties") == 0));
 
   } else {
     dict_table_assign_new_id(table, trx);

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -5930,7 +5930,8 @@ static int innobase_commit(handlerton *hton, /*!< in: InnoDB handlerton */
     }
 
     /* If SE needs to persist GTID we must have a transaction. */
-    if (thd->se_persists_gtid_explicit()) {
+    if (thd->se_persists_gtid_explicit() &&
+        (innobase_is_ddse() || !trx_state_eq(trx, TRX_STATE_PREPARED))) {
       trx_start_if_not_started(trx, true);
     }
 
@@ -12922,6 +12923,18 @@ static bool innobase_ddse_dict_init(
     return true;
   }
 
+  if (!innobase_is_ddse()) {
+    dd::Object_table *dd_properties_placeholder =
+        dd::Object_table::create_object_table("INNODB");
+    dd_properties_placeholder->set_hidden(true);
+    dd::Object_table_definition *def =
+        dd_properties_placeholder->target_table_definition();
+    def->set_table_name("dd_properties_placeholder");
+    def->add_field(0, "dummy", "dummy INT UNSIGNED NOT NULL");
+    def->add_index(0, "dummy_pk", "PRIMARY KEY (dummy)");
+    tables->push_back(dd_properties_placeholder);
+  }
+
   /* Instantiate table defs only if we are successful so far. */
   dd::Object_table *innodb_dynamic_metadata =
       dd::Object_table::create_object_table("INNODB");
@@ -15001,6 +15014,56 @@ bool ha_innobase::get_se_private_data(dd::Table *dd_table, bool reset) {
     // Also need to reset the set of DD table ids.
     dict_sys_t::s_dd_table_ids.clear();
   }
+
+  if (!innobase_is_ddse()) {
+    if (dd_table->name() == "dd_properties_placeholder") {
+      n_tables = 0;
+      n_indexes = 0;
+      n_pages = 4;
+    } else if (dd_table->name() == "innodb_dynamic_metadata") {
+      n_tables = 1;
+      n_indexes = 1;
+      n_pages = 5;
+    } else if (dd_table->name() == "innodb_table_stats") {
+      n_tables = 2;
+      n_indexes = 2;
+      n_pages = 6;
+    } else if (dd_table->name() == "innodb_index_stats") {
+      n_tables = 3;
+      n_indexes = 3;
+      switch (srv_page_size) {
+      case 4096:
+        n_pages = 8;
+        break;
+      case 8192:
+      case 16384:
+      case 32768:
+      case 65536:
+        n_pages = 7;
+        break;
+      default:
+        assert(false);
+      }
+    } else {
+      assert(dd_table->name() == "innodb_ddl_log");
+      n_tables = 4;
+      n_indexes = 4;
+      switch (srv_page_size) {
+      case 4096:
+        n_pages = 9;
+        break;
+      case 8192:
+      case 16384:
+      case 32768:
+      case 65536:
+        n_pages = 8;
+        break;
+      default:
+        assert(false);
+      }
+    }
+  }
+
 #ifdef UNIV_DEBUG
   const uint n_indexes_old = n_indexes;
 #endif
@@ -15023,7 +15086,10 @@ bool ha_innobase::get_se_private_data(dd::Table *dd_table, bool reset) {
   const innodb_dd_table_t &data = innodb_dd_table[n_tables];
 #endif
 
-  assert(dd_table->name() == data.name);
+  assert(dd_table->name() == data.name ||
+         (!innobase_is_ddse() &&
+          dd_table->name() == "dd_properties_placeholder" &&
+          strcmp(data.name, "dd_properties") == 0));
 
   dd_table->set_se_private_id(++n_tables);
   dd_table->set_tablespace_id(dict_sys_t::s_dd_dict_space_id);
@@ -16003,6 +16069,9 @@ static int innodb_drop_tablespace(handlerton *hton, THD *thd,
   trx_t *trx = check_trx_exists(thd);
   TrxInInnoDB trx_in_innodb(trx);
   trx_start_if_not_started(trx, true);
+  if (!innobase_is_ddse()) {
+    innobase_register_trx(hton, thd, trx);
+  }
   ++trx->will_lock;
 
   /* Acquire Exclusive MDL on SDI table of tablespace.
@@ -16335,6 +16404,9 @@ static int innodb_drop_undo_tablespace(handlerton *hton, THD *thd,
     can continue. */
     trx_t *trx = check_trx_exists(thd);
     trx_start_if_not_started(trx, true);
+    if (!innobase_is_ddse()) {
+      innobase_register_trx(hton, thd, trx);
+    }
     ++trx->will_lock;
 
     return (0);
@@ -16379,6 +16451,9 @@ static int innodb_drop_undo_tablespace(handlerton *hton, THD *thd,
   trx_t *trx = check_trx_exists(thd);
   TrxInInnoDB trx_in_innodb(trx);
   trx_start_if_not_started(trx, true);
+  if (!innobase_is_ddse()) {
+    innobase_register_trx(hton, thd, trx);
+  }
   ++trx->will_lock;
 
   auto err = log_ddl->write_delete_space_log(trx, nullptr, space_id,
@@ -24386,3 +24461,7 @@ static bool innobase_check_reserved_file_name(
   return (true);
 }
 #endif /* !UNIV_HOTBACKUP */
+
+bool innobase_is_ddse() {
+  return default_dd_storage_engine == DEFAULT_DD_INNODB;
+}

--- a/storage/innobase/include/dict0dd.h
+++ b/storage/innobase/include/dict0dd.h
@@ -55,6 +55,7 @@ Data dictionary interface */
 #include "dd/types/tablespace.h"
 #include "dd/types/tablespace_file.h"
 #include "dd_table_share.h"
+#include "ha_prototypes.h"
 #include "sess0sess.h"
 #else
 #include "mysql_com.h"
@@ -1360,7 +1361,7 @@ DDSE, the tables will be in another storage engine, thus the server layer
 interface must be used.
 @return whether server layer interface must be used to access the DD */
 [[nodiscard]] inline bool dd_access_through_server() noexcept {
-  return (default_dd_storage_engine != DEFAULT_DD_INNODB);
+  return !innobase_is_ddse();
 }
 
 #include "dict0dd.ic"

--- a/storage/innobase/include/ha_prototypes.h
+++ b/storage/innobase/include/ha_prototypes.h
@@ -436,4 +436,6 @@ ulong thd_parallel_read_threads(THD *thd);
 /** @return the number of DDL threads to use (global/session). */
 [[nodiscard]] size_t thd_ddl_threads(THD *thd) noexcept;
 
+[[nodiscard]] bool innobase_is_ddse();
+
 #endif /* HA_INNODB_PROTOTYPES_H */

--- a/storage/innobase/include/trx0purge.h
+++ b/storage/innobase/include/trx0purge.h
@@ -97,6 +97,8 @@ void trx_purge_stop(void);
 /** Resume purge, move to PURGE_STATE_RUN. */
 void trx_purge_run(void);
 
+void trx_purge_truncate_undo_spaces(void);
+
 /** Purge states */
 enum purge_state_t {
   PURGE_STATE_INIT,    /*!< Purge instance created */

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -3081,6 +3081,7 @@ static ulint srv_do_purge(ulint *n_total_purged) {
 
     /* Take a snapshot of the history list before purge. */
     if ((rseg_history_len = trx_sys->rseg_history_len.load()) == 0) {
+      if (!innobase_is_ddse()) trx_purge_truncate_undo_spaces();
       break;
     }
 

--- a/storage/innobase/trx/trx0purge.cc
+++ b/storage/innobase/trx/trx0purge.cc
@@ -1651,7 +1651,7 @@ static void trx_purge_truncate_history(purge_iter_t *limit,
 
 /** Select an undo tablespace to truncate, make sure it is empty of undo logs,
 then finally truncate it. */
-static void trx_purge_truncate_undo_spaces() {
+void trx_purge_truncate_undo_spaces() {
   /* If the server has been started for the purpose of upgrading from a
   previous version, do not do undo truncation. */
   if (srv_is_upgrade_mode) {


### PR DESCRIPTION
No functional changes when InnoDB is the DDSE. When InnoDB is not the DDSE:
- ha_innobase::get_se_private_data: make sure the InnoDB-specific DD tables (mysql.innodb_dynamic_metadata, mysql.innodb_table_stats, mysql.innodb_index_stats, & mysql.innodb_ddl_log) get the same hardcoded table, index, & root page IDs as they do when InnoDB is the DDSE.
- innobase_ddse_dict_init: register with the DD layer and create a placeholder DD table mysql.dd_properties_placeholder, whose purpose is to reserve the table, index, and root page IDs for the mysql.dd_properties table that is created when InnoDB is the DDSE.
- Make dict_build_table_def give out the hardcoded table IDs for the InnoDB DD tables.
- Add extra asserts to btr_create to ensure that the hardcoded InnoDB DD tables are created with the right IDs.
- Make purge truncate undo tablespaces unconditionally instead of when something purgeable exists. With DDSE in another engine, nothing purgable exists on e.g. dropping an undo tablespace, and without the truncate the undo tablespace state will not change to the one allowing the drop to complete.
- innodb_drop_tablespace, innodb_drop_undo_tablespace: register InnoDB DDL transactions with 2PC because the DDSE participates too.
- Expand MTR suite rocksdb_dd_innodb with InnoDB-specific tests that regressed during development with MyRocks DDSE.