### PR TITLE
Update or skip some MTR tests for MyRocks DDSE, part 3

### DIFF
--- a/mysql-test/suite/innodb/t/innodb.test
+++ b/mysql-test/suite/innodb/t/innodb.test
@@ -1,3 +1,6 @@
+# CREATE TABLE ... SELECT ... FROM a locked table returns different errors with
+# different DDSEs
+--source include/have_innodb_ddse.inc
 #Want to skip this test from daily Valgrind execution
 --source include/no_valgrind_without_big.inc
 

--- a/mysql-test/suite/innodb/t/innodb_misc1.test
+++ b/mysql-test/suite/innodb/t/innodb_misc1.test
@@ -1,4 +1,6 @@
-
+# CREATE TABLE ... SELECT ... FROM a locked table returns different errors with
+# different DDSEs
+-- source include/have_innodb_ddse.inc
 -- source include/have_innodb_max_16k.inc
 
 let $MYSQLD_DATADIR= `select @@datadir`;

--- a/mysql-test/suite/perfschema/include/statements_row_updated.inc
+++ b/mysql-test/suite/perfschema/include/statements_row_updated.inc
@@ -23,11 +23,11 @@
 --let $end_sum_rows_updated_global = query_get_value(select sum(SUM_ROWS_UPDATED) as Value from performance_schema.events_statements_summary_global_by_event_name, Value, 1)
 
 # Check sanity
---let $assert_text= SUM_ROWS_UPDATED on events_statements_summary_by_user_by_event_name should be increased by $expected_sum_rows_updated.
+--let $assert_text= SUM_ROWS_UPDATED on events_statements_summary_by_user_by_event_name should be increased by expected_sum_rows_updated.
 --let $assert_cond= $end_sum_rows_updated_user - $start_sum_rows_updated_user = $expected_sum_rows_updated
 --source include/assert.inc
 
---let $assert_text= SUM_ROWS_UPDATED on events_statements_summary_by_host_by_event_name should be increased by $expected_sum_rows_updated.
+--let $assert_text= SUM_ROWS_UPDATED on events_statements_summary_by_host_by_event_name should be increased by expected_sum_rows_updated.
 --let $assert_cond= $end_sum_rows_updated_host - $start_sum_rows_updated_host = $expected_sum_rows_updated
 --source include/assert.inc
 
@@ -35,10 +35,10 @@
 --let $assert_cond= $end_sum_rows_updated_program - $start_sum_rows_updated_program = 0
 --source include/assert.inc
 
---let $assert_text= SUM_ROWS_UPDATED on events_statements_summary_by_thread_by_event_name should be increased by $expected_sum_rows_updated.
+--let $assert_text= SUM_ROWS_UPDATED on events_statements_summary_by_thread_by_event_name should be increased by expected_sum_rows_updated.
 --let $assert_cond= $end_sum_rows_updated_event - $start_sum_rows_updated_event = $expected_sum_rows_updated
 --source include/assert.inc
 
---let $assert_text= SUM_ROWS_UPDATED on events_statements_summary_global_by_event_name should be increased by $expected_sum_rows_updated.
+--let $assert_text= SUM_ROWS_UPDATED on events_statements_summary_global_by_event_name should be increased by expected_sum_rows_updated.
 --let $assert_cond= $end_sum_rows_updated_global - $start_sum_rows_updated_global = $expected_sum_rows_updated
 --source include/assert.inc

--- a/mysql-test/suite/perfschema/r/esms_by_all.result
+++ b/mysql-test/suite/perfschema/r/esms_by_all.result
@@ -58,17 +58,17 @@ update t1 set c=c+300;
 update t1 set c=c+500;
 delete from t1 where c=905;
 delete from t1 where c=903;
