### PR TITLE
Fix macOS compilation errors in Sql_cmd_dump_table::execute

### DIFF
--- a/sql/sql_dump.cc
+++ b/sql/sql_dump.cc
@@ -606,12 +606,13 @@ exit:
   close_thread_tables(thd);
 
   if (!is_err) {
-    DBUG_PRINT("dump", ("Finished dumping table '%s' with %ld rows",
+    DBUG_PRINT("dump", ("Finished dumping table '%s' with %" PRId64 " rows",
                         table_ref->table_name, rownum));
 
     char msg[256];
-    snprintf(msg, sizeof(msg), "dump table complete: %ld rows, %d chunks",
-             rownum, chunk_id);
+    snprintf(msg, sizeof(msg),
+             "dump table complete: %" PRId64 " rows, %d chunks", rownum,
+             chunk_id);
     my_ok(thd, rownum, 0, msg);
   }
 


### PR DESCRIPTION
```
sql/sql_dump.cc:610:48: error: format specifies type 'long' but the argument has type 'int64_t' (aka 'long long') [-Werror,-Wformat]
                        table_ref->table_name, rownum));
                                               ^~~~~~
```

```
sql/sql_dump.cc:614:14: error: format specifies type 'long' but the argument has type 'int64_t' (aka 'long long') [-Werror,-Wformat]
             rownum, chunk_id);
             ^~~~~~
```

Squash with 6e1aae99d6e837162c87ec5970c2acb011d0f272