### PR TITLE
Do clangd-suggested include fixes in storage/rocksdb

### DIFF
--- a/storage/rocksdb/clone/client.cc
+++ b/storage/rocksdb/clone/client.cc
@@ -23,12 +23,10 @@
 
 #include "my_compiler.h"
 #include "mysql/psi/mysql_file.h"
-#include "mysql/psi/mysql_mutex.h"
 #include "mysqld_error.h"
 #include "sql/handler.h"
 #include "sql/sql_class.h"
 
-#include "../ha_rocksdb.h"
 #include "common.h"
 
 namespace {

--- a/storage/rocksdb/clone/common.h
+++ b/storage/rocksdb/clone/common.h
@@ -26,13 +26,13 @@
 #include <string>
 #include <unordered_set>
 
-#include "my_dbug.h"
 #include "my_inttypes.h"
 #include "mysql/plugin.h"
 #include "mysql/psi/mysql_cond.h"
 #include "mysql/psi/mysql_mutex.h"
 #include "mysql/psi/mysql_rwlock.h"
 #include "mysqld_error.h"
+#include "sql/handler.h"
 
 #include "../rdb_buff.h"
 #include "../rdb_psi.h"

--- a/storage/rocksdb/clone/donor.cc
+++ b/storage/rocksdb/clone/donor.cc
@@ -33,9 +33,6 @@
 #include "sql-common/json_dom.h"
 #include "sql/sql_class.h"
 
-// RocksDB includes
-#include "file/filename.h"
-
 // MyRocks includes
 #include "../ha_rocksdb.h"
 #include "../ha_rocksdb_proto.h"

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -36,7 +36,6 @@
 #include <deque>
 #include <limits>
 #include <map>
-#include <queue>
 #include <set>
 #include <string>
 #include <vector>
@@ -46,8 +45,6 @@
 #include <mysql/psi/mysql_table.h>
 #include <mysql/thread_pool_priv.h>
 #include <mysys_err.h>
-#include "my_bit.h"
-#include "my_stacktrace.h"
 #include "my_sys.h"
 #include "scope_guard.h"
 #include "sql/binlog.h"
@@ -66,20 +63,22 @@
 #include "sql/strfunc.h"
 
 /* RocksDB includes */
+#include "rocksdb/convenience.h"
 #include "env/composite_env_wrapper.h"
 #include "monitoring/histogram.h"
 #include "rocksdb/compaction_filter.h"
-#include "rocksdb/compaction_job_stats.h"
 #include "rocksdb/env.h"
 #include "rocksdb/memory_allocator.h"
+#include "rocksdb/perf_level.h"
 #include "rocksdb/persistent_cache.h"
 #include "rocksdb/rate_limiter.h"
 #include "rocksdb/slice_transform.h"
+#include "rocksdb/sst_file_manager.h"
 #include "rocksdb/thread_status.h"
 #include "rocksdb/trace_reader_writer.h"
 #include "rocksdb/utilities/checkpoint.h"
-#include "rocksdb/utilities/convenience.h"
 #include "rocksdb/utilities/memory_util.h"
+#include "rocksdb/utilities/options_util.h"
 #include "rocksdb/utilities/sim_cache.h"
 #include "rocksdb/utilities/write_batch_with_index.h"
 #include "util/stop_watch.h"

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -22,40 +22,34 @@
 /* C++ standard header files */
 #include <deque>
 #include <map>
-#include <set>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 /* MySQL header files */
-#include "my_checksum.h"
 #include "my_dbug.h"
 #include "my_icp.h" /* icp_result */
-#include "mysql/psi/mysql_rwlock.h"
 #include "sql/handler.h"    /* handler */
 #include "sql/sql_bitmap.h" /* Key_map */
 #include "sql/table.h"
 #include "sql_string.h"
 
 /* RocksDB header files */
-#include "rocksdb/cache.h"
 #include "rocksdb/merge_operator.h"
-#include "rocksdb/perf_context.h"
-#include "rocksdb/sst_file_manager.h"
-#include "rocksdb/statistics.h"
-#include "rocksdb/utilities/options_util.h"
-#include "rocksdb/utilities/transaction_db.h"
 #include "rocksdb/utilities/write_batch_with_index.h"
 
 /* MyRocks header files */
 #include "./rdb_buff.h"
 #include "./rdb_global.h"
 #include "./rdb_index_merge.h"
-#include "./rdb_io_watchdog.h"
 #include "./rdb_perf_context.h"
 #include "./rdb_sst_info.h"
 #include "./rdb_utils.h"
+
+#ifndef __APPLE__
+#include "./rdb_io_watchdog.h"
+#endif
 
 /**
   @note MyRocks Coding Conventions:

--- a/storage/rocksdb/ha_rocksdb_proto.h
+++ b/storage/rocksdb/ha_rocksdb_proto.h
@@ -23,6 +23,9 @@
 #include "rocksdb/table.h"
 #include "rocksdb/utilities/transaction_db.h"
 
+/* MySQL header files */
+#include "my_compiler.h"
+
 /* MyRocks header files */
 #include "./rdb_global.h"
 

--- a/storage/rocksdb/logger.h
+++ b/storage/rocksdb/logger.h
@@ -15,8 +15,16 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 #pragma once
 
-#include <sstream>
 #include <string>
+
+#include "rocksdb/env.h"
+
+#include "rdb_utils.h"  // LOG_COMPONENT_TAG for includes below
+
+#include "my_loglevel.h"
+#include "mysql/components/services/log_builtins.h"
+#include "mysql/components/services/log_shared.h"
+#include "mysqld_error.h"
 
 namespace myrocks {
 

--- a/storage/rocksdb/nosql_access.cc
+++ b/storage/rocksdb/nosql_access.cc
@@ -28,19 +28,17 @@
 #include <utility>
 #include <vector>
 
-/* C standard header files */
-#include <ctype.h>
-
 /* MySQL header files */
 #include "./sql/item.h"
 #include "./sql/item_func.h"
+#include "./sql/mysqld.h"
+#include "./sql/protocol.h"
 #include "./sql/query_result.h"
 #include "./sql/sql_base.h"
 #include "./sql/sql_lex_hash.h"
 #include "./sql/sql_select.h"
 #include "./sql/strfunc.h"
 #include "./sql/transaction.h"
-#include "mysql/services.h"
 #include "sql/dd/cache/dictionary_client.h"  // dd::cache::Dictionary_client
 #include "sql/sql_lex.h"
 

--- a/storage/rocksdb/nosql_access.h
+++ b/storage/rocksdb/nosql_access.h
@@ -15,20 +15,12 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 
 /* C++ standard header files */
-#include <array>
-#include <atomic>
 #include <deque>
 #include <mutex>
 #include <string>
-#include <vector>
-
-/* C standard header files */
-#include <ctype.h>
 
 /* MySQL header files */
 #include <mysql/service_rpc_plugin.h>
-#include "./sql_string.h"
-#include "sql/protocol.h"
 #include "sql/sql_class.h"
 
 #pragma once

--- a/storage/rocksdb/properties_collector.cc
+++ b/storage/rocksdb/properties_collector.cc
@@ -23,10 +23,6 @@
 #include <string>
 #include <vector>
 
-/* MySQL header files */
-#include "./my_stacktrace.h"
-#include "sql/sql_array.h"
-
 /* MyRocks header files */
 #include "./rdb_datadic.h"
 #include "./rdb_utils.h"

--- a/storage/rocksdb/properties_collector.h
+++ b/storage/rocksdb/properties_collector.h
@@ -16,10 +16,8 @@
 #pragma once
 
 /* C++ system header files */
-#include <map>
 #include <memory>
 #include <string>
-#include <unordered_set>
 #include <vector>
 
 /* RocksDB header files */

--- a/storage/rocksdb/rdb_buff.h
+++ b/storage/rocksdb/rdb_buff.h
@@ -44,7 +44,6 @@
 
 /* RocksDB header files */
 #include "rocksdb/slice.h"
-#include "rocksdb/status.h"
 
 namespace myrocks {
 

--- a/storage/rocksdb/rdb_cf_manager.cc
+++ b/storage/rocksdb/rdb_cf_manager.cc
@@ -19,9 +19,11 @@
 #endif
 
 /* MySQL header files */
+#ifndef NDEBUG
+#include "sql/sql_class.h"
 #include "sql/debug_sync.h"
+#endif
 
-#include "./rdb_threads.h"
 /* This C++ files header file */
 #include "./rdb_cf_manager.h"
 

--- a/storage/rocksdb/rdb_cf_manager.h
+++ b/storage/rocksdb/rdb_cf_manager.h
@@ -21,16 +21,12 @@
 #include <string>
 #include <vector>
 
-/* MySQL header files */
-#include "sql/sql_class.h"
-
 /* RocksDB header files */
 #include "rocksdb/db.h"
 
 /* MyRocks header files */
 #include "./rdb_cf_options.h"
 #include "./rdb_datadic.h"
-#include "./rdb_global.h"
 
 namespace myrocks {
 

--- a/storage/rocksdb/rdb_cf_options.cc
+++ b/storage/rocksdb/rdb_cf_options.cc
@@ -24,13 +24,10 @@
 /* C++ system header files */
 #include <string>
 
-/* MySQL header files */
-
 /* RocksDB header files */
-#include "rocksdb/utilities/convenience.h"
+#include "rocksdb/utilities/options_util.h"
 
 /* MyRocks header files */
-#include "./ha_rocksdb.h"
 #include "./rdb_cf_manager.h"
 #include "./rdb_compact_filter.h"
 #include "./rdb_sst_partitioner_factory.h"

--- a/storage/rocksdb/rdb_cf_options.h
+++ b/storage/rocksdb/rdb_cf_options.h
@@ -21,11 +21,10 @@
 #include <unordered_map>
 
 /* MySQL header files */
-#include "m_ctype.h"
+#include "my_compiler.h"
 
 /* RocksDB header files */
 #include "rocksdb/table.h"
-#include "rocksdb/utilities/options_util.h"
 
 /* MyRocks header files */
 #include "./rdb_global.h"

--- a/storage/rocksdb/rdb_compact_filter.h
+++ b/storage/rocksdb/rdb_compact_filter.h
@@ -21,7 +21,9 @@
 #endif
 
 /* C++ system header files */
-#include <time.h>
+#ifndef NDEBUG
+#include <ctime>
+#endif
 #include <optional>
 #include <string>
 

--- a/storage/rocksdb/rdb_converter.cc
+++ b/storage/rocksdb/rdb_converter.cc
@@ -19,14 +19,12 @@
 
 /* Standard C++ header files */
 #include <algorithm>
-#include <map>
 #include <string>
 #include <vector>
 
 /* MySQL header files */
-#include "./my_stacktrace.h"
+#include "my_checksum.h"
 #include "sql/field.h"
-#include "sql/sql_array.h"
 
 /* MyRocks header files */
 #include "./ha_rocksdb.h"

--- a/storage/rocksdb/rdb_converter.h
+++ b/storage/rocksdb/rdb_converter.h
@@ -17,12 +17,10 @@
 #pragma once
 
 // C++ standard header files
-#include <string>
 #include <vector>
 
 // MySQL header files
 #include "./sql_string.h"
-#include "./ut0counter.h"
 
 // MyRocks header files
 #include "./ha_rocksdb.h"

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -27,7 +27,9 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#ifndef NDEBUG
 #include <limits>
+#endif
 #include <map>
 #include <set>
 #include <string>
@@ -39,21 +41,19 @@
 #include "./my_bit.h"
 #include "./my_bitmap.h"
 #include "./my_byteorder.h"
-#include "my_compare.h"  // get_rec_bits
-#include "my_dir.h"
-#include "myisampack.h"  // mi_int2store
+#include "my_checksum.h"
 #include "mysql/thread_pool_priv.h"
 #include "sql/dd/cache/dictionary_client.h"  // dd::cache::Dictionary_client
 #include "sql/field.h"
 #include "sql/key.h"
+#include "sql/mysqld.h"
+#include "sql/sql_class.h"
 #include "sql/sql_table.h"
 
 /* MyRocks header files */
 #include "./ha_rocksdb.h"
 #include "./ha_rocksdb_proto.h"
-#include "./my_stacktrace.h"
 #include "./rdb_cf_manager.h"
-#include "./rdb_psi.h"
 #include "./rdb_utils.h"
 
 extern CHARSET_INFO my_charset_utf16_bin;

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -20,7 +20,6 @@
 #include <array>
 #include <atomic>
 #include <map>
-#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -34,6 +33,7 @@
 #include "./ha_rocksdb.h"
 #include "./properties_collector.h"
 #include "./rdb_buff.h"
+#include "./rdb_global.h"
 #include "./rdb_mutex_wrapper.h"
 #include "./rdb_utils.h"
 #include "./rdb_vector_db.h"
@@ -41,6 +41,17 @@
 /* Server header files */
 #include "sql/dd/object_id.h"
 #include "sql/fb_vector_base.h"
+
+// Forward declarations
+#ifdef ROCKSDB_CUSTOM_NAMESPACE
+namespace ROCKSDB_CUSTOM_NAMESPACE {
+#else
+namespace rocksdb {
+#endif
+
+class TransactionDB;
+
+}  // namespace ROCKSDB_CUSTOM_NAMESPACE / rocksdb
 
 namespace myrocks {
 

--- a/storage/rocksdb/rdb_global.h
+++ b/storage/rocksdb/rdb_global.h
@@ -19,7 +19,6 @@
 #pragma once
 
 /* C++ standard header files */
-#include <limits>
 #include <string>
 #include <vector>
 
@@ -28,8 +27,8 @@
 #endif
 
 /* MySQL header files */
-#include "./sql_string.h"
-#include "sql/handler.h" /* handler */
+#include "my_base.h"
+#include "my_inttypes.h"
 
 /* MyRocks headers */
 #include "./ut0counter.h"

--- a/storage/rocksdb/rdb_i_s.cc
+++ b/storage/rocksdb/rdb_i_s.cc
@@ -29,14 +29,10 @@
 #include "sql/sql_show.h"
 
 /* RocksDB header files */
-#include "rocksdb/version.h"
-#if ROCKSDB_MAJOR >= 8
 #include "rocksdb/advanced_cache.h"
-#endif  // ROCKSDB_MAJOR >= 8
 #include "rocksdb/compaction_filter.h"
 #include "rocksdb/convenience.h"
 #include "rocksdb/filter_policy.h"
-#include "rocksdb/memtablerep.h"
 #include "rocksdb/merge_operator.h"
 #include "rocksdb/slice_transform.h"
 #include "rocksdb/utilities/transaction_db.h"

--- a/storage/rocksdb/rdb_index_merge.cc
+++ b/storage/rocksdb/rdb_index_merge.cc
@@ -17,14 +17,17 @@
 /* This C++ file's header file */
 #include "./rdb_index_merge.h"
 
+#include "rdb_utils.h"  // LOG_COMPONENT_TAG for includes below
+
 /* MySQL header files */
+#include "mysql/components/services/log_builtins.h"
+#include "mysql/plugin.h"
 #include "mysql/psi/mysql_file.h"
-#include "sql/sql_class.h"
+#include "mysqld_error.h"
 #include "sql/sql_thd_internal_api.h"
 
 /* MyRocks header files */
-#include "./ha_rocksdb.h"
-#include "./rdb_datadic.h"
+#include "rdb_global.h"
 
 namespace myrocks {
 

--- a/storage/rocksdb/rdb_index_merge.h
+++ b/storage/rocksdb/rdb_index_merge.h
@@ -16,10 +16,6 @@
 
 #pragma once
 
-/* MySQL header files */
-#include "mysql/plugin.h"
-#include "sql/handler.h" /* handler */
-
 /* C++ standard header files */
 #include <queue>
 #include <set>
@@ -27,6 +23,11 @@
 
 /* RocksDB header files */
 #include "rocksdb/db.h"
+
+/* MySQL header files */
+#include "my_compiler.h"
+#include "my_inttypes.h"
+#include "mysql/components/services/bits/my_io_bits.h"
 
 /* MyRocks header files */
 #include "./rdb_global.h"

--- a/storage/rocksdb/rdb_io_watchdog.cc
+++ b/storage/rocksdb/rdb_io_watchdog.cc
@@ -25,6 +25,9 @@
 
 #include <fcntl.h>
 
+// MyRocks header files
+#include "rdb_utils.h"
+
 namespace myrocks {
 
 void Rdb_io_watchdog::expire_io_callback(

--- a/storage/rocksdb/rdb_io_watchdog.h
+++ b/storage/rocksdb/rdb_io_watchdog.h
@@ -19,19 +19,17 @@
 #ifndef __APPLE__
 
 /* C++ standard header files */
+#include <cassert>
 #include <signal.h>
 #include <stdlib.h>
-#include <string.h>
 #include <time.h>
 #include <atomic>
 #include <string>
 #include <vector>
 
 /* MySQL header files */
-#include "./my_stacktrace.h"
-
-/* MyRocks header files */
-#include "./rdb_utils.h"
+#include "thr_mutex.h"
+#include "mysql/psi/mysql_mutex.h"
 
 namespace myrocks {
 

--- a/storage/rocksdb/rdb_iterator.h
+++ b/storage/rocksdb/rdb_iterator.h
@@ -16,8 +16,6 @@
 
 #pragma once
 
-#include <map>
-
 // MySQL header files
 #include "sql/debug_sync.h"
 #include "sql/handler.h"

--- a/storage/rocksdb/rdb_mutex_wrapper.cc
+++ b/storage/rocksdb/rdb_mutex_wrapper.cc
@@ -18,11 +18,10 @@
 #include "./rdb_mutex_wrapper.h"
 
 /* MySQL header files */
+#include "sql/current_thd.h"
 #include "sql/replication.h"
-#include "sql/sql_class.h"
 
 /* MyRocks header files */
-#include "./ha_rocksdb.h"
 #include "./rdb_utils.h"
 
 namespace myrocks {

--- a/storage/rocksdb/rdb_mutex_wrapper.h
+++ b/storage/rocksdb/rdb_mutex_wrapper.h
@@ -17,22 +17,17 @@
 #pragma once
 
 /* C++ standard header file */
-#include <chrono>
-#include <condition_variable>
-#include <functional>
-#include <mutex>
 #include <unordered_map>
 
 /* MySQL header files */
-#include "./my_sys.h"
 #include "mysql/plugin.h"
 
 /* RocksDB header files */
 #include "rocksdb/utilities/transaction_db_mutex.h"
 
 /* MyRocks header files */
-#include "./rdb_global.h"
-#include "./rdb_psi.h"
+#include "rdb_global.h"
+#include "rdb_utils.h"
 
 namespace myrocks {
 

--- a/storage/rocksdb/rdb_native_dd.cc
+++ b/storage/rocksdb/rdb_native_dd.cc
@@ -21,6 +21,7 @@
 #include "sql/dd/types/table.h"  // dd::Table
 
 /* MyRocks header files */
+#include "sql/mysqld.h"
 #include "sql/plugin_table.h"
 #include "storage/rocksdb/ha_rocksdb_proto.h"
 #include "storage/rocksdb/rdb_datadic.h"

--- a/storage/rocksdb/rdb_nosql_digest.cc
+++ b/storage/rocksdb/rdb_nosql_digest.cc
@@ -1,13 +1,7 @@
 #include "./rdb_nosql_digest.h"
 
 /* MySQL header files */
-#include "sql/lexer_yystype.h"
-#include "sql/mysqld.h"
-#include "sql/sql_lex_hash.h"
 #include "sql/sql_yacc.h"
-
-/* PerfSchema header files */
-#include "storage/perfschema/pfs_server.h"
 
 namespace myrocks {
 

--- a/storage/rocksdb/rdb_nosql_digest.h
+++ b/storage/rocksdb/rdb_nosql_digest.h
@@ -5,7 +5,6 @@
 #include "./lex_string.h"
 #include "./m_string.h"
 #include "sql/item_func.h"
-#include "sql/sql_digest_stream.h"
 
 #pragma once
 

--- a/storage/rocksdb/rdb_sst_info.cc
+++ b/storage/rocksdb/rdb_sst_info.cc
@@ -18,14 +18,13 @@
 #include "./rdb_sst_info.h"
 
 /* C++ standard header files */
-#include <inttypes.h>
+#include <cinttypes>
 #include <cstdio>
 #include <string>
 #include <utility>
 #include <vector>
 
 /* MySQL header files */
-#include "./my_dir.h"
 #include "mysqld_error.h"
 
 /* RocksDB header files */
@@ -35,9 +34,7 @@
 #include "rocksdb/options.h"
 
 /* MyRocks header files */
-#include "./ha_rocksdb.h"
 #include "./ha_rocksdb_proto.h"
-#include "./rdb_cf_options.h"
 #include "./rdb_psi.h"
 
 namespace myrocks {

--- a/storage/rocksdb/rdb_sst_info.h
+++ b/storage/rocksdb/rdb_sst_info.h
@@ -18,12 +18,8 @@
 
 /* C++ standard header files */
 #include <atomic>
-#include <condition_variable>
-#include <mutex>
-#include <queue>
 #include <stack>
 #include <string>
-#include <thread>
 #include <utility>
 #include <vector>
 

--- a/storage/rocksdb/rdb_sst_partitioner_factory.h
+++ b/storage/rocksdb/rdb_sst_partitioner_factory.h
@@ -24,6 +24,7 @@
 #include <utility>
 
 #include "rocksdb/sst_partitioner.h"
+#include "rocksdb/utilities/transaction_db.h"
 
 #include "./rdb_cf_manager.h"
 #include "./rdb_datadic.h"

--- a/storage/rocksdb/rdb_threads.h
+++ b/storage/rocksdb/rdb_threads.h
@@ -20,7 +20,6 @@
 #include <deque>
 #include <map>
 #include <string>
-#include <utility>
 
 /* MySQL includes */
 #include <mysql/psi/mysql_table.h>
@@ -28,7 +27,6 @@
 #include "sql/sql_class.h"
 
 /* MyRocks header files */
-#include "./rdb_global.h"
 #include "./rdb_utils.h"
 #include "rocksdb/db.h"
 

--- a/storage/rocksdb/rdb_utils.cc
+++ b/storage/rocksdb/rdb_utils.cc
@@ -30,6 +30,7 @@
 #include "m_ctype.h"
 #include "my_dir.h"
 #include "mysys_err.h"
+#include "sql/mysqld.h"
 
 /* MyRocks header files */
 #include "./ha_rocksdb.h"

--- a/storage/rocksdb/rdb_utils.h
+++ b/storage/rocksdb/rdb_utils.h
@@ -23,7 +23,6 @@
 /* MySQL header files */
 #include "./my_stacktrace.h"
 #include "./sql_string.h"
-#include "sql/mysqld.h"
 #define LOG_COMPONENT_TAG "rocksdb"
 #include "mysql/components/services/log_builtins.h"
 #include "mysqld_error.h"

--- a/storage/rocksdb/rdb_vector_db.cc
+++ b/storage/rocksdb/rdb_vector_db.cc
@@ -15,10 +15,10 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 
 #include "./rdb_vector_db.h"
-#include <mutex>
 #include "sql-common/json_dom.h"
 #include "sql/field.h"
 #ifdef WITH_FB_VECTORDB
+#include <mutex>
 #include <faiss/IndexFlat.h>
 #endif
 

--- a/storage/rocksdb/rdb_vector_db.h
+++ b/storage/rocksdb/rdb_vector_db.h
@@ -16,14 +16,12 @@
 #pragma once
 #ifdef WITH_FB_VECTORDB
 #include <faiss/Index.h>
-#endif
 #include <memory>
 #include <shared_mutex>
 #include <unordered_map>
-#include "./rdb_global.h"
+#endif
 #include "rdb_utils.h"
 #include "sql/item_fb_vector_func.h"
-#include "sql/item_json_func.h"
 
 namespace myrocks {
 

--- a/storage/rocksdb/sql_dd.cc
+++ b/storage/rocksdb/sql_dd.cc
@@ -17,10 +17,8 @@
 #include "sql_dd.h"
 #include <assert.h>
 #include <memory>
-#include "./rdb_utils.h"
-#include "my_sys.h"
-#include "mysql/psi/psi_memory.h"
 #include "mysql/service_mysql_alloc.h"
+#include "sql/field.h"
 
 namespace myrocks {
 

--- a/storage/rocksdb/sql_dd.h
+++ b/storage/rocksdb/sql_dd.h
@@ -15,14 +15,9 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 
 #pragma once
-#include "m_ctype.h"
-#include "my_sys.h"
-#include "mysql/psi/psi_memory.h"
-#include "mysql/service_mysql_alloc.h"
 #include "sql/dd/properties.h"
 #include "sql/dd/types/column.h"
 #include "sql/dd/types/table.h"
-#include "sql/field.h"
 #include "sql/table.h"
 
 namespace myrocks {

--- a/storage/rocksdb/unittest/test_properties_collector.cc
+++ b/storage/rocksdb/unittest/test_properties_collector.cc
@@ -14,9 +14,12 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 
+// C++ standard header files
+#include <cstdint>
+#include <string>
+
 /* MyRocks header files */
-#include "../ha_rocksdb.h"
-#include "../rdb_datadic.h"
+#include "../properties_collector.h"
 
 void putKeys(myrocks::Rdb_tbl_prop_coll *coll, int num, bool is_delete,
              uint64_t expected_deleted) {

--- a/storage/rocksdb/ut0counter.h
+++ b/storage/rocksdb/ut0counter.h
@@ -27,6 +27,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef UT0COUNTER_H
 #define UT0COUNTER_H
 
+#include <cassert>
 #include <string.h>
 
 /** CPU cache line size */


### PR DESCRIPTION
To reduce the number of annoying wiggles under headers in the editor. Appears to be a net removal, which is good.

This is like `include-what-you-use` but less thorough, i.e. some `#include <string>` etc. are clearly missing but not suggested. https://clangd.llvm.org/guides/include-cleaner