### PR TITLE
multiple fix for ddse change

### DIFF
--- a/sql/dd/dd_table.cc
+++ b/sql/dd/dd_table.cc
@@ -2324,7 +2324,7 @@ static std::unique_ptr<dd::Table> create_dd_system_table(
       System_tables::instance()->find_type(system_schema.name(), table_name);
   if (opt_initialize ||
       (table_type != nullptr && *table_type == System_tables::Types::INERT) ||
-      dd::bootstrap::DD_bootstrap_ctx::instance().is_dd_engine_change()) {
+      bootstrap::DD_bootstrap_ctx::instance().is_dd_engine_change()) {
     if (file->ha_get_se_private_data(
             tab_obj.get(), (table_type != nullptr &&
                             *table_type == System_tables::Types::INERT)))
@@ -2392,12 +2392,12 @@ std::unique_ptr<dd::Table> create_table(
   const dd::Object_table *dd_table =
       dict->get_dd_table(sch_obj.name(), table_name);
 
-  // During DDSE change, when create a myrocks table
-  // treat <upgrade>.<table> as dd table if mysql.<table> is a dd table
-  if (dd_table == nullptr && sch_obj.name() != MYSQL_SCHEMA_NAME.str &&
-      thd->is_dd_system_thread() &&
+  // During DDSE change, when creating a MyRocks table
+  // treat <upgrade>.<table> as a DD table if mysql.<table> is a DD table
+  if (dd_table == nullptr && thd->is_dd_system_thread() &&
       dd::bootstrap::DD_bootstrap_ctx::instance().is_dd_engine_change() &&
       create_info->db_type->db_type == DB_TYPE_ROCKSDB &&
+      sch_obj.name() != MYSQL_SCHEMA_NAME.str &&
       dd::get_dictionary()->is_dd_table_name(MYSQL_SCHEMA_NAME.str,
                                              table_name)) {
     dd_table = dict->get_dd_table(MYSQL_SCHEMA_NAME.str, table_name);

--- a/sql/dd/impl/upgrade/dd.cc
+++ b/sql/dd/impl/upgrade/dd.cc
@@ -1138,10 +1138,10 @@ bool upgrade_dd_properties_table(THD *thd, Object_id mysql_schema_id,
   }
 
   // update myrocks own data dictionary
-  // for myrocks, previous changes involve <target_table> tbl_def,
+  // for MyRocks, previous changes involve <target_table> tbl_def and
   // update_myrocks_table_names will delete <target_table> tbl_def
-  // if commit changes after update_myrocks_table_names, will cause
-  // use-after-free issue
+  // If the changes are committed after update_myrocks_table_names, it will
+  // cause a use-after-free issue
   if (default_dd_storage_engine == DEFAULT_DD_ROCKSDB &&
       !dd::end_transaction(thd, false) &&
       update_myrocks_table_names(thd, target_table_schema_name,

--- a/sql/dd/impl/upgrade/dd.cc
+++ b/sql/dd/impl/upgrade/dd.cc
@@ -1138,7 +1138,12 @@ bool upgrade_dd_properties_table(THD *thd, Object_id mysql_schema_id,
   }
 
   // update myrocks own data dictionary
+  // for myrocks, previous changes involve <target_table> tbl_def,
+  // update_myrocks_table_names will delete <target_table> tbl_def
+  // if commit changes after update_myrocks_table_names, will cause
+  // use-after-free issue
   if (default_dd_storage_engine == DEFAULT_DD_ROCKSDB &&
+      !dd::end_transaction(thd, false) &&
       update_myrocks_table_names(thd, target_table_schema_name,
                                  MYSQL_SCHEMA_NAME.str,
                                  {dd_property_table_name})) {
@@ -1254,6 +1259,7 @@ bool upgrade_tables(THD *thd) {
   // update myrocks own data dictionary
   if (bootstrap::DD_bootstrap_ctx::instance().is_dd_engine_change() &&
       (default_dd_storage_engine == DEFAULT_DD_ROCKSDB) &&
+      !dd::end_transaction(thd, false) &&
       update_myrocks_table_names(thd, target_table_schema_name,
                                  MYSQL_SCHEMA_NAME.str, create_set)) {
     LogErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -15296,11 +15296,13 @@ be dropped
 @return	error number
 @retval 0 on success */
 int ha_innobase::delete_table(const char *name, const dd::Table *table_def) {
-  // during ddse change, s_dd_table_ids may contain old dd table ids, thus
-  // allow drop/rename if current se isn't target ddse
+  // during DDSE change, s_dd_table_ids may contain old dd table ids, thus
+  // allow drop/rename if current SE isn't target DDSE and current thread is
+  // dd bootstrap system thread
   if (table_def != nullptr &&
       dict_sys_t::is_dd_table_id(table_def->se_private_id()) &&
-      (default_dd_storage_engine == DEFAULT_DD_INNODB)) {
+      !(ha_thd()->is_dd_system_thread() &&
+        default_dd_storage_engine != DEFAULT_DD_INNODB)) {
     my_error(ER_NOT_ALLOWED_COMMAND, MYF(0));
     return (HA_ERR_UNSUPPORTED);
   }

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -15296,8 +15296,11 @@ be dropped
 @return	error number
 @retval 0 on success */
 int ha_innobase::delete_table(const char *name, const dd::Table *table_def) {
+  // during ddse change, s_dd_table_ids may contain old dd table ids, thus
+  // allow drop/rename if current se isn't target ddse
   if (table_def != nullptr &&
-      dict_sys_t::is_dd_table_id(table_def->se_private_id())) {
+      dict_sys_t::is_dd_table_id(table_def->se_private_id()) &&
+      (default_dd_storage_engine == DEFAULT_DD_INNODB)) {
     my_error(ER_NOT_ALLOWED_COMMAND, MYF(0));
     return (HA_ERR_UNSUPPORTED);
   }

--- a/storage/rocksdb/rdb_native_dd.cc
+++ b/storage/rocksdb/rdb_native_dd.cc
@@ -34,7 +34,10 @@ bool native_dd::is_dd_table_id(dd::Object_id id) {
 }
 
 int native_dd::reject_if_dd_table(const dd::Table *table_def) {
-  if (table_def != nullptr && is_dd_table_id(table_def->se_private_id())) {
+  // during ddse change, s_dd_table_ids may contain old dd table ids, thus
+  // allow drop/rename if current se isn't target ddse
+  if (table_def != nullptr && is_dd_table_id(table_def->se_private_id()) &&
+      (default_dd_storage_engine == DEFAULT_DD_ROCKSDB)) {
     my_error(ER_NOT_ALLOWED_COMMAND, MYF(0));
     return HA_ERR_UNSUPPORTED;
   }

--- a/storage/rocksdb/rdb_native_dd.cc
+++ b/storage/rocksdb/rdb_native_dd.cc
@@ -33,11 +33,14 @@ bool native_dd::is_dd_table_id(dd::Object_id id) {
           native_dd::s_dd_table_ids.end());
 }
 
-int native_dd::reject_if_dd_table(const dd::Table *table_def) {
-  // during ddse change, s_dd_table_ids may contain old dd table ids, thus
-  // allow drop/rename if current se isn't target ddse
+int native_dd::reject_if_dd_table(const dd::Table *table_def,
+                                  bool is_dd_system_thread) {
+  // during DDSE change, s_dd_table_ids may contain old dd table ids, thus
+  // allow drop/rename if current SE isn't target DDSE and current thread is
+  // dd bootstrap system thread
   if (table_def != nullptr && is_dd_table_id(table_def->se_private_id()) &&
-      (default_dd_storage_engine == DEFAULT_DD_ROCKSDB)) {
+      !(is_dd_system_thread &&
+        default_dd_storage_engine != DEFAULT_DD_ROCKSDB)) {
     my_error(ER_NOT_ALLOWED_COMMAND, MYF(0));
     return HA_ERR_UNSUPPORTED;
   }

--- a/storage/rocksdb/rdb_native_dd.h
+++ b/storage/rocksdb/rdb_native_dd.h
@@ -53,7 +53,8 @@ class native_dd {
 
   static void clear_dd_table_ids();
 
-  static int reject_if_dd_table(const dd::Table *table_def);
+  static int reject_if_dd_table(const dd::Table *table_def,
+                                bool is_dd_system_thread);
 };
 
 }  // namespace myrocks


### PR DESCRIPTION
Summary:

During DDSE change, for each DD table, it should always call ha_get_se_private_data() to fetch its table id and index ids. INNODB DD Tables and MyRocks DD tables has different table ids and index ids.

also During DDSE change, these DD table are temporarily created in <upgrade> schema and then rename it to "mysql".  Due to rename call in myrocks is a meta-data only change and DD table should always created in __system CF, We will always treat <upgrade> table as dd table if the corresponding mysql table is a DD table.

also During DDSE change, the old dd table should be dropped, thus we allow dd table to be dropped if current SE isn't DDSE.

During DDSE change, commit changes before rename tables to avoid use-after-free issue. This may need more crash recovery testing. 

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: