### PR TITLE
Fix one of the two binlog.cc build failures on macOS

### DIFF
--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -1749,7 +1749,7 @@ bool MYSQL_BIN_LOG::write_metadata_event(THD *thd,
     return false;
   }
 
-  if (param.checkpoint != std::pair(-1L, -1L)) {
+  if (param.checkpoint != std::pair<std::int64_t, std::int64_t>(-1L, -1L)) {
     metadata_ev.set_raft_ingestion_checkpoint(param.checkpoint);
     write_event = true;
   }


### PR DESCRIPTION
This fixes

sql/binlog.cc:1752:24: error: invalid operands to binary expression ('std::pair<int64_t, int64_t>' (aka 'pair<long long, long long>') and 'std::pair<long, long>' (aka 'pair<long, long>'))
  if (param.checkpoint != std::pair(-1L, -1L)) {
      ~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~

Squash with 77f27447c8be03bb10e442c64671e9068b7cd7bd