### PR TITLE
Add extra asserts to prevent incorrect moved-from Rdb_tbl_def uses

### DIFF
--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -4118,6 +4118,8 @@ bool Rdb_tbl_def::put_dict(Rdb_dict_manager *const dict,
                            Rdb_cf_manager *cf_manager,
                            rocksdb::WriteBatch *const batch,
                            const rocksdb::Slice &key) {
+  assert(m_pk_index <= MAX_INDEXES);
+
   StringBuffer<8 * Rdb_key_def::PACKED_SIZE> indexes;
   indexes.alloc(Rdb_key_def::VERSION_SIZE +
                 m_key_count * Rdb_key_def::PACKED_SIZE * 2);
@@ -4245,6 +4247,8 @@ void Rdb_tbl_def::set_name(const std::string &name) {
 }
 
 GL_INDEX_ID Rdb_tbl_def::get_autoincr_gl_index_id() {
+  assert(m_pk_index <= MAX_INDEXES);
+
   for (uint i = 0; i < m_key_count; i++) {
     auto &k = m_key_descr_arr[i];
     if (k->m_index_type == Rdb_key_def::INDEX_TYPE_PRIMARY ||


### PR DESCRIPTION
Rdb_tbl_def class has a move constructor-like two-arg constructor that takes the ownership of passed object's m_key_descr_arr field. Signify this moved-from state in the object by resetting m_pk_index-which is a related-field to MAX_INDEXES + 1, and add extra asserts that these and other related fields are not accessed in moved-from objects.

At the same time remove redundant "explicit" specifiers from two-argument constructors and clean them up to use initializer lists consistently.