### PR TITLE
Rename default_dd_storage_engine to default_dd_system_storage_engine

### DIFF
--- a/mysql-test/extra/rpl_tests/rpl_mts_spco_commands.test
+++ b/mysql-test/extra/rpl_tests/rpl_mts_spco_commands.test
@@ -207,7 +207,7 @@ SET @@global.binlog_transaction_dependency_tracking = COMMIT_ORDER;
 --echo # $tc_count. CREATE TABLE and CREATE TABLE IF NOT EXISTS
 --echo ####################################################################
 
---let $DEFAULT_DDSE = `SELECT @@default_dd_storage_engine`
+--let $DEFAULT_DDSE = `SELECT @@default_dd_system_storage_engine`
 if ($DEFAULT_DDSE == "RocksDB") {
   --let $mts_num_preceding_trans= 5
 }

--- a/mysql-test/include/have_innodb_ddse.inc
+++ b/mysql-test/include/have_innodb_ddse.inc
@@ -1,3 +1,3 @@
-if (`select count(*) = 0 from performance_schema.global_variables where variable_name = 'default_dd_storage_engine' and variable_value = 'InnoDB';`) {
+if (`select count(*) = 0 from performance_schema.global_variables where variable_name = 'default_dd_system_storage_engine' and variable_value = 'InnoDB';`) {
   --skip Test requires InnoDB DDSE
 }

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -398,7 +398,7 @@ The following options may be given as the first argument:
  hash the password.
  --default-collation-for-utf8mb4-init=name 
  The default collation for utf8mb4 charsets
- --default-dd-storage-engine=name 
+ --default-dd-system-storage-engine=name 
  The default storage engine for data dictionary
  --default-password-lifetime=# 
  The number of days after which the password will expire.
@@ -3249,7 +3249,7 @@ cte-max-recursion-depth 1000
 daemonize FALSE
 default-authentication-plugin caching_sha2_password
 default-collation-for-utf8mb4-init (No default value)
-default-dd-storage-engine InnoDB
+default-dd-system-storage-engine InnoDB
 default-password-lifetime 0
 default-storage-engine InnoDB
 default-table-encryption FALSE

--- a/mysql-test/suite/clone/include/clone_connection_begin.inc
+++ b/mysql-test/suite/clone/include/clone_connection_begin.inc
@@ -77,7 +77,7 @@ if ($inst_monitor) {
   --let $page_size= `select @@innodb_page_size`
   --let $error_verbosity = `select @@log_error_verbosity`
 
-  --let $default_dd_se = `select @@default_dd_storage_engine`
+  --let $default_dd_se = `select @@default_dd_system_storage_engine`
 
   # mysqld_path to be passed to --ledir
   perl;
@@ -103,7 +103,7 @@ if ($inst_monitor) {
   --source include/wait_until_disconnected.inc
 
   # 3. Run mysqld_safe script
-  --exec sh $MYSQLD_SAFE --defaults-file=$MYSQLTEST_VARDIR/my.cnf --server-id=$SERVER_ID --log-error=$MYSQLTEST_VARDIR/log/mysqld.$SERVER_ID.err --log-error-verbosity=$error_verbosity --basedir=$MYSQL_BASEDIR --ledir=$mysqld_path --mysqld=$mysqld_bin --datadir=$MYSQLD_DATADIR --socket=$MYSQL_SOCKET --mysqlx_socket=$MYSQLX_SOCKET --pid-file=$MYSQL_PIDFILE --port=$MYSQL_PORT --mysqlx_port=$MYSQLX_PORT --plugin_dir=$MYSQL_PLUGIN_DIR --timezone=SYSTEM --log-output=file --secure-file-priv="" --core-file --lc-messages-dir=$MYSQL_MESSAGESDIR --innodb-page-size=$page_size --default_dd_storage_engine=$default_dd_se < /dev/null > /dev/null 2>&1 &
+  --exec sh $MYSQLD_SAFE --defaults-file=$MYSQLTEST_VARDIR/my.cnf --server-id=$SERVER_ID --log-error=$MYSQLTEST_VARDIR/log/mysqld.$SERVER_ID.err --log-error-verbosity=$error_verbosity --basedir=$MYSQL_BASEDIR --ledir=$mysqld_path --mysqld=$mysqld_bin --datadir=$MYSQLD_DATADIR --socket=$MYSQL_SOCKET --mysqlx_socket=$MYSQLX_SOCKET --pid-file=$MYSQL_PIDFILE --port=$MYSQL_PORT --mysqlx_port=$MYSQLX_PORT --plugin_dir=$MYSQL_PLUGIN_DIR --timezone=SYSTEM --log-output=file --secure-file-priv="" --core-file --lc-messages-dir=$MYSQL_MESSAGESDIR --innodb-page-size=$page_size --default_dd_system_storage_engine=$default_dd_se < /dev/null > /dev/null 2>&1 &
   --enable_reconnect
   --source include/wait_until_connected_again.inc
   --disable_reconnect

--- a/mysql-test/suite/innodb/t/innodb_bug12400341.test
+++ b/mysql-test/suite/innodb/t/innodb_bug12400341.test
@@ -9,7 +9,7 @@
 
 --disable_query_log
 call mtr.add_suppression("\\[ERROR\\] .*MY-\\d+.* Cannot find a free slot for an undo log");
---let $DEFAULT_DDSE = `SELECT @@default_dd_storage_engine`
+--let $DEFAULT_DDSE = `SELECT @@default_dd_system_storage_engine`
 if ($DEFAULT_DDSE == "RocksDB") {
    # The InnoDB transactions will encounter lack of undo slots at different
    # points if it's DDSE and if it's not. When it's not, it will happen when

--- a/mysql-test/suite/innodb_undo/t/undo_tablespace_encrypt.test
+++ b/mysql-test/suite/innodb_undo/t/undo_tablespace_encrypt.test
@@ -11,7 +11,7 @@
 --echo # Bug #29492911 : ENABLING UNDO-TABLESPACE ENCRYPTION DOESN'T MARK TABLESPACE ENCRYPTION FLAG
 --echo #
 
-let $DDSE = `select @@default_dd_storage_engine`;
+let $DDSE = `select @@default_dd_system_storage_engine`;
 let $MYSQL_DATA_DIR = `select @@datadir`;
 
 SHOW VARIABLES LIKE "%innodb_undo_log_encrypt%";
@@ -33,7 +33,7 @@ EOF
 --source include/shutdown_mysqld.inc
 --source include/wait_until_disconnected.inc
 
---let NEW_CMD = $MYSQLD --no-defaults --innodb_dedicated_server=OFF --initialize-insecure --innodb_redo_log_capacity=$LOG_SIZE --innodb_page_size=$PAGE_SIZE --datadir=$MYSQL_ENC_DATADIR --init-file=$BOOTSTRAP_SQL --secure-file-priv="" --default-dd-storage-engine=$DDSE >>$BOOTSTRAP_LOG 2>&1
+--let NEW_CMD = $MYSQLD --no-defaults --innodb_dedicated_server=OFF --initialize-insecure --innodb_redo_log_capacity=$LOG_SIZE --innodb_page_size=$PAGE_SIZE --datadir=$MYSQL_ENC_DATADIR --init-file=$BOOTSTRAP_SQL --secure-file-priv="" --default-dd-system-storage-engine=$DDSE >>$BOOTSTRAP_LOG 2>&1
 --exec $NEW_CMD
 
 --echo ###############################################################################

--- a/mysql-test/suite/perfschema/t/statements_row_updated.test
+++ b/mysql-test/suite/perfschema/t/statements_row_updated.test
@@ -1,4 +1,4 @@
---let $default_ddse = `SELECT @@default_dd_storage_engine`
+--let $default_ddse = `SELECT @@default_dd_system_storage_engine`
 
 #
 --echo Variation 0: No-op Select

--- a/mysql-test/suite/rocksdb/combinations
+++ b/mysql-test/suite/rocksdb/combinations
@@ -1,4 +1,4 @@
 [innodb_ddse]
 
 [rocksdb_ddse]
-default_dd_storage_engine = rocksdb
+default_dd_system_storage_engine = rocksdb

--- a/mysql-test/suite/rocksdb/t/allow_to_start_after_corruption.test
+++ b/mysql-test/suite/rocksdb/t/allow_to_start_after_corruption.test
@@ -8,7 +8,7 @@
 
 --source include/have_debug.inc
 
---let ddse= query_get_value(SELECT @@default_dd_storage_engine, @@default_dd_storage_engine, 1)
+--let ddse=`SELECT @@default_dd_system_storage_engine`
 
 # use custom error log to assert on error message in search_pattern_in_file.inc
 --let LOG=$MYSQLTEST_VARDIR/tmp/allow_to_start_after_corruption_debug.err
@@ -62,7 +62,7 @@ select * from t1;
 # remove flag to ignore corruption
 --let $_mysqld_option=--log-error=$LOG
 --error 0
---exec $MYSQLD_CMD $_mysqld_option --default_dd_storage_engine=$ddse
+--exec $MYSQLD_CMD $_mysqld_option --default_dd_system_storage_engine=$ddse
 --let SEARCH_PATTERN=The server will exit normally and stop restart attempts
 --source include/search_pattern_in_file.inc
 --remove_file $LOG

--- a/mysql-test/suite/rocksdb/t/alter_column_default_inplace.test
+++ b/mysql-test/suite/rocksdb/t/alter_column_default_inplace.test
@@ -24,7 +24,7 @@ alter table t0 modify b char(100) default 'xyz';
 
 # for MyRocks DDSE, alter table require hold lock in DD
 --disable_query_log
-if (`SELECT @@default_dd_storage_engine = 'RocksDB'`) {
+if (`SELECT @@default_dd_system_storage_engine = 'RocksDB'`) {
 set @@rocksdb_max_row_locks = 10000;
 }
 --enable_query_log

--- a/mysql-test/suite/rocksdb/t/check_ignore_unknown_options.test
+++ b/mysql-test/suite/rocksdb/t/check_ignore_unknown_options.test
@@ -1,6 +1,6 @@
 --disable_warnings
 let $MYSQLD_DATADIR= `select @@datadir`;
---let ddse= query_get_value(SELECT @@default_dd_storage_engine, @@default_dd_storage_engine, 1)
+let ddse=`SELECT @@default_dd_system_storage_engine`;
 let $restart_file= $MYSQLTEST_VARDIR/tmp/mysqld.1.expect;
 let $error_log= $MYSQLTEST_VARDIR/log/my_restart.err;
 select variable_name, variable_value from performance_schema.global_variables where variable_name="rocksdb_ignore_unknown_options";
@@ -11,7 +11,7 @@ select variable_name, variable_value from performance_schema.global_variables wh
 --exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 --shutdown_server
 --error 1
---exec $MYSQLD_CMD --rocksdb_ignore_unknown_options=0 --loose-console --default_dd_storage_engine=$ddse > $error_log 2>&1
+--exec $MYSQLD_CMD --rocksdb_ignore_unknown_options=0 --loose-console --default_dd_system_storage_engine=$ddse > $error_log 2>&1
 
 let SEARCH_FILE= $error_log;
 let SEARCH_PATTERN= RocksDB: Compatibility check against existing database options failed;

--- a/mysql-test/suite/rocksdb/t/ddse-master.opt
+++ b/mysql-test/suite/rocksdb/t/ddse-master.opt
@@ -1,1 +1,1 @@
---initialize --default_dd_storage_engine=RocksDB
+--initialize --default_dd_system_storage_engine=RocksDB

--- a/mysql-test/suite/rocksdb/t/ddse_bug58669-master.opt
+++ b/mysql-test/suite/rocksdb/t/ddse_bug58669-master.opt
@@ -1,1 +1,1 @@
---initialize --default_dd_storage_engine=RocksDB --read-only
+--initialize --default_dd_system_storage_engine=RocksDB --read-only

--- a/mysql-test/suite/rocksdb/t/ddse_information_schema_statistics-master.opt
+++ b/mysql-test/suite/rocksdb/t/ddse_information_schema_statistics-master.opt
@@ -1,2 +1,2 @@
---initialize --default_dd_storage_engine=RocksDB
+--initialize --default_dd_system_storage_engine=RocksDB
 --information_schema_stats_expiry=86400

--- a/mysql-test/suite/rocksdb/t/drop_table2.inc
+++ b/mysql-test/suite/rocksdb/t/drop_table2.inc
@@ -120,7 +120,7 @@ let $wait_condition = select count(*) = 0
                       where TYPE = 'DDL_DROP_INDEX_ONGOING';
 --source include/wait_condition.inc
 
-let $is_rocksdb_ddse = `SELECT @@default_dd_storage_engine = 'RocksDB'`;
+let $is_rocksdb_ddse = `SELECT @@default_dd_system_storage_engine = 'RocksDB'`;
 # Check that space is reclaimed
 --exec du -c $MYSQLTEST_VARDIR/mysqld.1/data/.rocksdb/*.sst |grep total |sed 's/[\t]total/ after/' >> $output
 --exec perl suite/rocksdb/t/drop_table2_check.pl $output $is_rocksdb_ddse

--- a/mysql-test/suite/rocksdb/t/early_load_rocksdb_plugin.test
+++ b/mysql-test/suite/rocksdb/t/early_load_rocksdb_plugin.test
@@ -17,13 +17,13 @@ let extra_args=--no-defaults --basedir=$BASEDIR --debug=+d,ddse_rocksdb;
 --echo #
 --echo # Run the server with --help (a too-restrictive assert regression test)
 --echo #
---exec $MYSQLD --verbose --help --default_dd_storage_engine=RocksDB > /dev/null 2>&1
+--exec $MYSQLD --verbose --help --default_dd_system_storage_engine=RocksDB > /dev/null 2>&1
 
 
 --echo #
 --echo # Run the server with --initialize
 --echo #
---exec $MYSQLD $extra_args --initialize --default_dd_storage_engine=RocksDB --datadir=$DDIR --log-error-verbosity=3 > $MYSQLD_LOG 2>&1
+--exec $MYSQLD $extra_args --initialize --default_dd_system_storage_engine=RocksDB --datadir=$DDIR --log-error-verbosity=3 > $MYSQLD_LOG 2>&1
 --force-rmdir $DDIR
 --echo #
 --echo # Error log checks

--- a/mysql-test/suite/rocksdb/t/file_checksums.test
+++ b/mysql-test/suite/rocksdb/t/file_checksums.test
@@ -1,7 +1,7 @@
 --source include/have_rocksdb.inc
 
 --let $sst_dir=`SELECT CONCAT(@@datadir, @@rocksdb_datadir)`
---let ddse= query_get_value(SELECT @@default_dd_storage_engine, @@default_dd_storage_engine, 1)
+--let ddse=`SELECT @@default_dd_system_storage_engine`
 
 CREATE TABLE t1 (
        a INT NOT NULL, b CHAR(128),
@@ -42,7 +42,7 @@ let sst_file=`SELECT SST_NAME
 # DB open first.
 --error 1
 exec $MYSQLD --defaults-group-suffix=.1 --defaults-file=$MYSQLTEST_VARDIR/my.cnf
-     --rocksdb-file-checksums --default_dd_storage_engine=$ddse > $fail_err_log 2>&1;
+     --rocksdb-file-checksums --default_dd_system_storage_engine=$ddse > $fail_err_log 2>&1;
 
 --remove_file $sst
 --move_file $sst.bak $sst

--- a/mysql-test/suite/rocksdb/t/init_failure.test
+++ b/mysql-test/suite/rocksdb/t/init_failure.test
@@ -1,37 +1,37 @@
 --source include/have_debug.inc
 # 
 #--source include/have_innodb_ddse.inc
---let ddse= query_get_value(SELECT @@default_dd_storage_engine, @@default_dd_storage_engine, 1)
+--let ddse=`SELECT @@default_dd_system_storage_engine`
 
---let $_mysqld_option=--debug="+d,rocksdb_init_failure_files_corruption" --default_dd_storage_engine=$ddse
+--let $_mysqld_option=--debug="+d,rocksdb_init_failure_files_corruption" --default_dd_system_storage_engine=$ddse
 --source include/restart_mysqld_with_invalid_option.inc
 
---let $_mysqld_option=--debug="+d,rocksdb_init_failure_mutexes_initialized" --default_dd_storage_engine=$ddse
+--let $_mysqld_option=--debug="+d,rocksdb_init_failure_mutexes_initialized" --default_dd_system_storage_engine=$ddse
 --source include/restart_mysqld_with_invalid_option.inc
 
---let $_mysqld_option=--debug="+d,rocksdb_init_failure_reads" --default_dd_storage_engine=$ddse
+--let $_mysqld_option=--debug="+d,rocksdb_init_failure_reads" --default_dd_system_storage_engine=$ddse
 --source include/restart_mysqld_with_invalid_option.inc
 
---let $_mysqld_option=--debug="+d,rocksdb_init_failure_list_cf" --default_dd_storage_engine=$ddse
+--let $_mysqld_option=--debug="+d,rocksdb_init_failure_list_cf" --default_dd_system_storage_engine=$ddse
 --source include/restart_mysqld_with_invalid_option.inc
 
---let $_mysqld_option=--debug="+d,rocksdb_init_failure_cache" --default_dd_storage_engine=$ddse
+--let $_mysqld_option=--debug="+d,rocksdb_init_failure_cache" --default_dd_system_storage_engine=$ddse
 --source include/restart_mysqld_with_invalid_option.inc
 
---let $_mysqld_option=--debug="+d,rocksdb_init_failure_cf_options" --default_dd_storage_engine=$ddse
+--let $_mysqld_option=--debug="+d,rocksdb_init_failure_cf_options" --default_dd_system_storage_engine=$ddse
 --source include/restart_mysqld_with_invalid_option.inc
 
---let $_mysqld_option=--debug="+d,rocksdb_init_failure_incompatible_options" --default_dd_storage_engine=$ddse
+--let $_mysqld_option=--debug="+d,rocksdb_init_failure_incompatible_options" --default_dd_system_storage_engine=$ddse
 --source include/restart_mysqld_with_invalid_option.inc
 
---let $_mysqld_option=--debug="+d,rocksdb_init_failure_open_db" --default_dd_storage_engine=$ddse
+--let $_mysqld_option=--debug="+d,rocksdb_init_failure_open_db" --default_dd_system_storage_engine=$ddse
 --source include/restart_mysqld_with_invalid_option.inc
 
---let $_mysqld_option=--debug="+d,rocksdb_init_failure_managers" --default_dd_storage_engine=$ddse
+--let $_mysqld_option=--debug="+d,rocksdb_init_failure_managers" --default_dd_system_storage_engine=$ddse
 --source include/restart_mysqld_with_invalid_option.inc
 
---let $_mysqld_option=--debug="+d,rocksdb_init_failure_threads" --default_dd_storage_engine=$ddse
+--let $_mysqld_option=--debug="+d,rocksdb_init_failure_threads" --default_dd_system_storage_engine=$ddse
 --source include/restart_mysqld_with_invalid_option.inc
 
---let $_mysqld_option=--debug="+d,rocksdb_init_failure_everything_initialized" --default_dd_storage_engine=$ddse
+--let $_mysqld_option=--debug="+d,rocksdb_init_failure_everything_initialized" --default_dd_system_storage_engine=$ddse
 --source include/restart_mysqld_with_invalid_option.inc

--- a/mysql-test/suite/rocksdb/t/track_and_verify_wals_in_manifest.test
+++ b/mysql-test/suite/rocksdb/t/track_and_verify_wals_in_manifest.test
@@ -31,7 +31,7 @@ insert into t2 values (102);
 --let data_dir= query_get_value(SELECT @@DATADIR, @@DATADIR, 1)
 --let pid_file= query_get_value(SELECT @@pid_file, @@pid_file, 1)
 --let write_policy= query_get_value(SELECT @@rocksdb_write_policy, @@rocksdb_write_policy, 1)
---let ddse= query_get_value(SELECT @@default_dd_storage_engine, @@default_dd_storage_engine, 1)
+--let ddse=`SELECT @@default_dd_system_storage_engine`
 
 --let $_server_id= `SELECT @@server_id`
 --let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.$_server_id.expect
@@ -78,29 +78,29 @@ EOF
 
 # The restart has to fail with rocksdb_track_and_verify_wals_in_manifest=1 (default)
 --error 1,2
---exec $MYSQLD_CMD  --rocksdb_wal_recovery_mode=0 --rocksdb_write_policy=$write_policy --default_dd_storage_engine=$ddse > $_custom_err 2>&1
+--exec $MYSQLD_CMD  --rocksdb_wal_recovery_mode=0 --rocksdb_write_policy=$write_policy --default_dd_system_storage_engine=$ddse > $_custom_err 2>&1
 --exec grep "Size mismatch: WAL" $_custom_err | wc -l
 
 --error 1
---exec $MYSQLD_CMD  --rocksdb_wal_recovery_mode=2 --rocksdb_write_policy=$write_policy --default_dd_storage_engine=$ddse > $_custom_err 2>&1
+--exec $MYSQLD_CMD  --rocksdb_wal_recovery_mode=2 --rocksdb_write_policy=$write_policy --default_dd_system_storage_engine=$ddse > $_custom_err 2>&1
 --exec grep "Size mismatch: WAL" $_custom_err | wc -l
 
 --error 1
---exec $MYSQLD_CMD  --rocksdb_wal_recovery_mode=1 --rocksdb_write_policy=$write_policy --default_dd_storage_engine=$ddse > $_custom_err 2>&1
+--exec $MYSQLD_CMD  --rocksdb_wal_recovery_mode=1 --rocksdb_write_policy=$write_policy --default_dd_system_storage_engine=$ddse > $_custom_err 2>&1
 --exec grep "Size mismatch: WAL" $_custom_err | wc -l
 
 # The restart has to fail with rocksdb_wal_recovery_mode=1
 --error 1
---exec $MYSQLD_CMD  --rocksdb_wal_recovery_mode=1 --rocksdb_track_and_verify_wals_in_manifest=0 --rocksdb_write_policy=$write_policy --default_dd_storage_engine=$ddse > $_custom_err 2>&1
+--exec $MYSQLD_CMD  --rocksdb_wal_recovery_mode=1 --rocksdb_track_and_verify_wals_in_manifest=0 --rocksdb_write_policy=$write_policy --default_dd_system_storage_engine=$ddse > $_custom_err 2>&1
 
 #--echo forcing to restart with kPointInTimeRecovery will also fail with RocksDB PR#7701
 --error 1
---exec $MYSQLD_CMD  --rocksdb_wal_recovery_mode=2 --rocksdb_track_and_verify_wals_in_manifest=0 --rocksdb_write_policy=$write_policy --default_dd_storage_engine=$ddse > $_custom_err 2>&1
+--exec $MYSQLD_CMD  --rocksdb_wal_recovery_mode=2 --rocksdb_track_and_verify_wals_in_manifest=0 --rocksdb_write_policy=$write_policy --default_dd_system_storage_engine=$ddse > $_custom_err 2>&1
 --exec grep "Corruption: SST file is ahead of WALs" $_custom_err | wc -l
 
 #--echo forcing to restart with kSkipAnyCorruptedRecords
 #Needs trim-binlog-to-recover in 8.0 to repro, due to dual engine recovery
---exec echo "restart:--rocksdb_wal_recovery_mode=3 --rocksdb_track_and_verify_wals_in_manifest=0 --trim-binlog-to-recover" --rocksdb_write_policy=$write_policy --default_dd_storage_engine=$ddse > $_expect_file_name
+--exec echo "restart:--rocksdb_wal_recovery_mode=3 --rocksdb_track_and_verify_wals_in_manifest=0 --trim-binlog-to-recover" --rocksdb_write_policy=$write_policy --default_dd_system_storage_engine=$ddse > $_expect_file_name
 --enable_reconnect
 --source include/wait_until_connected_again.inc
 

--- a/mysql-test/suite/rocksdb/t/use_direct_reads_writes.test
+++ b/mysql-test/suite/rocksdb/t/use_direct_reads_writes.test
@@ -8,10 +8,10 @@
 
 --let LOG=$MYSQLTEST_VARDIR/tmp/use_direct_reads_writes.err
 --let SEARCH_FILE=$LOG
---let ddse= query_get_value(SELECT @@default_dd_storage_engine, @@default_dd_storage_engine, 1)
+--let ddse=`SELECT @@default_dd_system_storage_engine`
 
 --echo Checking direct reads
---let $_mysqld_option=--log-error=$LOG --rocksdb_use_direct_reads=1 --rocksdb_allow_mmap_reads=1 --default_dd_storage_engine=$ddse
+--let $_mysqld_option=--log-error=$LOG --rocksdb_use_direct_reads=1 --rocksdb_allow_mmap_reads=1 --default_dd_system_storage_engine=$ddse
 --replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
 --source include/restart_mysqld_with_invalid_option.inc
 
@@ -22,7 +22,7 @@
 
 # Repeat with direct-writes
 --echo Checking direct writes
---let $_mysqld_option=--log-error=$LOG --rocksdb_use_direct_io_for_flush_and_compaction=1 --rocksdb_allow_mmap_writes=1 --default_dd_storage_engine=$ddse
+--let $_mysqld_option=--log-error=$LOG --rocksdb_use_direct_io_for_flush_and_compaction=1 --rocksdb_allow_mmap_writes=1 --default_dd_system_storage_engine=$ddse
 --replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
 --source include/restart_mysqld_with_invalid_option.inc
 
@@ -33,7 +33,7 @@
 
 # Verify invalid direct-writes and --rocksdb_flush_log_at_trx_commit combination at startup fails
 --echo Checking rocksdb_flush_log_at_trx_commit
---let $_mysqld_option=--log-error=$LOG --rocksdb_flush_log_at_trx_commit=1 --rocksdb_allow_mmap_writes=1 --default_dd_storage_engine=$ddse
+--let $_mysqld_option=--log-error=$LOG --rocksdb_flush_log_at_trx_commit=1 --rocksdb_allow_mmap_writes=1 --default_dd_system_storage_engine=$ddse
 --replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
 --source include/restart_mysqld_with_invalid_option.inc
 

--- a/mysql-test/suite/rocksdb_dd_innodb/t/binlog_crash_safe_ddl-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/binlog_crash_safe_ddl-master.opt
@@ -1,2 +1,2 @@
---initialize --default-dd-storage-engine=ROCKSDB
+--initialize --default-dd-system-storage-engine=ROCKSDB
 $UDF_EXAMPLE_LIB_OPT --binlog-format=mixed

--- a/mysql-test/suite/rocksdb_dd_innodb/t/binlog_half_crash_safe_ddl-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/binlog_half_crash_safe_ddl-master.opt
@@ -1,2 +1,2 @@
---initialize --default-dd-storage-engine=ROCKSDB
+--initialize --default-dd-system-storage-engine=ROCKSDB
 --force-restart --binlog-format=MIXED

--- a/mysql-test/suite/rocksdb_dd_innodb/t/create_select_foreign_key-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/create_select_foreign_key-master.opt
@@ -1,1 +1,1 @@
---initialize --default-dd-storage-engine=ROCKSDB
+--initialize --default-dd-system-storage-engine=ROCKSDB

--- a/mysql-test/suite/rocksdb_dd_innodb/t/create_tablespace_32k-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/create_tablespace_32k-master.opt
@@ -1,3 +1,3 @@
---initialize --default-dd-storage-engine=ROCKSDB
+--initialize --default-dd-system-storage-engine=ROCKSDB
 --initialize --innodb_page_size=32k
 --innodb_directories=$MYSQL_TMP_DIR

--- a/mysql-test/suite/rocksdb_dd_innodb/t/create_tablespace_64k-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/create_tablespace_64k-master.opt
@@ -1,3 +1,3 @@
---initialize --default-dd-storage-engine=ROCKSDB
+--initialize --default-dd-system-storage-engine=ROCKSDB
 --initialize --innodb_page_size=64k
 --innodb_directories=$MYSQL_TMP_DIR

--- a/mysql-test/suite/rocksdb_dd_innodb/t/create_tablespace_debug-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/create_tablespace_debug-master.opt
@@ -1,1 +1,1 @@
---initialize --default-dd-storage-engine=ROCKSDB
+--initialize --default-dd-system-storage-engine=ROCKSDB

--- a/mysql-test/suite/rocksdb_dd_innodb/t/i_s_innodb_tables-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/i_s_innodb_tables-master.opt
@@ -1,1 +1,1 @@
---initialize --default-dd-storage-engine=ROCKSDB
+--initialize --default-dd-system-storage-engine=ROCKSDB

--- a/mysql-test/suite/rocksdb_dd_innodb/t/index_large_prefix_4k-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/index_large_prefix_4k-master.opt
@@ -1,2 +1,2 @@
---initialize --default-dd-storage-engine=ROCKSDB
+--initialize --default-dd-system-storage-engine=ROCKSDB
 --initialize --innodb_page_size=4k

--- a/mysql-test/suite/rocksdb_dd_innodb/t/innodb-table-online-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/innodb-table-online-master.opt
@@ -1,2 +1,2 @@
---initialize --default-dd-storage-engine=ROCKSDB
+--initialize --default-dd-system-storage-engine=ROCKSDB
 --innodb-sort-buffer-size=64k --innodb-online-alter-log-max-size=64k --innodb-buffer-pool-size=8M --innodb-log-buffer-size=1M

--- a/mysql-test/suite/rocksdb_dd_innodb/t/innodb_autoextend_import_export-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/innodb_autoextend_import_export-master.opt
@@ -1,4 +1,4 @@
---initialize --default-dd-storage-engine=ROCKSDB
+--initialize --default-dd-system-storage-engine=ROCKSDB
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring-file-data=$MYSQL_TMP_DIR/my_keyring2
 $KEYRING_PLUGIN_OPT

--- a/mysql-test/suite/rocksdb_dd_innodb/t/innodb_tablespace-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/innodb_tablespace-master.opt
@@ -1,1 +1,1 @@
---initialize --default-dd-storage-engine=ROCKSDB
+--initialize --default-dd-system-storage-engine=ROCKSDB

--- a/mysql-test/suite/rocksdb_dd_innodb/t/innodb_zip_8k-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/innodb_zip_8k-master.opt
@@ -1,2 +1,2 @@
---initialize --default-dd-storage-engine=ROCKSDB
+--initialize --default-dd-system-storage-engine=ROCKSDB
 --initialize --innodb_page_size=8k

--- a/mysql-test/suite/rocksdb_dd_innodb/t/known_directory-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/known_directory-master.opt
@@ -1,4 +1,4 @@
---initialize --default-dd-storage-engine=ROCKSDB
+--initialize --default-dd-system-storage-engine=ROCKSDB
 --initialize --innodb-undo-directory=../../tmp/undo_dir
 --innodb-undo-directory=$MYSQL_TMP_DIR/undo_dir
 --innodb-directories=$MYSQL_TMP_DIR/known_dir;$MYSQL_TMP_DIR/undo_dir

--- a/mysql-test/suite/rocksdb_dd_innodb/t/lock_contention-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/lock_contention-master.opt
@@ -1,2 +1,2 @@
---initialize --default-dd-storage-engine=ROCKSDB
+--initialize --default-dd-system-storage-engine=ROCKSDB
 --initialize --innodb_page_size=16k --information_schema_engine=MEMORY

--- a/mysql-test/suite/rocksdb_dd_innodb/t/optimizer_temporary_table-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/optimizer_temporary_table-master.opt
@@ -1,3 +1,3 @@
---initialize --default-dd-storage-engine=ROCKSDB
+--initialize --default-dd-system-storage-engine=ROCKSDB
 --big-tables=1
 --initialize --innodb_page_size=16k

--- a/mysql-test/suite/rocksdb_dd_innodb/t/partition-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/partition-master.opt
@@ -1,1 +1,1 @@
---initialize --default-dd-storage-engine=ROCKSDB
+--initialize --default-dd-system-storage-engine=ROCKSDB

--- a/mysql-test/suite/rocksdb_dd_innodb/t/pct_cached_evict-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/pct_cached_evict-master.opt
@@ -1,2 +1,2 @@
---initialize --default-dd-storage-engine=ROCKSDB
+--initialize --default-dd-system-storage-engine=ROCKSDB
 --innodb-buffer-pool-size=10M

--- a/mysql-test/suite/rocksdb_dd_innodb/t/rpl_gtid_mts_spco_commands_nobinlog-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/rpl_gtid_mts_spco_commands_nobinlog-master.opt
@@ -1,1 +1,1 @@
---initialize --default-dd-storage-engine=ROCKSDB
+--initialize --default-dd-system-storage-engine=ROCKSDB

--- a/mysql-test/suite/rocksdb_dd_innodb/t/rpl_gtid_mts_spco_commands_nobinlog-slave.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/rpl_gtid_mts_spco_commands_nobinlog-slave.opt
@@ -1,1 +1,1 @@
---initialize --default-dd-storage-engine=ROCKSDB
+--initialize --default-dd-system-storage-engine=ROCKSDB

--- a/mysql-test/suite/rocksdb_dd_innodb/t/rpl_gtid_mts_spco_commands_nobinlog.cnf
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/rpl_gtid_mts_spco_commands_nobinlog.cnf
@@ -6,9 +6,9 @@
 [mysqld]
 gtid-mode=on
 enforce-gtid-consistency
-default-dd-storage-engine=ROCKSDB
+default-dd-system-storage-engine=ROCKSDB
 
 [mysqld.2]
 skip-log-bin
 log-replica-updates=0
-default-dd-storage-engine=ROCKSDB
+default-dd-system-storage-engine=ROCKSDB

--- a/mysql-test/suite/rocksdb_dd_innodb/t/rpl_mts_spco_alter_table_analyze_partition_nobinlog-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/rpl_mts_spco_alter_table_analyze_partition_nobinlog-master.opt
@@ -1,1 +1,1 @@
---initialize --default-dd-storage-engine=ROCKSDB
+--initialize --default-dd-system-storage-engine=ROCKSDB

--- a/mysql-test/suite/rocksdb_dd_innodb/t/rpl_mts_spco_alter_table_analyze_partition_nobinlog-slave.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/rpl_mts_spco_alter_table_analyze_partition_nobinlog-slave.opt
@@ -1,1 +1,1 @@
---initialize --default-dd-storage-engine=ROCKSDB
+--initialize --default-dd-system-storage-engine=ROCKSDB

--- a/mysql-test/suite/rocksdb_dd_innodb/t/rpl_mts_spco_alter_table_analyze_partition_nobinlog.cnf
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/rpl_mts_spco_alter_table_analyze_partition_nobinlog.cnf
@@ -6,9 +6,9 @@
 [mysqld]
 gtid-mode=on
 enforce-gtid-consistency
-default-dd-storage-engine=ROCKSDB
+default-dd-system-storage-engine=ROCKSDB
 
 [mysqld.2]
 skip-log-bin
 log-replica-updates=0
-default-dd-storage-engine=ROCKSDB
+default-dd-system-storage-engine=ROCKSDB

--- a/mysql-test/suite/rocksdb_dd_innodb/t/undo_tablespace-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/undo_tablespace-master.opt
@@ -1,1 +1,1 @@
---initialize --default-dd-storage-engine=ROCKSDB
+--initialize --default-dd-system-storage-engine=ROCKSDB

--- a/mysql-test/suite/rocksdb_dd_innodb/t/undo_tablespace_encrypt-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/undo_tablespace_encrypt-master.opt
@@ -1,1 +1,1 @@
---initialize --default-dd-storage-engine=ROCKSDB
+--initialize --default-dd-system-storage-engine=ROCKSDB

--- a/mysql-test/suite/rocksdb_dd_innodb/t/virtual_basic-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/virtual_basic-master.opt
@@ -1,1 +1,1 @@
---initialize --default-dd-storage-engine=ROCKSDB
+--initialize --default-dd-system-storage-engine=ROCKSDB

--- a/mysql-test/suite/rocksdb_dd_innodb/t/virtual_no_storage-master.opt
+++ b/mysql-test/suite/rocksdb_dd_innodb/t/virtual_no_storage-master.opt
@@ -1,1 +1,1 @@
---initialize --default-dd-storage-engine=ROCKSDB
+--initialize --default-dd-system-storage-engine=ROCKSDB

--- a/mysql-test/suite/rocksdb_rpl/t/ddse_rpl-master.opt
+++ b/mysql-test/suite/rocksdb_rpl/t/ddse_rpl-master.opt
@@ -1,1 +1,1 @@
---initialize --default_dd_storage_engine=RocksDB --binlog_format=ROW
+--initialize --default_dd_system_storage_engine=RocksDB --binlog_format=ROW

--- a/mysql-test/suite/rocksdb_rpl/t/ddse_rpl-slave.opt
+++ b/mysql-test/suite/rocksdb_rpl/t/ddse_rpl-slave.opt
@@ -1,1 +1,1 @@
---initialize --default_dd_storage_engine=RocksDB --binlog_format=ROW
+--initialize --default_dd_system_storage_engine=RocksDB --binlog_format=ROW

--- a/mysql-test/suite/sys_vars/r/default_dd_storage_engine_basic.result
+++ b/mysql-test/suite/sys_vars/r/default_dd_storage_engine_basic.result
@@ -1,11 +1,11 @@
-SET @start_global_value = @@global.default_dd_storage_engine;
+SET @start_global_value = @@global.default_dd_system_storage_engine;
 SELECT @start_global_value;
 @start_global_value
 InnoDB
-select @@global.default_dd_storage_engine;
-@@global.default_dd_storage_engine
+select @@global.default_dd_system_storage_engine;
+@@global.default_dd_system_storage_engine
 InnoDB
-select @@session.default_dd_storage_engine;
-ERROR HY000: Variable 'default_dd_storage_engine' is a GLOBAL variable
-SET @@global.default_dd_storage_engine = @start_global_value;
-ERROR HY000: Variable 'default_dd_storage_engine' is a read only variable
+select @@session.default_dd_system_storage_engine;
+ERROR HY000: Variable 'default_dd_system_storage_engine' is a GLOBAL variable
+SET @@global.default_dd_system_storage_engine = @start_global_value;
+ERROR HY000: Variable 'default_dd_system_storage_engine' is a read only variable

--- a/mysql-test/suite/sys_vars/t/default_dd_storage_engine_basic.test
+++ b/mysql-test/suite/sys_vars/t/default_dd_storage_engine_basic.test
@@ -1,14 +1,14 @@
 --source include/load_sysvars.inc
 
-SET @start_global_value = @@global.default_dd_storage_engine;
+SET @start_global_value = @@global.default_dd_system_storage_engine;
 SELECT @start_global_value;
 
-select @@global.default_dd_storage_engine;
+select @@global.default_dd_system_storage_engine;
 
 # Global variable
 --error ER_INCORRECT_GLOBAL_LOCAL_VAR
-select @@session.default_dd_storage_engine;
+select @@session.default_dd_system_storage_engine;
 
 # Read only variable
 --error ER_INCORRECT_GLOBAL_LOCAL_VAR
-SET @@global.default_dd_storage_engine = @start_global_value;
+SET @@global.default_dd_system_storage_engine = @start_global_value;

--- a/mysql-test/t/all_persisted_variables.test
+++ b/mysql-test/t/all_persisted_variables.test
@@ -91,7 +91,7 @@ let $total_excluded_vars=`SELECT COUNT(*) FROM performance_schema.global_variabl
 'sql_wsenv_oncall',
 'sql_wsenv_uri_prefix',
 'sql_wsenv_lib_name',
-'default_dd_storage_engine',
+'default_dd_system_storage_engine',
 '_list_end_'
 )`;
 let $total_persistent_vars= `SELECT $total_persistent_vars - $total_excluded_vars`;

--- a/mysql-test/t/dd_bootstrap_debug.test
+++ b/mysql-test/t/dd_bootstrap_debug.test
@@ -13,7 +13,7 @@ let DDIR=       $MYSQL_TMP_DIR/dd_bootstrap_test;
 let extra_args= --no-defaults --innodb_dedicated_server=OFF --secure-file-priv="" --loose-skip-auto_generate_certs --loose-skip-sha256_password_auto_generate_rsa_keys --skip-ssl --basedir=$BASEDIR --lc-messages-dir=$MYSQL_SHAREDIR;
 let BOOTSTRAP_SQL= $MYSQL_TMP_DIR/tiny_bootstrap.sql;
 let PASSWD_FILE=   $MYSQL_TMP_DIR/password_file.txt;
-let DEFAULT_DDSE= `SELECT @@default_dd_storage_engine`;
+let DEFAULT_DDSE= `SELECT @@default_dd_system_storage_engine`;
 
 --echo # Preparation: Shut server down.
 --exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect

--- a/scripts/mysql_system_tables.sql
+++ b/scripts/mysql_system_tables.sql
@@ -26,7 +26,7 @@
 
 set @have_innodb= (select count(engine) from information_schema.engines where engine='INNODB' and support != 'NO');
 set @is_mysql_encrypted = (select ENCRYPTION from information_schema.INNODB_TABLESPACES where NAME='mysql');
-set @ddse= (select @@default_dd_storage_engine);
+set @ddse= (select @@default_dd_system_storage_engine);
 
 -- Tables below are NOT treated as DD tables by MySQL server yet.
 

--- a/sql/dd/dd_utility.h
+++ b/sql/dd/dd_utility.h
@@ -75,16 +75,17 @@ bool check_if_server_ddse_readonly(THD *thd, const char *schema_name = nullptr);
   @return isolation level
 */
 [[nodiscard]] inline enum_tx_isolation get_dd_isolation_level() {
-  assert(default_dd_storage_engine == DEFAULT_DD_ROCKSDB ||
-         default_dd_storage_engine == DEFAULT_DD_INNODB);
-  return default_dd_storage_engine == DEFAULT_DD_ROCKSDB ? ISO_READ_COMMITTED
-                                                         : ISO_READ_UNCOMMITTED;
+  assert(default_dd_system_storage_engine == DEFAULT_DD_ROCKSDB ||
+         default_dd_system_storage_engine == DEFAULT_DD_INNODB);
+  return default_dd_system_storage_engine == DEFAULT_DD_ROCKSDB
+             ? ISO_READ_COMMITTED
+             : ISO_READ_UNCOMMITTED;
 }
 
 [[nodiscard]] inline legacy_db_type get_dd_engine_type() {
-  assert(default_dd_storage_engine == DEFAULT_DD_ROCKSDB ||
-         default_dd_storage_engine == DEFAULT_DD_INNODB);
-  const auto db_type = default_dd_storage_engine == DEFAULT_DD_ROCKSDB
+  assert(default_dd_system_storage_engine == DEFAULT_DD_ROCKSDB ||
+         default_dd_system_storage_engine == DEFAULT_DD_INNODB);
+  const auto db_type = default_dd_system_storage_engine == DEFAULT_DD_ROCKSDB
                            ? DB_TYPE_ROCKSDB
                            : DB_TYPE_INNODB;
   return db_type;
@@ -96,9 +97,10 @@ bool check_if_server_ddse_readonly(THD *thd, const char *schema_name = nullptr);
 }
 
 [[nodiscard]] inline const char *get_dd_engine_name() {
-  assert(default_dd_storage_engine == DEFAULT_DD_ROCKSDB ||
-         default_dd_storage_engine == DEFAULT_DD_INNODB);
-  return default_dd_storage_engine == DEFAULT_DD_ROCKSDB ? "ROCKSDB" : "INNODB";
+  assert(default_dd_system_storage_engine == DEFAULT_DD_ROCKSDB ||
+         default_dd_system_storage_engine == DEFAULT_DD_INNODB);
+  return default_dd_system_storage_engine == DEFAULT_DD_ROCKSDB ? "ROCKSDB"
+                                                                : "INNODB";
 }
 
 [[nodiscard]] inline const char *get_dd_engine_name(legacy_db_type db_type) {

--- a/sql/dd/impl/bootstrap/bootstrap_ctx.h
+++ b/sql/dd/impl/bootstrap/bootstrap_ctx.h
@@ -104,9 +104,10 @@ class DD_bootstrap_ctx {
   uint m_actual_I_S_version = 0;
   // actual DDSE holds dd tables
   // its values is indicted by which SE hold mysql.dd_properties table
-  //  Druing boostrap time,  its value is equal to default_dd_storage_engine
-  //  During upgrade time, its value maybe not equal to
-  //  default_dd_storage_engine
+  // During boostrap time, its value is equal to
+  // default_dd_system_storage_engine
+  // During upgrade time, its value maybe be not equal to
+  // default_dd_system_storage_engine
   legacy_db_type m_actual_dd_engine = DB_TYPE_UNKNOWN;
   legacy_db_type m_did_dd_engine_upgrade_from = DB_TYPE_UNKNOWN;
 

--- a/sql/dd/impl/dictionary_impl.cc
+++ b/sql/dd/impl/dictionary_impl.cc
@@ -705,7 +705,7 @@ bool reset_tables_and_tablespaces() {
   if (ddse->dict_cache_reset_tables_and_tablespaces != nullptr)
     ddse->dict_cache_reset_tables_and_tablespaces();
 
-  if (default_dd_storage_engine != DEFAULT_DD_INNODB) {
+  if (default_dd_system_storage_engine != DEFAULT_DD_INNODB) {
     auto *const innodb_se = ha_resolve_by_legacy_type(thd.thd, DB_TYPE_INNODB);
     assert(innodb_se->dict_cache_reset_tables_and_tablespaces != nullptr);
     if (!ha_is_storage_engine_disabled(innodb_se) &&

--- a/sql/dd/impl/tables/index_column_usage.cc
+++ b/sql/dd/impl/tables/index_column_usage.cc
@@ -39,8 +39,8 @@ const Index_column_usage &Index_column_usage::instance() {
 ///////////////////////////////////////////////////////////////////////////
 
 Index_column_usage::Index_column_usage() {
-  assert(default_dd_storage_engine == DEFAULT_DD_INNODB ||
-         default_dd_storage_engine == DEFAULT_DD_ROCKSDB);
+  assert(default_dd_system_storage_engine == DEFAULT_DD_INNODB ||
+         default_dd_system_storage_engine == DEFAULT_DD_ROCKSDB);
 
   m_target_def.set_table_name("index_column_usage");
 
@@ -61,7 +61,7 @@ Index_column_usage::Index_column_usage() {
                          "NOT NULL");
   m_target_def.add_field(FIELD_HIDDEN, "FIELD_HIDDEN", "hidden BOOL NOT NULL");
 
-  if (default_dd_storage_engine == DEFAULT_DD_INNODB) {
+  if (default_dd_system_storage_engine == DEFAULT_DD_INNODB) {
     m_target_def.add_index(INDEX_UK_INDEX_ID_ORDINAL_POSITION,
                            "INDEX_UK_INDEX_ID_ORDINAL_POSITION",
                            "UNIQUE KEY (index_id, ordinal_position)");

--- a/sql/dd/impl/tables/index_stats.cc
+++ b/sql/dd/impl/tables/index_stats.cc
@@ -32,8 +32,8 @@ namespace tables {
 ///////////////////////////////////////////////////////////////////////////
 
 Index_stats::Index_stats() {
-  assert(default_dd_storage_engine == DEFAULT_DD_INNODB ||
-         default_dd_storage_engine == DEFAULT_DD_ROCKSDB);
+  assert(default_dd_system_storage_engine == DEFAULT_DD_INNODB ||
+         default_dd_system_storage_engine == DEFAULT_DD_ROCKSDB);
 
   m_target_def.set_table_name("index_stats");
 
@@ -50,7 +50,7 @@ Index_stats::Index_stats() {
   m_target_def.add_field(FIELD_CACHED_TIME, "FIELD_CACHED_TIME",
                          "cached_time TIMESTAMP NOT NULL");
 
-  if (default_dd_storage_engine == DEFAULT_DD_INNODB) {
+  if (default_dd_system_storage_engine == DEFAULT_DD_INNODB) {
     m_target_def.add_index(INDEX_UK_SCHEMA_TABLE_INDEX_COLUMN,
                            "INDEX_UK_SCHEMA_TABLE_INDEX_COLUMN",
                            "UNIQUE KEY (schema_name, table_name, "

--- a/sql/dd/impl/tables/tablespace_files.cc
+++ b/sql/dd/impl/tables/tablespace_files.cc
@@ -39,8 +39,8 @@ const Tablespace_files &Tablespace_files::instance() {
 ///////////////////////////////////////////////////////////////////////////
 
 Tablespace_files::Tablespace_files() {
-  assert(default_dd_storage_engine == DEFAULT_DD_INNODB ||
-         default_dd_storage_engine == DEFAULT_DD_ROCKSDB);
+  assert(default_dd_system_storage_engine == DEFAULT_DD_INNODB ||
+         default_dd_system_storage_engine == DEFAULT_DD_ROCKSDB);
 
   m_target_def.set_table_name("tablespace_files");
 
@@ -53,7 +53,7 @@ Tablespace_files::Tablespace_files() {
   m_target_def.add_field(FIELD_SE_PRIVATE_DATA, "FIELD_SE_PRIVATE_DATA",
                          "se_private_data MEDIUMTEXT");
 
-  if (default_dd_storage_engine == DEFAULT_DD_INNODB) {
+  if (default_dd_system_storage_engine == DEFAULT_DD_INNODB) {
     m_target_def.add_index(INDEX_UK_TABLESPACE_ID_ORDINAL_POSITION,
                            "INEDX_UK_TABLESPACE_ID_ORDINAL_POSITION",
                            "UNIQUE KEY (tablespace_id, ordinal_position)");

--- a/sql/dd/impl/types/object_table_impl.cc
+++ b/sql/dd/impl/types/object_table_impl.cc
@@ -33,8 +33,8 @@ namespace dd {
 
 Object_table_impl::Object_table_impl()
     : Object_table_impl(get_dd_engine_name()) {
-  assert(default_dd_storage_engine == DEFAULT_DD_INNODB ||
-         default_dd_storage_engine == DEFAULT_DD_ROCKSDB);
+  assert(default_dd_system_storage_engine == DEFAULT_DD_INNODB ||
+         default_dd_system_storage_engine == DEFAULT_DD_ROCKSDB);
 }
 
 Object_table_impl::Object_table_impl(const String_type &engine)

--- a/sql/dd/impl/upgrade/dd.cc
+++ b/sql/dd/impl/upgrade/dd.cc
@@ -1085,7 +1085,7 @@ bool update_myrocks_table_names(THD *thd, const String_type &old_schema_name,
                                 const String_type &new_schema_name,
     const std::set<String_type> &table_names,
     const std::set<String_type> &filter_table_names) {
-  assert(default_dd_storage_engine == DEFAULT_DD_ROCKSDB);
+  assert(default_dd_system_storage_engine == DEFAULT_DD_ROCKSDB);
   assert(bootstrap::DD_bootstrap_ctx::instance().is_dd_engine_change());
 
   auto *rocksdb_ddse = ha_resolve_by_legacy_type(thd, DB_TYPE_ROCKSDB);
@@ -1182,7 +1182,7 @@ bool upgrade_dd_properties_table(THD *thd, Object_id mysql_schema_id,
   // update_myrocks_table_names will delete <target_table> tbl_def
   // If the changes are committed after update_myrocks_table_names, it will
   // cause a use-after-free issue
-  if (default_dd_storage_engine == DEFAULT_DD_ROCKSDB &&
+  if (default_dd_system_storage_engine == DEFAULT_DD_ROCKSDB &&
       !dd::end_transaction(thd, false) &&
       update_myrocks_table_names(thd, target_table_schema_name,
                                  MYSQL_SCHEMA_NAME.str,
@@ -1299,7 +1299,7 @@ bool upgrade_tables(THD *thd) {
 
   // update myrocks own data dictionary
   if (bootstrap::DD_bootstrap_ctx::instance().is_dd_engine_change() &&
-      (default_dd_storage_engine == DEFAULT_DD_ROCKSDB) &&
+      (default_dd_system_storage_engine == DEFAULT_DD_ROCKSDB) &&
       !dd::end_transaction(thd, false) &&
       update_myrocks_table_names(thd, target_table_schema_name,
                                  MYSQL_SCHEMA_NAME.str, create_set,

--- a/sql/dd/info_schema/table_stats.cc
+++ b/sql/dd/info_schema/table_stats.cc
@@ -156,7 +156,7 @@ bool store_statistics_record(THD *thd, T *object) {
     */
     const auto mysql_errno = thd->get_stmt_da()->mysql_errno();
     if (mysql_errno == ER_DUP_ENTRY ||
-        (default_dd_storage_engine == DEFAULT_DD_ROCKSDB &&
+        (default_dd_system_storage_engine == DEFAULT_DD_ROCKSDB &&
          mysql_errno == ER_LOCK_WAIT_TIMEOUT)) {
       thd->clear_error();
       return false;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1171,7 +1171,7 @@ bool listen_admin_interface_in_separate_thread;
 static const char *default_collation_name;
 const char *default_storage_engine;
 const char *default_tmp_storage_engine;
-ulong default_dd_storage_engine;
+ulong default_dd_system_storage_engine;
 ulonglong temptable_max_ram;
 ulonglong temptable_max_mmap;
 bool temptable_track_shared_block_ram = false;

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -275,7 +275,7 @@ enum enum_dd_default_engine {
   DEFAULT_DD_INNODB,
   DEFAULT_DD_ROCKSDB,
 };
-extern ulong default_dd_storage_engine;
+extern ulong default_dd_system_storage_engine;
 extern ulonglong temptable_max_ram;
 extern ulonglong temptable_max_mmap;
 extern bool temptable_track_shared_block_ram;

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -1607,7 +1607,7 @@ bool plugin_register_builtin_and_init_core_se(int *argc, char **argv) {
       bool is_rocksdb = !strncmp(plugin->name, ROCKSDB, rocksdb_len);
       bool is_rocksdb_dd_se =
           !my_strcasecmp(&my_charset_latin1, plugin->name, ROCKSDB) &&
-          default_dd_storage_engine == DEFAULT_DD_ROCKSDB;
+          default_dd_system_storage_engine == DEFAULT_DD_ROCKSDB;
 
       std::optional<enum_plugin_load_option> force_load_option;
       if (is_rocksdb) {
@@ -1675,7 +1675,7 @@ bool plugin_register_builtin_and_init_core_se(int *argc, char **argv) {
           plugin_initialize(plugin_ptr))
         goto err_unlock;
 
-      if (is_rocksdb && default_dd_storage_engine == DEFAULT_DD_ROCKSDB)
+      if (is_rocksdb && default_dd_system_storage_engine == DEFAULT_DD_ROCKSDB)
         rocksdb_loaded = plugin_ptr->state == PLUGIN_IS_READY;
 
       /*
@@ -1705,7 +1705,8 @@ bool plugin_register_builtin_and_init_core_se(int *argc, char **argv) {
   assert(global_system_variables.temp_table_plugin);
 
   /* if ddse is rocksdb, rocksdb plugin should be loaded */
-  assert(rocksdb_loaded || default_dd_storage_engine != DEFAULT_DD_ROCKSDB ||
+  assert(rocksdb_loaded ||
+         default_dd_system_storage_engine != DEFAULT_DD_ROCKSDB ||
          is_help_or_validate_option());
 
   mysql_mutex_unlock(&LOCK_plugin);

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -6263,11 +6263,11 @@ static Sys_var_plugin Sys_default_tmp_storage_engine(
     NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(check_storage_engine));
 
 static const char *dd_storage_engine[] = {"InnoDB", "RocksDB", NullS};
-static Sys_var_enum Sys_default_dd_storage_engine(
-    "default_dd_storage_engine",
+static Sys_var_enum Sys_default_dd_system_storage_engine(
+    "default_dd_system_storage_engine",
     "The default storage engine for data dictionary",
-    READ_ONLY GLOBAL_VAR(default_dd_storage_engine), CMD_LINE(REQUIRED_ARG),
-    dd_storage_engine, DEFAULT(DEFAULT_DD_INNODB));
+    READ_ONLY GLOBAL_VAR(default_dd_system_storage_engine),
+    CMD_LINE(REQUIRED_ARG), dd_storage_engine, DEFAULT(DEFAULT_DD_INNODB));
 
 #if defined(ENABLED_DEBUG_SYNC)
 /*

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -24616,5 +24616,5 @@ static bool innobase_check_reserved_file_name(handlerton *, const char *name) {
 #endif /* !UNIV_HOTBACKUP */
 
 bool innobase_is_ddse() {
-  return default_dd_storage_engine == DEFAULT_DD_INNODB;
+  return default_dd_system_storage_engine == DEFAULT_DD_INNODB;
 }

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -16545,7 +16545,7 @@ inline bool ha_rocksdb::is_instant(const Alter_inplace_info *ha_alter_info) {
   @return True if DDSE is rocksdb and it is updating table metadata
 */
 bool ha_rocksdb::is_dd_update() const {
-  return default_dd_storage_engine == DEFAULT_DD_ROCKSDB &&
+  return default_dd_system_storage_engine == DEFAULT_DD_ROCKSDB &&
          thd_is_dd_update_stmt(ha_thd());
 }
 

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -4337,7 +4337,8 @@ bool Rdb_validate_tbls::validate(void) {
   // we load rocksdb plugin before initializing dd. So skip validation here.
   // TODO(chni): enable the validation once rocksdb dd is loaded
   if (!thd) {
-    assert(opt_initialize || default_dd_storage_engine == DEFAULT_DD_ROCKSDB);
+    assert(opt_initialize ||
+           default_dd_system_storage_engine == DEFAULT_DD_ROCKSDB);
     return true;
   }
 

--- a/storage/rocksdb/rdb_native_dd.cc
+++ b/storage/rocksdb/rdb_native_dd.cc
@@ -40,7 +40,7 @@ int native_dd::reject_if_dd_table(const dd::Table *table_def,
   // dd bootstrap system thread
   if (table_def != nullptr && is_dd_table_id(table_def->se_private_id()) &&
       !(is_dd_system_thread &&
-        default_dd_storage_engine != DEFAULT_DD_ROCKSDB)) {
+        default_dd_system_storage_engine != DEFAULT_DD_ROCKSDB)) {
     my_error(ER_NOT_ALLOWED_COMMAND, MYF(0));
     return HA_ERR_UNSUPPORTED;
   }


### PR DESCRIPTION
The system table engine will be governed by the same variable, and its old name did not reflect that.