### PR TITLE
Pass actual format string instead of nullptr in Parser_oom_handler::h…

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -7905,7 +7905,8 @@ class Parser_oom_handler : public Internal_error_handler {
           if (thd->variables.parser_exceeded_max_mem_capacity_action ==
               PARSER_EXCEEDED_MAX_MEM_CAPACITY_ACTION_WARN) {
             push_warning_printf(
-                thd, Sql_condition::SL_WARNING, ER_CAPACITY_EXCEEDED, nullptr,
+                thd, Sql_condition::SL_WARNING, ER_CAPACITY_EXCEEDED,
+                ER_THD(thd, ER_CAPACITY_EXCEEDED),
                 static_cast<ulonglong>(thd->variables.parser_max_mem_size),
                 "parser_max_mem_size",
                 ER_THD(thd, ER_CAPACITY_EXCEEDED_IN_PARSER));


### PR DESCRIPTION
…andle_condition

Should the code path be actually exercised, memory errors were likely to have occurred instead of diagnostics.

This fixes a GCC build error:

sql/sql_parse.cc:7909:17: error: too many arguments for format [-Werror=format-extra-args]
 7909 |                 static_cast<ulonglong>(thd->variables.parser_max_mem_size),

Squash with 67fcc60a43687c3e116c7f57e13b52732ad25231