### PR TITLE
Fix build error on std::pair comparison

### DIFF
--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -1646,7 +1646,7 @@ bool MYSQL_BIN_LOG::write_metadata_event(THD *thd,
     return false;
   }
 
-  if (param.checkpoint != std::pair(-1L, -1L)) {
+  if (param.checkpoint != std::pair<int64_t, int64_t>(-1, -1)) {
     metadata_ev.set_raft_ingestion_checkpoint(param.checkpoint);
     write_event = true;
   }


### PR DESCRIPTION
This fixes

/Users/laurynas/vilniusdb/fb-mysql-8.0.28/sql/binlog.cc:1649:24: error: invalid operands to binary expression ('std::pair<int64_t, int64_t>' (aka 'pair<long long, long long>') and 'std::pair<long, long>' (aka 'pair<long, long>'))
  if (param.checkpoint != std::pair(-1L, -1L)) {
      ~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~

by explicitly providing the std::pair types.

Squash with 6aa7549f0c0fb436f7ff3a01b5ad43ed58b1e21b