### PR TITLE
Cast enum into target type in a ternary operator

### DIFF
--- a/sql/rpl_replica.cc
+++ b/sql/rpl_replica.cc
@@ -7204,8 +7204,9 @@ static int slave_start_single_worker(Relay_log_info *rli, ulong i) {
   mysql_mutex_assert_owner(&rli->run_lock);
 
   if (!(w = Rpl_info_factory::create_worker(
-            rli->is_fake() ? INFO_REPOSITORY_DUMMY : opt_rli_repository_id, i,
-            rli, false))) {
+            rli->is_fake() ? static_cast<ulong>(INFO_REPOSITORY_DUMMY)
+                           : opt_rli_repository_id,
+            i, rli, false))) {
     LogErr(ERROR_LEVEL, ER_RPL_SLAVE_WORKER_THREAD_CREATION_FAILED,
            rli->get_for_channel_str());
     error = 1;


### PR DESCRIPTION
This fixes a GCC build error:

sql/rpl_replica.cc: In function ‘int slave_start_single_worker(Relay_log_info*, ulong)’: sql/rpl_replica.cc:7207:28: error: enumerated and non-enumerated type in conditional expression [-Werror=extra]
 7207 |             rli->is_fake() ? INFO_REPOSITORY_DUMMY : opt_rli_repository_id, i,
      |             ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Squash with 5b4ca994aa629ccbda9a4f32d1fa885c33c02761