### PR TITLE
apply slowrm to innodb clone recovery

### DIFF
--- a/storage/innobase/clone/clone0api.cc
+++ b/storage/innobase/clone/clone0api.cc
@@ -134,7 +134,7 @@ static void remove_file(const std::string &file) {
       return;
     }
 
-    auto ret = std::remove(file.c_str());
+    auto ret = slowfileremove(file.c_str());
 
     if (ret != 0) {
       ib::error(ER_IB_CLONE_STATUS_FILE)


### PR DESCRIPTION
Innodb clone doesn't apply slowrm when discarding files during recovery, which will potentially lock up I/O. Apply the existing slowrm feature to innodb clone from this PR: https://github.com/facebook/mysql-5.6/pull/1099?fbclid=IwAR25_2tPoiZsh0QTkyUzKnH5QgLk7Rl8dpFIG4kePgupYDkgXZfbGNhu_VA