-select schema_name, digest, user, client_id, plan_id, count_star, sum_rows_deleted, sum_rows_inserted, sum_rows_updated from performance_schema.events_statements_summary_by_all;
-schema_name	digest	user	client_id	plan_id	count_star	sum_rows_deleted	sum_rows_inserted	sum_rows_updated
-test	1bdaf02b6c6dd4f5bfc3045555865597	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	0	0
-test	aaee6b4d5f9c26d4d43d3967f53cd8c7	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	0	0
-test	ee539b147b1561c36bd9e7ad53e5fb38	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	2	0	0	0
-test	532f13eb85f19ef3ad1a5fabe39fcfca	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	2	0	0	0
-test	a532c6f3e890282b7eee77f35ee85ae9	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	3	0	0	0
-test	d210d88fff8eeea1393763fdcc68c999	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	12	6
-test	de4ac3f385e51f51f081f37368d6e55f	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	5	0	5	0
-test	437f75e69680d60cca3e8a82393fa4f1	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	3	0	0	15
-test	3379f8d08c8ef1406d99c65ff9b6b097	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	2	2	0	0
+select schema_name, digest, user, client_id, plan_id, count_star, sum_rows_deleted, sum_rows_inserted from performance_schema.events_statements_summary_by_all;
+schema_name	digest	user	client_id	plan_id	count_star	sum_rows_deleted	sum_rows_inserted
+test	1bdaf02b6c6dd4f5bfc3045555865597	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	0
+test	aaee6b4d5f9c26d4d43d3967f53cd8c7	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	0
+test	ee539b147b1561c36bd9e7ad53e5fb38	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	2	0	0
+test	532f13eb85f19ef3ad1a5fabe39fcfca	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	2	0	0
+test	a532c6f3e890282b7eee77f35ee85ae9	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	3	0	0
+test	d210d88fff8eeea1393763fdcc68c999	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	12
+test	de4ac3f385e51f51f081f37368d6e55f	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	5	0	5
+test	437f75e69680d60cca3e8a82393fa4f1	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	3	0	0
+test	3379f8d08c8ef1406d99c65ff9b6b097	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	2	2	0
 select schema_name, digest, count_star, sum_rows_deleted, sum_rows_inserted, sum_rows_updated from performance_schema.events_statements_summary_by_digest;
 schema_name	digest	count_star	sum_rows_deleted	sum_rows_inserted	sum_rows_updated
 Case 3: TRUNCATE TABLE
@@ -123,43 +123,43 @@ set @query= 'SELECT * FROM test.t11 WHERE a > 5 and a < 10 and a <> 9' ||||
 PREPARE STMT FROM @query; EXECUTE STMT; ||||
 a
 DROP TABLE test.t11 ||||
-select schema_name, query_sample_text, digest, user, client_id, plan_id, count_star, sum_rows_deleted, sum_rows_inserted, sum_rows_updated from performance_schema.events_statements_summary_by_all order by digest;
-schema_name	query_sample_text	digest	user	client_id	plan_id	count_star	sum_rows_deleted	sum_rows_inserted	sum_rows_updated
-test	drop table t2	0092392cb59149e0726b0b82c62d3b73	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	12	0	0
+select schema_name, query_sample_text, digest, user, client_id, plan_id, count_star, sum_rows_deleted, sum_rows_inserted from performance_schema.events_statements_summary_by_all order by digest;
+schema_name	query_sample_text	digest	user	client_id	plan_id	count_star	sum_rows_deleted	sum_rows_inserted
+test	drop table t2	0092392cb59149e0726b0b82c62d3b73	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	12	0
 test	create table t2(c int);
 insert into t2 values(100);
 select * from t2;
 update t2 set c=c+7;
 delete from t2 where c=107;
-drop table t2	08eb447c2908ae85dbf2389bb755a47c	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	12	6
-test	set global performance_schema_esms_by_all = on	1bdaf02b6c6dd4f5bfc3045555865597	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	0	0
-test	set @query= 'SELECT * FROM test.t11 WHERE a > 5 and a < 10 and a <> 9'	2e8c4504c4ed8aefa4a0601d8983caf2	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	0	0
+drop table t2	08eb447c2908ae85dbf2389bb755a47c	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	12
+test	set global performance_schema_esms_by_all = on	1bdaf02b6c6dd4f5bfc3045555865597	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	0
+test	set @query= 'SELECT * FROM test.t11 WHERE a > 5 and a < 10 and a <> 9'	2e8c4504c4ed8aefa4a0601d8983caf2	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	0
 test	update t2 set c=c+7;
 delete from t2 where c=107;
