### PR TITLE
Make MyRocks transactions never expire additional rows with TTL while running

### DIFF
--- a/mysql-test/suite/rocksdb/include/show_transaction_status.inc
+++ b/mysql-test/suite/rocksdb/include/show_transaction_status.inc
@@ -1,5 +1,5 @@
 # The output from SHOW ENGINE ROCKSDB TRANSACTION STATUS has some
 # non-deterministic results, replace them with deterministic placeholders.
 
---replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /(ACTIVE) [0-9]+ /\1 NUM / /(thread id) [0-9]+/\1 TID/ /(thread handle) [0-9]+/\1 PTR/ /(query id) [0-9]+/\1 QID/ /(root) [a-z ]+/\1 ACTION/ /WAITING KEY: [0-9a-f]{16}/KEY/ /TRANSACTION ID: [0-9]*/TXN_ID/ /INDEX_ID: [0-9a-f]*/IDX_ID/ /TIMESTAMP: [0-9]*/TSTAMP/
+--replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /(ACTIVE) [0-9]+ /\1 NUM / /(earliest snapshot created) [0-9]+ /\1 NUM / /(thread id) [0-9]+/\1 TID/ /(thread handle) [0-9]+/\1 PTR/ /(query id) [0-9]+/\1 QID/ /(root) [a-z ]+/\1 ACTION/ /WAITING KEY: [0-9a-f]{16}/KEY/ /TRANSACTION ID: [0-9]*/TXN_ID/ /INDEX_ID: [0-9a-f]*/IDX_ID/ /TIMESTAMP: [0-9]*/TSTAMP/
 SHOW ENGINE ROCKSDB TRANSACTION STATUS;

--- a/mysql-test/suite/rocksdb/r/deadlock_tracking.result
+++ b/mysql-test/suite/rocksdb/r/deadlock_tracking.result
@@ -18,6 +18,12 @@ TIMESTAMP ROCKSDB TRANSACTION MONITOR OUTPUT
 SNAPSHOTS
 ---------
 LIST OF SNAPSHOTS FOR EACH SESSION:
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
+SHOW ENGINE ROCKSDB TRANSACTION STATUS
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
 ----------LATEST DETECTED DEADLOCKS----------
 -----------------------------------------
 END OF ROCKSDB TRANSACTION MONITOR OUTPUT
@@ -49,6 +55,22 @@ TIMESTAMP ROCKSDB TRANSACTION MONITOR OUTPUT
 SNAPSHOTS
 ---------
 LIST OF SNAPSHOTS FOR EACH SESSION:
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
+SHOW ENGINE ROCKSDB TRANSACTION STATUS
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
 ----------LATEST DETECTED DEADLOCKS----------
 
 *** DEADLOCK PATH
@@ -100,6 +122,22 @@ TIMESTAMP ROCKSDB TRANSACTION MONITOR OUTPUT
 SNAPSHOTS
 ---------
 LIST OF SNAPSHOTS FOR EACH SESSION:
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
+SHOW ENGINE ROCKSDB TRANSACTION STATUS
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
 ----------LATEST DETECTED DEADLOCKS----------
 
 *** DEADLOCK PATH
@@ -172,6 +210,22 @@ TIMESTAMP ROCKSDB TRANSACTION MONITOR OUTPUT
 SNAPSHOTS
 ---------
 LIST OF SNAPSHOTS FOR EACH SESSION:
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
+SHOW ENGINE ROCKSDB TRANSACTION STATUS
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
 ----------LATEST DETECTED DEADLOCKS----------
 
 *** DEADLOCK PATH
@@ -248,6 +302,22 @@ TIMESTAMP ROCKSDB TRANSACTION MONITOR OUTPUT
 SNAPSHOTS
 ---------
 LIST OF SNAPSHOTS FOR EACH SESSION:
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
+SHOW ENGINE ROCKSDB TRANSACTION STATUS
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
 ----------LATEST DETECTED DEADLOCKS----------
 
 *** DEADLOCK PATH
@@ -313,6 +383,27 @@ TIMESTAMP ROCKSDB TRANSACTION MONITOR OUTPUT
 SNAPSHOTS
 ---------
 LIST OF SNAPSHOTS FOR EACH SESSION:
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
+SHOW ENGINE ROCKSDB TRANSACTION STATUS
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
 ----------LATEST DETECTED DEADLOCKS----------
 
 -------DEADLOCK EXCEEDED MAX DEPTH-------
