### PR TITLE
Remove rdb_sysvars_mutex

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -708,7 +708,6 @@ static void rocksdb_drop_index_wakeup_thread(
     void *const var_ptr MY_ATTRIBUTE((__unused__)), const void *const save);
 
 static bool rocksdb_pause_background_work = 0;
-static Rds_mysql_mutex rdb_sysvars_mutex;
 static Rds_mysql_mutex rdb_block_cache_resize_mutex;
 static Rds_mysql_mutex rdb_bottom_pri_background_compactions_resize_mutex;
 
@@ -716,7 +715,6 @@ static void rocksdb_set_pause_background_work(
     my_core::THD *const thd MY_ATTRIBUTE((__unused__)),
     struct SYS_VAR *const var MY_ATTRIBUTE((__unused__)),
     void *const var_ptr MY_ATTRIBUTE((__unused__)), const void *const save) {
-  RDB_MUTEX_LOCK_CHECK(rdb_sysvars_mutex);
   const bool pause_requested = *static_cast<const bool *>(save);
   if (rocksdb_pause_background_work != pause_requested) {
     if (pause_requested) {
@@ -726,7 +724,6 @@ static void rocksdb_set_pause_background_work(
     }
     rocksdb_pause_background_work = pause_requested;
   }
-  RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
 }
 
 static void rocksdb_set_compaction_options(THD *thd, struct SYS_VAR *var,
@@ -743,12 +740,10 @@ static void rocksdb_update_table_stats_use_table_scan(
 static void rocksdb_update_table_stats_skip_system_cf(
     THD *const /* thd */, struct SYS_VAR *const /* var */, void *const var_ptr,
     const void *const save) {
-  RDB_MUTEX_LOCK_CHECK(rdb_sysvars_mutex);
   bool old_val = *static_cast<const bool *>(var_ptr);
   bool new_val = *static_cast<const bool *>(save);
 
   if (old_val == new_val) {
-    RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
     return;
   }
 
@@ -757,7 +752,6 @@ static void rocksdb_update_table_stats_skip_system_cf(
   }
 
   *static_cast<bool *>(var_ptr) = new_val;
-  RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
 }
 
 static int rocksdb_index_stats_thread_renice(
@@ -1297,11 +1291,9 @@ static void rocksdb_set_rocksdb_info_log_level(
     void *const var_ptr MY_ATTRIBUTE((__unused__)), const void *const save) {
   assert(save != nullptr);
 
-  RDB_MUTEX_LOCK_CHECK(rdb_sysvars_mutex);
   rocksdb_info_log_level = *static_cast<const uint64_t *>(save);
   rocksdb_db_options->info_log->SetInfoLogLevel(
       static_cast<rocksdb::InfoLogLevel>(rocksdb_info_log_level));
-  RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
 }
 
 static void rocksdb_set_rocksdb_stats_level(
@@ -1310,14 +1302,12 @@ static void rocksdb_set_rocksdb_stats_level(
     void *const var_ptr MY_ATTRIBUTE((__unused__)), const void *const save) {
   assert(save != nullptr);
 
-  RDB_MUTEX_LOCK_CHECK(rdb_sysvars_mutex);
   rocksdb_db_options->statistics->set_stats_level(
       static_cast<rocksdb::StatsLevel>(*static_cast<const uint64_t *>(save)));
   // Actual stats level is defined at rocksdb dbopt::statistics::stats_level_
   // so adjusting rocksdb_stats_level here to make sure it points to
   // the correct stats level.
   rocksdb_stats_level = rocksdb_db_options->statistics->get_stats_level();
-  RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
 }
 
 static void rocksdb_set_reset_stats(
@@ -1327,8 +1317,6 @@ static void rocksdb_set_reset_stats(
   assert(save != nullptr);
   assert(rdb != nullptr);
   assert(rocksdb_stats != nullptr);
-
-  RDB_MUTEX_LOCK_CHECK(rdb_sysvars_mutex);
 
   *static_cast<bool *>(var_ptr) = *static_cast<const bool *>(save);
 
@@ -1342,8 +1330,6 @@ static void rocksdb_set_reset_stats(
     s = rocksdb_stats->Reset();
     assert(s == rocksdb::Status::OK());
   }
-
-  RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
 }
 
 int rocksdb_remove_checkpoint(std::string_view checkpoint_dir_raw) {
@@ -1377,14 +1363,10 @@ static void rocksdb_set_io_write_timeout(
   assert(rdb != nullptr);
   assert(io_watchdog != nullptr);
 
-  RDB_MUTEX_LOCK_CHECK(rdb_sysvars_mutex);
-
   const uint32_t new_val = *static_cast<const uint32_t *>(save);
 
   rocksdb_io_write_timeout_secs = new_val;
   io_watchdog->reset_timeout(rocksdb_io_write_timeout_secs);
-
-  RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
 }
 
 #endif  // !__APPLE__
@@ -7909,7 +7891,6 @@ static int rocksdb_init_internal(void *const p) {
   rdb_collation_exceptions = new Regex_list_handler();
 #endif
 
-  rdb_sysvars_mutex.init(rdb_sysvars_psi_mutex_key, MY_MUTEX_INIT_FAST);
   rdb_block_cache_resize_mutex.init(rdb_block_cache_resize_mutex_key,
                                     MY_MUTEX_INIT_FAST);
   rdb_bottom_pri_background_compactions_resize_mutex.init(
@@ -8217,19 +8198,15 @@ static int rocksdb_init_internal(void *const p) {
 
   if (rocksdb_collect_sst_properties) {
     properties_collector_factory =
-        std::make_shared<Rdb_tbl_prop_coll_factory>(&ddl_manager, &cf_manager);
+        std::make_shared<Rdb_tbl_prop_coll_factory>(ddl_manager, cf_manager);
 
     rocksdb_set_compaction_options(nullptr, nullptr, nullptr, nullptr);
-
-    RDB_MUTEX_LOCK_CHECK(rdb_sysvars_mutex);
 
     assert(rocksdb_table_stats_sampling_pct <= RDB_TBL_STATS_SAMPLE_PCT_MAX);
     properties_collector_factory->SetTableStatsSamplingPct(
         rocksdb_table_stats_sampling_pct);
     properties_collector_factory->SetSkipSystemCF(
         rocksdb_table_stats_skip_system_cf);
-
-    RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
   }
 
   if (rocksdb_persistent_cache_size_mb > 0) {
@@ -8684,7 +8661,6 @@ static int rocksdb_shutdown(bool minimalShutdown) {
   // deleting mutexes. The plan is to gradually increase this section so there's
   // one single shutdown function for all scenarios.
 
-  rdb_sysvars_mutex.destroy();
   rdb_block_cache_resize_mutex.destroy();
   rdb_bottom_pri_background_compactions_resize_mutex.destroy();
 
@@ -8732,6 +8708,7 @@ static int rocksdb_shutdown(bool minimalShutdown) {
 #endif /* HAVE_VALGRIND */
   }
 
+  properties_collector_factory.reset();
   rocksdb_db_options = nullptr;
   rocksdb_tbl_options = nullptr;
   rocksdb_stats = nullptr;
@@ -15662,10 +15639,14 @@ static int calculate_stats_for_table(
     const std::string &tbl_name, table_cardinality_scan_type scan_type,
     std::atomic<THD::killed_state> *killed = nullptr) {
   DBUG_ENTER_FUNC();
-  std::unordered_map<GL_INDEX_ID, std::shared_ptr<const Rdb_key_def>> to_recalc;
-  std::vector<GL_INDEX_ID> indexes;
-  ddl_manager.find_indexes(tbl_name, &indexes);
 
+  std::vector<GL_INDEX_ID> indexes;
+  auto err = ddl_manager.find_indexes(tbl_name, &indexes);
+  if (err != HA_EXIT_SUCCESS) {
+    DBUG_RETURN(err);
+  }
+
+  std::unordered_map<GL_INDEX_ID, std::shared_ptr<const Rdb_key_def>> to_recalc;
   for (const auto &index : indexes) {
     std::shared_ptr<const Rdb_key_def> keydef = ddl_manager.safe_find(index);
 
@@ -15692,7 +15673,7 @@ static int calculate_stats_for_table(
     }
   });
 
-  int err = calculate_stats(to_recalc, scan_type, killed);
+  err = calculate_stats(to_recalc, scan_type, killed);
   if (err != HA_EXIT_SUCCESS) {
     DBUG_RETURN(err);
   }
@@ -18522,8 +18503,6 @@ static void rocksdb_set_table_stats_sampling_pct(
     my_core::THD *const thd MY_ATTRIBUTE((__unused__)),
     my_core::SYS_VAR *const var MY_ATTRIBUTE((__unused__)),
     void *const var_ptr MY_ATTRIBUTE((__unused__)), const void *const save) {
-  RDB_MUTEX_LOCK_CHECK(rdb_sysvars_mutex);
-
   const uint32_t new_val = *static_cast<const uint32_t *>(save);
 
   if (new_val != rocksdb_table_stats_sampling_pct) {
@@ -18534,19 +18513,15 @@ static void rocksdb_set_table_stats_sampling_pct(
           rocksdb_table_stats_sampling_pct);
     }
   }
-
-  RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
 }
 
 static void rocksdb_update_table_stats_use_table_scan(
     THD *const /* thd */, struct SYS_VAR *const /* var */, void *const var_ptr,
     const void *const save) {
-  RDB_MUTEX_LOCK_CHECK(rdb_sysvars_mutex);
   bool old_val = *static_cast<const bool *>(var_ptr);
   bool new_val = *static_cast<const bool *>(save);
 
   if (old_val == new_val) {
-    RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
     return;
   }
 
@@ -18570,7 +18545,6 @@ static void rocksdb_update_table_stats_use_table_scan(
   }
 
   *static_cast<bool *>(var_ptr) = *static_cast<const bool *>(save);
-  RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
 }
 
 static int rocksdb_index_stats_thread_renice(
@@ -18632,8 +18606,6 @@ static void rocksdb_set_sst_mgr_rate_bytes_per_sec(
     my_core::THD *const thd MY_ATTRIBUTE((unused)),
     my_core::SYS_VAR *const var MY_ATTRIBUTE((__unused__)),
     void *const var_ptr MY_ATTRIBUTE((__unused__)), const void *const save) {
-  RDB_MUTEX_LOCK_CHECK(rdb_sysvars_mutex);
-
   const uint64_t new_val = *static_cast<const uint64_t *>(save);
 
   if (new_val != rocksdb_sst_mgr_rate_bytes_per_sec) {
@@ -18642,14 +18614,11 @@ static void rocksdb_set_sst_mgr_rate_bytes_per_sec(
     rocksdb_db_options->sst_file_manager->SetDeleteRateBytesPerSecond(
         rocksdb_sst_mgr_rate_bytes_per_sec);
   }
-
-  RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
 }
 
 static void rocksdb_set_delayed_write_rate(
     THD *thd MY_ATTRIBUTE((unused)), struct SYS_VAR *var MY_ATTRIBUTE((unused)),
     void *var_ptr MY_ATTRIBUTE((unused)), const void *save) {
-  RDB_MUTEX_LOCK_CHECK(rdb_sysvars_mutex);
   const uint64_t new_val = *static_cast<const uint64_t *>(save);
   if (rocksdb_delayed_write_rate != new_val) {
     rocksdb_delayed_write_rate = new_val;
@@ -18664,19 +18633,16 @@ static void rocksdb_set_delayed_write_rate(
                       s.code(), s.ToString().c_str());
     }
   }
-  RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
 }
 
 static void rocksdb_set_max_latest_deadlocks(
     THD *thd MY_ATTRIBUTE((unused)), struct SYS_VAR *var MY_ATTRIBUTE((unused)),
     void *var_ptr MY_ATTRIBUTE((unused)), const void *save) {
-  RDB_MUTEX_LOCK_CHECK(rdb_sysvars_mutex);
   const uint32_t new_val = *static_cast<const uint32_t *>(save);
   if (rocksdb_max_latest_deadlocks != new_val) {
     rocksdb_max_latest_deadlocks = new_val;
     rdb->SetDeadlockInfoBufferSize(rocksdb_max_latest_deadlocks);
   }
-  RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
 }
 
 static void rdb_set_collation_exception_list(const char *const exception_list) {
@@ -18803,8 +18769,6 @@ static void rocksdb_set_max_background_jobs(
   assert(rocksdb_db_options != nullptr);
   assert(rocksdb_db_options->env != nullptr);
 
-  RDB_MUTEX_LOCK_CHECK(rdb_sysvars_mutex);
-
   const int new_val = *static_cast<const int *>(save);
 
   if (rocksdb_db_options->max_background_jobs != new_val) {
@@ -18820,8 +18784,6 @@ static void rocksdb_set_max_background_jobs(
                       s.code(), s.ToString().c_str());
     }
   }
-
-  RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
 }
 
 static void rocksdb_set_max_background_compactions(
@@ -18831,8 +18793,6 @@ static void rocksdb_set_max_background_compactions(
   assert(save != nullptr);
   assert(rocksdb_db_options != nullptr);
   assert(rocksdb_db_options->env != nullptr);
-
-  RDB_MUTEX_LOCK_CHECK(rdb_sysvars_mutex);
 
   const int new_val = *static_cast<const int *>(save);
 
@@ -18849,8 +18809,6 @@ static void rocksdb_set_max_background_compactions(
                       s.code(), s.ToString().c_str());
     }
   }
-
-  RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
 }
 
 /**
@@ -18902,8 +18860,6 @@ static void rocksdb_set_bytes_per_sync(
   assert(rocksdb_db_options != nullptr);
   assert(rocksdb_db_options->env != nullptr);
 
-  RDB_MUTEX_LOCK_CHECK(rdb_sysvars_mutex);
-
   const ulonglong new_val = *static_cast<const ulonglong *>(save);
 
   if (rocksdb_db_options->bytes_per_sync != new_val) {
@@ -18919,8 +18875,6 @@ static void rocksdb_set_bytes_per_sync(
                       s.code(), s.ToString().c_str());
     }
   }
-
-  RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
 }
 
 static void rocksdb_set_wal_bytes_per_sync(
@@ -18930,8 +18884,6 @@ static void rocksdb_set_wal_bytes_per_sync(
   assert(save != nullptr);
   assert(rocksdb_db_options != nullptr);
   assert(rocksdb_db_options->env != nullptr);
-
-  RDB_MUTEX_LOCK_CHECK(rdb_sysvars_mutex);
 
   const ulonglong new_val = *static_cast<const ulonglong *>(save);
 
@@ -18948,8 +18900,6 @@ static void rocksdb_set_wal_bytes_per_sync(
                       s.code(), s.ToString().c_str());
     }
   }
-
-  RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
 }
 
 /*
@@ -19045,11 +18995,8 @@ static void rocksdb_set_update_cf_options(THD *const /* unused */,
                                           const void *const save) {
   const char *const val = *static_cast<const char *const *>(save);
 
-  RDB_MUTEX_LOCK_CHECK(rdb_sysvars_mutex);
-
   if (!val) {
     *reinterpret_cast<char **>(var_ptr) = nullptr;
-    RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
     return;
   }
 
@@ -19065,7 +19012,6 @@ static void rocksdb_set_update_cf_options(THD *const /* unused */,
 
   // This should never fail, because of rocksdb_validate_update_cf_options
   if (!Rdb_cf_options::parse_cf_options(val, &option_map)) {
-    RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
     return;
   }
 
@@ -19141,8 +19087,6 @@ static void rocksdb_set_update_cf_options(THD *const /* unused */,
 
   // Our caller (`plugin_var_memalloc_global_update`) will call `my_free` to
   // free up resources used before.
-
-  RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
 }
 
 void rdb_queue_save_stats_request() { rdb_bg_thread.request_save_stats(); }

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -4431,7 +4431,7 @@ void Rdb_ddl_manager::remove_uncommitted_keydefs(
   mysql_rwlock_unlock(&m_rwlock);
 }
 
-int Rdb_ddl_manager::find_in_uncommitted_keydef(const uint32_t cf_id) {
+int Rdb_ddl_manager::find_in_uncommitted_keydef(const uint32_t cf_id) const {
   mysql_rwlock_rdlock(&m_rwlock);
   for (const auto &pr : m_index_num_to_uncommitted_keydef) {
     const auto &kd = pr.second;
@@ -4567,7 +4567,7 @@ bool Rdb_validate_tbls::validate(void) {
   Validate that all the tables in the RocksDB database dictionary match the
   MySQL data dictionary
 */
-bool Rdb_ddl_manager::validate_schemas(void) {
+bool Rdb_ddl_manager::validate_schemas(void) const {
   Rdb_validate_tbls table_list;
 
   /* Get the list of tables from the RocksDB database dictionary */
@@ -4582,7 +4582,7 @@ bool Rdb_ddl_manager::validate_schemas(void) {
   Validate that all auto increment values in the data dictionary are on a
   supported version.
 */
-bool Rdb_ddl_manager::validate_auto_incr() {
+bool Rdb_ddl_manager::validate_auto_incr() const {
   auto dict_user_table =
       m_dict->get_dict_manager_selector_const(false /*is_tmp_table*/);
   std::unique_ptr<rocksdb::Iterator> it(dict_user_table->new_iterator());
@@ -4867,7 +4867,7 @@ bool Rdb_ddl_manager::init(Rdb_dict_manager_selector *const dict_arg,
 }
 
 Rdb_tbl_def *Rdb_ddl_manager::find(const std::string &table_name,
-                                   const bool lock) {
+                                   bool lock) const {
   if (lock) {
     mysql_rwlock_rdlock(&m_rwlock);
   }
@@ -4886,7 +4886,7 @@ Rdb_tbl_def *Rdb_ddl_manager::find(const std::string &table_name,
 }
 
 int Rdb_ddl_manager::find_indexes(const std::string &table_name,
-                                  std::vector<GL_INDEX_ID> *indexes) {
+                                  std::vector<GL_INDEX_ID> *indexes) const {
   mysql_rwlock_rdlock(&m_rwlock);
 
   Rdb_tbl_def *tdef = nullptr;
@@ -4910,7 +4910,7 @@ int Rdb_ddl_manager::find_indexes(const std::string &table_name,
 }
 
 int Rdb_ddl_manager::find_table_stats(const std::string &table_name,
-                                      Rdb_table_stats *tbl_stats) {
+                                      Rdb_table_stats *tbl_stats) const {
   mysql_rwlock_rdlock(&m_rwlock);
 
   Rdb_tbl_def *tdef = nullptr;
@@ -4936,7 +4936,7 @@ int Rdb_ddl_manager::find_table_stats(const std::string &table_name,
 // are finding it.  Copying it into 'ret' increments the count making sure
 // that the object will not be discarded until we are finished with it.
 std::shared_ptr<const Rdb_key_def> Rdb_ddl_manager::safe_find(
-    GL_INDEX_ID gl_index_id) {
+    GL_INDEX_ID gl_index_id) const {
   std::shared_ptr<const Rdb_key_def> ret(nullptr);
 
   mysql_rwlock_rdlock(&m_rwlock);
@@ -4968,7 +4968,7 @@ std::shared_ptr<const Rdb_key_def> Rdb_ddl_manager::safe_find(
 
 // this method assumes at least read-only lock on m_rwlock
 const std::shared_ptr<Rdb_key_def> &Rdb_ddl_manager::find(
-    GL_INDEX_ID gl_index_id) {
+    GL_INDEX_ID gl_index_id) const {
   const auto it = m_index_num_to_keydef.find(gl_index_id);
   if (it != m_index_num_to_keydef.end()) {
     const auto table_def = find(it->second.first, false);
@@ -4993,7 +4993,7 @@ const std::shared_ptr<Rdb_key_def> &Rdb_ddl_manager::find(
 // this method returns the name of the table based on an index id. It acquires
 // a read lock on m_rwlock.
 const std::string Rdb_ddl_manager::safe_get_table_name(
-    const GL_INDEX_ID &gl_index_id) {
+    GL_INDEX_ID gl_index_id) const {
   std::string ret;
   mysql_rwlock_rdlock(&m_rwlock);
   auto it = m_index_num_to_keydef.find(gl_index_id);
@@ -5256,7 +5256,8 @@ void Rdb_ddl_manager::cleanup(bool destroy_rwlock) {
   m_tmp_table_sequence.cleanup();
 }
 
-int Rdb_ddl_manager::scan_for_tables(Rdb_tables_scanner *const tables_scanner) {
+int Rdb_ddl_manager::scan_for_tables(
+    Rdb_tables_scanner *const tables_scanner) const {
   int ret;
   Rdb_tbl_def *rec;
 

--- a/storage/rocksdb/rdb_psi.cc
+++ b/storage/rocksdb/rdb_psi.cc
@@ -51,8 +51,8 @@ my_core::PSI_thread_info all_rocksdb_threads[] = {
 my_core::PSI_mutex_key rdb_psi_open_tbls_mutex_key, rdb_signal_bg_psi_mutex_key,
     rdb_signal_drop_idx_psi_mutex_key, rdb_signal_is_psi_mutex_key,
     rdb_signal_mc_psi_mutex_key, rdb_collation_data_mutex_key,
-    rdb_mem_cmp_space_mutex_key, key_mutex_tx_list, rdb_sysvars_psi_mutex_key,
-    rdb_cfm_mutex_key, rdb_sst_commit_key, rdb_block_cache_resize_mutex_key,
+    rdb_mem_cmp_space_mutex_key, key_mutex_tx_list, rdb_cfm_mutex_key,
+    rdb_sst_commit_key, rdb_block_cache_resize_mutex_key,
     rdb_bottom_pri_background_compactions_resize_mutex_key,
     clone_donor_file_metadata_mutex_key, key_rwlock_clone_client_files,
     clone_main_task_remaining_mutex_key, clone_error_mutex_key;
@@ -73,8 +73,6 @@ my_core::PSI_mutex_info all_rocksdb_mutexes[] = {
     {&rdb_mem_cmp_space_mutex_key, "collation space char data init",
      PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
     {&key_mutex_tx_list, "tx_list", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
-    {&rdb_sysvars_psi_mutex_key, "setting sysvar", PSI_FLAG_SINGLETON, 0,
-     PSI_DOCUMENT_ME},
     {&rdb_cfm_mutex_key, "column family manager", PSI_FLAG_SINGLETON, 0,
      PSI_DOCUMENT_ME},
     {&rdb_sst_commit_key, "sst commit", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
@@ -92,7 +90,7 @@ my_core::PSI_mutex_info all_rocksdb_mutexes[] = {
 
 my_core::PSI_rwlock_key key_rwlock_collation_exception_list,
     key_rwlock_read_free_rpl_tables, key_rwlock_clone_task_id_set,
-    key_rwlock_clone_active_clones;
+    key_rwlock_clone_active_clones, key_rwlock_tbl_prop_coll_factory_lock;
 
 my_core::PSI_rwlock_info all_rocksdb_rwlocks[] = {
     {&key_rwlock_collation_exception_list, "collation_exception_list",
@@ -104,6 +102,8 @@ my_core::PSI_rwlock_info all_rocksdb_rwlocks[] = {
      0, PSI_DOCUMENT_ME},
     {&key_rwlock_clone_client_files, "clone_client_files", PSI_FLAG_SINGLETON,
      0, PSI_DOCUMENT_ME},
+    {&key_rwlock_tbl_prop_coll_factory_lock, "properties_collector_factory", 0,
+     PSI_FLAG_SINGLETON, PSI_DOCUMENT_ME},
 };
 
 my_core::PSI_cond_key rdb_signal_bg_psi_cond_key,

--- a/storage/rocksdb/rdb_psi.h
+++ b/storage/rocksdb/rdb_psi.h
@@ -45,15 +45,16 @@ extern my_core::PSI_mutex_key rdb_psi_open_tbls_mutex_key,
     rdb_signal_bg_psi_mutex_key, rdb_signal_drop_idx_psi_mutex_key,
     rdb_signal_is_psi_mutex_key, rdb_signal_mc_psi_mutex_key,
     rdb_collation_data_mutex_key, rdb_mem_cmp_space_mutex_key,
-    key_mutex_tx_list, rdb_sysvars_psi_mutex_key, rdb_cfm_mutex_key,
-    rdb_sst_commit_key, rdb_block_cache_resize_mutex_key,
+    key_mutex_tx_list, rdb_cfm_mutex_key, rdb_sst_commit_key,
+    rdb_block_cache_resize_mutex_key,
     rdb_bottom_pri_background_compactions_resize_mutex_key,
     clone_donor_file_metadata_mutex_key, clone_main_task_remaining_mutex_key,
     clone_error_mutex_key;
 
 extern my_core::PSI_rwlock_key key_rwlock_collation_exception_list,
     key_rwlock_read_free_rpl_tables, key_rwlock_clone_task_id_set,
-    key_rwlock_clone_active_clones, key_rwlock_clone_client_files;
+    key_rwlock_clone_active_clones, key_rwlock_clone_client_files,
+    key_rwlock_tbl_prop_coll_factory_lock;
 
 extern my_core::PSI_cond_key rdb_signal_bg_psi_cond_key,
     rdb_signal_drop_idx_psi_cond_key, rdb_signal_is_psi_cond_key,


### PR DESCRIPTION
The mutex is used by sysvar update functions and synchronizes updates to a
subset of global system variables. But sysvar update functions are called with
LOCK_global_system_variables server lock taken, making the extra locking in the
SE redundant, thus just remove it.

However it was also partially (writes but not reads) protecting concurrent
accesses to properties_collector_factory variable, thus introduce
synchronization for its class Rdb_tbl_prop_coll_factory by adding an rwlock.

At the same time convert Rdb_tbl_prop_coll_factory pointer fields to const
references, remove redundant explicit from two-argument constructor, add
[[nodiscard]] to touched methods, make the class non-movable. Remove redundant
const from passed by-value arguments.

To enable converting m_ddl_manager field to a const reference, mark
Rdb_ddl_manager::m_rwlock field as mutable, which then enables marking many
logically-const methods as such. Also mark touched methods [[nodiscard]], remove
redundant const from passed by-value arguments, convert pass by const reference
to pass by value for a small object arguments of GL_INDEX_ID type.

Add return value handling for one call site of Rdb_ddl_manager::find_indexes as
pointed out by [[nodiscard]].