-drop table t2	37a4ab3f20bfa2cadc339f81a225a3ea	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	0	1
-test	EXECUTE STMT	6c3a3828b4683176bf5613bf50781aff	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	0	0
-test	DROP TABLE test.t11	8fa792b76e7a194c5f7335c9064b77a2	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	12	0	0
+drop table t2	37a4ab3f20bfa2cadc339f81a225a3ea	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	0
+test	EXECUTE STMT	6c3a3828b4683176bf5613bf50781aff	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	0
+test	DROP TABLE test.t11	8fa792b76e7a194c5f7335c9064b77a2	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	12	0
 test	select * from t2;
 update t2 set c=c+7;
 delete from t2 where c=107;
-drop table t2	9355f873b85ca62c15f9c76c7d577a46	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	0	0
+drop table t2	9355f873b85ca62c15f9c76c7d577a46	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	0
 test	select 1;
 create table t2(c int);
 insert into t2 values(100);
 select * from t2;
 update t2 set c=c+7;
 delete from t2 where c=107;
-drop table t2	a532c6f3e890282b7eee77f35ee85ae9	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	0	0
-test	select @@performance_schema_esms_by_all	aaee6b4d5f9c26d4d43d3967f53cd8c7	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	0	0
-test	CREATE TABLE test.t11(a int)	b90de024eac53b1869f604d5e84bf832	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	12	6
+drop table t2	a532c6f3e890282b7eee77f35ee85ae9	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	0
+test	select @@performance_schema_esms_by_all	aaee6b4d5f9c26d4d43d3967f53cd8c7	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	0
+test	CREATE TABLE test.t11(a int)	b90de024eac53b1869f604d5e84bf832	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	12
 test	delete from t2 where c=107;
-drop table t2	c6b47f584c3c723a695af80568462861	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	1	0	0
-test	PREPARE STMT FROM @query; EXECUTE STMT	e6e3e2d3faddc5b422a8775cd7c37755	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	0	0
+drop table t2	c6b47f584c3c723a695af80568462861	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	1	0
+test	PREPARE STMT FROM @query; EXECUTE STMT	e6e3e2d3faddc5b422a8775cd7c37755	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	0
 test	insert into t2 values(100);
 select * from t2;
 update t2 set c=c+7;
 delete from t2 where c=107;
-drop table t2	ea8d7221939e31cd79bb5a0800f1c421	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	1	0
+drop table t2	ea8d7221939e31cd79bb5a0800f1c421	user_super	0000000000000000d194f27ab572142e	00000000000000000000000000000000	1	0	1
 select schema_name, digest, count_star, sum_rows_deleted, sum_rows_inserted, sum_rows_updated from performance_schema.events_statements_summary_by_digest;
 schema_name	digest	count_star	sum_rows_deleted	sum_rows_inserted	sum_rows_updated
 Verify index working properly

--- a/mysql-test/suite/perfschema/r/perf_schema_periodic_snapshot_debug.result
+++ b/mysql-test/suite/perfschema/r/perf_schema_periodic_snapshot_debug.result
@@ -19,13 +19,13 @@ i
 1
 3
 4