@@ -362,6 +453,27 @@ TIMESTAMP ROCKSDB TRANSACTION MONITOR OUTPUT
 SNAPSHOTS
 ---------
 LIST OF SNAPSHOTS FOR EACH SESSION:
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
+SHOW ENGINE ROCKSDB TRANSACTION STATUS
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
 ----------LATEST DETECTED DEADLOCKS----------
 
 *** DEADLOCK PATH
@@ -421,6 +533,12 @@ TIMESTAMP ROCKSDB TRANSACTION MONITOR OUTPUT
 SNAPSHOTS
 ---------
 LIST OF SNAPSHOTS FOR EACH SESSION:
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
+SHOW ENGINE ROCKSDB TRANSACTION STATUS
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
 ----------LATEST DETECTED DEADLOCKS----------
 
 *** DEADLOCK PATH
@@ -481,6 +599,12 @@ TIMESTAMP ROCKSDB TRANSACTION MONITOR OUTPUT
 SNAPSHOTS
 ---------
 LIST OF SNAPSHOTS FOR EACH SESSION:
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
+SHOW ENGINE ROCKSDB TRANSACTION STATUS
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
 ----------LATEST DETECTED DEADLOCKS----------
 -----------------------------------------
 END OF ROCKSDB TRANSACTION MONITOR OUTPUT

--- a/mysql-test/suite/rocksdb/r/drop_cf_before_show_deadlock_info.result
+++ b/mysql-test/suite/rocksdb/r/drop_cf_before_show_deadlock_info.result
@@ -56,7 +56,7 @@ set global rocksdb_deadlock_detect = @prior_deadlock_detect;
 set global rocksdb_max_latest_deadlocks = 0;
 # Clears deadlock buffer of any existent deadlocks.
 set global rocksdb_max_latest_deadlocks = @prior_max_latest_deadlocks;
-show engine rocksdb transaction status;
+SHOW ENGINE ROCKSDB TRANSACTION STATUS;
 Type	Name	Status
 rocksdb		
 ============================================================
@@ -66,6 +66,22 @@ TIMESTAMP ROCKSDB TRANSACTION MONITOR OUTPUT
 SNAPSHOTS
 ---------
 LIST OF SNAPSHOTS FOR EACH SESSION:
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
+SHOW ENGINE ROCKSDB TRANSACTION STATUS
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
 ----------LATEST DETECTED DEADLOCKS----------
 -----------------------------------------
 END OF ROCKSDB TRANSACTION MONITOR OUTPUT

--- a/mysql-test/suite/rocksdb/r/issue243_transactionStatus.result
+++ b/mysql-test/suite/rocksdb/r/issue243_transactionStatus.result
@@ -25,6 +25,12 @@ TIMESTAMP ROCKSDB TRANSACTION MONITOR OUTPUT
 SNAPSHOTS
 ---------
 LIST OF SNAPSHOTS FOR EACH SESSION:
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
+SHOW ENGINE ROCKSDB TRANSACTION STATUS
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
 ----------LATEST DETECTED DEADLOCKS----------
 -----------------------------------------
 END OF ROCKSDB TRANSACTION MONITOR OUTPUT
@@ -60,6 +66,7 @@ LIST OF SNAPSHOTS FOR EACH SESSION:
 ---SNAPSHOT, ACTIVE NUM sec
 MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
 SHOW ENGINE ROCKSDB TRANSACTION STATUS
+earliest snapshot created NUM sec ago
 lock count 4, write count 4
 insert count 2, update count 1, delete count 1
 ----------LATEST DETECTED DEADLOCKS----------
@@ -78,6 +85,12 @@ TIMESTAMP ROCKSDB TRANSACTION MONITOR OUTPUT
 SNAPSHOTS
 ---------
 LIST OF SNAPSHOTS FOR EACH SESSION:
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
+SHOW ENGINE ROCKSDB TRANSACTION STATUS
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
 ----------LATEST DETECTED DEADLOCKS----------
 -----------------------------------------
 END OF ROCKSDB TRANSACTION MONITOR OUTPUT
@@ -98,6 +111,7 @@ LIST OF SNAPSHOTS FOR EACH SESSION:
 ---SNAPSHOT, ACTIVE NUM sec
 MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
 SHOW ENGINE ROCKSDB TRANSACTION STATUS
+earliest snapshot created NUM sec ago
 lock count 1, write count 1
 insert count 1, update count 0, delete count 0
 ----------LATEST DETECTED DEADLOCKS----------
@@ -116,6 +130,12 @@ TIMESTAMP ROCKSDB TRANSACTION MONITOR OUTPUT
 SNAPSHOTS
 ---------
 LIST OF SNAPSHOTS FOR EACH SESSION:
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
+SHOW ENGINE ROCKSDB TRANSACTION STATUS
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
 ----------LATEST DETECTED DEADLOCKS----------
 -----------------------------------------
 END OF ROCKSDB TRANSACTION MONITOR OUTPUT
