### PR TITLE
Upgrade all system tables(exclude mysql.gtid_executed) from INNODB to MyRocks

### DIFF
--- a/mysql-test/include/dd_schema_definition_after_upgrade_debug.inc
+++ b/mysql-test/include/dd_schema_definition_after_upgrade_debug.inc
@@ -65,7 +65,7 @@ if (!$VERSION)
 --echo ########################################################################
 --let $actual_dd_props = $MYSQL_TMP_DIR/actual_dd_properties.txt
 --let $file = $actual_dd_props
---let $filter = id|root|MYSQLD_VERSION_LO
+--let $filter = id|root|MYSQLD_VERSION_LO|DD_ENGINE_UPGRADED
 --source include/dd_schema_dd_properties.inc
 --diff_files $target_dd_props $actual_dd_props
 

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -2754,6 +2754,10 @@ The following options may be given as the first argument:
  --skip-slave-start  This option is deprecated. Use skip_replica_start
  instead.
  --skip-stack-trace  Don't print a stack trace on failure.
+ --skip-sys-tables-engine-check 
+ skip System Tables Engine check. If On, System Tables can
+ use any storage engines; If Off, System Tables can only
+ use default_dd_system_storage_engine
  --slave-allow-batching 
  This option is deprecated. Use replica_allow_batching
  instead.
@@ -4007,6 +4011,7 @@ skip-networking FALSE
 skip-replica-start FALSE
 skip-show-database FALSE
 skip-slave-start FALSE
+skip-sys-tables-engine-check FALSE
 slave-allow-batching TRUE
 slave-check-before-image-consistency OFF
 slave-checkpoint-group 512

--- a/mysql-test/r/system_tables_myisam.result
+++ b/mysql-test/r/system_tables_myisam.result
@@ -6,6 +6,7 @@ CALL mtr.add_suppression("Column count of");
 CALL mtr.add_suppression("Incorrect definition of table");
 CALL mtr.add_suppression("Cannot load from");
 CALL mtr.add_suppression("Storage engine 'MyISAM' does not");
+SET GLOBAL skip_sys_tables_engine_check=true;
 #-----------------------------------------------------------------------
 # Test cases to verify system table's behavior with storage engines
 # InnoDB and MyISAM.
@@ -594,3 +595,4 @@ WHERE table_schema='mysql'
 TABLE_SCHEMA	TABLE_NAME	ENGINE
 mysql	event	MyISAM
 mysql	proc	MyISAM
+SET GLOBAL skip_sys_tables_engine_check=default;

--- a/mysql-test/r/system_tables_myisam_lctn_1.result
+++ b/mysql-test/r/system_tables_myisam_lctn_1.result
@@ -1,3 +1,4 @@
+SET GLOBAL skip_sys_tables_engine_check=true;
 #
 # Bug#30248138 - adding a function once mysql.func is converted to myisam
 #                leads to crash