-select schema_name, digest, user, SUBSTRING(query_sample_text, 1, 10), count_star, sum_rows_inserted, sum_rows_examined, sum_rows_updated, sum_rows_sent from performance_schema.events_statements_summary_by_all order by query_sample_text asc;
-schema_name	digest	user	SUBSTRING(query_sample_text, 1, 10)	count_star	sum_rows_inserted	sum_rows_examined	sum_rows_updated	sum_rows_sent
-test	6ee210714b5c265b79d47f096ecb00ba	user_super	create tab	1	12	0	6	0
-test	1f74b5cfb4ff7bba7c55d5916085ad51	user_super	insert int	3	3	0	0	0
-test	a34c4ef3c24d1443f126bfb04005e81c	user_super	select * f	1	0	3	0	3
-test	61cbecbde57649b01f98367d1b9e6649	user_super	select sch	1	0	0	0	3
-test	2a2ebea9b4e0bae3afcc55ae0d867ad4	user_super	set @@glob	1	0	0	0	0
+select schema_name, digest, user, SUBSTRING(query_sample_text, 1, 10), count_star, sum_rows_inserted, sum_rows_examined, sum_rows_sent from performance_schema.events_statements_summary_by_all order by query_sample_text asc;
+schema_name	digest	user	SUBSTRING(query_sample_text, 1, 10)	count_star	sum_rows_inserted	sum_rows_examined	sum_rows_sent
+test	6ee210714b5c265b79d47f096ecb00ba	user_super	create tab	1	12	0	0
+test	1f74b5cfb4ff7bba7c55d5916085ad51	user_super	insert int	3	3	0	0
+test	a34c4ef3c24d1443f126bfb04005e81c	user_super	select * f	1	0	3	3
+test	e399a529ef8585a30a99a3d9a9ae0a3f	user_super	select sch	1	0	0	3
+test	2a2ebea9b4e0bae3afcc55ae0d867ad4	user_super	set @@glob	1	0	0	0
 select query_sample_text, schema_name from performance_schema.events_statements_summary_by_all where sum_cpu_time > 2000000000000 and sum_elapsed_time > 2000000000000 and query_sample_text LIKE '%create table%' order by query_sample_text;
 query_sample_text	schema_name
 create table t71 (i int)	test
@@ -56,34 +56,34 @@ c
 100
 set @@global.debug = '-d,add_busy_loop_2sec';
 set @@global.debug = '-d,skip_end_statement';
-select schema_name, digest, user, query_sample_text, count_star, sum_rows_inserted, sum_rows_examined, sum_rows_updated, sum_rows_sent from performance_schema.events_statements_summary_by_all order by query_sample_text asc;
-schema_name	digest	user	query_sample_text	count_star	sum_rows_inserted	sum_rows_examined	sum_rows_updated	sum_rows_sent
+select schema_name, digest, user, query_sample_text, count_star, sum_rows_inserted, sum_rows_examined, sum_rows_sent from performance_schema.events_statements_summary_by_all order by query_sample_text asc;
+schema_name	digest	user	query_sample_text	count_star	sum_rows_inserted	sum_rows_examined	sum_rows_sent
 test	85682d1656cce207e22bbbd0a14f44c0	user_super	create table t72(c int);
 insert into t72 values(100);
 select * from t72;
 update t72 set c=c+7;
 update t72 set c=c+7;
 delete from t72 where c=114;
-drop table t72	1	12	0	6	0
+drop table t72	1	12	0	0
 test	ab1fef38406db6e6dbb72e33ff05d5f7	user_super	delete from t72 where c=114;
-drop table t72	1	0	1	0	0
-test	23e04b97ff39b4948f7c37c38983f112	user_super	drop table t72	1	0	0	0	0
+drop table t72	1	0	1	0
+test	23e04b97ff39b4948f7c37c38983f112	user_super	drop table t72	1	0	0	0
 test	7fb804dd7a29b5e49e2a10c43b84726e	user_super	insert into t72 values(100);
 select * from t72;
 update t72 set c=c+7;
 update t72 set c=c+7;
 delete from t72 where c=114;
-drop table t72	1	1	0	0	0
+drop table t72	1	1	0	0
 test	d977632b07be45578e5e5e06c3531d47	user_super	select * from t72;
 update t72 set c=c+7;
 update t72 set c=c+7;
 delete from t72 where c=114;
