### PR TITLE
Refactor MyRocks iterator status handling

### DIFF
--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -1262,19 +1262,15 @@ inline void rocksdb_smart_prev(bool seek_backward,
   }
 }
 
-// If the iterator is not valid it might be because of EOF but might be due
-// to IOError or corruption. The good practice is always check it.
-// https://github.com/facebook/rocksdb/wiki/Iterator#error-handling
-bool is_valid_iterator(rocksdb::Iterator *scan_it);
-
-bool rdb_should_hide_ttl_rec(const Rdb_key_def &kd,
-                             const rocksdb::Slice *const ttl_rec_val,
-                             Rdb_transaction *tx);
+[[nodiscard]] bool rdb_should_hide_ttl_rec(
+    const Rdb_key_def &kd, const rocksdb::Slice *const ttl_rec_val,
+    Rdb_transaction &tx);
 
 bool rdb_tx_started(Rdb_transaction *tx, const TABLE_TYPE table_type);
-int rdb_tx_set_status_error(Rdb_transaction *tx, const rocksdb::Status &s,
-                            const Rdb_key_def &kd,
-                            const Rdb_tbl_def *const tbl_def);
+[[nodiscard]] int rdb_tx_set_status_error(Rdb_transaction &tx,
+                                          const rocksdb::Status &s,
+                                          const Rdb_key_def &kd,
+                                          const Rdb_tbl_def *const tbl_def);
 
 int rocksdb_create_checkpoint(std::string_view checkpoint_dir_raw);
 int rocksdb_remove_checkpoint(std::string_view checkpoint_dir_raw);

--- a/storage/rocksdb/rdb_iterator.h
+++ b/storage/rocksdb/rdb_iterator.h
@@ -28,6 +28,11 @@
 
 namespace myrocks {
 
+// If the iterator is not valid it might be because of EOF but might be due
+// to IOError or corruption. The good practice is always check it.
+// https://github.com/facebook/rocksdb/wiki/Iterator#error-handling
+[[nodiscard]] bool is_valid_rdb_iterator(const rocksdb::Iterator &it);
+
 class Rdb_iterator {
  public:
   virtual ~Rdb_iterator() = 0;
@@ -86,9 +91,11 @@ class Rdb_iterator_base : public Rdb_iterator {
                        const int bytes_changed_by_succ,
                        const rocksdb::Slice &end_key);
   int next_with_direction(bool move_forward, bool skip_next);
-  int convert_get_status(myrocks::Rdb_transaction *tx,
-                         const rocksdb::Status &status,
-                         rocksdb::PinnableSlice *value, bool skip_ttl_check);
+  [[nodiscard]] int convert_get_status(myrocks::Rdb_transaction &tx,
+                                       const rocksdb::Status &status,
+                                       rocksdb::PinnableSlice *value,
+                                       bool skip_ttl_check) const;
+  [[nodiscard]] int convert_iterator_status() const;
 
  public:
   Rdb_iterator_base(THD *thd, ha_rocksdb *rocksdb_handler,

--- a/storage/rocksdb/rdb_utils.h
+++ b/storage/rocksdb/rdb_utils.h
@@ -24,6 +24,7 @@
 /* MySQL header files */
 #include "./my_stacktrace.h"
 #include "./sql_string.h"
+#include "my_compiler.h"
 #define LOG_COMPONENT_TAG "rocksdb"
 #include "mysql/components/services/log_builtins.h"
 #include "mysqld_error.h"
@@ -277,6 +278,7 @@ bool rdb_has_rocksdb_corruption();
 
 // stores a marker file in the data directory so that after restart server
 // is still aware that rocksdb data is corrupted
+MY_ATTRIBUTE((cold, noinline))
 void rdb_persist_corruption_marker();
 
 // Perform the given function on each directory entry. Supported flags are


### PR DESCRIPTION
- Move is_valid_iterator from ha_rocksdb.cc to rdb_iterator.cc, rename to
  is_valid_rdb_iterator, make its argument const reference. Remove redundant
  rdb_persist_corruption_marker call because rdb_handle_io_error calls it too.
- Introduce Rdb_iterator_base::convert_iterator_status similar to existing
  Rdb_iterator_base::convert_get_status, move HA_ERR_END_OF_FILE-returning logic
  there and additionally handle any other non-I/O errors by saving them in the
  transaction for a later return.
- Make Rdb_iterator_base::convert_get_status take transaction by reference, make
  it const method. Propagate down the callstack pointer-to-reference changes:
  rdb_should_hide_ttl_rec, rdb_tx_set_status_error.
- Mark touched functions and methods [[nodiscard]] where appropriate.
- Annotate rdb_persist_corruption_marker with cold and noinline attributes.
- Remove dbug_change_status_to_corrupted, use DBUG_EVALUATE_IF so that the
  variable gets its final value right at the declaration and could be made const
  too.

This is split out from the range locking feature.
