### PR TITLE
Do not create mysql.password_history in MyRocks if MyRocks is the DDSE

### DIFF
--- a/scripts/mysql_system_tables.sql
+++ b/scripts/mysql_system_tables.sql
@@ -185,7 +185,7 @@ SET @cmd = "CREATE TABLE IF NOT EXISTS password_history
   User CHAR(80) BINARY DEFAULT '' NOT NULL,
   Password_timestamp TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   Password TEXT,";
-SET @str = IF(@ddse = 'ROCKSDB', CONCAT(@cmd, "PRIMARY KEY(Host, User, Password_timestamp))", " engine=ROCKSDB CHARACTER SET utf8 COLLATE utf8_bin comment='Password history for user accounts'"), CONCAT(@cmd, "PRIMARY KEY(Host, User, Password_timestamp DESC))", " engine=InnoDB STATS_PERSISTENT=0 CHARACTER SET utf8 COLLATE utf8_bin comment='Password history for user accounts' ROW_FORMAT=DYNAMIC TABLESPACE=mysql", " ENCRYPTION='", @is_mysql_encrypted, "'"));
+SET @str = CONCAT(@cmd, "PRIMARY KEY(Host, User, Password_timestamp DESC))", " engine=InnoDB STATS_PERSISTENT=0 CHARACTER SET utf8 COLLATE utf8_bin comment='Password history for user accounts' ROW_FORMAT=DYNAMIC TABLESPACE=mysql", " ENCRYPTION='", @is_mysql_encrypted, "'");
 PREPARE stmt FROM @str;
 EXECUTE stmt;
 DROP PREPARE stmt;


### PR DESCRIPTION
This table is a system table, not a DD table. Eventually we'll create it in MyRocks, but for now the mix-up between system and DD tables is confusing, and the source code counterpart allowing the creation of password_history in MyRocks was already reverted in https://github.com/facebook/mysql-5.6/pull/1333