### PR TITLE
MyRocks: remove some std::shared_ptr uses

### DIFF
--- a/storage/rocksdb/event_listener.cc
+++ b/storage/rocksdb/event_listener.cc
@@ -39,8 +39,8 @@ static std::vector<Rdb_index_stats> extract_index_stats(
   for (const auto &fn : files) {
     const auto it = props.find(fn);
     assert(it != props.end());
-    std::vector<Rdb_index_stats> stats;
-    Rdb_tbl_prop_coll::read_stats_from_tbl_props(it->second, &stats);
+    const auto stats =
+        Rdb_tbl_prop_coll::read_stats_from_tbl_props(*it->second);
     ret.insert(ret.end(), stats.begin(), stats.end());
   }
   return ret;
@@ -49,11 +49,8 @@ static std::vector<Rdb_index_stats> extract_index_stats(
 void Rdb_event_listener::update_index_stats(
     const rocksdb::TableProperties &props) {
   assert(m_ddl_manager != nullptr);
-  const auto tbl_props =
-      std::make_shared<const rocksdb::TableProperties>(props);
 
-  std::vector<Rdb_index_stats> stats;
-  Rdb_tbl_prop_coll::read_stats_from_tbl_props(tbl_props, &stats);
+  const auto stats = Rdb_tbl_prop_coll::read_stats_from_tbl_props(props);
 
   // In the new approach cardinality and non-cardinality stats
   // for a table are calculated at the same time. That is,

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -8863,7 +8863,7 @@ ulonglong ha_rocksdb::load_auto_incr_value_from_index() {
 
   assert(!m_key_descr_arr[active_index_pos()]->is_partial_index());
   std::unique_ptr<Rdb_iterator> save_iterator(new Rdb_iterator_base(
-      ha_thd(), nullptr, m_key_descr_arr[active_index_pos()], m_pk_descr,
+      ha_thd(), nullptr, *m_key_descr_arr[active_index_pos()], *m_pk_descr,
       m_tbl_def));
   std::swap(m_iterator, save_iterator);
 
@@ -8968,7 +8968,7 @@ int ha_rocksdb::load_hidden_pk_value() {
   const uint8 save_table_status = table->m_status;
 
   std::unique_ptr<Rdb_iterator> save_iterator(new Rdb_iterator_base(
-      ha_thd(), nullptr, m_key_descr_arr[active_index_pos()], m_pk_descr,
+      ha_thd(), nullptr, *m_key_descr_arr[active_index_pos()], *m_pk_descr,
       m_tbl_def));
   std::swap(m_iterator, save_iterator);
 
@@ -9307,7 +9307,7 @@ int ha_rocksdb::convert_record_from_storage_format(
 int ha_rocksdb::convert_record_from_storage_format(
     const rocksdb::Slice *const key, const rocksdb::Slice *const value,
     uchar *const buf) {
-  int rc = m_converter->decode(m_pk_descr, buf, key, value);
+  auto rc = m_converter->decode(*m_pk_descr, buf, key, value);
 
   DBUG_EXECUTE_IF(
       "simulate_corrupt_data_read", if (m_tbl_def->full_tablename() == "a.t1") {
@@ -11890,8 +11890,8 @@ int ha_rocksdb::index_next_with_direction_intern(uchar *const buf,
 
 Rdb_iterator_base *ha_rocksdb::get_pk_iterator() {
   if (!m_pk_iterator) {
-    m_pk_iterator.reset(new Rdb_iterator_base(ha_thd(), nullptr, m_pk_descr,
-                                              m_pk_descr, m_tbl_def));
+    m_pk_iterator.reset(new Rdb_iterator_base(ha_thd(), nullptr, *m_pk_descr,
+                                              *m_pk_descr, m_tbl_def));
   }
   return m_pk_iterator.get();
 }
@@ -12653,8 +12653,8 @@ int ha_rocksdb::check_and_lock_sk(
     The bloom filter may need to be disabled for this lookup.
   */
   assert(!m_key_descr_arr[key_id]->is_partial_index());
-  Rdb_iterator_base iter(ha_thd(), nullptr, m_key_descr_arr[key_id], m_pk_descr,
-                         m_tbl_def);
+  Rdb_iterator_base iter(ha_thd(), nullptr, *m_key_descr_arr[key_id],
+                         *m_pk_descr, m_tbl_def);
 
   /*
     If all_parts_used is true, then PK uniqueness check/lock would already
@@ -12920,7 +12920,7 @@ int ha_rocksdb::update_write_pk(const Rdb_key_def &kd,
   rocksdb::Slice value_slice;
   /* Prepare the new record to be written into RocksDB */
   if ((rc = m_converter->encode_value_slice(
-           m_pk_descr, row_info.new_pk_slice, row_info.new_pk_unpack_info,
+           *m_pk_descr, row_info.new_pk_slice, row_info.new_pk_unpack_info,
            !row_info.old_pk_slice.empty(), should_store_row_debug_checksums(),
            m_ttl_bytes, &m_ttl_bytes_updated, &value_slice))) {
     return rc;
@@ -13516,11 +13516,12 @@ int ha_rocksdb::index_init(uint idx, bool sorted MY_ATTRIBUTE((__unused__))) {
       DBUG_RETURN(HA_ERR_ROCKSDB_INVALID_TABLE);
     }
     m_iterator.reset(
-        new Rdb_iterator_partial(thd, m_key_descr_arr[active_index_pos()],
-                                 m_pk_descr, m_tbl_def, table, dd_table));
+        new Rdb_iterator_partial(thd, *m_key_descr_arr[active_index_pos()],
+                                 *m_pk_descr, m_tbl_def, table, dd_table));
   } else {
-    m_iterator.reset(new Rdb_iterator_base(
-        thd, this, m_key_descr_arr[active_index_pos()], m_pk_descr, m_tbl_def));
+    m_iterator.reset(new Rdb_iterator_base(thd, this,
+                                           *m_key_descr_arr[active_index_pos()],
+                                           *m_pk_descr, m_tbl_def));
   }
 
   // If m_lock_rows is not RDB_LOCK_NONE then we will be doing a get_for_update
@@ -15463,8 +15464,8 @@ static int read_stats_from_ssts(
   }
 
   for (const auto &it : props) {
-    std::vector<Rdb_index_stats> sst_stats;
-    Rdb_tbl_prop_coll::read_stats_from_tbl_props(it.second, &sst_stats);
+    const auto sst_stats =
+        Rdb_tbl_prop_coll::read_stats_from_tbl_props(*it.second);
     /*
       sst_stats is a list of index statistics for indexes that have entries
       in the current SST file.

--- a/storage/rocksdb/nosql_access.cc
+++ b/storage/rocksdb/nosql_access.cc
@@ -2428,11 +2428,11 @@ bool INLINE_ATTR select_exec::run_pk_point_query() {
 
 bool INLINE_ATTR select_exec::setup_iterator(THD *thd) {
   if (m_key_def->is_partial_index()) {
-    m_iterator.reset(new Rdb_iterator_partial(thd, m_key_def, m_pk_def,
+    m_iterator.reset(new Rdb_iterator_partial(thd, *m_key_def, *m_pk_def,
                                               m_tbl_def, m_table, m_dd_table));
   } else {
     m_iterator.reset(
-        new Rdb_iterator_base(thd, nullptr, m_key_def, m_pk_def, m_tbl_def));
+        new Rdb_iterator_base(thd, nullptr, *m_key_def, *m_pk_def, m_tbl_def));
   }
 
   return m_iterator == nullptr;
@@ -2490,7 +2490,7 @@ bool INLINE_ATTR select_exec::eval_cond() {
 bool INLINE_ATTR select_exec::unpack_for_pk(const rocksdb::Slice &rkey,
                                             const rocksdb::Slice &rvalue) {
   // decode will handle key/value decoding for PK
-  int rc = m_converter->decode(m_key_def, m_table->record[0], &rkey, &rvalue);
+  int rc = m_converter->decode(*m_key_def, m_table->record[0], &rkey, &rvalue);
   if (rc) {
     m_handler->print_error(rc, 0);
     return true;
@@ -2542,7 +2542,7 @@ bool INLINE_ATTR select_exec::unpack_for_sk(txn_wrapper *txn,
     return true;
   }
 
-  rc = m_converter->decode(m_pk_def, m_table->record[0], &pk_key, &m_pk_value);
+  rc = m_converter->decode(*m_pk_def, m_table->record[0], &pk_key, &m_pk_value);
   if (rc) {
     m_handler->print_error(rc, 0);
     return true;

--- a/storage/rocksdb/properties_collector.cc
+++ b/storage/rocksdb/properties_collector.cc
@@ -338,17 +338,17 @@ std::string Rdb_tbl_prop_coll::GetReadableStats(const Rdb_index_stats &it) {
   Given the properties of an SST file, reads the stats from it and returns it.
 */
 
-void Rdb_tbl_prop_coll::read_stats_from_tbl_props(
-    const std::shared_ptr<const rocksdb::TableProperties> &table_props,
-    std::vector<Rdb_index_stats> *const out_stats_vector) {
-  assert(out_stats_vector != nullptr);
-  const auto &user_properties = table_props->user_collected_properties;
+std::vector<Rdb_index_stats> Rdb_tbl_prop_coll::read_stats_from_tbl_props(
+    const rocksdb::TableProperties &table_props) {
+  std::vector<Rdb_index_stats> res;
+  const auto &user_properties = table_props.user_collected_properties;
   const auto it2 = user_properties.find(std::string(INDEXSTATS_KEY));
   if (it2 != user_properties.end()) {
-    auto result MY_ATTRIBUTE((__unused__)) =
-        Rdb_index_stats::unmaterialize(it2->second, out_stats_vector);
+    const auto result [[maybe_unused]] =
+        Rdb_index_stats::unmaterialize(it2->second, &res);
     assert(result == 0);
   }
+  return res;
 }
 
 /*

--- a/storage/rocksdb/properties_collector.h
+++ b/storage/rocksdb/properties_collector.h
@@ -164,9 +164,8 @@ class Rdb_tbl_prop_coll : public rocksdb::TablePropertiesCollector {
  public:
   uint64_t GetMaxDeletedRows() const { return m_max_deleted_rows; }
 
-  static void read_stats_from_tbl_props(
-      const std::shared_ptr<const rocksdb::TableProperties> &table_props,
-      std::vector<Rdb_index_stats> *out_stats_vector);
+  [[nodiscard]] static std::vector<Rdb_index_stats> read_stats_from_tbl_props(
+      const rocksdb::TableProperties &table_props);
 
  private:
   static std::string GetReadableStats(const Rdb_index_stats &it);

--- a/storage/rocksdb/rdb_converter.h
+++ b/storage/rocksdb/rdb_converter.h
@@ -130,8 +130,10 @@ class Rdb_converter {
   */
   Rdb_converter(const THD *thd, const Rdb_tbl_def *tbl_def, TABLE *table,
                 const dd::Table *dd_table);
-  Rdb_converter(const Rdb_converter &decoder) = delete;
-  Rdb_converter &operator=(const Rdb_converter &decoder) = delete;
+  Rdb_converter(const Rdb_converter &) = delete;
+  Rdb_converter(Rdb_converter &&) = delete;
+  Rdb_converter &operator=(const Rdb_converter &) = delete;
+  Rdb_converter &operator=(Rdb_converter &&) = delete;
   ~Rdb_converter();
 
   void setup_field_decoders(const MY_BITMAP *field_map, uint active_index,
@@ -147,16 +149,16 @@ class Rdb_converter {
     }
   }
 
-  int decode(const std::shared_ptr<Rdb_key_def> &key_def, uchar *dst,
-             const rocksdb::Slice *key_slice, const rocksdb::Slice *value_slice,
-             bool decode_value = true);
+  [[nodiscard]] int decode(const Rdb_key_def &key_def, uchar *dst,
+                           const rocksdb::Slice *key_slice,
+                           const rocksdb::Slice *value_slice,
+                           bool decode_value = true);
 
-  int encode_value_slice(const std::shared_ptr<Rdb_key_def> &pk_def,
-                         const rocksdb::Slice &pk_packed_slice,
-                         Rdb_string_writer *pk_unpack_info, bool is_update_row,
-                         bool store_row_debug_checksums, char *ttl_bytes,
-                         bool *is_ttl_bytes_updated,
-                         rocksdb::Slice *const value_slice);
+  [[nodiscard]] int encode_value_slice(
+      const Rdb_key_def &pk_def, const rocksdb::Slice &pk_packed_slice,
+      Rdb_string_writer *pk_unpack_info, bool is_update_row,
+      bool store_row_debug_checksums, char *ttl_bytes,
+      bool *is_ttl_bytes_updated, rocksdb::Slice *const value_slice);
 
   my_core::ha_rows get_row_checksums_checked() const {
     return m_row_checksums_checked;
@@ -185,23 +187,22 @@ class Rdb_converter {
   const MY_BITMAP *get_lookup_bitmap() { return &m_lookup_bitmap; }
 
  private:
-  int decode_value_header_for_pk(Rdb_string_reader *reader,
-                                 const std::shared_ptr<Rdb_key_def> &pk_def,
-                                 rocksdb::Slice *unpack_slice);
+  [[nodiscard]] int decode_value_header_for_pk(Rdb_string_reader *reader,
+                                               const Rdb_key_def &pk_def,
+                                               rocksdb::Slice *unpack_slice);
 
   void setup_field_encoders(const dd::Table *dd_table);
 
   void get_storage_type(Rdb_field_encoder *const encoder, const uint kp);
 
-  int convert_record_from_storage_format(
-      const std::shared_ptr<Rdb_key_def> &pk_def,
-      const rocksdb::Slice *const key, const rocksdb::Slice *const value,
-      uchar *const buf, bool decode_value);
+  [[nodiscard]] int convert_record_from_storage_format(
+      const Rdb_key_def &pk_def, const rocksdb::Slice *const key,
+      const rocksdb::Slice *const value, uchar *const buf, bool decode_value);
 
-  int verify_row_debug_checksum(const std::shared_ptr<Rdb_key_def> &pk_def,
-                                Rdb_string_reader *reader,
-                                const rocksdb::Slice *key,
-                                const rocksdb::Slice *value);
+  [[nodiscard]] int verify_row_debug_checksum(const Rdb_key_def &pk_def,
+                                              Rdb_string_reader *reader,
+                                              const rocksdb::Slice *key,
+                                              const rocksdb::Slice *value);
 
  private:
   /*

--- a/storage/rocksdb/rdb_i_s.cc
+++ b/storage/rocksdb/rdb_i_s.cc
@@ -2071,8 +2071,8 @@ static int rdb_i_s_index_file_map_fill_table(
           sst_name.data(), sst_name.size(), system_charset_info);
 
       /* Get the __indexstats__ data out of the table property */
-      std::vector<Rdb_index_stats> stats;
-      Rdb_tbl_prop_coll::read_stats_from_tbl_props(props.second, &stats);
+      const auto stats =
+          Rdb_tbl_prop_coll::read_stats_from_tbl_props(*props.second);
 
       if (stats.empty()) {
         field[RDB_INDEX_FILE_MAP_FIELD::COLUMN_FAMILY]->store(-1, true);

--- a/storage/rocksdb/rdb_iterator.h
+++ b/storage/rocksdb/rdb_iterator.h
@@ -92,8 +92,7 @@ class Rdb_iterator_base : public Rdb_iterator {
 
  public:
   Rdb_iterator_base(THD *thd, ha_rocksdb *rocksdb_handler,
-                    const std::shared_ptr<Rdb_key_def> kd,
-                    const std::shared_ptr<Rdb_key_def> pkd,
+                    const Rdb_key_def &kd, const Rdb_key_def &pkd,
                     const Rdb_tbl_def *tbl_def);
 
   ~Rdb_iterator_base() override;
@@ -130,10 +129,10 @@ class Rdb_iterator_base : public Rdb_iterator {
   void setup_prefix_buffer(enum ha_rkey_function find_flag,
                            const rocksdb::Slice start_key);
 
-  const std::shared_ptr<Rdb_key_def> m_kd;
+  const Rdb_key_def &m_kd;
 
   // Rdb_key_def of the primary key
-  const std::shared_ptr<Rdb_key_def> m_pkd;
+  const Rdb_key_def &m_pkd;
 
   const Rdb_tbl_def *m_tbl_def;
 
@@ -161,6 +160,11 @@ class Rdb_iterator_base : public Rdb_iterator {
   bool m_valid;
   bool m_check_iterate_bounds;
   bool m_ignore_killed;
+
+  Rdb_iterator_base(const Rdb_iterator_base &) = delete;
+  Rdb_iterator_base(Rdb_iterator_base &&) = delete;
+  Rdb_iterator_base &operator=(const Rdb_iterator_base &) = delete;
+  Rdb_iterator_base &operator=(Rdb_iterator_base &&) = delete;
 };
 
 class Rdb_iterator_partial : public Rdb_iterator_base {
@@ -232,8 +236,7 @@ class Rdb_iterator_partial : public Rdb_iterator_base {
   slice_comparator m_comparator;
 
  public:
-  Rdb_iterator_partial(THD *thd, const std::shared_ptr<Rdb_key_def> kd,
-                       const std::shared_ptr<Rdb_key_def> pkd,
+  Rdb_iterator_partial(THD *thd, const Rdb_key_def &kd, const Rdb_key_def &pkd,
                        const Rdb_tbl_def *tbl_def, TABLE *table,
                        const dd::Table *dd_table);
   ~Rdb_iterator_partial() override;
@@ -257,6 +260,11 @@ class Rdb_iterator_partial : public Rdb_iterator_base {
     assert(false);
     return false;
   }
+
+  Rdb_iterator_partial(const Rdb_iterator_partial &) = delete;
+  Rdb_iterator_partial(Rdb_iterator_partial &&) = delete;
+  Rdb_iterator_partial &operator=(const Rdb_iterator_partial &) = delete;
+  Rdb_iterator_partial &operator=(Rdb_iterator_partial &&) = delete;
 };
 
 }  // namespace myrocks


### PR DESCRIPTION
`std::shared_ptr` should be stored and passed around in situations where the
pointed-to object lifetime is unclear, when it has to be extended, or when
forced to (i.e. RocksDB API returns it). Some of the uses in MyRocks do not fall
under these categories and can be simplified to direct (constant) references.

This cleans up some low hanging fruit, focusing on `Rdb_converter`,
`Rdb_iterator_base`, & `Rdb_iterator_partial` classes. Since these classes replace
shared pointer fields with reference ones, make them non-copyable and
non-moveable for safety, which matches their existing use. At the same time make
`Rdb_tbl_prop_coll::read_stats_from_tbl_prop` return vector directly instead of
using an output parameter.