### PR TITLE
Remove Rdb_transaction::m_ddl_transaction

### DIFF
--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -806,23 +806,19 @@ class ha_rocksdb : public my_core::handler, public blob_buffer {
   enum icp_result check_index_cond() const;
 
   void calc_updated_indexes();
-  int update_write_row(const uchar *const old_data, const uchar *const new_data,
-                       const bool skip_unique_check)
-      MY_ATTRIBUTE((__warn_unused_result__));
+  [[nodiscard]] int update_write_row(const uchar *const old_data,
+                                     const uchar *const new_data);
   int get_pk_for_update(struct update_row_info *const row_info);
-  int check_and_lock_unique_pk(const struct update_row_info &row_info,
-                               bool *const found, const bool skip_unique_check)
-      MY_ATTRIBUTE((__warn_unused_result__));
+  [[nodiscard]] int check_and_lock_unique_pk(
+      const struct update_row_info &row_info, bool *const found);
   int acquire_prefix_lock(const Rdb_key_def &kd, Rdb_transaction *tx,
                           const uchar *data)
       MY_ATTRIBUTE((__warn_unused_result__));
-  int check_and_lock_sk(const uint key_id,
-                        const struct update_row_info &row_info,
-                        bool *const found, const bool skip_unique_check)
-      MY_ATTRIBUTE((__warn_unused_result__));
-  int check_uniqueness_and_lock(const struct update_row_info &row_info,
-                                bool pk_changed, const bool skip_unique_check)
-      MY_ATTRIBUTE((__warn_unused_result__));
+  [[nodiscard]] int check_and_lock_sk(const uint key_id,
+                                      const struct update_row_info &row_info,
+                                      bool *const found);
+  [[nodiscard]] int check_uniqueness_and_lock(
+      const struct update_row_info &row_info, bool pk_changed);
   bool over_bulk_load_threshold(int *err)
       MY_ATTRIBUTE((__warn_unused_result__));
   int check_duplicate_sk(const TABLE *table_arg, const Rdb_key_def &key_def,


### PR DESCRIPTION
With DD tables in MyRocks, the property of whether it is safe to skip uniqueness checks on writes should be resolved on a table, not transaction level. Thus fold the logic of setting m_ddl_transaction to true into ha_rocksdb::skip_unique. At the same time this flag is duplicated between struct update_row_info and callstack of affected functions, thus remove it from the callstack.