### PR TITLE
Update MyRocks MTR tests for MyRocks DDSE

### DIFF
--- a/mysql-test/suite/rocksdb/r/alter_table_comment_inplace.result
+++ b/mysql-test/suite/rocksdb/r/alter_table_comment_inplace.result
@@ -209,17 +209,19 @@ ALTER TABLE t3 COMMENT="ttl_duration=1;custom_p1_ttl_duration=1000;custom_p1_ttl
 ERROR 0A000: ALGORITHM=INPLACE is not supported for this operation. Try ALGORITHM=COPY.
 ALTER TABLE t3 COMMENT="ttl_duration=1;custom_p1_ttl_duration=1000;custom_p1_ttl_col=c2;custom_p2_ttl_col=c1;custom_p2_ttl_duration=5000;",ALGORITHM=INPLACE;
 ERROR 0A000: ALGORITHM=INPLACE is not supported for this operation. Try ALGORITHM=COPY.
-SELECT TABLE_NAME,TTL_DURATION,INDEX_FLAGS from INFORMATION_SCHEMA.ROCKSDB_DDL where TABLE_NAME = 't3';
+SELECT TABLE_NAME,TTL_DURATION,INDEX_FLAGS FROM INFORMATION_SCHEMA.ROCKSDB_DDL
+WHERE TABLE_NAME = 't3' ORDER BY TTL_DURATION;
 TABLE_NAME	TTL_DURATION	INDEX_FLAGS
-t3	5000	1
-t3	1000	1
 t3	1	1
-ALTER TABLE t3 comment = 'ttl_duration=5;custom_p1_ttl_duration=100;custom_p1_ttl_col=c2;custom_p2_ttl_duration=1000;', ALGORITHM=INPLACE;
-SELECT TABLE_NAME,TTL_DURATION,INDEX_FLAGS from INFORMATION_SCHEMA.ROCKSDB_DDL where TABLE_NAME = 't3';
-TABLE_NAME	TTL_DURATION	INDEX_FLAGS
 t3	1000	1
-t3	100	1
+t3	5000	1
+ALTER TABLE t3 comment = 'ttl_duration=5;custom_p1_ttl_duration=100;custom_p1_ttl_col=c2;custom_p2_ttl_duration=1000;', ALGORITHM=INPLACE;
+SELECT TABLE_NAME,TTL_DURATION,INDEX_FLAGS FROM INFORMATION_SCHEMA.ROCKSDB_DDL
+WHERE TABLE_NAME = 't3' ORDER BY TTL_DURATION;
+TABLE_NAME	TTL_DURATION	INDEX_FLAGS
 t3	5	1
+t3	100	1
+t3	1000	1
 SET GLOBAL rocksdb_debug_ttl_snapshot_ts = 300;
 set global rocksdb_force_flush_memtable_now=1;
 set @@global.rocksdb_compact_cf = 'foo';

--- a/mysql-test/suite/rocksdb/t/alter_table_comment_inplace.test
+++ b/mysql-test/suite/rocksdb/t/alter_table_comment_inplace.test
@@ -245,9 +245,11 @@ ALTER TABLE t3 COMMENT="ttl_duration=1;custom_p1_ttl_duration=1000;custom_p1_ttl
 ALTER TABLE t3 COMMENT="ttl_duration=1;custom_p1_ttl_duration=1000;custom_p1_ttl_col=c2;custom_p2_ttl_col=c1;custom_p2_ttl_duration=5000;",ALGORITHM=INPLACE;
 
 # support inplace change ttl duration value
-SELECT TABLE_NAME,TTL_DURATION,INDEX_FLAGS from INFORMATION_SCHEMA.ROCKSDB_DDL where TABLE_NAME = 't3';
+SELECT TABLE_NAME,TTL_DURATION,INDEX_FLAGS FROM INFORMATION_SCHEMA.ROCKSDB_DDL
+       WHERE TABLE_NAME = 't3' ORDER BY TTL_DURATION;
 ALTER TABLE t3 comment = 'ttl_duration=5;custom_p1_ttl_duration=100;custom_p1_ttl_col=c2;custom_p2_ttl_duration=1000;', ALGORITHM=INPLACE;
-SELECT TABLE_NAME,TTL_DURATION,INDEX_FLAGS from INFORMATION_SCHEMA.ROCKSDB_DDL where TABLE_NAME = 't3';
+SELECT TABLE_NAME,TTL_DURATION,INDEX_FLAGS FROM INFORMATION_SCHEMA.ROCKSDB_DDL
+       WHERE TABLE_NAME = 't3' ORDER BY TTL_DURATION;
 
 SET GLOBAL rocksdb_debug_ttl_snapshot_ts = 300;
 set global rocksdb_force_flush_memtable_now=1;

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_large_prefix_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_large_prefix_basic.test
@@ -1,3 +1,5 @@
+# Can't disable rocksdb_large_prefix when MyRocks is the DDSE
+--source include/have_innodb_ddse.inc
 --source include/have_rocksdb.inc
 
 CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_write_batch_max_bytes_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_write_batch_max_bytes_basic.test
@@ -1,3 +1,5 @@
+# Memory limit reached sooner when MyRocks is the DDSE
+--source include/have_innodb_ddse.inc
 --source include/have_rocksdb.inc
 
 create table t (i int);


### PR DESCRIPTION
- Stabilize rocksdb.alter_table_commit_inplace by adding some ORDER BYs.
- Skip rocksdb_sys_vars.rocksdb_large_prefix_basic and rocksdb_sys_vars.rocksdb_write_batch_max_bytes_basic with MyRocks DDSE because of DDSE requirements.