### PR TITLE
Do not run perfschema.start_server_low_table_lock under MyRocks DDSE

### DIFF
--- a/mysql-test/suite/perfschema/t/start_server_low_table_lock.test
+++ b/mysql-test/suite/perfschema/t/start_server_low_table_lock.test
@@ -1,3 +1,8 @@
+# If run with a different DDSE, due to the option file, the instance is created
+# with one DDSE and then changed to another on startup, filling the PFS tables
+# with extra events.
+--source include/have_innodb_ddse.inc
+
 # Tests for PERFORMANCE_SCHEMA
 
 --source ../include/start_server_common.inc


### PR DESCRIPTION
If MyRocks is the DDSE, then the test server instance is bootstrapped with InnoDB DDSE and then converted to MyRocks DDSE. The conversion will result in many PFS events, changing the test results.