### PR TITLE
Partially convert Rdb_cf_options class to use std::string_view

### DIFF
--- a/share/messages_to_clients.txt
+++ b/share/messages_to_clients.txt
@@ -10139,7 +10139,7 @@ ER_SK_POPULATE_DURING_ALTER
   eng "MyRocks failed populating secondary key during alter."
 
 ER_CF_DIFFERENT
-  eng "Column family ('%s') flag (%d) is different from an existing flag (%d). Assign a new CF flag, or do not change existing CF flag."
+  eng "Column family ('%.*s') flag (%d) is different from an existing flag (%d). Assign a new CF flag, or do not change existing CF flag."
 
 ER_RDB_TTL_UNSUPPORTED
   eng "TTL support is currently disabled when table has a hidden PK."

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -10029,7 +10029,7 @@ bool ha_rocksdb::create_cfs(
         return true;
       }
 
-      if (cf_manager.create_cf_flags_if_needed(local_dict_manager,
+      if (cf_manager.create_cf_flags_if_needed(*local_dict_manager,
                                                cf_handle->GetID(), cf_name,
                                                per_part_match_found)) {
         return true;
@@ -10042,7 +10042,7 @@ bool ha_rocksdb::create_cfs(
     auto &cf = cfs[i];
 
     cf.cf_handle = cf_handle;
-    cf.is_reverse_cf = Rdb_cf_manager::is_cf_name_reverse(cf_name.c_str());
+    cf.is_reverse_cf = Rdb_cf_manager::is_cf_name_reverse(cf_name);
     cf.is_per_partition_cf = per_part_match_found;
   }
 
@@ -19005,7 +19005,7 @@ static int rocksdb_validate_update_cf_options(THD * /* unused */,
 
   // Basic sanity checking and parsing the options into a map. If this fails
   // then there's no point to proceed.
-  if (!Rdb_cf_options::parse_cf_options(str, &option_map, &output)) {
+  if (!Rdb_cf_options::parse_cf_options(str, option_map, &output)) {
     my_printf_error(ER_WRONG_VALUE_FOR_VAR, "%s", MYF(0), output.str().c_str());
     return HA_EXIT_FAILURE;
   }
@@ -19027,8 +19027,8 @@ static int rocksdb_validate_update_cf_options(THD * /* unused */,
         return HA_EXIT_FAILURE;
       }
 
-      if (cf_manager.create_cf_flags_if_needed(local_dict_manager, cfh->GetID(),
-                                               cf_name)) {
+      if (cf_manager.create_cf_flags_if_needed(*local_dict_manager,
+                                               cfh->GetID(), cf_name)) {
         return HA_EXIT_FAILURE;
       }
     }
@@ -19064,7 +19064,7 @@ static void rocksdb_set_update_cf_options(THD *const /* unused */,
   Rdb_cf_options::Name_to_config_t option_map;
 
   // This should never fail, because of rocksdb_validate_update_cf_options
-  if (!Rdb_cf_options::parse_cf_options(val, &option_map)) {
+  if (!Rdb_cf_options::parse_cf_options(val, option_map)) {
     RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
     return;
   }

--- a/storage/rocksdb/rdb_cf_manager.h
+++ b/storage/rocksdb/rdb_cf_manager.h
@@ -19,6 +19,7 @@
 /* C++ system header files */
 #include <map>
 #include <string>
+#include <string_view>
 #include <vector>
 
 /* RocksDB header files */
@@ -61,7 +62,7 @@ class Rdb_cf_manager : public Ensure_initialized {
   Rdb_cf_manager &operator=(const Rdb_cf_manager &) = delete;
   Rdb_cf_manager() = default;
 
-  static bool is_cf_name_reverse(const char *const name);
+  [[nodiscard]] static bool is_cf_name_reverse(std::string_view name);
 
   /*
     This is called right after the DB::Open() call. The parameters describe
@@ -107,9 +108,9 @@ class Rdb_cf_manager : public Ensure_initialized {
               Rdb_dict_manager *const dict_manager, const std::string &cf_name);
 
   /* Create cf flags if it does not exist */
-  int create_cf_flags_if_needed(const Rdb_dict_manager *const dict_manager,
-                                const uint32 &cf_id, const std::string &cf_name,
-                                const bool is_per_partition_cf = false);
+  [[nodiscard]] int create_cf_flags_if_needed(
+      const Rdb_dict_manager &dict_manager, uint32_t cf_id,
+      std::string_view cf_name, bool is_per_partition_cf = false);
 
   /* return true when success */
   bool get_cf_options(const std::string &cf_name,

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -5878,7 +5878,7 @@ int Rdb_dict_manager::add_missing_cf_flags(
     std::shared_ptr<rocksdb::ColumnFamilyHandle> cfh =
         cf_manager->get_cf(cf_name);
 
-    if (cf_manager->create_cf_flags_if_needed(this, cfh->GetID(), cf_name)) {
+    if (cf_manager->create_cf_flags_if_needed(*this, cfh->GetID(), cf_name)) {
       return HA_EXIT_FAILURE;
     }
   }


### PR DESCRIPTION
- Partially convert Rdb_cf_options methods to take std::string_view parameters.
  Specifically, do not convert the ones that are passed as keys to m_name_map,
  which is a std::unordered_map<string, string>. This can be converted in C++20,
  where lookups through a different key type are supported.
- Convert Rdb_cf_manager::is_cf_name_reverse and create_cf_flags_if_needed
  methods to take std::string_view arguments, update callers.
- Convert pointer arguments for the touched methods to const reference and
  reference ones, where possible, remove redundant nullptr-checking asserts.
  Remove redundant const from pass-by-value arguments, add [[nodiscard]].
- Update ER_CF_DIFFERENT to print an std::string_view parameter.