-drop table t72	1	0	0	0	1
-test	049d4858e9f8dc77d3e81a62ec745598	user_super	select schema_name, digest, user, query_sample_text, count_star, sum_rows_inserted, sum_rows_examined, sum_rows_updated, sum_rows_sent from performance_schema.events_statements_summary_by_all order by query_sample_text asc	1	0	0	0	5
-test	2a2ebea9b4e0bae3afcc55ae0d867ad4	user_super	set @@global.debug = '-d,skip_end_statement'	1	0	0	0	0
+drop table t72	1	0	0	1
+test	1400af9987c0ee222336dc74df8d718a	user_super	select schema_name, digest, user, query_sample_text, count_star, sum_rows_inserted, sum_rows_examined, sum_rows_sent from performance_schema.events_statements_summary_by_all order by query_sample_text asc	1	0	0	5
+test	2a2ebea9b4e0bae3afcc55ae0d867ad4	user_super	set @@global.debug = '-d,skip_end_statement'	1	0	0	0
 test	86b2664dd62cd95b3ca469fa4431ce90	user_super	update t72 set c=c+7;
 delete from t72 where c=114;
-drop table t72	2	0	2	2	0
+drop table t72	2	0	2	0
 select query_sample_text, schema_name from performance_schema.events_statements_summary_by_all where sum_cpu_time > 2000000000000 and sum_elapsed_time > 2000000000000 order by query_sample_text;
 query_sample_text	schema_name
 create table t72(c int);

--- a/mysql-test/suite/perfschema/r/statements_row_updated.result
+++ b/mysql-test/suite/perfschema/r/statements_row_updated.result
@@ -2,68 +2,68 @@ Variation 0: No-op Select
 SELECT 1;;
 1
 1
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_user_by_event_name should be increased by 0.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_host_by_event_name should be increased by 0.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_user_by_event_name should be increased by expected_sum_rows_updated.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_host_by_event_name should be increased by expected_sum_rows_updated.]
 include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_program should be increased by 0.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_thread_by_event_name should be increased by 0.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_global_by_event_name should be increased by 0.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_thread_by_event_name should be increased by expected_sum_rows_updated.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_global_by_event_name should be increased by expected_sum_rows_updated.]
 Variation 1: Create Table. 
 CREATE TABLE t1 (a INT) ENGINE=InnoDB;;
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_user_by_event_name should be increased by 6.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_host_by_event_name should be increased by 6.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_user_by_event_name should be increased by expected_sum_rows_updated.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_host_by_event_name should be increased by expected_sum_rows_updated.]
 include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_program should be increased by 0.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_thread_by_event_name should be increased by 6.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_global_by_event_name should be increased by 6.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_thread_by_event_name should be increased by expected_sum_rows_updated.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_global_by_event_name should be increased by expected_sum_rows_updated.]
 Variation 2: Insert three rows into Table t1. 
 INSERT INTO t1 VALUES (1), (2), (3);;
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_user_by_event_name should be increased by 0.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_host_by_event_name should be increased by 0.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_user_by_event_name should be increased by expected_sum_rows_updated.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_host_by_event_name should be increased by expected_sum_rows_updated.]
 include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_program should be increased by 0.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_thread_by_event_name should be increased by 0.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_global_by_event_name should be increased by 0.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_thread_by_event_name should be increased by expected_sum_rows_updated.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_global_by_event_name should be increased by expected_sum_rows_updated.]
 Variation 3: Select all rows from Table. 
 SELECT * FROM t1;;
 a
 1
 2
 3
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_user_by_event_name should be increased by 0.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_host_by_event_name should be increased by 0.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_user_by_event_name should be increased by expected_sum_rows_updated.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_host_by_event_name should be increased by expected_sum_rows_updated.]
 include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_program should be increased by 0.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_thread_by_event_name should be increased by 0.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_global_by_event_name should be increased by 0.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_thread_by_event_name should be increased by expected_sum_rows_updated.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_global_by_event_name should be increased by expected_sum_rows_updated.]
 Variation 4: Update one row. 
 UPDATE t1 SET a = 1 where a = 2;;
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_user_by_event_name should be increased by 1.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_host_by_event_name should be increased by 1.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_user_by_event_name should be increased by expected_sum_rows_updated.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_host_by_event_name should be increased by expected_sum_rows_updated.]
 include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_program should be increased by 0.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_thread_by_event_name should be increased by 1.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_global_by_event_name should be increased by 1.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_thread_by_event_name should be increased by expected_sum_rows_updated.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_global_by_event_name should be increased by expected_sum_rows_updated.]
 Variation 5: DELETE rows from Table. 
 DELETE FROM t1;;
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_user_by_event_name should be increased by 0.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_host_by_event_name should be increased by 0.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_user_by_event_name should be increased by expected_sum_rows_updated.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_host_by_event_name should be increased by expected_sum_rows_updated.]
 include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_program should be increased by 0.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_thread_by_event_name should be increased by 0.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_global_by_event_name should be increased by 0.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_thread_by_event_name should be increased by expected_sum_rows_updated.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_global_by_event_name should be increased by expected_sum_rows_updated.]
 Variation 6: Set up for next variation
 INSERT INTO t1 VALUES (1), (2), (3); CREATE TABLE t2 (a INT); INSERT INTO t2 VALUES (1), (2), (3);;
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_user_by_event_name should be increased by 6.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_host_by_event_name should be increased by 6.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_user_by_event_name should be increased by expected_sum_rows_updated.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_host_by_event_name should be increased by expected_sum_rows_updated.]
 include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_program should be increased by 0.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_thread_by_event_name should be increased by 6.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_global_by_event_name should be increased by 6.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_thread_by_event_name should be increased by expected_sum_rows_updated.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_global_by_event_name should be increased by expected_sum_rows_updated.]
 Variation 7: Update rows from two tables. 
 UPDATE t1, t2 SET t1.a = t2.a + 2, t2.a = t2.a + 3 WHERE t1.a = t2.a;;
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_user_by_event_name should be increased by 6.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_host_by_event_name should be increased by 6.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_user_by_event_name should be increased by expected_sum_rows_updated.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_host_by_event_name should be increased by expected_sum_rows_updated.]
 include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_program should be increased by 0.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_thread_by_event_name should be increased by 6.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_global_by_event_name should be increased by 6.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_thread_by_event_name should be increased by expected_sum_rows_updated.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_global_by_event_name should be increased by expected_sum_rows_updated.]
 Variation 8: Drop Table. 
 DROP TABLE t1; DROP TABLE t2;;
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_user_by_event_name should be increased by 0.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_host_by_event_name should be increased by 0.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_user_by_event_name should be increased by expected_sum_rows_updated.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_host_by_event_name should be increased by expected_sum_rows_updated.]
 include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_program should be increased by 0.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_thread_by_event_name should be increased by 0.]
