### PR TITLE
Do not define static variables in a header file

### DIFF
--- a/storage/rocksdb/nosql_access.cc
+++ b/storage/rocksdb/nosql_access.cc
@@ -77,6 +77,17 @@ bool inline is_supported_item_func(Item_func::Functype type) {
 
 namespace {
 
+LEX_CSTRING select_tok{STRING_WITH_LEN("SELECT")};
+LEX_CSTRING from_tok{STRING_WITH_LEN("FROM")};
+LEX_CSTRING where_tok{STRING_WITH_LEN("WHERE")};
+LEX_CSTRING force_tok{STRING_WITH_LEN("FORCE")};
+LEX_CSTRING index_tok{STRING_WITH_LEN("INDEX")};
+LEX_CSTRING order_tok{STRING_WITH_LEN("ORDER")};
+LEX_CSTRING by_tok{STRING_WITH_LEN("BY")};
+LEX_CSTRING limit_tok{STRING_WITH_LEN("LIMIT")};
+LEX_CSTRING asc_tok{STRING_WITH_LEN("ASC")};
+LEX_CSTRING desc_tok{STRING_WITH_LEN("DESC")};
+
 bool check_field_name_match(Field *field, const char *field_name) {
   return (field->field_name &&
           !my_strcasecmp(system_charset_info, field->field_name, field_name));

--- a/storage/rocksdb/rdb_nosql_digest.h
+++ b/storage/rocksdb/rdb_nosql_digest.h
@@ -16,25 +16,14 @@
 
 namespace myrocks {
 
-static LEX_CSTRING select_tok{STRING_WITH_LEN("SELECT")};
-static LEX_CSTRING from_tok{STRING_WITH_LEN("FROM")};
-static LEX_CSTRING where_tok{STRING_WITH_LEN("WHERE")};
-static LEX_CSTRING force_tok{STRING_WITH_LEN("FORCE")};
-static LEX_CSTRING index_tok{STRING_WITH_LEN("INDEX")};
-static LEX_CSTRING order_tok{STRING_WITH_LEN("ORDER")};
-static LEX_CSTRING by_tok{STRING_WITH_LEN("BY")};
-static LEX_CSTRING limit_tok{STRING_WITH_LEN("LIMIT")};
-static LEX_CSTRING asc_tok{STRING_WITH_LEN("ASC")};
-static LEX_CSTRING desc_tok{STRING_WITH_LEN("DESC")};
-
-static LEX_CSTRING eq_tok{STRING_WITH_LEN("=")};
-static LEX_CSTRING lt_tok{STRING_WITH_LEN("<")};
-static LEX_CSTRING gt_tok{STRING_WITH_LEN(">")};
-static LEX_CSTRING le_tok{STRING_WITH_LEN("<=")};
-static LEX_CSTRING ge_tok{STRING_WITH_LEN(">=")};
-
 // This should always be synced with rocksdb::convert_where_op
 inline LEX_CSTRING get_op_lex_string(Item_func::Functype op) {
+  static LEX_CSTRING eq_tok{STRING_WITH_LEN("=")};
+  static LEX_CSTRING lt_tok{STRING_WITH_LEN("<")};
+  static LEX_CSTRING gt_tok{STRING_WITH_LEN(">")};
+  static LEX_CSTRING le_tok{STRING_WITH_LEN("<=")};
+  static LEX_CSTRING ge_tok{STRING_WITH_LEN(">=")};
+
   switch (op) {
     case Item_func::EQ_FUNC:
       return eq_tok;


### PR DESCRIPTION
Since they are used only once, move them to their respective use locations. This fixes a GCC compilation error:

In file included from /home/laurynas/vilniusdb/fb-mysql/storage/rocksdb/rdb_nosql_digest.cc:1: /home/laurynas/vilniusdb/fb-mysql/storage/rocksdb/./rdb_nosql_digest.h:28:20: error: ‘myrocks::desc_tok’ defined but not used [-Werror=unused-variable]
   28 | static LEX_CSTRING desc_tok{STRING_WITH_LEN("DESC")};
      |                    ^~~~~~~~
/home/laurynas/vilniusdb/fb-mysql/storage/rocksdb/./rdb_nosql_digest.h:27:20: error: ‘myrocks::asc_tok’ defined but not used [-Werror=unused-variable]
   27 | static LEX_CSTRING asc_tok{STRING_WITH_LEN("ASC")};
      |                    ^~~~~~~
/home/laurynas/vilniusdb/fb-mysql/storage/rocksdb/./rdb_nosql_digest.h:26:20: error: ‘myrocks::limit_tok’ defined but not used [-Werror=unused-variable]
   26 | static LEX_CSTRING limit_tok{STRING_WITH_LEN("LIMIT")};
      |                    ^~~~~~~~~
/home/laurynas/vilniusdb/fb-mysql/storage/rocksdb/./rdb_nosql_digest.h:25:20: error: ‘myrocks::by_tok’ defined but not used [-Werror=unused-variable]
   25 | static LEX_CSTRING by_tok{STRING_WITH_LEN("BY")};
      |                    ^~~~~~
/home/laurynas/vilniusdb/fb-mysql/storage/rocksdb/./rdb_nosql_digest.h:24:20: error: ‘myrocks::order_tok’ defined but not used [-Werror=unused-variable]
   24 | static LEX_CSTRING order_tok{STRING_WITH_LEN("ORDER")};
      |                    ^~~~~~~~~
/home/laurynas/vilniusdb/fb-mysql/storage/rocksdb/./rdb_nosql_digest.h:23:20: error: ‘myrocks::index_tok’ defined but not used [-Werror=unused-variable]
   23 | static LEX_CSTRING index_tok{STRING_WITH_LEN("INDEX")};
      |                    ^~~~~~~~~
/home/laurynas/vilniusdb/fb-mysql/storage/rocksdb/./rdb_nosql_digest.h:22:20: error: ‘myrocks::force_tok’ defined but not used [-Werror=unused-variable]
   22 | static LEX_CSTRING force_tok{STRING_WITH_LEN("FORCE")};
      |                    ^~~~~~~~~
/home/laurynas/vilniusdb/fb-mysql/storage/rocksdb/./rdb_nosql_digest.h:21:20: error: ‘myrocks::where_tok’ defined but not used [-Werror=unused-variable]
   21 | static LEX_CSTRING where_tok{STRING_WITH_LEN("WHERE")};
      |                    ^~~~~~~~~
/home/laurynas/vilniusdb/fb-mysql/storage/rocksdb/./rdb_nosql_digest.h:20:20: error: ‘myrocks::from_tok’ defined but not used [-Werror=unused-variable]
   20 | static LEX_CSTRING from_tok{STRING_WITH_LEN("FROM")};
      |                    ^~~~~~~~
/home/laurynas/vilniusdb/fb-mysql/storage/rocksdb/./rdb_nosql_digest.h:19:20: error: ‘myrocks::select_tok’ defined but not used [-Werror=unused-variable]
   19 | static LEX_CSTRING select_tok{STRING_WITH_LEN("SELECT")};
      |                    ^~~~~~~~~~