### PR TITLE
use original se_private_data during DDSE change early steps

### DIFF
--- a/sql/dd/dd_table.cc
+++ b/sql/dd/dd_table.cc
@@ -2349,15 +2349,18 @@ static std::unique_ptr<dd::Table> create_dd_system_table(
     return nullptr;
 
   /*
-    During --initialize, DDSE change and for inert tables, get the SE private
-    data from the SE, and store it in the dd_properties table at a later stage.
+    During --initialize, upgrade table (SYNCED stage) in DDSE change and for
+    inert tables, get the SE private data from the SE, and store it in the
+    dd_properties table at a later stage.
     Otherwise, get the SE private data from the 'dd_properties' table.
   */
   const System_tables::Types *table_type =
       System_tables::instance()->find_type(system_schema.name(), table_name);
   if (opt_initialize ||
       (table_type != nullptr && *table_type == System_tables::Types::INERT) ||
-      bootstrap::DD_bootstrap_ctx::instance().is_dd_engine_change()) {
+      (bootstrap::DD_bootstrap_ctx::instance().is_dd_engine_change() &&
+       bootstrap::DD_bootstrap_ctx::instance().get_stage() ==
+           bootstrap::Stage::SYNCED)) {
     if (file->ha_get_se_private_data(
             tab_obj.get(), (table_type != nullptr &&
                             *table_type == System_tables::Types::INERT)))


### PR DESCRIPTION
Summary:

INNODB hit crash during DDSE change due to use wrong root page/index_id calculated from DD tables private data.

```
mysqld`rec_get_offsets
mysqld`btr_estimate_number_of_different_key_vals(index=0x00007fffab987c88)
mysqld`dict_stats_update_transient_for_index
mysqld`dict_stats_update_transient
mysqld`dict_stats_update
mysqld`dict_stats_init
mysqld`ha_innobase::open
mysqld`handler::ha_open
mysqld`open_table_from_share
mysqld`open_table
  ```

During DDSE change(such as INNODB to ROCKSDB), it will 
1. populate existing DD tables in mysql with INNODB, 
2. create these DD tables in <upgrade> with ROCKSDB 
3. copy data form INNODB DD tables into ROCKSDB DD tables

Even in step1:
- Before this fix, it will calculate index ids/root pages through handle API and ignore se_private_data stored in dd_properties table.  if these index ids/root pages are same, then everything are okay. but if these index ids and root pages has been changed(such as mysql.columns index ids changed from 22,23,24 to 600,601,602), then we use wrong index ids/root pages to read page..

- With this fix, always use se_private_data stored in dd_properties table to populate these DD tables(or didn't call handler API to calculate se_private_data again).

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: