### PR TITLE
Fix recent macOS build regression on test_bypass_rpc_plugin

### DIFF
--- a/plugin/test_bypass_rpc_plugin/test_bypass_rpc_plugin_info.cc
+++ b/plugin/test_bypass_rpc_plugin/test_bypass_rpc_plugin_info.cc
@@ -498,7 +498,7 @@ static void test_rpc(void *) {
 
     LogPluginErrMsg(
         INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
-        "calling bypass_select with query '%s', hlc_lower_bound_ts %lu",
+        "calling bypass_select with query '%s', hlc_lower_bound_ts %" PRIu64,
         query_str.c_str(), hlc_lower_bound_ts);
     const auto &exception = bypass_select(&param);
     if (exception.errnum) {


### PR DESCRIPTION
Use `PRIu64` to format `uint64_t` values to fix:
```
plugin/test_bypass_rpc_plugin/test_bypass_rpc_plugin_info.cc:502:28: error: format specifies type 'unsigned long' but the argument has type 'uint64_t' (aka 'unsigned long long') [-Werror,-Wformat]
  501 |         "calling bypass_select with query '%s', hlc_lower_bound_ts %lu",
      |                                                                    ~~~
      |                                                                    %llu
  502 |         query_str.c_str(), hlc_lower_bound_ts);
      |                            ^~~~~~~~~~~~~~~~~~
include/mysql/components/services/log_builtins.h:838:66: note: expanded from macro 'LogPluginErrMsg'
  838 |       .message_quoted("Plugin " LOG_COMPONENT_TAG " reported", ##__VA_ARGS__)
      |                                                                  ^~~~~~~~~~~
```