@@ -314,3 +315,4 @@ Warning	1726	Storage engine 'MyISAM' does not support system tables. [mysql.user
 DROP PROCEDURE test_create_system_table;
 DROP PROCEDURE execute_stmt;
 DROP TABLE system_tables;
+SET GLOBAL skip_sys_tables_engine_check=default;

--- a/mysql-test/r/transactional_acl_tables.result
+++ b/mysql-test/r/transactional_acl_tables.result
@@ -3,6 +3,7 @@ CALL mtr.add_suppression("Column count of mysql.* is wrong. "
                          "Expected .*, found .*. "
                          "The table is probably corrupted");
 CALL mtr.add_suppression("Cannot load from mysql.*. The table is probably corrupted");
+SET GLOBAL skip_sys_tables_engine_check=true;
 #
 # WL7158: Move privilege system tables from MyISAM to InnoDB
 #
@@ -1858,6 +1859,7 @@ GRANT SHUTDOWN ON *.* TO 'mysql.session'@localhost;
 GRANT CONNECTION_ADMIN ON *.* TO 'mysql.session'@localhost;
 GRANT SYSTEM_USER ON *.* TO 'mysql.session'@localhost;
 FLUSH PRIVILEGES;
+SET GLOBAL skip_sys_tables_engine_check=default;
 DROP USER u1@h;
 DROP TABLE t1;
 #

--- a/mysql-test/suite/auth_sec/r/atomic_rename_user.result
+++ b/mysql-test/suite/auth_sec/r/atomic_rename_user.result
@@ -1,4 +1,5 @@
 include/save_binlog_position.inc
+SET global skip_sys_tables_engine_check=true;
 # -----------------------------------------------------------------------
 # Begin : Tests for RENAME USER
 CREATE USER userX, userY, userZ;
@@ -176,3 +177,4 @@ CONNECTED_USER	a@%
 DROP USER a;
 # End : Tests for RENAME USER
 # -----------------------------------------------------------------------
+SET GLOBAL skip_sys_tables_engine_check=default;

--- a/mysql-test/suite/auth_sec/t/atomic_rename_user.test
+++ b/mysql-test/suite/auth_sec/t/atomic_rename_user.test
@@ -3,6 +3,7 @@
 
 # Save the initial number of concurrent sessions
 --source include/count_sessions.inc
+SET global skip_sys_tables_engine_check=true; 
 
 --echo # -----------------------------------------------------------------------
 
@@ -197,5 +198,6 @@ DROP USER a;
 
 --echo # -----------------------------------------------------------------------
 
+SET GLOBAL skip_sys_tables_engine_check=default; 
 # Wait till we reached the initial number of concurrent sessions
 --source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/perfschema/r/error_log.result
+++ b/mysql-test/suite/perfschema/r/error_log.result
@@ -1,6 +1,7 @@
 # WL#13681: Make error-log available for queries from a connection
 
 SET @@global.log_error_verbosity=3;
+SET GLOBAL skip_sys_tables_engine_check=1;
 
 # FR-1.1 Table name
 # FR-1.2 Columns and names
@@ -130,6 +131,7 @@ Note	MY-013627	InnoDB
 Note	MY-013018	InnoDB
 Note	MY-012976	InnoDB
 System	MY-013577	InnoDB
+Note	MY-014007	Server
 Note	MY-011089	Server
 Note	MY-012357	InnoDB
 Note	MY-012356	InnoDB

--- a/mysql-test/suite/perfschema/t/error_log.test
+++ b/mysql-test/suite/perfschema/t/error_log.test
@@ -5,6 +5,7 @@
 
 let $LOG_VERBOSE= `select @@global.log_error_verbosity`;
 SET @@global.log_error_verbosity=3;
+SET GLOBAL skip_sys_tables_engine_check=1;
 
 # This test does not rely on debug features. If you need to add a case that
 # does, start a new file, or add it to error_log_debug.test instead.

--- a/mysql-test/suite/rocksdb/r/singledelete.result
+++ b/mysql-test/suite/rocksdb/r/singledelete.result
@@ -1,3 +1,4 @@
+select case when @@default_dd_system_storage_engine = "RocksDB" then 20 else 0 end into @delta;
 CREATE TABLE t1 (id INT, value int, PRIMARY KEY (id), INDEX (value)) ENGINE=RocksDB;
 INSERT INTO t1 VALUES (1,1);
 select variable_value into @s from performance_schema.global_status where variable_name='rocksdb_number_sst_entry_singledelete';
@@ -47,8 +48,8 @@ test.t4	optimize	status	OK
 select case when variable_value-@s > 5 and variable_value-@s < 100 then 'true' else 'false' end from performance_schema.global_status where variable_name='rocksdb_number_sst_entry_singledelete';
 case when variable_value-@s > 5 and variable_value-@s < 100 then 'true' else 'false' end
 true
-select case when variable_value-@d < 10 then 'true' else 'false' end from performance_schema.global_status where variable_name='rocksdb_number_sst_entry_delete';
-case when variable_value-@d < 10 then 'true' else 'false' end
+select case when variable_value-@d < (10 + @delta) then 'true' else 'false' end from performance_schema.global_status where variable_name='rocksdb_number_sst_entry_delete';
+case when variable_value-@d < (10 + @delta) then 'true' else 'false' end
 true
 CREATE TABLE t5 (id1 INT, id2 INT, PRIMARY KEY (id1, id2), INDEX(id2)) ENGINE=RocksDB;
 INSERT INTO t5 VALUES (1, 1);
@@ -60,8 +61,8 @@ test.t5	optimize	status	OK
 select case when variable_value-@s > 5 and variable_value-@s < 100 then 'true' else 'false' end from performance_schema.global_status where variable_name='rocksdb_number_sst_entry_singledelete';
 case when variable_value-@s > 5 and variable_value-@s < 100 then 'true' else 'false' end
 true
-select case when variable_value-@d < 10 then 'true' else 'false' end from performance_schema.global_status where variable_name='rocksdb_number_sst_entry_delete';
-case when variable_value-@d < 10 then 'true' else 'false' end
+select case when variable_value-@d < (10 + @delta) then 'true' else 'false' end from performance_schema.global_status where variable_name='rocksdb_number_sst_entry_delete';
+case when variable_value-@d < (10 + @delta) then 'true' else 'false' end
 true
 CREATE TABLE t6 (
 pk VARCHAR(64) COLLATE latin1_swedish_ci PRIMARY KEY

--- a/mysql-test/suite/rocksdb/r/sys_tables_alter.result
+++ b/mysql-test/suite/rocksdb/r/sys_tables_alter.result
@@ -1,0 +1,64 @@
+ALTER TABLE mysql.columns_priv ENGINE="ENGINE";
+ERROR HY000: System table [mysql.columns_priv] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.component ENGINE="ENGINE";
+ERROR HY000: System table [mysql.component] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.db ENGINE="ENGINE";
+ERROR HY000: System table [mysql.db] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.default_roles ENGINE="ENGINE";
+ERROR HY000: System table [mysql.default_roles] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.engine_cost ENGINE="ENGINE";
+ERROR HY000: System table [mysql.engine_cost] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.func ENGINE="ENGINE";
+ERROR HY000: System table [mysql.func] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.global_grants ENGINE="ENGINE";
+ERROR HY000: System table [mysql.global_grants] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.help_category ENGINE="ENGINE";
+ERROR HY000: System table [mysql.help_category] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.help_keyword ENGINE="ENGINE";
+ERROR HY000: System table [mysql.help_keyword] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.help_relation ENGINE="ENGINE";
+ERROR HY000: System table [mysql.help_relation] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.help_topic ENGINE="ENGINE";
+ERROR HY000: System table [mysql.help_topic] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.password_history ENGINE="ENGINE";
+ERROR HY000: System table [mysql.password_history] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.plugin ENGINE="ENGINE";
+ERROR HY000: System table [mysql.plugin] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.procs_priv ENGINE="ENGINE";
+ERROR HY000: System table [mysql.procs_priv] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.proxies_priv ENGINE="ENGINE";
+ERROR HY000: System table [mysql.proxies_priv] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.replication_asynchronous_connection_failover ENGINE="ENGINE";
+ERROR HY000: System table [mysql.replication_asynchronous_connection_failover] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.replication_asynchronous_connection_failover_managed ENGINE="ENGINE";
+ERROR HY000: System table [mysql.replication_asynchronous_connection_failover_managed] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.replication_group_configuration_version ENGINE="ENGINE";
+ERROR HY000: System table [mysql.replication_group_configuration_version] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.replication_group_member_actions ENGINE="ENGINE";
+ERROR HY000: System table [mysql.replication_group_member_actions] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.role_edges ENGINE="ENGINE";
+ERROR HY000: System table [mysql.role_edges] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.server_cost ENGINE="ENGINE";
+ERROR HY000: System table [mysql.server_cost] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.servers ENGINE="ENGINE";
+ERROR HY000: System table [mysql.servers] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.slave_master_info ENGINE="ENGINE";
+ERROR HY000: System table [mysql.slave_master_info] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.slave_relay_log_info ENGINE="ENGINE";
+ERROR HY000: System table [mysql.slave_relay_log_info] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.slave_worker_info ENGINE="ENGINE";
+ERROR HY000: System table [mysql.slave_worker_info] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.tables_priv ENGINE="ENGINE";
+ERROR HY000: System table [mysql.tables_priv] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.time_zone ENGINE="ENGINE";
+ERROR HY000: System table [mysql.time_zone] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.time_zone_leap_second ENGINE="ENGINE";
+ERROR HY000: System table [mysql.time_zone_leap_second] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.time_zone_name ENGINE="ENGINE";
+ERROR HY000: System table [mysql.time_zone_name] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.time_zone_transition ENGINE="ENGINE";
+ERROR HY000: System table [mysql.time_zone_transition] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.time_zone_transition_type ENGINE="ENGINE";
+ERROR HY000: System table [mysql.time_zone_transition_type] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.
+ALTER TABLE mysql.user ENGINE="ENGINE";
+ERROR HY000: System table [mysql.user] couldn't use specified engine ENGINE. System tables should always use default-dd-system-storage-engine.

--- a/mysql-test/suite/rocksdb/r/sys_tables_transactional_acl_tables.result
+++ b/mysql-test/suite/rocksdb/r/sys_tables_transactional_acl_tables.result
@@ -3,6 +3,7 @@ CALL mtr.add_suppression("Column count of mysql.* is wrong. "
                          "Expected .*, found .*. "
                          "The table is probably corrupted");
 CALL mtr.add_suppression("Cannot load from mysql.*. The table is probably corrupted");
+SET GLOBAL skip_sys_tables_engine_check=true;
 #
 # WL7158: Move privilege system tables from MyISAM to InnoDB
 #
@@ -1858,5 +1859,6 @@ GRANT SHUTDOWN ON *.* TO 'mysql.session'@localhost;
 GRANT CONNECTION_ADMIN ON *.* TO 'mysql.session'@localhost;
 GRANT SYSTEM_USER ON *.* TO 'mysql.session'@localhost;
 FLUSH PRIVILEGES;
+SET GLOBAL skip_sys_tables_engine_check=default;
 DROP USER u1@h;
 DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/r/ttl_secondary_with_partitions.result
+++ b/mysql-test/suite/rocksdb/r/ttl_secondary_with_partitions.result
@@ -469,6 +469,7 @@ CREATE INDEX kc2 on t1 (c2);
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='foo';
 set global rocksdb_compact_cf='default';
+set global rocksdb_compact_cf='default';
 SELECT * FROM t1 FORCE INDEX (PRIMARY);
 c1	c2
 2	2

--- a/mysql-test/suite/rocksdb/t/cancel_mc-master.opt
+++ b/mysql-test/suite/rocksdb/t/cancel_mc-master.opt
@@ -1,1 +1,4 @@
---rocksdb_rate_limiter_bytes_per_sec=256k --rocksdb_default_cf_options=write_buffer_size=64k;target_file_size_base=64k;max_bytes_for_level_base=1m;compression_per_level=kNoCompression;max_compaction_bytes=256k
+# Specify DDSE as INNODB, since during DDSE upgrade system table,
+# with MC is enabled, the instance startup will timeout
+--initialize
+--rocksdb_rate_limiter_bytes_per_sec=256k --rocksdb_default_cf_options=write_buffer_size=64k;target_file_size_base=64k;max_bytes_for_level_base=1m;compression_per_level=kNoCompression;max_compaction_bytes=256k --default-dd-system-storage-engine=InnoDB

--- a/mysql-test/suite/rocksdb/t/compact_deletes2.test
+++ b/mysql-test/suite/rocksdb/t/compact_deletes2.test
@@ -1,4 +1,7 @@
 --source include/have_rocksdb.inc
+# current test expects no entry during compaction
+# with rocksdb DDSE, this couldn't happen
+--source include/have_innodb_ddse.inc
 
 --disable_warnings
 DROP TABLE IF EXISTS r1;

--- a/mysql-test/suite/rocksdb/t/rocksdb_fault_injection-master.opt
+++ b/mysql-test/suite/rocksdb/t/rocksdb_fault_injection-master.opt
@@ -1,1 +1,4 @@
+# Specify DDSE as INNODB, since during DDSE upgrade system table,
+# myrocks drop index thread will crash due to fault inject IO error
 --rocksdb_fault_injection_options="{"retry":true,"failure_ratio":1,"filetypes":["kTableFile"]}"
+--default-dd-system-storage-engine=InnoDB

--- a/mysql-test/suite/rocksdb/t/rocksdb_read_free_rpl.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_read_free_rpl.test
@@ -1,6 +1,22 @@
 source include/have_debug.inc;
 source include/have_rocksdb.inc;
 source include/master-slave.inc;
+# rocksdb stats value in replica is different between innodb and rocksdb ddse
+# when rocksdb is ddse, during applier execute binlog event, it write/flush data
+# into mysql.slave_relay_log_info table, which increase
+# rocksdb_num_get_for_update_calls stats
+# call stack
+#     mysqld`myrocks::rdb_tx_get_for_update
+#     mysqld`myrocks::ha_rocksdb::get_row_by_rowid
+#     mysqld`Rpl_info_table_access::find_info
+#     mysqld`Rpl_info_table::do_flush_info
+#     mysqld`Rpl_info_handler::flush_info
+#     mysqld`Relay_log_info::flush_info
+#     mysqld`Xid_apply_log_event::do_apply_event
+#     mysqld`Log_event::apply_event
+#     mysqld`apply_event_and_update_pos
+#     mysqld`exec_relay_log_event
+source include/have_innodb_system_tables.inc;
 
 # initialization/insert
 --source include/rpl_connection_master.inc

--- a/mysql-test/suite/rocksdb/t/singledelete.test
+++ b/mysql-test/suite/rocksdb/t/singledelete.test
@@ -1,5 +1,7 @@
 --source include/have_rocksdb.inc
 
+select case when @@default_dd_system_storage_engine = "RocksDB" then 20 else 0 end into @delta;
+
 # only SingleDelete increases
 CREATE TABLE t1 (id INT, value int, PRIMARY KEY (id), INDEX (value)) ENGINE=RocksDB;
 INSERT INTO t1 VALUES (1,1);
@@ -67,7 +69,7 @@ while ($i <= 10000) {
 --enable_query_log
 optimize table t4;
 select case when variable_value-@s > 5 and variable_value-@s < 100 then 'true' else 'false' end from performance_schema.global_status where variable_name='rocksdb_number_sst_entry_singledelete';
-select case when variable_value-@d < 10 then 'true' else 'false' end from performance_schema.global_status where variable_name='rocksdb_number_sst_entry_delete';
+select case when variable_value-@d < (10 + @delta) then 'true' else 'false' end from performance_schema.global_status where variable_name='rocksdb_number_sst_entry_delete';
 
 # only SingleDelete increases
 CREATE TABLE t5 (id1 INT, id2 INT, PRIMARY KEY (id1, id2), INDEX(id2)) ENGINE=RocksDB;
@@ -84,7 +86,7 @@ while ($i <= 10000) {
 --enable_query_log
 optimize table t5;
 select case when variable_value-@s > 5 and variable_value-@s < 100 then 'true' else 'false' end from performance_schema.global_status where variable_name='rocksdb_number_sst_entry_singledelete';
-select case when variable_value-@d < 10 then 'true' else 'false' end from performance_schema.global_status where variable_name='rocksdb_number_sst_entry_delete';
+select case when variable_value-@d < (10 + @delta) then 'true' else 'false' end from performance_schema.global_status where variable_name='rocksdb_number_sst_entry_delete';
 
 # SingleDelete used for PK. Verify old PK is always deleted.
 CREATE TABLE t6 (

--- a/mysql-test/suite/rocksdb/t/sys_tables_alter.test
+++ b/mysql-test/suite/rocksdb/t/sys_tables_alter.test
@@ -1,0 +1,135 @@
+--let ddse=`SELECT UPPER(@@default_dd_system_storage_engine)`
+
+let engine = "INNODB";
+if($ddse == "INNODB")
+{
+  let engine = "ROCKSDB";
+}
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.columns_priv ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.component ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.db ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.default_roles ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.engine_cost ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.func ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.global_grants ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.help_category ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.help_keyword ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.help_relation ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.help_topic ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.password_history ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.plugin ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.procs_priv ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.proxies_priv ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.replication_asynchronous_connection_failover ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.replication_asynchronous_connection_failover_managed ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.replication_group_configuration_version ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.replication_group_member_actions ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.role_edges ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.server_cost ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.servers ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.slave_master_info ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.slave_relay_log_info ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.slave_worker_info ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.tables_priv ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.time_zone ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.time_zone_leap_second ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.time_zone_name ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.time_zone_transition ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.time_zone_transition_type ENGINE=$engine;
+
+--replace_regex /innodb/ENGINE/i /rocksdb/ENGINE/i
+--error ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+EVAL ALTER TABLE mysql.user ENGINE=$engine;

--- a/mysql-test/suite/rocksdb/t/ttl_secondary_with_partitions.test
+++ b/mysql-test/suite/rocksdb/t/ttl_secondary_with_partitions.test
@@ -391,6 +391,7 @@ CREATE INDEX kc2 on t1 (c2);
 set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='foo';
 set global rocksdb_compact_cf='default';
+set global rocksdb_compact_cf='default';
 
 # 1,4, and 7 should be gone
 --sorted_result

--- a/mysql-test/suite/sys_vars/r/skip_sys_tables_engine_check_basic.result
+++ b/mysql-test/suite/sys_vars/r/skip_sys_tables_engine_check_basic.result
@@ -1,0 +1,97 @@
+CREATE TABLE valid_values (value VARCHAR(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(1), (0), ('on'), ('off'), ('true'), ('false');
+CREATE TABLE invalid_values (value VARCHAR(255)) ENGINE=myisam;
+INSERT INTO invalid_values VALUES('aaa'), ('bbb'), (3.14);
+SET @start_global_value = @@global.SKIP_SYS_TABLES_ENGINE_CHECK;
+SELECT @start_global_value;
+@start_global_value
+0
+'# Setting to valid values in global scope#'
+"Trying to set variable @@global.SKIP_SYS_TABLES_ENGINE_CHECK to 1"
+SET @@global.SKIP_SYS_TABLES_ENGINE_CHECK   = 1;
+SELECT @@global.SKIP_SYS_TABLES_ENGINE_CHECK;
+@@global.SKIP_SYS_TABLES_ENGINE_CHECK
+1
+"Setting the global scope variable back to default"
+SET @@global.SKIP_SYS_TABLES_ENGINE_CHECK = DEFAULT;
+SELECT @@global.SKIP_SYS_TABLES_ENGINE_CHECK;
+@@global.SKIP_SYS_TABLES_ENGINE_CHECK
+0
+"Trying to set variable @@global.SKIP_SYS_TABLES_ENGINE_CHECK to 0"
+SET @@global.SKIP_SYS_TABLES_ENGINE_CHECK   = 0;
+SELECT @@global.SKIP_SYS_TABLES_ENGINE_CHECK;
+@@global.SKIP_SYS_TABLES_ENGINE_CHECK
+0
+"Setting the global scope variable back to default"
+SET @@global.SKIP_SYS_TABLES_ENGINE_CHECK = DEFAULT;
+SELECT @@global.SKIP_SYS_TABLES_ENGINE_CHECK;
+@@global.SKIP_SYS_TABLES_ENGINE_CHECK
+0
+"Trying to set variable @@global.SKIP_SYS_TABLES_ENGINE_CHECK to on"
+SET @@global.SKIP_SYS_TABLES_ENGINE_CHECK   = on;
+SELECT @@global.SKIP_SYS_TABLES_ENGINE_CHECK;
+@@global.SKIP_SYS_TABLES_ENGINE_CHECK
+1
+"Setting the global scope variable back to default"
+SET @@global.SKIP_SYS_TABLES_ENGINE_CHECK = DEFAULT;
+SELECT @@global.SKIP_SYS_TABLES_ENGINE_CHECK;
+@@global.SKIP_SYS_TABLES_ENGINE_CHECK
+0
+"Trying to set variable @@global.SKIP_SYS_TABLES_ENGINE_CHECK to off"
+SET @@global.SKIP_SYS_TABLES_ENGINE_CHECK   = off;
+SELECT @@global.SKIP_SYS_TABLES_ENGINE_CHECK;
+@@global.SKIP_SYS_TABLES_ENGINE_CHECK
+0
+"Setting the global scope variable back to default"
+SET @@global.SKIP_SYS_TABLES_ENGINE_CHECK = DEFAULT;
+SELECT @@global.SKIP_SYS_TABLES_ENGINE_CHECK;
+@@global.SKIP_SYS_TABLES_ENGINE_CHECK
+0
+"Trying to set variable @@global.SKIP_SYS_TABLES_ENGINE_CHECK to true"
+SET @@global.SKIP_SYS_TABLES_ENGINE_CHECK   = true;
+SELECT @@global.SKIP_SYS_TABLES_ENGINE_CHECK;
+@@global.SKIP_SYS_TABLES_ENGINE_CHECK
+1
+"Setting the global scope variable back to default"
+SET @@global.SKIP_SYS_TABLES_ENGINE_CHECK = DEFAULT;
+SELECT @@global.SKIP_SYS_TABLES_ENGINE_CHECK;
+@@global.SKIP_SYS_TABLES_ENGINE_CHECK
+0
+"Trying to set variable @@global.SKIP_SYS_TABLES_ENGINE_CHECK to false"
+SET @@global.SKIP_SYS_TABLES_ENGINE_CHECK   = false;
+SELECT @@global.SKIP_SYS_TABLES_ENGINE_CHECK;
+@@global.SKIP_SYS_TABLES_ENGINE_CHECK
+0
+"Setting the global scope variable back to default"
+SET @@global.SKIP_SYS_TABLES_ENGINE_CHECK = DEFAULT;
+SELECT @@global.SKIP_SYS_TABLES_ENGINE_CHECK;
+@@global.SKIP_SYS_TABLES_ENGINE_CHECK
+0
+"Trying to set variable @@session.SKIP_SYS_TABLES_ENGINE_CHECK to 444."
+"It should fail because it is not session."
+SET @@session.SKIP_SYS_TABLES_ENGINE_CHECK   = 444;
+ERROR HY000: Variable 'skip_sys_tables_engine_check' is a GLOBAL variable and should be set with SET GLOBAL
+'# Testing with invalid values in global scope #'
+"Trying to set variable @@global.SKIP_SYS_TABLES_ENGINE_CHECK to aaa"
+SET @@global.SKIP_SYS_TABLES_ENGINE_CHECK   = aaa;
+Got one of the listed errors
+SELECT @@global.SKIP_SYS_TABLES_ENGINE_CHECK;
+@@global.SKIP_SYS_TABLES_ENGINE_CHECK
+0
+"Trying to set variable @@global.SKIP_SYS_TABLES_ENGINE_CHECK to bbb"
+SET @@global.SKIP_SYS_TABLES_ENGINE_CHECK   = bbb;
+Got one of the listed errors
+SELECT @@global.SKIP_SYS_TABLES_ENGINE_CHECK;
+@@global.SKIP_SYS_TABLES_ENGINE_CHECK
+0
+"Trying to set variable @@global.SKIP_SYS_TABLES_ENGINE_CHECK to 3.14"
+SET @@global.SKIP_SYS_TABLES_ENGINE_CHECK   = 3.14;
+Got one of the listed errors
+SELECT @@global.SKIP_SYS_TABLES_ENGINE_CHECK;
+@@global.SKIP_SYS_TABLES_ENGINE_CHECK
+0
+SET @@global.SKIP_SYS_TABLES_ENGINE_CHECK = @start_global_value;
+SELECT @@global.SKIP_SYS_TABLES_ENGINE_CHECK;
+@@global.SKIP_SYS_TABLES_ENGINE_CHECK
+0
+DROP TABLE valid_values, invalid_values;

--- a/mysql-test/suite/sys_vars/t/skip_sys_tables_engine_check_basic.test
+++ b/mysql-test/suite/sys_vars/t/skip_sys_tables_engine_check_basic.test
@@ -1,0 +1,14 @@
+--source include/have_myisam.inc
+
+CREATE TABLE valid_values (value VARCHAR(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(1), (0), ('on'), ('off'), ('true'), ('false');
+
+CREATE TABLE invalid_values (value VARCHAR(255)) ENGINE=myisam;
+INSERT INTO invalid_values VALUES('aaa'), ('bbb'), (3.14);
+
+--let $sys_var=SKIP_SYS_TABLES_ENGINE_CHECK
+--let $read_only=0
+--let $session=0
+--source ../inc/sys_var.inc
+
+DROP TABLE valid_values, invalid_values;

--- a/mysql-test/t/dd_schema_dd_properties_debug.test
+++ b/mysql-test/t/dd_schema_dd_properties_debug.test
@@ -8,8 +8,10 @@
 
 --source include/have_case_sensitive_file_system.inc
 
+SET GLOBAL skip_sys_tables_engine_check=true; 
 --let $file = $MYSQL_TMP_DIR/dd_properties.txt
 --let $filter = MYSQLD_VERSION|DD_VERSION|NDBINFO_VERSION|LCTN|IS_VERSION|PS_VERSION|SDI_VERSION|MINOR_DOWNGRADE_THRESHOLD|DD_ENGINE
 --source include/dd_schema_dd_properties.inc
 --cat_file $file
 --remove_file $file
+SET GLOBAL skip_sys_tables_engine_check=default; 

--- a/mysql-test/t/dd_schema_definition_after_upgrade_57_debug.test
+++ b/mysql-test/t/dd_schema_definition_after_upgrade_57_debug.test
@@ -43,7 +43,7 @@
 --let $file = $target_dd_props
   # We must filter out unpredictable values such as root page no and ids.
   # This simple filter will remove a bit more than strictly necessary.
---let $filter = id|root|MYSQLD_VERSION_LO
+--let $filter = id|root|MYSQLD_VERSION_LO|DD_ENGINE_UPGRADED
 --source include/dd_schema_dd_properties.inc
 
 --echo ########################################################################

--- a/mysql-test/t/dd_schema_definition_after_upgrade_80_debug.test
+++ b/mysql-test/t/dd_schema_definition_after_upgrade_80_debug.test
@@ -47,7 +47,7 @@
 --let $file = $target_dd_props
   # We must filter out unpredictable values such as root page no and ids.
   # This simple filter will remove a bit more than strictly necessary.
---let $filter = id|root|MYSQLD_VERSION_LO|DD_ENGINE
+--let $filter = id|root|MYSQLD_VERSION_LO|DD_ENGINE|DD_ENGINE_UPGRADED
 --source include/dd_schema_dd_properties.inc
 
 --echo ########################################################################

--- a/mysql-test/t/system_tables_myisam.test
+++ b/mysql-test/t/system_tables_myisam.test
@@ -12,6 +12,7 @@ CALL mtr.add_suppression("Column count of");
 CALL mtr.add_suppression("Incorrect definition of table");
 CALL mtr.add_suppression("Cannot load from");
 CALL mtr.add_suppression("Storage engine 'MyISAM' does not");
+SET GLOBAL skip_sys_tables_engine_check=true;
 
 --echo #-----------------------------------------------------------------------
 --echo # Test cases to verify system table's behavior with storage engines
@@ -308,3 +309,4 @@ SELECT table_schema, table_name, engine FROM information_schema.tables
 SELECT table_schema, table_name, engine FROM information_schema.tables
                                         WHERE table_schema='mysql'
                                               AND engine='MyISAM';
+SET GLOBAL skip_sys_tables_engine_check=default;

--- a/mysql-test/t/system_tables_myisam_lctn_1.test
+++ b/mysql-test/t/system_tables_myisam_lctn_1.test
@@ -1,5 +1,6 @@
 #
 --source include/force_restart.inc
+SET GLOBAL skip_sys_tables_engine_check=true;
 
 --echo #
 --echo # Bug#30248138 - adding a function once mysql.func is converted to myisam
@@ -16,3 +17,4 @@
 --echo #-----------------------------------------------------------------------
 --let uppercase_system_table_names= `SELECT @@global.lower_case_table_names`
 --source include/system_tables_storage_engine_tests.inc
+SET GLOBAL skip_sys_tables_engine_check=default;

--- a/mysql-test/t/transactional_acl_tables.test
+++ b/mysql-test/t/transactional_acl_tables.test
@@ -9,7 +9,7 @@ CALL mtr.add_suppression("Column count of mysql.* is wrong. "
 CALL mtr.add_suppression("Cannot load from mysql.*. The table is probably corrupted");
 
 --let $SYSSE=`SELECT @@default_dd_system_storage_engine`
-
+SET GLOBAL skip_sys_tables_engine_check=true;
 --echo #
 --echo # WL7158: Move privilege system tables from MyISAM to InnoDB
 --echo #
@@ -2277,6 +2277,7 @@ GRANT SYSTEM_USER ON *.* TO 'mysql.session'@localhost;
 
 FLUSH PRIVILEGES;
 
+SET GLOBAL skip_sys_tables_engine_check=default;
 DROP USER u1@h;
 DROP TABLE t1;
 

--- a/scripts/mysql_system_tables_fix.sql
+++ b/scripts/mysql_system_tables_fix.sql
@@ -1164,6 +1164,158 @@ EXECUTE stmt;
 DROP PREPARE stmt;
 
 --
+-- alter table engine=DDSE if necessary by check actual engine
+--
+SET @component_engine = (select ENGINE from information_schema.tables where
+    table_schema='mysql' and table_name='component');
+SET @cmd = CONCAT("ALTER TABLE component ENGINE=",
+    IF(@ddse = 'ROCKSDB', "ROCKSDB", "InnoDB"));
+SET @str = IF(@ddse = @component_engine, "SET @dummy = 0", @cmd);
+PREPARE stmt FROM @str;
+EXECUTE stmt;
+DROP PREPARE stmt;
+
+SET @default_roles_engine = (select ENGINE from information_schema.tables where
+    table_schema='mysql' and table_name='default_roles');
+SET @cmd = CONCAT("ALTER TABLE default_roles ENGINE=",
+    IF(@ddse = 'ROCKSDB', "ROCKSDB", "InnoDB"));
+SET @str = IF(@ddse = @default_roles_engine, "SET @dummy = 0", @cmd);
+PREPARE stmt FROM @str;
+EXECUTE stmt;
+DROP PREPARE stmt;
+
+SET @engine_cost_engine = (select ENGINE from information_schema.tables where
+    table_schema='mysql' and table_name='engine_cost');
+SET @cmd = CONCAT("ALTER TABLE engine_cost ENGINE=",
+    IF(@ddse = 'ROCKSDB', "ROCKSDB", "InnoDB"));
+SET @str = IF(@ddse = @engine_cost_engine, "SET @dummy = 0", @cmd);
+PREPARE stmt FROM @str;
+EXECUTE stmt;
+DROP PREPARE stmt;
+
+SET @global_grants_engine = (select ENGINE from information_schema.tables where
+    table_schema='mysql' and table_name='global_grants');
+SET @cmd = CONCAT("ALTER TABLE global_grants ENGINE=",
+    IF(@ddse = 'ROCKSDB', "ROCKSDB", "InnoDB"));
+SET @str = IF(@ddse = @global_grants_engine, "SET @dummy = 0", @cmd);
+PREPARE stmt FROM @str;
+EXECUTE stmt;
+DROP PREPARE stmt;
+
+SET @help_topic_engine = (select ENGINE from information_schema.tables where
+    table_schema='mysql' and table_name='help_topic');
+SET @cmd = CONCAT("ALTER TABLE help_topic ENGINE=",
+    IF(@ddse = 'ROCKSDB', "ROCKSDB", "InnoDB"));
+SET @str = IF(@ddse = @help_topic_engine, "SET @dummy = 0", @cmd);
+PREPARE stmt FROM @str;
+EXECUTE stmt;
+DROP PREPARE stmt;
+
+SET @replication_asynchronous_connection_failover_engine = (select ENGINE from information_schema.tables where
+    table_schema='mysql' and table_name='replication_asynchronous_connection_failover');
+SET @cmd = CONCAT("ALTER TABLE replication_asynchronous_connection_failover ENGINE=",
+    IF(@ddse = 'ROCKSDB', "ROCKSDB", "InnoDB"));
+SET @str = IF(@ddse = @replication_asynchronous_connection_failover_engine, "SET @dummy = 0", @cmd);
+PREPARE stmt FROM @str;
+EXECUTE stmt;
+DROP PREPARE stmt;
+
+SET @replication_asynchronous_connection_failover_managed_engine = (select ENGINE from information_schema.tables where
+    table_schema='mysql' and table_name='replication_asynchronous_connection_failover_managed');
+SET @cmd = CONCAT("ALTER TABLE replication_asynchronous_connection_failover_managed ENGINE=",
+    IF(@ddse = 'ROCKSDB', "ROCKSDB", "InnoDB"));
+SET @str = IF(@ddse = @replication_asynchronous_connection_failover_managed_engine, "SET @dummy = 0", @cmd);
+PREPARE stmt FROM @str;
+EXECUTE stmt;
+DROP PREPARE stmt;
+
+SET @replication_group_configuration_version_engine = (select ENGINE from
+    information_schema.tables where table_schema='mysql' and
+    table_name='replication_group_configuration_version');
+SET @cmd = CONCAT("ALTER TABLE replication_group_configuration_version ENGINE=",
+    IF(@ddse = 'ROCKSDB', "ROCKSDB", "InnoDB"));
+SET @str = IF(@ddse = @replication_group_configuration_version_engine,
+    "SET @dummy = 0", @cmd);
+PREPARE stmt FROM @str;
+EXECUTE stmt;
+DROP PREPARE stmt;
+
+SET @replication_group_member_actions_engine = (select ENGINE from information_schema.tables where
+    table_schema='mysql' and table_name='replication_group_member_actions');
+SET @cmd = CONCAT("ALTER TABLE replication_group_member_actions ENGINE=",
+    IF(@ddse = 'ROCKSDB', "ROCKSDB", "InnoDB"));
+SET @str = IF(@ddse = @replication_group_member_actions_engine, "SET @dummy = 0", @cmd);
+PREPARE stmt FROM @str;
+EXECUTE stmt;
+DROP PREPARE stmt;
+
+SET @role_edges_engine = (select ENGINE from information_schema.tables where
+    table_schema='mysql' and table_name='role_edges');
+SET @cmd = CONCAT("ALTER TABLE role_edges ENGINE=",
+    IF(@ddse = 'ROCKSDB', "ROCKSDB", "InnoDB"));
+SET @str = IF(@ddse = @role_edges_engine, "SET @dummy = 0", @cmd);
+PREPARE stmt FROM @str;
+EXECUTE stmt;
+DROP PREPARE stmt;
+SET @server_cost_engine = (select ENGINE from information_schema.tables where
+    table_schema='mysql' and table_name='server_cost');
+SET @cmd = CONCAT("ALTER TABLE server_cost ENGINE=",
+    IF(@ddse = 'ROCKSDB', "ROCKSDB", "InnoDB"));
+SET @str = IF(@ddse = @server_cost_engine, "SET @dummy = 0", @cmd);
+PREPARE stmt FROM @str;
+EXECUTE stmt;
+DROP PREPARE stmt;
+
+SET @slave_master_info_engine = (select ENGINE from information_schema.tables where
+    table_schema='mysql' and table_name='slave_master_info');
+SET @cmd = CONCAT("ALTER TABLE slave_master_info ENGINE=",
+    IF(@ddse = 'ROCKSDB', "ROCKSDB", "InnoDB"));
+SET @str = IF(@ddse = @slave_master_info_engine, "SET @dummy = 0", @cmd);
+PREPARE stmt FROM @str;
+EXECUTE stmt;
+DROP PREPARE stmt;
+
+SET @slave_relay_log_info_engine = (select ENGINE from information_schema.tables where
+    table_schema='mysql' and table_name='slave_relay_log_info');
+SET @cmd = CONCAT("ALTER TABLE slave_relay_log_info ENGINE=",
+    IF(@ddse = 'ROCKSDB', "ROCKSDB", "InnoDB"));
+SET @str = IF(@ddse = @slave_relay_log_info_engine, "SET @dummy = 0", @cmd);
+PREPARE stmt FROM @str;
+EXECUTE stmt;
+DROP PREPARE stmt;
+
+SET @slave_worker_info_engine = (select ENGINE from information_schema.tables where
+    table_schema='mysql' and table_name='slave_worker_info');
+SET @cmd = CONCAT("ALTER TABLE slave_worker_info ENGINE=",
+    IF(@ddse = 'ROCKSDB', "ROCKSDB", "InnoDB"));
+SET @str = IF(@ddse = @slave_worker_info_engine, "SET @dummy = 0", @cmd);
+PREPARE stmt FROM @str;
+EXECUTE stmt;
+DROP PREPARE stmt;
+
+#
+# Drop DESC due to MyRocks not supporting DESC yet
+#
+SET @password_history_engine = (select ENGINE from information_schema.tables
+    where table_schema='mysql' and table_name='password_history');
+SET @cmd = CONCAT("ALTER TABLE password_history DROP PRIMARY KEY,",
+    IF(@ddse = 'ROCKSDB', "ADD PRIMARY KEY(Host, User, Password_timestamp)",
+        "ADD PRIMARY KEY(Host, User, Password_timestamp DESC)"));
+SET @str = IF(@ddse = @password_history_engine, "SET @dummy = 0", @cmd);
+PREPARE stmt FROM @str;
+EXECUTE stmt;
+DROP PREPARE stmt;
+
+SET @password_history_engine = (select ENGINE from information_schema.tables
+    where table_schema='mysql' and table_name='password_history');
+SET @cmd = CONCAT("ALTER TABLE password_history ENGINE=",
+    IF(@ddse = 'ROCKSDB', "ROCKSDB", "InnoDB"));
+SET @str = IF(@ddse = @password_history_engine, "SET @dummy = 0", @cmd);
+PREPARE stmt FROM @str;
+EXECUTE stmt;
+DROP PREPARE stmt;
+
+--
 -- CREATE_ROLE_ACL and DROP_ROLE_ACL
 --
 ALTER TABLE user ADD Create_role_priv enum('N','Y') COLLATE utf8mb3_general_ci DEFAULT 'N' NOT NULL AFTER account_locked;

--- a/share/messages_to_clients.txt
+++ b/share/messages_to_clients.txt
@@ -10402,6 +10402,10 @@ ER_RDB_TTL_WRITES_WITH_STALE_SNAPSHOT
 OBSOLETE_ER_RDB_DDSE_CANNOT_DISABLE_LARGE_PREFIX
   eng "Can't disable rocksdb_large_prefix when MyRocks is the MySQL data dictionary engine"
 
+ER_ALTER_SYSTEM_TABLE_WITH_NOT_DDSE
+  eng "System table [%s.%s] couldn't use specified engine %s. System tables should always use default-dd-system-storage-engine."
+
+
 #
 # End of 8.0 FB MySQL error messages.
 # (Please read comments from the header of this section before adding error

--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -12093,6 +12093,12 @@ ER_UNSUPPORTED_DD_ENGINE
 ER_CANT_CREATE_DUMP_THREAD
   eng "Can't create thread for DUMP TABLE (errno= %d)"
 
+ER_SYSTEM_TABLE_SERVER_UPGRADE_STATUS
+  eng "Server upgrade from '%s' to '%s' %s."
+
+ER_DD_SYSTEM_ENGINE_UPGRADED_NOT_FOUND
+  eng "The DD_SYSTEM_ENGINE_UPGRADED property for the data dictionary was not found. Starting the server using DD_ENGINE='%s'."
+
 # DO NOT add server-to-client messages here;
 # they go in messages_to_clients.txt
 # in the same directory as this file.

--- a/sql/dd/impl/bootstrap/bootstrap_ctx.h
+++ b/sql/dd/impl/bootstrap/bootstrap_ctx.h
@@ -110,6 +110,7 @@ class DD_bootstrap_ctx {
   // default_dd_system_storage_engine
   legacy_db_type m_actual_dd_engine = DB_TYPE_UNKNOWN;
   legacy_db_type m_did_dd_engine_upgrade_from = DB_TYPE_UNKNOWN;
+  legacy_db_type m_upgraded_dd_system_engine = DB_TYPE_UNKNOWN;
 
  public:
   DD_bootstrap_ctx() = default;
@@ -185,6 +186,14 @@ class DD_bootstrap_ctx {
 
   uint get_upgraded_server_version() const { return m_upgraded_server_version; }
 
+  void set_upgraded_dd_system_engine(legacy_db_type upgraded_dd_engine) {
+    m_upgraded_dd_system_engine = upgraded_dd_engine;
+  }
+
+  legacy_db_type get_upgraded_dd_engine() const {
+    return m_upgraded_dd_system_engine;
+  }
+
   bool upgraded_server_version_is(uint compare_upgraded_server_version) const {
     return (m_upgraded_server_version == compare_upgraded_server_version);
   }
@@ -202,7 +211,9 @@ class DD_bootstrap_ctx {
   }
 
   bool is_server_upgrade() const {
-    return !opt_initialize && (m_upgraded_server_version < MYSQL_VERSION_ID);
+    return !opt_initialize &&
+           ((m_upgraded_server_version < MYSQL_VERSION_ID) ||
+            (m_upgraded_dd_system_engine != get_dd_engine_type()));
   }
 
   bool is_dd_upgrade_from_before(uint compare_actual_dd_version) const {

--- a/sql/dd/impl/bootstrap/bootstrapper.cc
+++ b/sql/dd/impl/bootstrap/bootstrapper.cc
@@ -1162,9 +1162,15 @@ bool create_dd_schema(THD *thd) {
   For upgrade, "actual" is gotten by checking table_exists_in_engine and then
     compute.
   The only difference between "actual" and "target" is SE.
+
+ @param [IN]  thd  THD Handle
+ @param [OUT] dd_properties_engine which SE stores mysql.dd_properties table
+
+ @return mysql.dd_properties table definition
 */
 [[nodiscard]] const Object_table_definition *get_dd_properties_table_definition(
-    THD *thd) {
+    THD *thd, legacy_db_type &dd_properties_engine) {
+  dd_properties_engine = get_dd_engine_type();
   if (!opt_initialize) {
     // Find out which SE contains dd_properties table during restart
     // Try rocksdb first
@@ -1176,9 +1182,11 @@ bool create_dd_schema(THD *thd) {
           rocksdb_hton, thd, MYSQL_SCHEMA_NAME.str,
           dd::tables::DD_properties::instance().name().c_str());
     }
+
+    dd_properties_engine =
+        (error == HA_ERR_TABLE_EXIST) ? DB_TYPE_ROCKSDB : DB_TYPE_INNODB;
     dd::tables::DD_properties::instance().set_actual_engine(
-        error == HA_ERR_TABLE_EXIST ? String_type("ROCKSDB")
-                                    : String_type("INNODB"));
+        get_dd_engine_name(dd_properties_engine));
   }
 
   // Create the dd_properties table.
@@ -1195,8 +1203,10 @@ bool create_dd_schema(THD *thd) {
 
 bool initialize_dd_properties(THD *thd) {
   // Create the dd_properties table.
+  legacy_db_type dd_properties_engine = DB_TYPE_UNKNOWN;
   const Object_table_definition *dd_properties_def =
-      get_dd_properties_table_definition(thd);
+      get_dd_properties_table_definition(thd, dd_properties_engine);
+  assert(dd_properties_engine != DB_TYPE_UNKNOWN);
 
   if (dd::execute_query(thd, dd_properties_def->get_ddl())) return true;
 
@@ -1213,6 +1223,8 @@ bool initialize_dd_properties(THD *thd) {
       actual_server_version);
   bootstrap::DD_bootstrap_ctx::instance().set_actual_dd_engine(
       get_dd_engine_type());
+  bootstrap::DD_bootstrap_ctx::instance().set_upgraded_dd_system_engine(
+      dd_properties_engine);
 
   if (!opt_initialize) {
     bool exists = false;
@@ -1319,10 +1331,11 @@ bool initialize_dd_properties(THD *thd) {
       unsupported DD_ENGINE; use INNODB if couldn't find DD_ENGINE, since
       existing INNODB DDSE instance doesn't contain DD_ENGINE property
     */
-    uint actual_dd_engine = DB_TYPE_UNKNOWN;
+    legacy_db_type actual_dd_engine = DB_TYPE_UNKNOWN;
     exists = false;
-    if (dd::tables::DD_properties::instance().get(thd, "DD_ENGINE",
-                                                  &actual_dd_engine, &exists) ||
+    if (dd::tables::DD_properties::instance().get(
+            thd, "DD_ENGINE", reinterpret_cast<uint *>(&actual_dd_engine),
+            &exists) ||
         !exists) {
       LogErr(INFORMATION_LEVEL, ER_DD_ENGINE_NOT_FOUND,
              get_dd_engine_name(DB_TYPE_INNODB));
@@ -1341,7 +1354,25 @@ bool initialize_dd_properties(THD *thd) {
       return true;
     }
     bootstrap::DD_bootstrap_ctx::instance().set_actual_dd_engine(
-        static_cast<legacy_db_type>(actual_dd_engine));
+        actual_dd_engine);
+
+    /*
+      Read DD_SYSTEM_ENGINE_UPGRADED from dd_properties, if it does not exist,
+      use INNODB instead;
+    */
+    legacy_db_type upgraded_dd_system_engine = DB_TYPE_UNKNOWN;
+    bool exists_upgraded_dd_system_engine = false;
+    if (dd::tables::DD_properties::instance().get(
+            thd, "DD_SYSTEM_ENGINE_UPGRADED",
+            reinterpret_cast<uint *>(&upgraded_dd_system_engine),
+            &exists_upgraded_dd_system_engine) ||
+        !exists_upgraded_dd_system_engine) {
+      LogErr(INFORMATION_LEVEL, ER_DD_SYSTEM_ENGINE_UPGRADED_NOT_FOUND,
+             get_dd_engine_name(DB_TYPE_INNODB));
+      upgraded_dd_system_engine = DB_TYPE_INNODB;
+    }
+    bootstrap::DD_bootstrap_ctx::instance().set_upgraded_dd_system_engine(
+        upgraded_dd_system_engine);
   }
 
   if (bootstrap::DD_bootstrap_ctx::instance().is_initialize())
@@ -1923,6 +1954,10 @@ bool update_versions(THD *thd, bool is_dd_upgrade_57) {
       bootstrap::DD_bootstrap_ctx::instance().set_upgraded_server_version(
           MYSQL_VERSION_ID);
     }
+
+    bootstrap::DD_bootstrap_ctx::instance().set_upgraded_dd_system_engine(
+        get_dd_engine_type());
+
   } else {
     uint mysqld_version_lo = 0;
     uint mysqld_version_hi = 0;
@@ -1932,6 +1967,8 @@ bool update_versions(THD *thd, bool is_dd_upgrade_57) {
     bool exists_hi = false;
     bool exists = false;
     bool exists_upgraded_version = false;
+    legacy_db_type upgrade_dd_system_engine = DB_TYPE_UNKNOWN;
+
     if ((dd::tables::DD_properties::instance().get(
              thd, "MYSQLD_VERSION_LO", &mysqld_version_lo, &exists_lo) ||
          !exists_lo) ||
@@ -2000,6 +2037,22 @@ bool update_versions(THD *thd, bool is_dd_upgrade_57) {
                                                   get_dd_engine_type()))
       return dd::end_transaction(thd, true);
 
+    /*
+      Initialize ctx DD_SYSTEM_ENGINE_UPGRADED for update SYSTEM TALBES later
+    */
+    bool exists_upgraded_dd_system_engine = false;
+    if (dd::tables::DD_properties::instance().get(
+            thd, "DD_SYSTEM_ENGINE_UPGRADED",
+            reinterpret_cast<uint *>(&upgrade_dd_system_engine),
+            &exists_upgraded_dd_system_engine) ||
+        !exists_upgraded_dd_system_engine) {
+      upgrade_dd_system_engine = DB_TYPE_INNODB;
+      if (dd::tables::DD_properties::instance().set(
+              thd, "DD_SYSTEM_ENGINE_UPGRADED", upgrade_dd_system_engine))
+        return dd::end_transaction(thd, true);
+    }
+    bootstrap::DD_bootstrap_ctx::instance().set_upgraded_dd_system_engine(
+        upgrade_dd_system_engine);
     /*
       Update the minor downgrade threshold in case of upgrade.
       Note that on downgrade, we keep the threshold version which is

--- a/sql/dd/impl/tables/dd_properties.cc
+++ b/sql/dd/impl/tables/dd_properties.cc
@@ -96,6 +96,8 @@ DD_properties::DD_properties() : m_properties() {
       MYSQLD_VERSION_UPGRADED   The server version of the last
                                 completed successful upgrade.
       DD_ENGINE                 Actual DD engine
+      DD_SYSTEM_ENGINE_UPGRADED The DD SYSTEM engine of the last
+                                completed successful upgrade.
   */
   m_property_desc = {
       {"DD_VERSION", Property_type::UNSIGNED_INT_32},
@@ -112,7 +114,8 @@ DD_properties::DD_properties() : m_properties() {
       {"UPGRADE_TARGET_SCHEMA", Property_type::CHARACTER_STRING},
       {"UPGRADE_ACTUAL_SCHEMA", Property_type::CHARACTER_STRING},
       {"MYSQLD_VERSION_UPGRADED", Property_type::UNSIGNED_INT_32},
-      {"DD_ENGINE", Property_type::UNSIGNED_INT_32}};
+      {"DD_ENGINE", Property_type::UNSIGNED_INT_32},
+      {"DD_SYSTEM_ENGINE_UPGRADED", Property_type::UNSIGNED_INT_32}};
 }
 
 // Read all properties from disk and populate the cache.

--- a/sql/dd/impl/upgrade/server.cc
+++ b/sql/dd/impl/upgrade/server.cc
@@ -876,10 +876,34 @@ bool upgrade_system_schemas(THD *thd) {
         !exists_version)
       return true;
 
-  MySQL_check check;
+  legacy_db_type dd_system_engine = DB_TYPE_UNKNOWN;
+  bool exists_dd_system_engine = false;
+  if (dd::tables::DD_properties::instance().get(
+          thd, "DD_SYSTEM_ENGINE_UPGRADED",
+          reinterpret_cast<uint *>(&dd_system_engine),
+          &exists_dd_system_engine) ||
+      !exists_dd_system_engine)
+    if (dd::tables::DD_properties::instance().get(
+            thd, "DD_ENGINE", reinterpret_cast<uint *>(&dd_system_engine),
+            &exists_dd_system_engine) ||
+        !exists_dd_system_engine)
+      return true;
 
-  LogErr(SYSTEM_LEVEL, ER_SERVER_UPGRADE_STATUS, server_version,
-         MYSQL_VERSION_ID, "started");
+  // force upgrade or either version changed or dd system engine is changed
+  // when force upgrade is specified, do code as version changed
+  assert(is_force_upgrade() || ((server_version == MYSQL_VERSION_ID) ^
+                                (dd_system_engine == get_dd_engine_type())));
+
+  MySQL_check check;
+  if (dd_system_engine != get_dd_engine_type()) {
+    LogErr(SYSTEM_LEVEL, ER_SYSTEM_TABLE_SERVER_UPGRADE_STATUS,
+           get_dd_engine_name(dd_system_engine), get_dd_engine_name(),
+           "started");
+  } else {
+    LogErr(SYSTEM_LEVEL, ER_SERVER_UPGRADE_STATUS, server_version,
+           MYSQL_VERSION_ID, "started");
+  }
+
   sysd::notify("STATUS=Server upgrade in progress\n");
 
   bootstrap_error_handler.set_log_error(false);
@@ -899,14 +923,23 @@ bool upgrade_system_schemas(THD *thd) {
                : check.check_system_schemas(thd)) ||
           check.repair_tables(thd) ||
           dd::tables::DD_properties::instance().set(
-              thd, "MYSQLD_VERSION_UPGRADED", MYSQL_VERSION_ID);
+              thd, "MYSQLD_VERSION_UPGRADED", MYSQL_VERSION_ID) ||
+          dd::tables::DD_properties::instance().set(
+              thd, "DD_SYSTEM_ENGINE_UPGRADED", get_dd_engine_type());
   }
   create_upgrade_file();
   bootstrap_error_handler.set_log_error(true);
 
-  if (!err)
-    LogErr(SYSTEM_LEVEL, ER_SERVER_UPGRADE_STATUS, server_version,
-           MYSQL_VERSION_ID, "completed");
+  if (!err) {
+    if (dd_system_engine != get_dd_engine_type()) {
+      LogErr(SYSTEM_LEVEL, ER_SYSTEM_TABLE_SERVER_UPGRADE_STATUS,
+             get_dd_engine_name(dd_system_engine), get_dd_engine_name(),
+             "completed");
+    } else {
+      LogErr(SYSTEM_LEVEL, ER_SERVER_UPGRADE_STATUS, server_version,
+             MYSQL_VERSION_ID, "completed");
+    }
+  }
   sysd::notify("STATUS=Server upgrade complete\n");
 
   /*

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1577,7 +1577,7 @@ bool opt_group_replication_plugin_hooks = false;
 bool opt_core_file = false;
 bool skip_core_dump_on_error = false;
 bool show_query_digest = false;
-
+bool skip_sys_tables_engine_check = false;
 /* write_control_level:
  * Global variable to control write throttling for short running writes
  */

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -785,6 +785,8 @@ extern thread_local MEM_ROOT **THR_MALLOC;
 extern PSI_file_key key_file_binlog_cache;
 extern PSI_file_key key_file_binlog_index_cache;
 
+extern bool skip_sys_tables_engine_check;
+
 #ifdef HAVE_PSI_INTERFACE
 
 extern PSI_mutex_key key_LOCK_tc;

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -10397,3 +10397,11 @@ static Sys_var_uint Sys_fb_vector_max_dimension(
     SESSION_VAR(fb_vector_max_dimension), CMD_LINE(OPT_ARG),
     VALID_RANGE(1, 1024 * 1024), DEFAULT(4 * 1024), BLOCK_SIZE(1),
     NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(nullptr), ON_UPDATE(nullptr));
+
+static Sys_var_bool Sys_skip_sys_tables_engine_check(
+    "skip_sys_tables_engine_check",
+    "skip System Tables storage engine check. If True, System Tables can use "
+    "any supported storage engines; If False, System Tables can only use "
+    "default_dd_system_storage_engine",
+    GLOBAL_VAR(skip_sys_tables_engine_check), CMD_LINE(OPT_ARG),
+    DEFAULT(false));


### PR DESCRIPTION
Summary:

During mysqld version changes, it call upgrade_system_schemas() to upgrade SYSTEM tables. During DDSE change, It will also call upgrade_system_schemas() to upgrade these SYSTEM tables.

One question is how to "reliability" upgrade SYSTEM tables during DDSE change(upgrade SYSTEM tables occurs after DD_ENGINE properties has been changed to target DDSE):
- [Current] add a new persistent variable DD_ENGINE_UPGRADED in mysql.dd_properities table, whose value is last dd engine name during dd engine change. For example, when DDSE is changed from INNODB to ROCKSDB, the DD_ENGINE_UPGRADED value will be set to "INNODB" during DD Tables upgrade. Later, mysqld will check whether  DD_ENGINE_UPGRADED is same as target DDSE in no_server_upgrade_required(), if not, upgrade these SYSTEM tables to target DDSE if required.
- add a new global variables, such as DD_ENGINE_UPGRADING. During crash recovery, we need to re-initiate this values.

Details:
- add a new Properties DD_ENGINE_UPGRADED into DD_Properties table 
- mysql_system_tables_fix.sql: update system tables if necessary. 
- main.dd_schema_definition_after_upgrade_57_debug, main.dd_schema_definition_after_upgrade_80_debug: skip DD_ENGINE_UPGRADED compare, similar to DD_ENGINE
- rocksdb.rocksdb_read_free_rpl, rocksdb.singledelete: add delta for rocksdb stats due to system table involved during commit
- rocksdb.cancel_mc, rocksdb.rocksdb_fault_injection: force to use INNODB DDSE

The change has several assumptions:
- SYSTEM Tables and DD Tables always has same SE(DDSE).
- When force upgrade is specified(https://dev.mysql.com/doc/refman/8.0/en/upgrading-what-is-upgraded.html), it won't run ALTER SYSTEM tables to target DDSE again and it will run similar as mysqld version change

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: https://phabricator.intern.facebook.com/D51085626