@@ -149,6 +169,7 @@ LIST OF SNAPSHOTS FOR EACH SESSION:
 ---SNAPSHOT, ACTIVE NUM sec
 MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
 SHOW ENGINE ROCKSDB TRANSACTION STATUS
+earliest snapshot created NUM sec ago
 lock count 4, write count 7
 insert count 2, update count 1, delete count 1
 ----------LATEST DETECTED DEADLOCKS----------
@@ -185,6 +206,7 @@ LIST OF SNAPSHOTS FOR EACH SESSION:
 ---SNAPSHOT, ACTIVE NUM sec
 MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
 SHOW ENGINE ROCKSDB TRANSACTION STATUS
+earliest snapshot created NUM sec ago
 lock count 4, write count 7
 insert count 2, update count 1, delete count 1
 ----------LATEST DETECTED DEADLOCKS----------

--- a/mysql-test/suite/rocksdb/r/max_row_locks.result
+++ b/mysql-test/suite/rocksdb/r/max_row_locks.result
@@ -15,6 +15,7 @@ LIST OF SNAPSHOTS FOR EACH SESSION:
 ---SNAPSHOT, ACTIVE NUM sec
 MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
 SHOW ENGINE ROCKSDB TRANSACTION STATUS
+earliest snapshot created NUM sec ago
 lock count 0, write count 0
 insert count 0, update count 0, delete count 0
 ----------LATEST DETECTED DEADLOCKS----------
@@ -47,6 +48,7 @@ LIST OF SNAPSHOTS FOR EACH SESSION:
 ---SNAPSHOT, ACTIVE NUM sec
 MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
 SHOW ENGINE ROCKSDB TRANSACTION STATUS
+earliest snapshot created NUM sec ago
 lock count 10, write count 0
 insert count 0, update count 0, delete count 0
 ----------LATEST DETECTED DEADLOCKS----------
@@ -72,6 +74,7 @@ LIST OF SNAPSHOTS FOR EACH SESSION:
 ---SNAPSHOT, ACTIVE NUM sec
 MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
 SHOW ENGINE ROCKSDB TRANSACTION STATUS
+earliest snapshot created NUM sec ago
 lock count 1000, write count 0
 insert count 0, update count 0, delete count 0
 ----------LATEST DETECTED DEADLOCKS----------

--- a/mysql-test/suite/rocksdb/r/show_engine.result
+++ b/mysql-test/suite/rocksdb/r/show_engine.result
@@ -445,6 +445,12 @@ TIMESTAMP ROCKSDB TRANSACTION MONITOR OUTPUT
 SNAPSHOTS
 ---------
 LIST OF SNAPSHOTS FOR EACH SESSION:
+---NO ACTIVE SNAPSHOT
+MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
+SHOW ENGINE ROCKSDB TRANSACTION STATUS
+earliest snapshot never created
+lock count 0, write count 0
+insert count 0, update count 0, delete count 0
 ----------LATEST DETECTED DEADLOCKS----------
 -----------------------------------------
 END OF ROCKSDB TRANSACTION MONITOR OUTPUT
@@ -464,6 +470,7 @@ LIST OF SNAPSHOTS FOR EACH SESSION:
 ---SNAPSHOT, ACTIVE NUM sec
 MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
 SHOW ENGINE ROCKSDB TRANSACTION STATUS
+earliest snapshot created NUM sec ago
 lock count 0, write count 0
 insert count 0, update count 0, delete count 0
 ----------LATEST DETECTED DEADLOCKS----------

--- a/mysql-test/suite/rocksdb/r/ttl_primary_read_filtering.result
+++ b/mysql-test/suite/rocksdb/r/ttl_primary_read_filtering.result
@@ -265,3 +265,26 @@ a
 7
 set global rocksdb_enable_ttl_read_filtering=1;
 DROP TABLE t1;
+#
+# Statement rollbacks should not expire additional rows in transactions
+#
+CREATE TABLE t16 (pk INT PRIMARY KEY, a CHAR(8)) ENGINE=ROCKSDB
+COMMENT='ttl_duration=5;';
+INSERT INTO t16 VALUES (1, 'a'), (2, 'b');
+BEGIN;
+SELECT * FROM t16;
+pk	a
+1	a
+2	b
+SELECT * FROM t16;
+pk	a
+1	a
+2	b
+UPDATE t16 SET pk = 100, a = 'updated' WHERE a IN ('a', 'b');
+ERROR 23000: Duplicate entry '100' for key 't16.PRIMARY'
+SELECT * FROM t16;
+pk	a
+1	a
+2	b
+COMMIT;
+DROP TABLE t16;

