### PR TITLE
Bug#35137978: Equality operator needs to be updated after LWG-3865

### DIFF
--- a/sql/auth/auth_internal.h
+++ b/sql/auth/auth_internal.h
@@ -253,7 +253,7 @@ void revoke_dynamic_privileges_from_auth_id(
     const Role_id &id, const std::vector<std::string> &priv_list);
 bool operator==(const Role_id &a, const Auth_id_ref &b);
 bool operator==(const Auth_id_ref &a, const Role_id &b);
-bool operator==(const std::pair<const Role_id, const Role_id> &a,
+bool operator==(const std::pair<const Role_id, Role_id> &a,
                 const Auth_id_ref &b);
 bool operator==(const Role_id &a, const Role_id &b);
 bool operator==(std::pair<const Role_id, std::pair<std::string, bool>> &a,

--- a/sql/auth/sql_authorization.cc
+++ b/sql/auth/sql_authorization.cc
@@ -7465,7 +7465,7 @@ bool operator==(const Role_id &a, const Auth_id_ref &b) {
 
 bool operator==(const Auth_id_ref &a, const Role_id &b) { return b == a; }
 
-bool operator==(const std::pair<const Role_id, const Role_id> &a,
+bool operator==(const std::pair<const Role_id, Role_id> &a,
                 const Auth_id_ref &b) {
   return ((a.second.user().length() == b.first.length) &&
           (a.second.host().length() == b.second.length) &&


### PR DESCRIPTION
The C++ Standardization Committee's Library Working Group recently resolved an issue, LWG-3865 "Sorting a range of pairs" (see https://cplusplus.github.io/LWG/issue3865 ), which changes how std::pair's comparison operators are defined. Such issues are considered "defect reports" and apply retroactively to all published Standards.

Based on a suggestion by the Microsoft Visual Studio team.

Change-Id: I8ac997fecfab9b53b4c3bdebd9ab995316aab6b7