### PR TITLE
Increase clone compatibility with MyRocks as DDSE

### DIFF
--- a/mysql-test/suite/clone/include/clone_connection_begin.inc
+++ b/mysql-test/suite/clone/include/clone_connection_begin.inc
@@ -77,6 +77,8 @@ if ($inst_monitor) {
   --let $page_size= `select @@innodb_page_size`
   --let $error_verbosity = `select @@log_error_verbosity`
 
+  --let $default_dd_se = `select @@default_dd_storage_engine`
+
   # mysqld_path to be passed to --ledir
   perl;
     my $dir = $ENV{'MYSQLTEST_VARDIR'};
@@ -101,7 +103,7 @@ if ($inst_monitor) {
   --source include/wait_until_disconnected.inc
 
   # 3. Run mysqld_safe script
-  --exec sh $MYSQLD_SAFE --defaults-file=$MYSQLTEST_VARDIR/my.cnf --server-id=$SERVER_ID --log-error=$MYSQLTEST_VARDIR/log/mysqld.$SERVER_ID.err --log-error-verbosity=$error_verbosity --basedir=$MYSQL_BASEDIR --ledir=$mysqld_path --mysqld=$mysqld_bin --datadir=$MYSQLD_DATADIR --socket=$MYSQL_SOCKET --mysqlx_socket=$MYSQLX_SOCKET --pid-file=$MYSQL_PIDFILE --port=$MYSQL_PORT --mysqlx_port=$MYSQLX_PORT --plugin_dir=$MYSQL_PLUGIN_DIR --timezone=SYSTEM --log-output=file --secure-file-priv="" --core-file --lc-messages-dir=$MYSQL_MESSAGESDIR --innodb-page-size=$page_size < /dev/null > /dev/null 2>&1 &
+  --exec sh $MYSQLD_SAFE --defaults-file=$MYSQLTEST_VARDIR/my.cnf --server-id=$SERVER_ID --log-error=$MYSQLTEST_VARDIR/log/mysqld.$SERVER_ID.err --log-error-verbosity=$error_verbosity --basedir=$MYSQL_BASEDIR --ledir=$mysqld_path --mysqld=$mysqld_bin --datadir=$MYSQLD_DATADIR --socket=$MYSQL_SOCKET --mysqlx_socket=$MYSQLX_SOCKET --pid-file=$MYSQL_PIDFILE --port=$MYSQL_PORT --mysqlx_port=$MYSQLX_PORT --plugin_dir=$MYSQL_PLUGIN_DIR --timezone=SYSTEM --log-output=file --secure-file-priv="" --core-file --lc-messages-dir=$MYSQL_MESSAGESDIR --innodb-page-size=$page_size --default_dd_storage_engine=$default_dd_se < /dev/null > /dev/null 2>&1 &
   --enable_reconnect
   --source include/wait_until_connected_again.inc
   --disable_reconnect

--- a/mysql-test/suite/clone/t/remote_dml_recovery.test
+++ b/mysql-test/suite/clone/t/remote_dml_recovery.test
@@ -1,5 +1,9 @@
 # Test recovery crash for remote clone with concurrent DML
 
+# Clone rollback is not supported across MyRocks and InnoDB when MyRocks is the
+# DDSE
+--source include/have_innodb_ddse.inc
+
 --source include/not_valgrind.inc
 --source include/have_mysqld_safe.inc
 --source include/have_debug.inc

--- a/storage/innobase/include/clone0api.h
+++ b/storage/innobase/include/clone0api.h
@@ -147,7 +147,7 @@ int clone_add_to_list_file(const char *list_file_name, const char *file_name);
 void clone_remove_list_file(const char *file_name);
 
 /** Revert back clone changes in case of an error. */
-void clone_files_error();
+void clone_files_error(bool after_restart = false);
 
 #ifdef UNIV_DEBUG
 /** Debug function to check and crash during recovery.


### PR DESCRIPTION
- Forbid clone rollbacks if InnoDB is not the DDSE, because cross-engine rollbacks are only supported if InnoDB is the first one to rollback, which is not the case when another engine is the DDSE.
- Disable clone.remote_dml_recovery under MyRocks DDSE because it relies on the cross-engine clone rollback.
- Make sure that the right default-dd-storage-engine is passed to mysqld_safe-managed instance in mysql-test/clone/include/clone_connection_begin.inc