-include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_global_by_event_name should be increased by 0.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_by_thread_by_event_name should be increased by expected_sum_rows_updated.]
+include/assert.inc [SUM_ROWS_UPDATED on events_statements_summary_global_by_event_name should be increased by expected_sum_rows_updated.]

--- a/mysql-test/suite/perfschema/t/esms_by_all.test
+++ b/mysql-test/suite/perfschema/t/esms_by_all.test
@@ -48,7 +48,7 @@ update t1 set c=c+500;
 delete from t1 where c=905;
 delete from t1 where c=903;
 
-select schema_name, digest, user, client_id, plan_id, count_star, sum_rows_deleted, sum_rows_inserted, sum_rows_updated from performance_schema.events_statements_summary_by_all;
+select schema_name, digest, user, client_id, plan_id, count_star, sum_rows_deleted, sum_rows_inserted from performance_schema.events_statements_summary_by_all;
 select schema_name, digest, count_star, sum_rows_deleted, sum_rows_inserted, sum_rows_updated from performance_schema.events_statements_summary_by_digest;
 
 ####################################################
@@ -97,7 +97,7 @@ DROP TABLE test.t11 ||||
 
 # reset delimiter
 delimiter ;||||
-select schema_name, query_sample_text, digest, user, client_id, plan_id, count_star, sum_rows_deleted, sum_rows_inserted, sum_rows_updated from performance_schema.events_statements_summary_by_all order by digest;
+select schema_name, query_sample_text, digest, user, client_id, plan_id, count_star, sum_rows_deleted, sum_rows_inserted from performance_schema.events_statements_summary_by_all order by digest;
 select schema_name, digest, count_star, sum_rows_deleted, sum_rows_inserted, sum_rows_updated from performance_schema.events_statements_summary_by_digest;
 
 --echo Verify index working properly