--- a/mysql-test/suite/rocksdb/t/drop_cf_before_show_deadlock_info.test
+++ b/mysql-test/suite/rocksdb/t/drop_cf_before_show_deadlock_info.test
@@ -1,6 +1,9 @@
 --source include/have_debug.inc
 --source include/have_debug_sync.inc
 --source include/have_rocksdb.inc
+# Different output with different DDSEs. OK to re-record with either one.
+--source include/have_innodb_ddse.inc
+
 --source include/count_sessions.inc
 
 --disable_query_log
@@ -68,8 +71,8 @@ set global rocksdb_deadlock_detect = @prior_deadlock_detect;
 set global rocksdb_max_latest_deadlocks = 0;
 --echo # Clears deadlock buffer of any existent deadlocks.
 set global rocksdb_max_latest_deadlocks = @prior_max_latest_deadlocks;
---replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /WAITING KEY: [0-9a-f]{16}/KEY/ /TRANSACTION ID: [0-9]*/TXN_ID/ /INDEX_ID: [0-9a-f]*/IDX_ID/ /TIMESTAMP: [0-9]*/TSTAMP/
-show engine rocksdb transaction status;
+
+--source ../include/show_transaction_status.inc
 
 set @@global.debug = @old_debug;
 

--- a/mysql-test/suite/rocksdb/t/ttl_primary_read_filtering.test
+++ b/mysql-test/suite/rocksdb/t/ttl_primary_read_filtering.test
@@ -385,5 +385,30 @@ disconnect con1;
 connection default;
 
 DROP TABLE t1;
+
+--echo #
+--echo # Statement rollbacks should not expire additional rows in transactions
+--echo #
+
+CREATE TABLE t16 (pk INT PRIMARY KEY, a CHAR(8)) ENGINE=ROCKSDB
+       COMMENT='ttl_duration=5;';
+INSERT INTO t16 VALUES (1, 'a'), (2, 'b');
+
+BEGIN;
+SELECT * FROM t16;
+
+--sleep 6
+
+SELECT * FROM t16;
+
+--error ER_DUP_ENTRY
+UPDATE t16 SET pk = 100, a = 'updated' WHERE a IN ('a', 'b');
+
+SELECT * FROM t16;
+
+COMMIT;
+
+DROP TABLE t16;
+
 # Wait till we reached the initial number of concurrent sessions
 --source include/wait_until_count_sessions.inc

--- a/storage/rocksdb/ha_rocksdb_proto.h
+++ b/storage/rocksdb/ha_rocksdb_proto.h
@@ -97,6 +97,8 @@ bool rdb_has_wsenv();
 /* Whether SyncWAL is supported in current scenario */
 bool rdb_sync_wal_supported();
 
+[[nodiscard]] std::uint64_t oldest_transaction_timestamp();
+
 enum operation_type : int;
 void rdb_update_global_stats(const operation_type &type, uint count,
                              Rdb_tbl_def *td = nullptr);


### PR DESCRIPTION
The TTL row filtering is governed by Rdb_transaction::m_snapshot_timestamp
field. This field sometimes get reset to zero when a snapshot is released,
indicating that it should be reinitialized at the next snapshot, or to the
current timestamp (when a single statement in a multi-statement transaction gets
rolled back). The timestamp going forward means that additional rows may be
hidden in the same transaction if they happened to expire between the two
snapshots. Change it so that additional rows are never expired:

- Only initialize the field once per transaction, when the first snapshot is
  created.
- Do not touch it for single-statement rollbacks in multi-statement
  transactions.
- Rename the field to m_earliest_snapshot_ts to better reflect what it does.
- Change the global transaction list to be sorted by the oldest snapshot
  timestamp, so that the oldest global one can be found by reading the
  transaction at the list head. The transactions without snapshot are inserted
  to the its tail, and reinserted as needed upon acquiring the first snapshot.
  To make reinsertions fast, a third list pointer is maintained that points to
  the newest transaction with a snapshot.
- Extend the SHOW ENGINE ROCKSDB TRANSACTION STATUS output with transactions
  that currently do not have a snapshot, for both cases of having a snapshot
  before and never having had one.
- Add a test to rocksdb.ttl_primary_read_filtering for the behavior
  difference introduced by this commit.

At the same time:
- Initialize m_earliest_snapshot_ts from the binlog HLC instead of the current
  system time.
