### PR TITLE
MTR updates for MyRocks DDSE, part 6

### DIFF
--- a/mysql-test/suite/innodb/r/portability_basic.result
+++ b/mysql-test/suite/innodb/r/portability_basic.result
@@ -94,7 +94,7 @@ DROP UNDO TABLESPACE undo_003;
 DROP UNDO TABLESPACE undo_004;
 # Stop DB server with new datadir
 # Re-start with old --datadir
-# restart: --datadir=OLD_DATADIR
+# restart: --datadir=OLD_DATADIR --default-dd-storage-engine=DDSE
 # Check --datadir started with old
 SELECT @@datadir;
 @@datadir

--- a/mysql-test/suite/innodb/r/portability_tablespace.result
+++ b/mysql-test/suite/innodb/r/portability_tablespace.result
@@ -1,5 +1,5 @@
 # Define old data locations
-# restart: --innodb-directories=MYSQL_TMP_DIR/old/remote_dir
+# restart: --innodb-directories=MYSQL_TMP_DIR/old/remote_dir --default-dd-storage-engine=DEFAULT_DDSE
 # Define and create new datadir folders
 ## create all kinds of tables including absolute paths
 CREATE TABLESPACE ts1 ADD DATAFILE 'ts1.ibd' Engine=InnoDB;
