### PR TITLE
Fix build error on std::pair comparison

### DIFF
--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -6623,7 +6623,8 @@ bool MYSQL_BIN_LOG::open_binlog(
         update_prev_gtid_and_opid(
             previous_logged_gtids, raft_rotate_info->rotate_opid.first,
             raft_rotate_info->rotate_opid.second, need_sid_lock);
-        if (raft_rotate_info->ingestion_checkpoint != std::pair(-1L, -1L)) {
+        if (raft_rotate_info->ingestion_checkpoint !=
+            std::pair<int64_t, int64_t>(-1, -1)) {
           metadata_ev.set_raft_ingestion_prev_checkpoint(
               raft_rotate_info->ingestion_checkpoint);
         }
@@ -8805,7 +8806,7 @@ int MYSQL_BIN_LOG::new_file_impl(
       param.force = true;  // we force a checkpoint update on rotation
       if (!RUN_HOOK_STRICT(raft_replication, ingestion,
                            (current_thd, &param))) {
-        if (param.checkpoint != std::pair(-1L, -1L)) {
+        if (param.checkpoint != std::pair<int64_t, int64_t>(-1, -1)) {
           me.set_raft_ingestion_checkpoint(param.checkpoint);
           raft_rotate_info->ingestion_checkpoint = param.checkpoint;
         }


### PR DESCRIPTION
This fixes

sql/binlog.cc:6626:52: error: invalid operands to binary expression ('std::pair<int64_t, int64_t>' (aka 'pair<long long, long long>') and 'std::pair<long, long>' (aka 'pair<long, long>'))
        if (raft_rotate_info->ingestion_checkpoint != std::pair(-1L, -1L)) {
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~

and

sql/binlog.cc:8809:30: error: invalid operands to binary expression ('std::pair<int64_t, int64_t>' (aka 'pair<long long, long long>') and 'std::pair<long, long>' (aka 'pair<long, long>'))
        if (param.checkpoint != std::pair(-1L, -1L)) {
            ~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~

Done in a separate commit from 2ad105fc364672361a6228238dd9523c835bf399 because of a different squash patch target.

Squash with e0c8fde56ec9777307d609a69acb5c5a92c21907