### PR TITLE
Fix GCC compilation error in rocksdb_dict_recover

### DIFF
--- a/storage/rocksdb/rdb_native_dd.cc
+++ b/storage/rocksdb/rdb_native_dd.cc
@@ -102,6 +102,8 @@ bool rocksdb_dict_recover(dict_recovery_mode_t dict_recovery_mode, uint) {
     case DICT_RECOVERY_RESTART_SERVER:
       return false;
   }
+  MY_ASSERT_UNREACHABLE();
+  return true;
 }
 
 void rocksdb_dict_cache_reset(const char *, const char *) {


### PR DESCRIPTION
storage/rocksdb/rdb_native_dd.cc: In function ‘bool myrocks::rocksdb_dict_recover(dict_recovery_mode_t, uint)’:
storage/rocksdb/rdb_native_dd.cc:105:1: error: control reaches end of non-void function [-Werror=return-type]