### PR TITLE
Update and skip MTR tests for MyRocks DDSE, part 4

### DIFF
--- a/mysql-test/extra/rpl_tests/rpl_mts_spco_commands.test
+++ b/mysql-test/extra/rpl_tests/rpl_mts_spco_commands.test
@@ -207,7 +207,13 @@ SET @@global.binlog_transaction_dependency_tracking = COMMIT_ORDER;
 --echo # $tc_count. CREATE TABLE and CREATE TABLE IF NOT EXISTS
 --echo ####################################################################
 
---let $mts_num_preceding_trans= 6
+--let $DEFAULT_DDSE = `SELECT @@default_dd_storage_engine`
+if ($DEFAULT_DDSE == "RocksDB") {
+  --let $mts_num_preceding_trans= 5
+}
+if ($DEFAULT_DDSE == "InnoDB") {
+  --let $mts_num_preceding_trans= 6
+}
 
 --let $mts_spco_skip_init_statement= 1
 --let $mts_spco_start_statement = CREATE TABLE t1 (c1 INT PRIMARY KEY) ENGINE = InnoDB; CREATE TABLE t2 (c1 INT PRIMARY KEY) ENGINE = InnoDB

--- a/mysql-test/r/initialize.result
+++ b/mysql-test/r/initialize.result
@@ -127,10 +127,10 @@ a
 # Run the server with --initialize-insecure and 4K pages.
 # Look for error messages from my_message_stderr (there should be none)
 # Restart the server against the 4k DDIR to make sure it can be started
-SELECT * FROM information_schema.schemata;
+SELECT * FROM information_schema.schemata ORDER BY SCHEMA_NAME;
 CATALOG_NAME	SCHEMA_NAME	DEFAULT_CHARACTER_SET_NAME	DEFAULT_COLLATION_NAME	SQL_PATH	DEFAULT_ENCRYPTION
-def	mysql	utf8mb4	utf8mb4_0900_ai_ci	NULL	NO
 def	information_schema	utf8	utf8_general_ci	NULL	NO
+def	mysql	utf8mb4	utf8mb4_0900_ai_ci	NULL	NO
 def	performance_schema	utf8mb4	utf8mb4_0900_ai_ci	NULL	NO
 def	sys	utf8mb4	utf8mb4_0900_ai_ci	NULL	NO
 def	test	utf8mb4	utf8mb4_0900_ai_ci	NULL	NO

--- a/mysql-test/suite/innodb/r/innodb_read_only-1.result
+++ b/mysql-test/suite/innodb/r/innodb_read_only-1.result
@@ -55,7 +55,7 @@ i	LEFT(j,20)
 2	bbbbbbbbbbbbbbbbbbbb
 3	cccccccccccccccccccc
 CREATE TABLE t2 ( i int ,j blob) ENGINE = Innodb;
-ERROR HY000: Running in read-only mode
+Got one of the listed errors
 UPDATE t1 SET i = i+1;
 ERROR HY000: Can't lock file (errno: 165 - Table is read only)
 # disconnect con_test1_user
@@ -72,7 +72,7 @@ i	LEFT(j,20)
 2	bbbbbbbbbbbbbbbbbbbb
 3	cccccccccccccccccccc
 CREATE TABLE t2 ( i int , j blob) ENGINE = Innodb;
-ERROR HY000: Running in read-only mode
+Got one of the listed errors
 UPDATE t1 SET i = i+1;
 ERROR HY000: Can't lock file (errno: 165 - Table is read only)
 FLUSH STATUS;
@@ -91,7 +91,7 @@ i	LEFT(j,20)
 2	bbbbbbbbbbbbbbbbbbbb
 3	cccccccccccccccccccc
 CREATE TABLE t2 ( i int , j blob) ENGINE = Innodb;
-ERROR HY000: Running in read-only mode
+Got one of the listed errors
 UPDATE t1 SET i = i+1;
 ERROR HY000: Can't lock file (errno: 165 - Table is read only)
 INSERT INTO otherlocation VALUES (1),(2),(3);