--- a/mysql-test/suite/perfschema/t/perf_schema_periodic_snapshot_debug.test
+++ b/mysql-test/suite/perfschema/t/perf_schema_periodic_snapshot_debug.test
@@ -31,7 +31,7 @@ insert into t71 values(4);
 set @@global.debug = '-d,skip_end_statement';
 select * from t71;
 
-select schema_name, digest, user, SUBSTRING(query_sample_text, 1, 10), count_star, sum_rows_inserted, sum_rows_examined, sum_rows_updated, sum_rows_sent from performance_schema.events_statements_summary_by_all order by query_sample_text asc;
+select schema_name, digest, user, SUBSTRING(query_sample_text, 1, 10), count_star, sum_rows_inserted, sum_rows_examined, sum_rows_sent from performance_schema.events_statements_summary_by_all order by query_sample_text asc;
 select query_sample_text, schema_name from performance_schema.events_statements_summary_by_all where sum_cpu_time > 2000000000000 and sum_elapsed_time > 2000000000000 and query_sample_text LIKE '%create table%' order by query_sample_text;
 
 drop table t71;
@@ -73,7 +73,7 @@ set @@global.debug = '-d,add_busy_loop_2sec';
 
 set @@global.debug = '-d,skip_end_statement';
 
-select schema_name, digest, user, query_sample_text, count_star, sum_rows_inserted, sum_rows_examined, sum_rows_updated, sum_rows_sent from performance_schema.events_statements_summary_by_all order by query_sample_text asc;
+select schema_name, digest, user, query_sample_text, count_star, sum_rows_inserted, sum_rows_examined, sum_rows_sent from performance_schema.events_statements_summary_by_all order by query_sample_text asc;
 select query_sample_text, schema_name from performance_schema.events_statements_summary_by_all where sum_cpu_time > 2000000000000 and sum_elapsed_time > 2000000000000 order by query_sample_text;
 
 set @@SESSION.min_examined_row_limit_sql_stats=DEFAULT;

--- a/mysql-test/suite/perfschema/t/statements_row_updated.test
+++ b/mysql-test/suite/perfschema/t/statements_row_updated.test
@@ -1,3 +1,5 @@
+--let $default_ddse = `SELECT @@default_dd_storage_engine`
+
 #
 --echo Variation 0: No-op Select
 #
@@ -12,7 +14,12 @@
 #
 
 --let $sql = CREATE TABLE t1 (a INT) ENGINE=InnoDB;
---let $expected_sum_rows_updated = 6
+if ($default_ddse == "InnoDB") {
+  --let $expected_sum_rows_updated = 6
+}
+if ($default_ddse == "RocksDB") {
+  --let $expected_sum_rows_updated = 10
+}
 --source ../include/statements_row_updated.inc
 
 
@@ -57,7 +64,12 @@
 #
 
 --let $sql = INSERT INTO t1 VALUES (1), (2), (3); CREATE TABLE t2 (a INT); INSERT INTO t2 VALUES (1), (2), (3);
---let $expected_sum_rows_updated = 6
+if ($default_ddse == "InnoDB") {
+  --let $expected_sum_rows_updated = 6
+}
+if ($default_ddse == "RocksDB") {
+  --let $expected_sum_rows_updated = 10
+}
 --source ../include/statements_row_updated.inc
 
 


### PR DESCRIPTION
The perfschema tests concern performance_schema sum_rows_updated columns in various tables. InnoDB detects when a row update does not actually need to update anything and returns HA_ERR_RECORD_IS_THE_SAME, and MyRocks does not, resulting in sum_rows_updated differences on DDL with different DDSE setting. Adjust esms_by_all and perfschema_periodic_snapshot_debug not to query sum_rows_updated at all, as neither replace_value nor replace_regex could handle different values well enough. For statements_row_updated, accept either value depending on what is the DDSE.

Skip innodb.innodb and innodb.innodb_misc1 because both test construct CREATE TABLE ... SELECT ... FROM a locked table, executed twice in parallel, returning different locked table errors.