### PR TITLE
Fix printf formatting for enum class values

### DIFF
--- a/storage/rocksdb/rdb_cmd_srv_helper.cc
+++ b/storage/rocksdb/rdb_cmd_srv_helper.cc
@@ -212,8 +212,9 @@ Rdb_cmd_srv_status Rdb_cmd_srv_helper::get_json_column(
 
   if (dom_ptr->json_type() != expected_type) {
     LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
-                    "expect json type %u, but got %u", expected_type,
-                    dom_ptr->json_type());
+                    "expect json type %d, but got %d",
+                    static_cast<int>(expected_type),
+                    static_cast<int>(dom_ptr->json_type()));
     return Rdb_cmd_srv_status("Unexpected json type for column " +
                               std::to_string(col));
   }


### PR DESCRIPTION
These values do not implicitly cast to ints, thus cast them manually.

This fixes the following LLVM 17 build error:
```
storage/rocksdb/rdb_cmd_srv_helper.cc:215:56: error: format specifies type 'unsigned int' but the argument has type 'enum_json_type' [-Werror,-Wformat]
  215 |                     "expect json type %u, but got %u", expected_type,
      |                                       ~~               ^~~~~~~~~~~~~
      |                                                        static_cast<int>( )
include/mysql/components/services/log_builtins.h:838:66: note: expanded from macro 'LogPluginErrMsg'
  838 |       .message_quoted("Plugin " LOG_COMPONENT_TAG " reported", ##__VA_ARGS__)
      |                                                                  ^~~~~~~~~~~
storage/rocksdb/rdb_cmd_srv_helper.cc:216:21: error: format specifies type 'unsigned int' but the argument has type 'enum_json_type' [-Werror,-Wformat]
  215 |                     "expect json type %u, but got %u", expected_type,
      |                                                   ~~
  216 |                     dom_ptr->json_type());
      |                     ^~~~~~~~~~~~~~~~~~~~
      |                     static_cast<int>(   )
include/mysql/components/services/log_builtins.h:838:66: note: expanded from macro 'LogPluginErrMsg'
  838 |       .message_quoted("Plugin " LOG_COMPONENT_TAG " reported", ##__VA_ARGS__)
      |                                                                  ^~~~~~~~~~~
2 errors generated.
```