### PR TITLE
Make my_checksum.h include headers it uses

### DIFF
--- a/include/my_checksum.h
+++ b/include/my_checksum.h
@@ -30,6 +30,8 @@
 */
 
 #include <cassert>
+#include <cstdint>      // std::uint32_t
+#include <cstring>      // memcpy
 #include <limits>       // std::numeric_limits
 #include <type_traits>  // std::is_convertible
 


### PR DESCRIPTION
This fixes, on Linux on ARM:
```
In file included from /home/laurynas/vilniusdb/fb-mysql/_build-debug-llvm-12/include/installed_headers.cc:2: /home/laurynas/vilniusdb/fb-mysql/include/my_checksum.h:94:5: error: call to function 'memcpy' that is neither visible in the template definition nor found by argument-dependent lookup
    memcpy(&pv, buf, sizeof(PT));
    ^
/home/laurynas/vilniusdb/fb-mysql/include/my_checksum.h:119:21: note: in instantiation of function template specialization 'mycrc32::PunnedCrc32<unsigned long>' requested here
    return mycrc32::PunnedCrc32<std::uint64_t>(crc, pos, length);
                    ^
/usr/include/string.h:43:14: note: 'memcpy' should be declared prior to the call site extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
             ^
```
Squash with 12c04a015cf2bd5f2c6c7bd2b17ecaf03ef0a53a