### PR TITLE
Fix ExplainPrintCosts function signature

### DIFF
--- a/sql/opt_explain_traditional.h
+++ b/sql/opt_explain_traditional.h
@@ -114,7 +114,7 @@ class Explain_format_tree_plan : public Explain_format_tree {
 
  private:
   void ExplainPrintCosts(const Json_object *obj [[maybe_unused]],
-                         std::string *explain) {
+                         std::string *explain) override {
     // Costs are not needed for the normalized plan
     *explain += "\n";
     return;


### PR DESCRIPTION
Mark `Explain_format_tree_plan::ExplainPrintCosts` as an override to resolve build warnings.