### PR TITLE
Remove redundant function prototypes from ha_rocksdb.cc

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -132,46 +132,6 @@ SERVICE_TYPE(log_builtins) *log_bi = nullptr;
 SERVICE_TYPE(log_builtins_string) *log_bs = nullptr;
 #endif
 
-// Internal MySQL APIs not exposed in any header.
-extern "C" {
-/**
-  Mark transaction to rollback and mark error as fatal to a sub-statement.
-  @param  thd   Thread handle
-  @param  all   true <=> rollback main transaction.
-*/
-void thd_mark_transaction_to_rollback(MYSQL_THD thd, int all);
-}
-
-/**
- *   Get the user thread's binary logging format
- *   @param thd  user thread
- *   @return Value to be used as index into the binlog_format_names array
- */
-int thd_binlog_format(const MYSQL_THD thd);
-
-/**
- *   Check if binary logging is filtered for thread's current db.
- *   @param  thd   Thread handle
- *   @retval 1 the query is not filtered, 0 otherwise.
- */
-bool thd_binlog_filter_ok(const MYSQL_THD thd);
-
-/**
-  Check if a user thread is a replication slave thread
-  @param thd user thread
-  @retval 0 the user thread is not a replication slave thread
-  @retval 1 the user thread is a replication slave thread
-*/
-int thd_slave_thread(const THD *thd);
-
-/**
-  Check if THD is executing binlog events
-  @param thd THD
-  @retval false THD is not executing binlog events
-  @retval true  THD is executing binlog events
-*/
-bool thd_is_executing_binlog_events(const THD *thd);
-
 namespace myrocks {
 
 static st_global_stats global_stats;


### PR DESCRIPTION
They are already provided through already-included plugin.h and
sql_thd_internal_api.h.