@@ -143,7 +143,7 @@ i	LEFT(j,20)
 40	a40a40a40a40a40a40a4
 50	a50a50a50a50a50a50a5
 CREATE TABLE t2 ( i int , j blob) ENGINE = Innodb;
-ERROR HY000: Running in read-only mode
+Got one of the listed errors
 UPDATE t1 SET i = i+1;
 ERROR HY000: Can't lock file (errno: 165 - Table is read only)
 SELECT i,LEFT(j,20) FROM t1  WHERE i%10=0  ORDER BY i;
@@ -1277,7 +1277,7 @@ ERROR HY000: Can't lock file (errno: 165 - Table is read only)
 DELETE FROM t1;
 ERROR HY000: Can't lock file (errno: 165 - Table is read only)
 CREATE TABLE t2 ( i INT ) ENGINE = Innodb;
-ERROR HY000: Running in read-only mode
+Got one of the listed errors
 CREATE USER 'test5'@'localhost' IDENTIFIED BY '123';
 ERROR HY000: The ACL operation failed due to the following error from SE: errcode 165 - Table is read only
 # restart: --read-only

--- a/mysql-test/suite/innodb/t/innodb_bug12400341.test
+++ b/mysql-test/suite/innodb/t/innodb_bug12400341.test
@@ -9,6 +9,13 @@
 
 --disable_query_log
 call mtr.add_suppression("\\[ERROR\\] .*MY-\\d+.* Cannot find a free slot for an undo log");
+--let $DEFAULT_DDSE = `SELECT @@default_dd_storage_engine`
+if ($DEFAULT_DDSE == "RocksDB") {
+   # The InnoDB transactions will encounter lack of undo slots at different
+   # points if it's DDSE and if it's not. When it's not, it will happen when
+   # trying to write to the DDL log.
+   call mtr.add_suppression("Couldn't insert entry in ddl log for ddl.");
+}
 
 set @old_innodb_trx_rseg_n_slots_debug = @@innodb_trx_rseg_n_slots_debug;
 set global innodb_trx_rseg_n_slots_debug = 5;

--- a/mysql-test/suite/innodb/t/innodb_read_only-1.test
+++ b/mysql-test/suite/innodb/t/innodb_read_only-1.test
@@ -80,7 +80,7 @@ USE testdb_wl6445;
 --ERROR ER_CANT_LOCK
 INSERT INTO t1 VALUES (11,repeat('a',200)),(12,repeat('b',200)),(13,repeat('c',200));
 SELECT i,LEFT(j,20) FROM t1 ORDER BY i;
---ERROR ER_READ_ONLY_MODE
+--ERROR ER_READ_ONLY_MODE, ER_INNODB_READ_ONLY
 CREATE TABLE t2 ( i int ,j blob) ENGINE = Innodb;
 --ERROR ER_CANT_LOCK
 UPDATE t1 SET i = i+1;
@@ -96,7 +96,7 @@ USE testdb_wl6445;
 --ERROR ER_CANT_LOCK
 INSERT INTO t1 VALUES (11,repeat('a',200)),(12,repeat('b',200)),(13,repeat('c',200));
 SELECT i,LEFT(j,20) FROM t1 ORDER BY i;
---ERROR ER_READ_ONLY_MODE
+--ERROR ER_READ_ONLY_MODE, ER_INNODB_READ_ONLY
 CREATE TABLE t2 ( i int , j blob) ENGINE = Innodb;
 --ERROR ER_CANT_LOCK
 UPDATE t1 SET i = i+1;
@@ -119,7 +119,7 @@ USE testdb_wl6445;
 --ERROR ER_CANT_LOCK
 INSERT INTO t1 VALUES (11,repeat('a',200)),(12,repeat('b',200)),(13,repeat('c',200));
 SELECT i,LEFT(j,20) FROM t1 ORDER BY i;
---ERROR ER_READ_ONLY_MODE
+--ERROR ER_READ_ONLY_MODE, ER_INNODB_READ_ONLY
 CREATE TABLE t2 ( i int , j blob) ENGINE = Innodb;
 --ERROR ER_CANT_LOCK
 UPDATE t1 SET i = i+1;
