### PR TITLE
Allow unsupported transaction isolation levels for DD operations

### DIFF
--- a/mysql-test/suite/rocksdb/r/ddse.result
+++ b/mysql-test/suite/rocksdb/r/ddse.result
@@ -3,3 +3,12 @@ include/assert.inc [a DD table must exist in MyRocks and be in the __system__ CF
 CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=ROCKSDB;
 include/assert.inc [Creating user table should not bump MAX_DD_INDEX_ID]
 DROP TABLE t1;
+#
+# Incompatible transaction isolation levels should not prevent DDL
+#
+SET SESSION TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+CREATE TABLE t1 (a INT PRIMARY KEY);
+DROP TABLE t1;
+SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+CREATE TABLE t1 (a INT PRIMARY KEY);
+DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/t/ddse.test
+++ b/mysql-test/suite/rocksdb/t/ddse.test
@@ -21,3 +21,16 @@ let $max_dd_index_id_1=query_get_value(SELECT * FROM INFORMATION_SCHEMA.ROCKSDB_
 --source include/assert.inc
 
 DROP TABLE t1;
+
+--echo #
+--echo # Incompatible transaction isolation levels should not prevent DDL
+--echo #
+SET SESSION TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+
+CREATE TABLE t1 (a INT PRIMARY KEY);
+DROP TABLE t1;
+
+SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
+CREATE TABLE t1 (a INT PRIMARY KEY);
+DROP TABLE t1;


### PR DESCRIPTION
If the current transaction isolation level is lower than READ COMMITTED, or higher than REPEATABLE READ, allow it silently if it's a DD operation. The rest of MyRocks code will work by silently clamping to the nearest supported level, and the clamped level is good enough for DD operations. InnoDB has similar code, even though it supports the other isolation levels.