@@ -101,7 +101,8 @@ tab3	CREATE TABLE `tab3` (
 /*!50100 PARTITION BY HASH (`empno`)
 (PARTITION P0 DATA DIRECTORY = 'MYSQL_TMP_DIR/new/remote_dir' ENGINE = InnoDB,
  PARTITION P1 DATA DIRECTORY = 'MYSQL_TMP_DIR/new/remote_dir' ENGINE = InnoDB) */
-SELECT file_name,file_type,tablespace_name FROM INFORMATION_SCHEMA.FILES WHERE file_type LIKE '%undo%';
+SELECT file_name,file_type,tablespace_name FROM INFORMATION_SCHEMA.FILES
+WHERE file_type LIKE '%undo%' ORDER BY tablespace_name;
 FILE_NAME	FILE_TYPE	TABLESPACE_NAME
 MYSQL_TMP_DIR/new/undo_dir/undo_001	UNDO LOG	innodb_undo_001
 MYSQL_TMP_DIR/new/undo_dir/undo_002	UNDO LOG	innodb_undo_002
@@ -115,7 +116,7 @@ MYSQL_TMP_DIR/new/undo_dir/undo_002
 MYSQL_TMP_DIR/new/undo_dir/undo_003.ibu
 # Stop DB server
 # Start with new --datadir only
-# restart: --datadir=MYSQL_TMP_DIR/new/data --innodb_undo_directory=MYSQL_TMP_DIR/new/undo_dir --innodb_data_home_dir=MYSQL_TMP_DIR/new/data_home_dir --innodb_log_group_home_dir=MYSQL_TMP_DIR/new/data_home_dir --innodb-directories=MYSQL_TMP_DIR/new/remote_dir
+# restart: --datadir=MYSQL_TMP_DIR/new/data --innodb_undo_directory=MYSQL_TMP_DIR/new/undo_dir --innodb_data_home_dir=MYSQL_TMP_DIR/new/data_home_dir --innodb_log_group_home_dir=MYSQL_TMP_DIR/new/data_home_dir --innodb-directories=MYSQL_TMP_DIR/new/remote_dir --default-dd-storage-engine=DEFAULT_DDSE
 # Check with new --datadir
 SELECT @@datadir;
 @@datadir
@@ -155,7 +156,8 @@ tab3	CREATE TABLE `tab3` (
 /*!50100 PARTITION BY HASH (`empno`)
 (PARTITION P0 DATA DIRECTORY = 'MYSQL_TMP_DIR/new/remote_dir' ENGINE = InnoDB,
  PARTITION P1 DATA DIRECTORY = 'MYSQL_TMP_DIR/new/remote_dir' ENGINE = InnoDB) */
-SELECT file_name,file_type,tablespace_name FROM INFORMATION_SCHEMA.FILES WHERE file_type LIKE '%undo%';
+SELECT file_name,file_type,tablespace_name FROM INFORMATION_SCHEMA.FILES
+WHERE file_type LIKE '%undo%' ORDER BY tablespace_name;
 FILE_NAME	FILE_TYPE	TABLESPACE_NAME
 MYSQL_TMP_DIR/new/undo_dir/undo_001	UNDO LOG	innodb_undo_001
 MYSQL_TMP_DIR/new/undo_dir/undo_002	UNDO LOG	innodb_undo_002
@@ -241,7 +243,7 @@ DROP TABLESPACE ts1;
 # Cleanup the new DATA DIRECTORY *.ibd files
 # Test by providing the relative path
 # Re-start with old --datadir with --innodb-directories as remote *.ibd files are existing.
-# restart: --innodb-directories=MYSQL_TMP_DIR/old/remote_dir
+# restart: --innodb-directories=MYSQL_TMP_DIR/old/remote_dir --default-dd-storage-engine=DEFAULT_DDSE
 # Check --datadir started with old
 SELECT @@datadir;
 @@datadir

--- a/mysql-test/suite/innodb/t/portability_basic.test
+++ b/mysql-test/suite/innodb/t/portability_basic.test
@@ -9,6 +9,7 @@
 --source include/have_innodb_default_undo_tablespaces.inc
 
 let $MYSQLD_OLD_DATADIR = `select @@datadir`;
+let $DEFAULT_DDSE = `select @@default_dd_storage_engine`;
 
 # Create new datadir folders like data
 --mkdir $MYSQL_TMP_DIR/new_datadir
@@ -49,6 +50,9 @@ SELECT  file_name,file_type,tablespace_name FROM
 --source include/shutdown_mysqld.inc
 
 --echo # Copy whole --datadir files into new location
+if ($DEFAULT_DDSE == "RocksDB") {
+   --force-cpdir $MYSQLD_OLD_DATADIR/.rocksdb $MYSQLD_NEW_DATADIR
+}
 --copy_file $MYSQLD_OLD_DATADIR/auto.cnf $MYSQLD_NEW_DATADIR/auto.cnf
 --copy_file $MYSQLD_OLD_DATADIR/ib_buffer_pool $MYSQLD_NEW_DATADIR/ib_buffer_pool
 --copy_file $MYSQLD_OLD_DATADIR/ibdata1 $MYSQLD_NEW_DATADIR/ibdata1
@@ -63,7 +67,7 @@ SELECT  file_name,file_type,tablespace_name FROM
 --copy_files_wildcard $MYSQLD_OLD_DATADIR/mtr/  $MYSQLD_NEW_DATADIR/mtr/ *.*
 
 --echo ## Start with new --datadir
---let $restart_parameters="restart: --datadir=$MYSQLD_NEW_DATADIR"
+--let $restart_parameters="restart: --datadir=$MYSQLD_NEW_DATADIR" --default-dd-storage-engine=$DEFAULT_DDSE
 --source include/start_mysqld_no_echo.inc
 
 --echo ## Check datadir started with new one
@@ -139,8 +143,8 @@ DROP UNDO TABLESPACE undo_004;
 --force-rmdir $MYSQL_TMP_DIR/new_datadir
 
 --echo # Re-start with old --datadir
---replace_result $MYSQLD_OLD_DATADIR OLD_DATADIR
---let $restart_parameters="restart: --datadir=$MYSQLD_OLD_DATADIR"
+--replace_result $MYSQLD_OLD_DATADIR OLD_DATADIR $DEFAULT_DDSE DDSE
+--let $restart_parameters="restart: --datadir=$MYSQLD_OLD_DATADIR --default-dd-storage-engine=$DEFAULT_DDSE"
 --source include/start_mysqld.inc
 
 --echo # Check --datadir started with old

--- a/mysql-test/suite/innodb/t/portability_tablespace.test
+++ b/mysql-test/suite/innodb/t/portability_tablespace.test
@@ -22,10 +22,12 @@ let $MYSQLD_OLD                = $MYSQL_TMP_DIR/old;
 let $MYSQLD_OLD_REMOTE_DIR     = $MYSQLD_OLD/remote_dir;
 let $MYSQLD_OLD_REDO_LOG_DIR   = $MYSQLD_OLD_DATADIR/#innodb_redo;
 
+let $DEFAULT_DDSE = `select @@default_dd_storage_engine`;
+
 --disable_query_log
 --replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
---let $restart_parameters = restart: --innodb-directories=$MYSQLD_OLD_REMOTE_DIR
---replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
+--let $restart_parameters = restart: --innodb-directories=$MYSQLD_OLD_REMOTE_DIR --default-dd-storage-engine=$DEFAULT_DDSE
+--replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR $DEFAULT_DDSE DEFAULT_DDSE
 --source include/restart_mysqld.inc
 --enable_query_log
 
@@ -117,6 +119,9 @@ SELECT path FROM INFORMATION_SCHEMA.INNODB_DATAFILES WHERE path LIKE '%undo_0%' 
 --source include/shutdown_mysqld.inc
 
 --echo # Copy whole --datadir files into new locations
+if ($DEFAULT_DDSE == "RocksDB") {
+  --force-cpdir $MYSQLD_OLD_DATADIR/.rocksdb $MYSQLD_NEW_DATADIR
+}
 --copy_file $MYSQLD_OLD_DATADIR/auto.cnf         $MYSQLD_NEW_DATADIR/auto.cnf
 --copy_file $MYSQLD_OLD_DATADIR/ib_buffer_pool   $MYSQLD_NEW_DATA_HOME_DIR/ib_buffer_pool
 --copy_file $MYSQLD_OLD_DATADIR/ibdata1          $MYSQLD_NEW_DATA_HOME_DIR/ibdata1
@@ -138,6 +143,9 @@ SELECT path FROM INFORMATION_SCHEMA.INNODB_DATAFILES WHERE path LIKE '%undo_0%' 
 --copy_files_wildcard $MYSQLD_OLD_REMOTE_DIR/test/ $MYSQLD_NEW_REMOTE_DIR/test tab3*.ibd
 
 --echo # Remove the old datadir files and *.ibd files
+if ($DEFAULT_DDSE == "RocksDB") {
+  --force-rmdir $MYSQLD_OLD_DATADIR/.rocksdb
+}
 --remove_files_wildcard $MYSQLD_OLD_REMOTE_DIR/test/ *.ibd
 --remove_files_wildcard $MYSQLD_OLD_REDO_LOG_DIR/ #ib_redo*
 --remove_files_wildcard $MYSQLD_OLD_DATADIR/ ib_buffer*
@@ -153,8 +161,8 @@ SELECT path FROM INFORMATION_SCHEMA.INNODB_DATAFILES WHERE path LIKE '%undo_0%' 
 --remove_files_wildcard $MYSQLD_OLD_DATADIR/mtr/ *
 
 --echo # Start with --innodb-directories along with other initDB options
---replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
---let $restart_parameters=restart: --datadir=$MYSQLD_NEW_DATADIR --innodb_undo_directory=$MYSQLD_NEW_UNDO_DIR --innodb_data_home_dir=$MYSQLD_NEW_DATA_HOME_DIR --innodb_log_group_home_dir=$MYSQLD_NEW_DATA_HOME_DIR --innodb-directories=$MYSQLD_NEW_REMOTE_DIR
+--replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR $DEFAULT_DDSE DEFAULT_DDSE
+--let $restart_parameters=restart: --datadir=$MYSQLD_NEW_DATADIR --innodb_undo_directory=$MYSQLD_NEW_UNDO_DIR --innodb_data_home_dir=$MYSQLD_NEW_DATA_HOME_DIR --innodb_log_group_home_dir=$MYSQLD_NEW_DATA_HOME_DIR --innodb-directories=$MYSQLD_NEW_REMOTE_DIR --default-dd-storage-engine=$DEFAULT_DDSE
 --source include/start_mysqld_no_echo.inc
 
 --echo # Check new datadir
@@ -175,7 +183,8 @@ SHOW CREATE TABLE tab3;
 
 # Check if the metadata info is correct.
 --replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
-SELECT file_name,file_type,tablespace_name FROM INFORMATION_SCHEMA.FILES WHERE file_type LIKE '%undo%';
+SELECT file_name,file_type,tablespace_name FROM INFORMATION_SCHEMA.FILES
+       WHERE file_type LIKE '%undo%' ORDER BY tablespace_name;
 --replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
 SELECT path FROM INFORMATION_SCHEMA.INNODB_DATAFILES WHERE path LIKE '%undo_0%' ORDER BY path;
 
@@ -184,8 +193,8 @@ SELECT path FROM INFORMATION_SCHEMA.INNODB_DATAFILES WHERE path LIKE '%undo_0%' 
 --source include/shutdown_mysqld.inc
 
 --echo # Start with new --datadir only
---replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
---let $restart_parameters=restart: --datadir=$MYSQLD_NEW_DATADIR --innodb_undo_directory=$MYSQLD_NEW_UNDO_DIR --innodb_data_home_dir=$MYSQLD_NEW_DATA_HOME_DIR --innodb_log_group_home_dir=$MYSQLD_NEW_DATA_HOME_DIR --innodb-directories=$MYSQLD_NEW_REMOTE_DIR
+--replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR $DEFAULT_DDSE DEFAULT_DDSE
+--let $restart_parameters=restart: --datadir=$MYSQLD_NEW_DATADIR --innodb_undo_directory=$MYSQLD_NEW_UNDO_DIR --innodb_data_home_dir=$MYSQLD_NEW_DATA_HOME_DIR --innodb_log_group_home_dir=$MYSQLD_NEW_DATA_HOME_DIR --innodb-directories=$MYSQLD_NEW_REMOTE_DIR --default-dd-storage-engine=$DEFAULT_DDSE
 --source include/start_mysqld.inc
 
 --echo # Check with new --datadir
@@ -211,7 +220,8 @@ SHOW CREATE TABLE tab3;
 
 # Check if the metadata info is correct.
 --replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
-SELECT file_name,file_type,tablespace_name FROM INFORMATION_SCHEMA.FILES WHERE file_type LIKE '%undo%';
+SELECT file_name,file_type,tablespace_name FROM INFORMATION_SCHEMA.FILES
+       WHERE file_type LIKE '%undo%' ORDER BY tablespace_name;
 --replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
 SELECT path FROM INFORMATION_SCHEMA.INNODB_DATAFILES WHERE path LIKE '%undo_0%' ORDER BY path;
 
@@ -289,6 +299,10 @@ DROP TABLESPACE ts1;
 --source include/shutdown_mysqld.inc
 
 --echo # Copy back --datadir and *.ibd files into old location
+if ($DEFAULT_DDSE == "RocksDB") {
+  --force-cpdir $MYSQLD_NEW_DATADIR/.rocksdb $MYSQLD_OLD_DATADIR
+}
+
 --copy_files_wildcard $MYSQLD_NEW_REMOTE_DIR/test $MYSQLD_OLD_REMOTE_DIR/test *.ibd
 --copy_files_wildcard $MYSQLD_NEW_REMOTE_DIR  $MYSQLD_OLD_REMOTE_DIR/test ts3.ibd
 --copy_files_wildcard $MYSQLD_NEW_UNDO_DIR  $MYSQLD_OLD_DATADIR undo*
@@ -314,8 +328,8 @@ DROP TABLESPACE ts1;
 
 --echo # Test by providing the relative path
 --echo # Re-start with old --datadir with --innodb-directories as remote *.ibd files are existing.
---replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
---let $restart_parameters= restart: --innodb-directories=$MYSQLD_OLD_REMOTE_DIR
+--replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR $DEFAULT_DDSE DEFAULT_DDSE
+--let $restart_parameters= restart: --innodb-directories=$MYSQLD_OLD_REMOTE_DIR --default-dd-storage-engine=$DEFAULT_DDSE
 --source include/start_mysqld.inc
 
 --echo # Check --datadir started with old

--- a/mysql-test/suite/innodb/t/portability_tablespace_linux.test
+++ b/mysql-test/suite/innodb/t/portability_tablespace_linux.test
@@ -1,3 +1,5 @@
+# The Windows datadir was not prepared with MyRocks DDSE
+--source include/have_innodb_ddse.inc
 # *************************************************************************
 # wl#8619 : Test the functionality of portability to a different OS
 # Test windows --datadir and tablespaces runs on Linx (posix compliant) OS


### PR DESCRIPTION
Update the InnoDB portable tablespace testcases. Make sure to start new server instances with the same DDSE the test runs under, and copy the MyRocks data when it carries the DD. Skip the portability_tablespace_linux test because it relies on a pre-packaged datadir that was not prepared with MyRocks DDSE.