@@ -198,7 +198,7 @@ USE testdb_wl6445;
 --ERROR ER_CANT_LOCK
 INSERT INTO t1 VALUES (211,repeat('a',200)),(212,repeat('b',200)),(213,repeat('c',200));
 SELECT i,LEFT(j,20) FROM t1 WHERE i%10=0 ORDER BY i;
---ERROR ER_READ_ONLY_MODE
+--ERROR ER_READ_ONLY_MODE, ER_INNODB_READ_ONLY
 CREATE TABLE t2 ( i int , j blob) ENGINE = Innodb;
 --ERROR ER_CANT_LOCK
 UPDATE t1 SET i = i+1;
@@ -533,7 +533,7 @@ INSERT INTO t1 VALUES (11,repeat('a',200)),(12,repeat('b',200)),(13,repeat('c',2
 UPDATE t1 SET i = i + 20;
 --ERROR ER_CANT_LOCK
 DELETE FROM t1;
---ERROR ER_READ_ONLY_MODE
+--ERROR ER_READ_ONLY_MODE, ER_INNODB_READ_ONLY
 CREATE TABLE t2 ( i INT ) ENGINE = Innodb;
 
 # User-manipulation statements are disallowed since ACL tables use InnoDB.

--- a/mysql-test/suite/perfschema/t/init_pfs_from_dd.test
+++ b/mysql-test/suite/perfschema/t/init_pfs_from_dd.test
@@ -1,3 +1,6 @@
+# --innodb-read-only does not prevent server startup on P_S version change if
+# the DDSE is not InnoDB
+--source include/have_innodb_ddse.inc
 --echo #
 --echo # WL7900 -- New DD: Support flexible creation and versioning of
 --echo #           virtual P_S tables

--- a/mysql-test/suite/rpl/t/rpl_gtid_innodb_sys_header.test
+++ b/mysql-test/suite/rpl/t/rpl_gtid_innodb_sys_header.test
@@ -20,7 +20,7 @@ create table t1 (a int);
 insert into t1 values(1);
 --eval SET GLOBAL debug = '+d,crash_before_writing_xid'
 --let LOG=$MYSQLTEST_VARDIR/tmp/rpl_gtid_innodb_sys_header.err
---exec echo "restart:--log-error=$LOG --rocksdb=0" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--exec echo "restart:--log-error=$LOG --loose-rocksdb=0" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 --error 2013
 insert into t1 values(2);
 --source include/wait_until_disconnected.inc

--- a/mysql-test/suite/rpl/t/rpl_innodb_bug68220.test
+++ b/mysql-test/suite/rpl/t/rpl_innodb_bug68220.test
@@ -1,3 +1,5 @@
+# If InnoDB is not the DDSE, the system row counters will not be bumped.
+--source include/have_innodb_ddse.inc
 --source include/master-slave.inc
 
 #

--- a/mysql-test/suite/rpl_gtid/t/rpl_check_gtid-master.opt
+++ b/mysql-test/suite/rpl_gtid/t/rpl_check_gtid-master.opt
@@ -1,1 +1,1 @@
---skip-rocksdb
+--loose-skip-rocksdb

--- a/mysql-test/suite/rpl_gtid/t/rpl_check_gtid-slave.opt
+++ b/mysql-test/suite/rpl_gtid/t/rpl_check_gtid-slave.opt
@@ -1,2 +1,2 @@
 --skip-binlog-gtid-simple-recovery
---skip-rocksdb
+--loose-skip-rocksdb

--- a/mysql-test/suite/rpl_gtid/t/rpl_gtid_create_select-slave.opt
+++ b/mysql-test/suite/rpl_gtid/t/rpl_gtid_create_select-slave.opt
@@ -1,1 +1,1 @@
---skip-rocksdb
+--loose-skip-rocksdb

--- a/mysql-test/suite/rpl_gtid/t/rpl_gtid_create_select.test
+++ b/mysql-test/suite/rpl_gtid/t/rpl_gtid_create_select.test
@@ -1,1 +1,5 @@
+# The test results in different replica positions in different storage engines,
+# making it incompatible with idempotent RBR recovery patch.
+--source include/have_innodb_ddse.inc
+
 --source extra/rpl_tests/rpl_create_select.inc

--- a/mysql-test/suite/rpl_gtid/t/rpl_gtid_mts_recovery_with_missing_relay_log-slave.opt
+++ b/mysql-test/suite/rpl_gtid/t/rpl_gtid_mts_recovery_with_missing_relay_log-slave.opt
@@ -1,1 +1,1 @@
---skip-rocksdb
+--loose-skip-rocksdb

--- a/mysql-test/suite/rpl_gtid/t/rpl_gtid_mts_recovery_with_missing_relay_log.test
+++ b/mysql-test/suite/rpl_gtid/t/rpl_gtid_mts_recovery_with_missing_relay_log.test
@@ -1,3 +1,6 @@
+# The test results in different replica positions in different storage engines,
+# making it incompatible with idempotent RBR recovery patch.
+--source include/have_innodb_ddse.inc
 # === Purpose ===
 #
 # This test verifies that MTS crash recovery succeeds with GTID Auto Position=ON

--- a/mysql-test/suite/rpl_recovery/t/rpl_gtid_crash_safe_idempotent-master.opt
+++ b/mysql-test/suite/rpl_recovery/t/rpl_gtid_crash_safe_idempotent-master.opt
@@ -1,2 +1,2 @@
 --gtid-mode=ON --enforce-gtid-consistency
---skip-rocksdb
+--loose-skip-rocksdb

--- a/mysql-test/suite/rpl_recovery/t/rpl_gtid_crash_safe_idempotent-slave.opt
+++ b/mysql-test/suite/rpl_recovery/t/rpl_gtid_crash_safe_idempotent-slave.opt
@@ -1,4 +1,4 @@
 --gtid-mode=ON --enforce-gtid-consistency
 --sync-binlog=1000 --relay-log-recovery=1
 --slave-use-idempotent-for-recovery=YES
---skip-rocksdb
+--loose-skip-rocksdb

--- a/mysql-test/suite/rpl_recovery/t/rpl_gtid_crash_safe_idempotent.test
+++ b/mysql-test/suite/rpl_recovery/t/rpl_gtid_crash_safe_idempotent.test
@@ -1,3 +1,6 @@
+# The test results in different replica positions in different storage engines,
+# making it incompatible with idempotent RBR recovery patch.
+--source include/have_innodb_ddse.inc
 --source include/have_debug.inc
 --source include/not_valgrind.inc
 --source include/have_binlog_format_row.inc

--- a/mysql-test/suite/rpl_recovery/t/rpl_gtid_mts_holes-slave.opt
+++ b/mysql-test/suite/rpl_recovery/t/rpl_gtid_mts_holes-slave.opt
@@ -1,3 +1,3 @@
 --gtid-mode=ON --enforce-gtid-consistency
 --slave-parallel-workers=10 --relay-log-recovery=1
---skip-rocksdb
+--loose-skip-rocksdb

--- a/mysql-test/suite/rpl_recovery/t/rpl_gtid_mts_holes.test
+++ b/mysql-test/suite/rpl_recovery/t/rpl_gtid_mts_holes.test
@@ -1,3 +1,6 @@
+# The test results in different replica positions in different storage engines,
+# making it incompatible with idempotent RBR recovery patch.
+--source include/have_innodb_ddse.inc
 --source include/not_valgrind.inc
 --source include/master-slave.inc
 

--- a/mysql-test/suite/rpl_recovery/t/rpl_gtid_mts_stress_crash-master.opt
+++ b/mysql-test/suite/rpl_recovery/t/rpl_gtid_mts_stress_crash-master.opt
@@ -1,3 +1,3 @@
 --gtid-mode=ON --enforce-gtid-consistency
 --binlog-rows-query-log-events=TRUE
---skip-rocksdb
+--loose-skip-rocksdb

--- a/mysql-test/suite/rpl_recovery/t/rpl_gtid_mts_stress_crash-slave.opt
+++ b/mysql-test/suite/rpl_recovery/t/rpl_gtid_mts_stress_crash-slave.opt
@@ -1,3 +1,3 @@
 --gtid-mode=ON --enforce-gtid-consistency --max-binlog-size=50000
 --slave-parallel-workers=30 --relay-log-recovery=1 --innodb-flush-log-at-trx-commit=0
---skip-rocksdb
+--loose-skip-rocksdb

--- a/mysql-test/suite/rpl_recovery/t/rpl_gtid_stress_crash-master.opt
+++ b/mysql-test/suite/rpl_recovery/t/rpl_gtid_stress_crash-master.opt
@@ -1,1 +1,1 @@
---gtid-mode=ON --enforce-gtid-consistency --skip-rocksdb
+--gtid-mode=ON --enforce-gtid-consistency --loose-skip-rocksdb

--- a/mysql-test/suite/rpl_recovery/t/rpl_gtid_stress_crash-slave.opt
+++ b/mysql-test/suite/rpl_recovery/t/rpl_gtid_stress_crash-slave.opt
@@ -1,3 +1,3 @@
 --gtid-mode=ON --enforce-gtid-consistency --max-binlog-size=50000
 --relay-log-recovery=1 --innodb_flush_log_at_trx_commit=0
---skip-rocksdb
+--loose-skip-rocksdb

--- a/mysql-test/suite/rpl_recovery/t/rpl_slave_recovery_with_schema_change-master.opt
+++ b/mysql-test/suite/rpl_recovery/t/rpl_slave_recovery_with_schema_change-master.opt
@@ -3,4 +3,4 @@
 --log_slave_updates
 --binlog_rows_query_log_events=ON
 --log_column_names
---skip-rocksdb
+--loose-skip-rocksdb

--- a/mysql-test/suite/rpl_recovery/t/rpl_slave_recovery_with_schema_change-slave.opt
+++ b/mysql-test/suite/rpl_recovery/t/rpl_slave_recovery_with_schema_change-slave.opt
@@ -7,4 +7,4 @@
 --slave_parallel_workers=10
 --slave_type_conversions=ALL_NON_LOSSY
 --log_column_names
---skip-rocksdb
+--loose-skip-rocksdb

--- a/mysql-test/suite/sys_vars/t/all_vars-master.opt
+++ b/mysql-test/suite/sys_vars/t/all_vars-master.opt
@@ -1,2 +1,2 @@
 $SEMISYNC_PLUGIN_OPT --loose-skip-ndbinfo
---skip-rocksdb
+--loose-skip-rocksdb

--- a/mysql-test/suite/sys_vars/t/all_vars.test
+++ b/mysql-test/suite/sys_vars/t/all_vars.test
@@ -1,3 +1,5 @@
+# We want to skip the MyRocks sysvars, which is impossible when it's the DDSE
+--source include/have_innodb_ddse.inc
 --source include/not_threadpool.inc
 
 # 2010-01-28 OBN Added support to load 'innodb' and 'semisync' if possible.

--- a/mysql-test/t/all_persisted_variables-master.opt
+++ b/mysql-test/t/all_persisted_variables-master.opt
@@ -1,2 +1,2 @@
 --mysqlx=ON
---skip-rocksdb
+--loose-skip-rocksdb

--- a/mysql-test/t/all_persisted_variables.test
+++ b/mysql-test/t/all_persisted_variables.test
@@ -1,3 +1,5 @@
+# We want to skip the MyRocks sysvars, which is impossible when it's the DDSE
+--source include/have_innodb_ddse.inc
 ################################################################################
 #
 # Creation Date: 19-Feb-2018

--- a/mysql-test/t/dd_bootstrap_debug.test
+++ b/mysql-test/t/dd_bootstrap_debug.test
@@ -13,6 +13,7 @@ let DDIR=       $MYSQL_TMP_DIR/dd_bootstrap_test;
 let extra_args= --no-defaults --innodb_dedicated_server=OFF --secure-file-priv="" --loose-skip-auto_generate_certs --loose-skip-sha256_password_auto_generate_rsa_keys --skip-ssl --basedir=$BASEDIR --lc-messages-dir=$MYSQL_SHAREDIR;
 let BOOTSTRAP_SQL= $MYSQL_TMP_DIR/tiny_bootstrap.sql;
 let PASSWD_FILE=   $MYSQL_TMP_DIR/password_file.txt;
+let DEFAULT_DDSE= `SELECT @@default_dd_storage_engine`;
 
 --echo # Preparation: Shut server down.
 --exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
@@ -131,6 +132,11 @@ remove_file $BOOTSTRAP_SQL;
 --echo # 3.5 Delete log file.
 remove_file $MYSQLD_LOG;
 
+# With MyRocks DDSE, ALTER TABLE on DD tables that involve temporary tables are
+# not currently supported with skip_dd_table_access_check enabled. The reason is
+# that MyRocks handlerton does not support HTON_SUPPORTS_ATOMIC_DDL, thus does
+# intermediate commits, observing inconsistent data dictionary.
+if ($DEFAULT_DDSE == "InnoDB") {
 --echo #
 --echo # 4. Try restart after altering the schemata table.
 --echo # -------------------------------------------------
@@ -180,6 +186,8 @@ remove_file $BOOTSTRAP_SQL;
 
 --echo # 4.9 Delete log file.
 remove_file $MYSQLD_LOG;
+
+} # if ($DEFAULT_DDSE == "InnoDB")
 
 --echo #
 --echo # 5. Try to access a DD table in an init-file during --initialize.

--- a/mysql-test/t/initialize.test
+++ b/mysql-test/t/initialize.test
@@ -297,7 +297,7 @@ EOF
 --enable_reconnect
 --source include/wait_until_connected_again.inc
 
-SELECT * FROM information_schema.schemata;
+SELECT * FROM information_schema.schemata ORDER BY SCHEMA_NAME;
 
 --echo # Shut server down
 --exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect


### PR DESCRIPTION
- Stabilize main.initialize across DDSEs by adding ORDER BY to a SELECT * FROM information_schema.schemata.
- Make main.dd_bootstrap_debug run under both DDSE settings by checking the DDSE and disabling the MyRocks-incompatible bit.
- Make innodb.innodb_read_only-1 to run with either DDSE by accepting both possible errors (DD level and SE level) when a write is attempted to InnoDB in read-only mode.
- innodb.innodb_bug12400341: suppress one more warning from InnoDB due to undo slot exhaustion because that happens at different points when InnoDB is the DDSE and when it's not.
- perfschema.init_pfs_from_dd is skipped because --innodb-read-only does not prevent server startup on P_S version change.
- Adapt extra/rpl_tests/rpl_mts_spco_commands.test to work with either DDSE.
- rpl.rpl_innodb_bug68220 is skipped because the InnoDB system row counters are not updated when InnoDB is not the DDSE.
- rpl_recovery.rpl_gtid_crash_safe_idempotent, rpl_gtid.rpl_gtid_create_select, rpl_gtid.rpl_gtid_mts_recovery_with_missing_relay_log, & rpl_recovery.rpl_gtid_mts_holes are skipped due to incompatibility between multiple transactional SEs (which happens when MyRocks is DDSE but the rest of instance isn't) and idempotent RBR recovery.
- rpl.rpl_gtid_innodb_sys_header, rpl_gtid.rpl_check_gtid, rpl_recovery.rpl_gtid_mts_stress_crash, and rpl_recovery.rpl_gtid_stress_crash: "loose-" prefix is added to the test option files and to the in-test server restarts so that they work with a statically-compiled MyRocks SE.
- Add loose- to --skip-rocksdb to rpl_recovery.rpl_slave_recovery_with_schema_change option files even though that test is a pre-existing failure.
- sys_vars.all_vars & main.all_persisted_variables are skipped with MyRocks DDSE because they need to ignore the MyRocks sysvars, which is impossible in the case of statically compiled-in MyRocks.