### PR TITLE
fix: fopen race condition

### DIFF
--- a/extra/curl/curl-7.86.0/lib/fopen.c
+++ b/extra/curl/curl-7.86.0/lib/fopen.c
@@ -56,13 +56,14 @@ CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
   int fd = -1;
   *tempname = NULL;
 
-  if(stat(filename, &sb) == -1 || !S_ISREG(sb.st_mode)) {
-    /* a non-regular file, fallback to direct fopen() */
-    *fh = fopen(filename, FOPEN_WRITETEXT);
-    if(*fh)
-      return CURLE_OK;
+  *fh = fopen(filename, FOPEN_WRITETEXT);
+  if(!*fh)
+
     goto fail;
-  }
+  if(fstat(fileno(*fh), &sb) == -1 || !S_ISREG(sb.st_mode))
+    return CURLE_OK;
+  fclose(*fh);
+  *fh = NULL;
 
   result = Curl_rand_hex(data, randsuffix, sizeof(randsuffix));
   if(result)


### PR DESCRIPTION
libcurl can be told to save cookie, HSTS and/or alt-svc data to files. When doing this, it called stat() followed by fopen() in a way that made it vulnerable to a TOCTOU race condition problem.

ref:
Patch: https://github.com/curl/curl/commit/0c667188e0c6cda615a0 https://curl.se/docs/CVE-2023-32001.html
https://hackerone.com/reports/2039870
https://hackerone.com/reports/2039870