### PR TITLE
Avoid memory leak during Rdb_ddl_manager::reset_map

### DIFF
--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -5078,6 +5078,9 @@ bool Rdb_ddl_manager::rename(const std::string &from, const std::string &to,
 }
 
 void Rdb_ddl_manager::reset_map() {
+  for (const auto &kv : m_ddl_map) {
+    delete kv.second;
+  }
   m_ddl_map.clear();
   populate(0);
 }


### PR DESCRIPTION
Summary:
These tbl_def pointers in m_ddl_map must be released before clear() during reset_map

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: