### PR TITLE
Fix memory leak in i_s_innodb_tablespaces_fill_table

### DIFF
--- a/storage/innobase/handler/i_s.cc
+++ b/storage/innobase/handler/i_s.cc
@@ -7108,14 +7108,13 @@ static int i_s_innodb_tablespaces_fill_table(THD *thd, TABLE_LIST *tables,
   heap = mem_heap_create(1000);
 
   if (dd_access_through_server()) {
-    return for_all_innodb_objects_in_dd<dd::Tablespace>(
+    int result = for_all_innodb_objects_in_dd<dd::Tablespace>(
         thd, [&heap, &tables](THD *thd, const dd::Tablespace &tablespace) {
           const auto &se_private_data = tablespace.se_private_data();
 
           space_id_t space;
           if (se_private_data.get(dd_space_key_strings[DD_SPACE_ID], &space)) {
             assert(false);
-            mem_heap_free(heap);
             return 1;
           }
 
@@ -7132,7 +7131,6 @@ static int i_s_innodb_tablespaces_fill_table(THD *thd, TABLE_LIST *tables,
           if (se_private_data.get(dd_space_key_strings[DD_SPACE_FLAGS],
                                   &flags)) {
             assert(false);
-            mem_heap_free(heap);
             return 1;
           }
 
@@ -7140,7 +7138,6 @@ static int i_s_innodb_tablespaces_fill_table(THD *thd, TABLE_LIST *tables,
           if (properties.exists("encryption") &&
               properties.get("encryption", &encryption)) {
             assert(false);
-            mem_heap_free(heap);
             return 1;
           }
 
@@ -7155,7 +7152,6 @@ static int i_s_innodb_tablespaces_fill_table(THD *thd, TABLE_LIST *tables,
           if (se_private_data.get(dd_space_key_strings[DD_SPACE_SERVER_VERSION],
                                   &server_version)) {
             assert(false);
-            mem_heap_free(heap);
             return 1;
           }
 
@@ -7163,7 +7159,6 @@ static int i_s_innodb_tablespaces_fill_table(THD *thd, TABLE_LIST *tables,
           if (se_private_data.get(dd_space_key_strings[DD_SPACE_VERSION],
                                   &space_version)) {
             assert(false);
-            mem_heap_free(heap);
             return 1;
           }
 
@@ -7172,7 +7167,6 @@ static int i_s_innodb_tablespaces_fill_table(THD *thd, TABLE_LIST *tables,
           if (se_private_data.get(dd_space_key_strings[DD_SPACE_STATE],
                                   &state)) {
             assert(false);
-            mem_heap_free(heap);
             return 1;
           }
 
@@ -7180,7 +7174,6 @@ static int i_s_innodb_tablespaces_fill_table(THD *thd, TABLE_LIST *tables,
           if (properties.exists(autoextend_size_str) &&
               properties.get(autoextend_size_str, &autoextend_size)) {
             assert(false);
-            mem_heap_free(heap);
             return 1;
           }
 
@@ -7192,6 +7185,8 @@ static int i_s_innodb_tablespaces_fill_table(THD *thd, TABLE_LIST *tables,
 
           return 0;
         });
+    mem_heap_free(heap);
+    return result;
   }
 
   assert(!dd_access_through_server());


### PR DESCRIPTION
Summary:

Looks like when space is 0, we forgot to release memory.

Following innodb code, after finish works, then call release heap memory at end


Test Plan: MTR under asan build

Reviewers:

Subscribers:

Tasks:

Tags: