### PR TITLE
Convert MyRocks clone and associated code to use std::string_view

### DIFF
--- a/storage/rocksdb/clone/common.cc
+++ b/storage/rocksdb/clone/common.cc
@@ -18,7 +18,7 @@
 
 #include <atomic>
 #include <cstdint>
-#include <cstring>
+#include <string_view>
 
 #include "my_compiler.h"
 #include "my_dir.h"
@@ -30,8 +30,10 @@
 
 namespace {
 
+using namespace std::string_view_literals;
+
 constexpr char in_place_old_datadir[] = ".rocksdb.saved";
-constexpr char old_wal_suffix[] = ".saved";
+constexpr std::string_view old_wal_suffix = ".saved"sv;
 
 // Must be kept in sync with CLONE_FORCE_OTHER_ENGINES_ROLLBACK_FILE in
 // storage/innobase/include/clone0clone.h.
@@ -105,8 +107,7 @@ void move_temp_dir_to_destination(const std::string &temp,
   myrocks::rdb_path_rename_or_abort(temp, dest);
 
   if (dest_exists) {
-    const auto success [[maybe_unused]] =
-        myrocks::clone::remove_dir(old.c_str(), true);
+    const auto success [[maybe_unused]] = myrocks::clone::remove_dir(old, true);
     assert(success);
   }
 }
@@ -127,12 +128,14 @@ void move_temp_dir_contents_to_dest(const std::string &temp,
     // Pass 1: rename old files in the destination directory
     if (dest_existed) {
       myrocks::for_each_in_dir(dest, MY_FAE, [&dest](const fileinfo &f_info) {
-        if (myrocks::has_file_extension(f_info.name, old_wal_suffix))
-          myrocks::rdb_fatal_error("MyRocks clone fixup temp file %s found",
-                                   f_info.name);
+        const auto fn = std::string_view{f_info.name};
 
-        const auto old_path = myrocks::rdb_concat_paths(dest, f_info.name);
-        const auto saved_old_path = old_path + old_wal_suffix;
+        if (myrocks::has_file_extension(fn, old_wal_suffix))
+          myrocks::rdb_fatal_error("MyRocks clone fixup temp file %.*s found",
+                                   static_cast<int>(fn.length()), fn.data());
+
+        const auto old_path = myrocks::rdb_concat_paths(dest, fn);
+        const auto saved_old_path = std::string{old_path} += old_wal_suffix;
         if (my_rename(old_path.c_str(), saved_old_path.c_str(),
                       MYF(MY_WME | MY_FAE))) {
           myrocks::rdb_fatal_error("Failed to rename %s to %s",
@@ -144,8 +147,10 @@ void move_temp_dir_contents_to_dest(const std::string &temp,
     // Pass 2: move new files to the destination
     myrocks::for_each_in_dir(
         temp, MY_FAE, [&temp, &dest](const fileinfo &f_info) {
-          const auto old_path = myrocks::rdb_concat_paths(temp, f_info.name);
-          const auto new_path = myrocks::rdb_concat_paths(dest, f_info.name);
+          const auto fn = std::string_view{f_info.name};
+
+          const auto old_path = myrocks::rdb_concat_paths(temp, fn);
+          const auto new_path = myrocks::rdb_concat_paths(dest, fn);
           myrocks::rdb_path_rename_or_abort(old_path, new_path);
           return true;
         });
@@ -153,10 +158,10 @@ void move_temp_dir_contents_to_dest(const std::string &temp,
     if (dest_existed) {
       // Pass 3: remove old files
       myrocks::for_each_in_dir(dest, MY_FAE, [&dest](const fileinfo &f_info) {
-        if (!myrocks::has_file_extension(f_info.name, old_wal_suffix))
-          return true;
-        const auto saved_old_path =
-            myrocks::rdb_concat_paths(dest, f_info.name);
+        const auto fn = std::string_view{f_info.name};
+
+        if (!myrocks::has_file_extension(fn, old_wal_suffix)) return true;
+        const auto saved_old_path = myrocks::rdb_concat_paths(dest, fn);
         myrocks::rdb_file_delete_or_abort(saved_old_path);
         return true;
       });
@@ -237,9 +242,10 @@ void fixup_on_startup() {
     move_temp_dir_contents_to_dest(in_place_temp_wal_dir, rocksdb_wal_dir);
   } else if (path_exists(in_place_temp_wal_dir)) {
     for_each_in_dir(in_place_temp_wal_dir, MY_FAE, [](const fileinfo &f_info) {
-      const auto old_log_path =
-          rdb_concat_paths(in_place_temp_wal_dir, f_info.name);
-      const auto new_log_path = rdb_concat_paths(rocksdb_datadir, f_info.name);
+      const auto fn = std::string_view{f_info.name};
+
+      const auto old_log_path = rdb_concat_paths(in_place_temp_wal_dir, fn);
+      const auto new_log_path = rdb_concat_paths(rocksdb_datadir, fn);
       myrocks::rdb_path_rename_or_abort(old_log_path, new_log_path);
       return true;
     });
@@ -253,19 +259,20 @@ void fixup_on_startup() {
     const auto errno_copy = my_errno();
     if (errno_copy != ENOENT) {
       rdb_fatal_error("Failed to open directory %s, errno %d",
-                      checkpoint_base_dir().c_str(), errno_copy);
+                      checkpoint_base_dir_str.c_str(), errno_copy);
     }
     return;
   }
 
   for (uint i = 0; i < dir->number_off_files; ++i) {
     const auto &f_info = dir->dir_entry[i];
-    if (!S_ISDIR(f_info.mystat->st_mode) ||
-        strncmp(f_info.name, checkpoint_name_prefix,
-                sizeof(checkpoint_name_prefix) - 1) != 0)
+    if (!S_ISDIR(f_info.mystat->st_mode)) continue;
+    const auto fn = std::string_view{f_info.name};
+    // Replace with fn.starts_with at C++20
+    if (fn.substr(0, checkpoint_name_prefix.length()) != checkpoint_name_prefix)
       continue;
     const auto checkpoint_dir_path =
-        rdb_concat_paths(checkpoint_base_dir_str, f_info.name);
+        rdb_concat_paths(checkpoint_base_dir_str, fn);
     const auto success [[maybe_unused]] = remove_dir(checkpoint_dir_path, true);
     assert(success);
   }
@@ -282,9 +289,9 @@ void fixup_on_startup() {
   return (da != nullptr && da->is_error()) ? da->message_text() : "";
 }
 
-[[nodiscard]] bool should_use_direct_io(const std::string &file_name,
+[[nodiscard]] bool should_use_direct_io(std::string_view file_name,
                                         enum mode_for_direct_io mode) {
-  const auto is_sst = has_file_extension(file_name, ".sst");
+  const auto is_sst = has_file_extension(file_name, ".sst"sv);
   if (!is_sst) return false;
 
   const auto &rdb_opts = *myrocks::get_rocksdb_db_options();

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -39,6 +39,7 @@
 #include <queue>
 #include <set>
 #include <string>
+#include <string_view>
 #include <vector>
 
 /* MySQL includes */
@@ -442,17 +443,16 @@ class Rdb_open_tables_map {
 
 static Rdb_open_tables_map rdb_open_tables;
 
-static std::string rdb_normalize_dir(std::string dir) {
-  while (dir.size() > 0 && dir.back() == '/') {
-    dir.resize(dir.size() - 1);
+static std::string_view rdb_normalize_dir(std::string_view dir) {
+  while (!dir.empty() && dir.back() == '/') {
+    dir.remove_suffix(1);
   }
   return dir;
 }
 
-int rocksdb_create_checkpoint(const char *checkpoint_dir_raw) {
-  assert(checkpoint_dir_raw);
-
-  const auto checkpoint_dir = rdb_normalize_dir(checkpoint_dir_raw);
+int rocksdb_create_checkpoint(std::string_view checkpoint_dir_raw) {
+  const auto checkpoint_dir =
+      std::string{rdb_normalize_dir(checkpoint_dir_raw)};
   LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
                   "creating checkpoint in directory: %s\n",
                   checkpoint_dir.c_str());
@@ -1300,8 +1300,9 @@ static void rocksdb_set_reset_stats(
   RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
 }
 
-int rocksdb_remove_checkpoint(const char *checkpoint_dir_raw) {
-  const auto checkpoint_dir = rdb_normalize_dir(checkpoint_dir_raw);
+int rocksdb_remove_checkpoint(std::string_view checkpoint_dir_raw) {
+  const auto checkpoint_dir =
+      std::string{rdb_normalize_dir(checkpoint_dir_raw)};
   LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
                   "deleting temporary checkpoint in directory : %s\n",
                   checkpoint_dir.c_str());
@@ -1310,7 +1311,7 @@ int rocksdb_remove_checkpoint(const char *checkpoint_dir_raw) {
   op.sst_file_manager.reset(NewSstFileManager(
       rocksdb_db_options->env, rocksdb_db_options->info_log, "",
       rocksdb_sst_mgr_rate_bytes_per_sec, false /* delete_existing_trash */));
-  const auto status = rocksdb::DestroyDB(checkpoint_dir, op);
+  const auto status = rocksdb::DestroyDB(checkpoint_dir.c_str(), op);
 
   if (status.ok()) {
     return HA_EXIT_SUCCESS;
@@ -7448,17 +7449,15 @@ static int rocksdb_table_exists_in_engine(handlerton *, THD *,
 }
 
 static rocksdb::Status check_rocksdb_options_compatibility(
-    const char *const dbpath, const rocksdb::Options &main_opts,
+    const std::string &dbpath, const rocksdb::Options &main_opts,
     const std::vector<rocksdb::ColumnFamilyDescriptor> &cf_descr) {
-  assert(rocksdb_datadir != nullptr);
-
   rocksdb::DBOptions loaded_db_opt;
   std::vector<rocksdb::ColumnFamilyDescriptor> loaded_cf_descs;
   rocksdb::ConfigOptions config_options;
   config_options.ignore_unknown_options = rocksdb_ignore_unknown_options;
   config_options.input_strings_escaped = true;
   config_options.env = rocksdb::Env::Default();
-  rocksdb::Status status = LoadLatestOptions(config_options, dbpath,
+  rocksdb::Status status = LoadLatestOptions(config_options, dbpath.c_str(),
                                              &loaded_db_opt, &loaded_cf_descs);
 
   // If we're starting from scratch and there are no options saved yet then this
@@ -7505,7 +7504,7 @@ static rocksdb::Status check_rocksdb_options_compatibility(
       rocksdb_ignore_unknown_options;
   config_options_for_check.input_strings_escaped = true;
   config_options_for_check.env = rocksdb::Env::Default();
-  status = CheckOptionsCompatibility(config_options_for_check, dbpath,
+  status = CheckOptionsCompatibility(config_options_for_check, dbpath.c_str(),
                                      main_opts, loaded_cf_descs);
 
   return status;
@@ -7575,11 +7574,13 @@ static void move_wals_to_target_dir() {
 
     for_each_in_dir(
         rocksdb_datadir, MY_WANT_STAT | MY_FAE, [](const fileinfo &f_info) {
+          const auto fn = std::string_view{f_info.name};
+
           if (!S_ISREG(f_info.mystat->st_mode) ||
-              !has_file_extension(f_info.name, ".log"))
+              !has_file_extension(fn, ".log"sv))
             return true;
-          const auto src_path = rdb_concat_paths(rocksdb_datadir, f_info.name);
-          const auto dst_path = rdb_concat_paths(rocksdb_wal_dir, f_info.name);
+          const auto src_path = rdb_concat_paths(rocksdb_datadir, fn);
+          const auto dst_path = rdb_concat_paths(rocksdb_wal_dir, fn);
           rdb_path_rename_or_abort(src_path, dst_path);
           return true;
         });
@@ -8368,7 +8369,7 @@ static int rocksdb_init_internal(void *const p) {
 
   // 2. Transaction logs.
   if (is_wal_dir_separate()) {
-    directories.push_back(myrocks::rocksdb_wal_dir);
+    directories.emplace_back(myrocks::rocksdb_wal_dir);
   }
 
 #ifndef __APPLE__

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -24,6 +24,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -1281,8 +1282,8 @@ int rdb_tx_set_status_error(Rdb_transaction *tx, const rocksdb::Status &s,
                             const Rdb_key_def &kd,
                             const Rdb_tbl_def *const tbl_def);
 
-int rocksdb_create_checkpoint(const char *checkpoint_dir_raw);
-int rocksdb_remove_checkpoint(const char *checkpoint_dir_raw);
+int rocksdb_create_checkpoint(std::string_view checkpoint_dir_raw);
+int rocksdb_remove_checkpoint(std::string_view checkpoint_dir_raw);
 
 extern std::atomic<uint64_t> rocksdb_select_bypass_executed;
 extern std::atomic<uint64_t> rocksdb_select_bypass_rejected;
@@ -1315,14 +1316,14 @@ extern uint rocksdb_clone_checkpoint_max_count;
 
 extern unsigned long long rocksdb_converter_record_cached_length;
 
-inline bool is_wal_dir_separate() noexcept {
+[[nodiscard]] inline bool is_wal_dir_separate() noexcept {
   return rocksdb_wal_dir && *rocksdb_wal_dir &&
-         // Prefer cheapness over accuracy by doing lexicographic
-         // path comparison only
+         // Prefer cheapness over accuracy by doing lexicographic path
+         // comparison only
          strcmp(rocksdb_wal_dir, rocksdb_datadir);
 }
 
-inline char *get_wal_dir() noexcept {
+[[nodiscard]] inline char *get_wal_dir() noexcept {
   return (rocksdb_wal_dir && *rocksdb_wal_dir) ? rocksdb_wal_dir
                                                : rocksdb_datadir;
 }

--- a/storage/rocksdb/rdb_utils.cc
+++ b/storage/rocksdb/rdb_utils.cc
@@ -21,6 +21,7 @@
 #include <array>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 /* C standard header files */
@@ -261,7 +262,7 @@ std::string rdb_hexdump(const char *data, const std::size_t data_len,
 }
 
 // Return dir + '/' + file
-std::string rdb_concat_paths(const std::string &dir, const std::string &file) {
+std::string rdb_concat_paths(std::string_view dir, std::string_view file) {
   std::string result;
   result.reserve(dir.length() + file.length() + 2);
   result = dir;
@@ -273,7 +274,7 @@ std::string rdb_concat_paths(const std::string &dir, const std::string &file) {
 /*
   Attempt to access the database subdirectory to see if it exists
 */
-bool rdb_database_exists(const std::string &db_name) {
+bool rdb_database_exists(std::string_view db_name) {
   const auto dir = rdb_concat_paths(mysql_real_data_home, db_name);
   struct MY_DIR *const dir_info =
       my_dir(dir.c_str(), MYF(MY_DONT_SORT | MY_WANT_STAT));
@@ -443,8 +444,10 @@ void rdb_path_rename_or_abort(const std::string &source,
       rdb_mkdir_or_abort(dest, stat_info.st_mode);
       myrocks::for_each_in_dir(
           source, MY_FAE, [&source, &dest](const fileinfo &f_info) {
-            const auto old_file = rdb_concat_paths(source, f_info.name);
-            const auto new_file = rdb_concat_paths(dest, f_info.name);
+            const auto fn = std::string_view{f_info.name};
+
+            const auto old_file = rdb_concat_paths(source, fn);
+            const auto new_file = rdb_concat_paths(dest, fn);
             rdb_file_copy_and_delete_or_abort(old_file, new_file);
             return true;
           });

--- a/storage/rocksdb/rdb_utils.h
+++ b/storage/rocksdb/rdb_utils.h
@@ -18,6 +18,7 @@
 /* C++ standard header files */
 #include <chrono>
 #include <string>
+#include <string_view>
 #include <vector>
 
 /* MySQL header files */
@@ -347,12 +348,12 @@ std::string rdb_hexdump(const char *data, const std::size_t data_len,
 /*
   Helper function to return dir + '/' + file
  */
-std::string rdb_concat_paths(const std::string &dir, const std::string &file);
+std::string rdb_concat_paths(std::string_view dir, std::string_view file);
 
 /*
   Helper function to see if a database exists
  */
-bool rdb_database_exists(const std::string &db_name);
+bool rdb_database_exists(std::string_view db_name);
 
 /**
   Helper class wrappers to meansure startup time
@@ -462,8 +463,8 @@ class Ensure_initialized {
 };
 
 // extension must start with a dot.
-[[nodiscard]] inline bool has_file_extension(const std::string &fn,
-                                             const std::string &extension) {
+[[nodiscard]] inline bool has_file_extension(std::string_view fn,
+                                             std::string_view extension) {
   const auto ext_len = extension.length();
   assert(ext_len > 0);
   assert(extension[0] == '.');


### PR DESCRIPTION
std::string_view has several advantages over std::string char char *:
- it's a non-owning view that cheaply converts from std::string and converts from char * with a cost of a strlen call (which the patch takes care to remove where possible)
- is more efficient (ones less level of indirection to string contents, no SSO checking) than std::string while supporting similar (read-only) API
- it's cheaper to pass std::string_view by value than std::string by const reference;
- in some cases it avoids the cost of constructing new std::strings.

In converting clone code, also convert some utility functions that also called from elsewhere. In particular, convert rocksdb_datadir and rocksdb_wal_dir sysvars to be std::string_views, keeping the pointer-to-char variables only for interfacing with the MYSQL_SYSVAR macros.