### PR TITLE
Use python3 from $PATH instead of absolute paths

### DIFF
--- a/mysql-test/include/raft_config.py
+++ b/mysql-test/include/raft_config.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/mysql-test/suite/innodb_stress/include/innodb_stress.inc
+++ b/mysql-test/suite/innodb_stress/include/innodb_stress.inc
@@ -39,7 +39,7 @@ if ($do_checksum)
 {
     # populate the table and store its checksum before any load.
     let $exec =
-/usr/bin/python3 $MYSQL_TEST_DIR/suite/innodb_stress/t/load_generator.py $pid_file $kill_db_after
+$PYTHON $MYSQL_TEST_DIR/suite/innodb_stress/t/load_generator.py $pid_file $kill_db_after
 $num_records 0 0 $user $master_host $MASTER_MYPORT
 $table 0 $max_rows $MYSQL_TMP_DIR/load_generator 0 0 0;
     exec $exec >> $MYSQL_TMP_DIR/load_generator/errors.log;
@@ -68,14 +68,14 @@ while ($num_crashes)
   if ($use_blob)
   {
     let $exec =
-/usr/bin/python3 $MYSQL_TEST_DIR/suite/innodb_stress/t/load_generator.py $pid_file $kill_db_after
+$PYTHON $MYSQL_TEST_DIR/suite/innodb_stress/t/load_generator.py $pid_file $kill_db_after
 $num_records  $num_workers $num_transactions $user $master_host $MASTER_MYPORT
 $table 1 $max_rows $MYSQL_TMP_DIR/load_generator 0 $checksum $secondary_index_checks;
   }
   if (!$use_blob)
   {
     let $exec =
-/usr/bin/python3 $MYSQL_TEST_DIR/suite/innodb_stress/t/load_generator.py $pid_file $kill_db_after
+$PYTHON $MYSQL_TEST_DIR/suite/innodb_stress/t/load_generator.py $pid_file $kill_db_after
 $num_records  $num_workers $num_transactions $user $master_host $MASTER_MYPORT
 $table 0 $max_rows $MYSQL_TMP_DIR/load_generator 0 $checksum $secondary_index_checks;
   }
@@ -106,7 +106,7 @@ $table 0 $max_rows $MYSQL_TMP_DIR/load_generator 0 $checksum $secondary_index_ch
     --echo applying fake updates to the slave
     let $slave_pid_file = `SELECT @@pid_file`;
     let $slave_exec =
-/usr/bin/python3 $MYSQL_TEST_DIR/suite/innodb_stress/t/load_generator.py $slave_pid_file $kill_db_after
+$PYTHON $MYSQL_TEST_DIR/suite/innodb_stress/t/load_generator.py $slave_pid_file $kill_db_after
 0  $num_workers $num_transactions $user $master_host $SLAVE_MYPORT
 $table 0 $max_rows $MYSQL_TMP_DIR/load_generator_slave 1 $checksum $secondary_index_checks;
     exec $slave_exec >> $MYSQL_TMP_DIR/load_generator/errors.log;

--- a/mysql-test/suite/rocksdb/t/allow_no_pk_concurrent_insert.test
+++ b/mysql-test/suite/rocksdb/t/allow_no_pk_concurrent_insert.test
@@ -15,7 +15,7 @@ drop table if exists t1;
 # create the actual table
 CREATE TABLE t1 (a INT) ENGINE=rocksdb;
 
-let $exec = /usr/bin/python3 suite/rocksdb/t/rocksdb_concurrent_insert.py root 127.0.0.1 $MASTER_MYPORT test t1 100 4;
+let $exec = python3 suite/rocksdb/t/rocksdb_concurrent_insert.py root 127.0.0.1 $MASTER_MYPORT test t1 100 4;
 exec $exec;
 
 SELECT COUNT(*) from t1;

--- a/mysql-test/suite/rocksdb/t/partial_index_stress.test
+++ b/mysql-test/suite/rocksdb/t/partial_index_stress.test
@@ -19,7 +19,7 @@ CREATE TABLE `link_table` (
   KEY `id1_type` (`link_type`, `id1`, `visibility`,`time`,`id2`,`version`,`data`) COMMENT 'cfname=rev:cf_link_id1_type;partial_group_keyparts=2;partial_group_threshold=10'
 ) ENGINE=ROCKSDB DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8;
 
-exec /usr/bin/python3 suite/rocksdb/t/partial_index_stress.py root 127.0.0.1 $MASTER_MYPORT test link_table 1000 10;
+exec python3 suite/rocksdb/t/partial_index_stress.py root 127.0.0.1 $MASTER_MYPORT test link_table 1000 10;
 
 DROP TABLE link_table;
 
@@ -37,7 +37,7 @@ CREATE TABLE `link_table` (
   KEY `id1_type` (`link_type`, `id1`, `visibility`,`time`,`id2`,`version`,`data`) COMMENT 'cfname=rev:cf_link_id1_type;partial_group_keyparts=2;partial_group_threshold=10'
 ) ENGINE=ROCKSDB DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8;
 
-exec /usr/bin/python3 suite/rocksdb/t/partial_index_stress.py root 127.0.0.1 $MASTER_MYPORT test link_table 1000 10;
+exec python3 suite/rocksdb/t/partial_index_stress.py root 127.0.0.1 $MASTER_MYPORT test link_table 1000 10;
 
 DROP TABLE link_table;
 
@@ -55,7 +55,7 @@ CREATE TABLE `link_table` (
   KEY `id1_type` (`link_type`, `id1`, `visibility`,`time`,`id2`,`version`,`data`(255)) COMMENT 'cfname=rev:cf_link_id1_type;partial_group_keyparts=2;partial_group_threshold=10'
 ) ENGINE=ROCKSDB DEFAULT CHARSET=latin1 COLLATE=latin1_bin ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=4;
 
-exec /usr/bin/python3 suite/rocksdb/t/partial_index_stress.py root 127.0.0.1 $MASTER_MYPORT test link_table 1000 10;
+exec python3 suite/rocksdb/t/partial_index_stress.py root 127.0.0.1 $MASTER_MYPORT test link_table 1000 10;
 
 DROP TABLE link_table;
 

--- a/mysql-test/suite/rocksdb/t/rocksdb_deadlock_stress.inc
+++ b/mysql-test/suite/rocksdb/t/rocksdb_deadlock_stress.inc
@@ -11,7 +11,7 @@ set @prior_rocksdb_deadlock_detect = @@rocksdb_deadlock_detect;
 set global rocksdb_lock_wait_timeout = 100000;
 set global rocksdb_deadlock_detect = ON;
 
-exec /usr/bin/python3 suite/rocksdb/t/rocksdb_deadlock_stress.py root 127.0.0.1 $MASTER_MYPORT test t1 1000 10;
+exec python3 suite/rocksdb/t/rocksdb_deadlock_stress.py root 127.0.0.1 $MASTER_MYPORT test t1 1000 10;
 
 set global rocksdb_lock_wait_timeout = @prior_rocksdb_lock_wait_timeout;
 set global rocksdb_deadlock_detect = @prior_rocksdb_deadlock_detect;

--- a/mysql-test/suite/rocksdb_hotbackup/include/create_slocket_socket.sh
+++ b/mysql-test/suite/rocksdb_hotbackup/include/create_slocket_socket.sh
@@ -1,2 +1,2 @@
 src_data_dir="${MYSQLTEST_VARDIR}/mysqld.1/data/"
-python2 -c "import socket as s; sock = s.socket(s.AF_UNIX); sock.bind('${src_data_dir}/slocket')"
+python -c "import socket as s; sock = s.socket(s.AF_UNIX); sock.bind('${src_data_dir}/slocket')"

--- a/mysql-test/suite/rocksdb_rpl/t/multiclient_2pc.test
+++ b/mysql-test/suite/rocksdb_rpl/t/multiclient_2pc.test
@@ -64,7 +64,7 @@ SET DEBUG_SYNC='now SIGNAL go';
 --source include/wait_until_connected_again.inc
 --disable_reconnect
 
---exec /usr/bin/python3 suite/rocksdb/t/check_log_for_xa.py $LOG prepare,commit,rollback
+--exec python3 suite/rocksdb/t/check_log_for_xa.py $LOG prepare,commit,rollback
 
 select * from t1 where a=1;
 select count(*) from t1;

--- a/mysql-test/suite/rocksdb_rpl/t/rpl_gtid_crash_safe_wal_corrupt.inc
+++ b/mysql-test/suite/rocksdb_rpl/t/rpl_gtid_crash_safe_wal_corrupt.inc
@@ -78,7 +78,7 @@ EOF
 select "--- slave state after crash recovery, slave stop, one transaction recovered---" as "";
 --enable_query_log
 connection slave;
---exec /usr/bin/python3 suite/rocksdb/t/check_log_for_xa.py $LOG commit,prepare,rollback
+--exec python3 suite/rocksdb/t/check_log_for_xa.py $LOG commit,prepare,rollback
 select * from x;
 -- replace_result $uuid uuid
 select @@global.gtid_executed;

--- a/mysql-test/suite/rocksdb_rpl/t/rpl_gtid_crash_safe_wal_corrupt_dual_engine.test
+++ b/mysql-test/suite/rocksdb_rpl/t/rpl_gtid_crash_safe_wal_corrupt_dual_engine.test
@@ -138,7 +138,7 @@ EOF
 select "--- slave state after crash recovery, slave stop, one transaction recovered---" as "";
 --enable_query_log
 connection slave;
---exec /usr/bin/python3 suite/rocksdb/t/check_log_for_xa.py $LOG commit,prepare,rollback
+--exec python3 suite/rocksdb/t/check_log_for_xa.py $LOG commit,prepare,rollback
 
 --disable_query_log
 select "--- slave state after restart, slave start ---" as "";

--- a/mysql-test/suite/rocksdb_stress/include/rocksdb_stress.inc
+++ b/mysql-test/suite/rocksdb_stress/include/rocksdb_stress.inc
@@ -7,7 +7,7 @@
 --let $master_host = 127.0.0.1
 
 let $exec =
-  /usr/bin/python3 $MYSQL_TEST_DIR/suite/rocksdb_stress/t/load_generator.py
+  python3 $MYSQL_TEST_DIR/suite/rocksdb_stress/t/load_generator.py
   -L $MYSQL_TMP_DIR/load_generator.log -H $master_host -t $table
   -P $MASTER_MYPORT -n $num_records -m $max_records
   -l $num_loaders -c $num_checkers -r $num_requests

--- a/mysql-test/suite/rocksdb_stress/t/drop_cf_stress.test
+++ b/mysql-test/suite/rocksdb_stress/t/drop_cf_stress.test
@@ -61,7 +61,7 @@ WHILE ($i < $num_cfs)
 }
 
 let $exec =
-  /usr/bin/python3 $MYSQL_TEST_DIR/suite/rocksdb_stress/t/drop_cf_stress.py
+  python3 $MYSQL_TEST_DIR/suite/rocksdb_stress/t/drop_cf_stress.py
   -L $MYSQL_TMP_DIR/drop_cf_stress.log -H $local_host
   -P $MASTER_MYPORT
   -w $num_workers -r $num_requests -v

--- a/mysql-test/suite/thread_pool/t/admission_control_multi_query.test
+++ b/mysql-test/suite/thread_pool/t/admission_control_multi_query.test
@@ -9,7 +9,7 @@ grant all on test.* to test_user@localhost;
 use test_db;
 create table t1 (a int primary key, b int) engine=InnoDB;
 
-let $exec = /usr/bin/python3 $MYSQL_TEST_DIR/suite/thread_pool/t/admission_control_multi_query.py --user='test_user' --host=127.0.0.1 --port=$MASTER_MYPORT --database='test_db';
+let $exec = python3 $MYSQL_TEST_DIR/suite/thread_pool/t/admission_control_multi_query.py --user='test_user' --host=127.0.0.1 --port=$MASTER_MYPORT --database='test_db';
 exec $exec > $MYSQLTEST_VARDIR/tmp/admission_control_multi_query.output;
 
 drop database test_db;

--- a/mysql-test/suite/thread_pool/t/admission_control_multi_query_wait_events.test
+++ b/mysql-test/suite/thread_pool/t/admission_control_multi_query_wait_events.test
@@ -10,7 +10,7 @@ grant all on test.* to test_user@localhost;
 use test_db;
 create table t1 (a int primary key, b int) engine=InnoDB;
 
-let $exec = /usr/bin/python3 $MYSQL_TEST_DIR/suite/thread_pool/t/admission_control_multi_query.py --user='test_user' --host=127.0.0.1 --port=$MASTER_MYPORT --database='test_db' --wait-events;
+let $exec = python3 $MYSQL_TEST_DIR/suite/thread_pool/t/admission_control_multi_query.py --user='test_user' --host=127.0.0.1 --port=$MASTER_MYPORT --database='test_db' --wait-events;
 exec $exec > $MYSQLTEST_VARDIR/tmp/admission_control_multi_query.output;
 
 drop database test_db;

--- a/mysql-test/suite/thread_pool/t/admission_control_multi_query_weighted.test
+++ b/mysql-test/suite/thread_pool/t/admission_control_multi_query_weighted.test
@@ -10,7 +10,7 @@ grant all on test.* to test_user@localhost;
 use test_db;
 create table t1 (a int primary key, b int) engine=InnoDB;
 
-let $exec = /usr/bin/python3 $MYSQL_TEST_DIR/suite/thread_pool/t/admission_control_multi_query.py --user='test_user' --host=127.0.0.1 --port=$MASTER_MYPORT --database='test_db' --weighted-queues;
+let $exec = python3 $MYSQL_TEST_DIR/suite/thread_pool/t/admission_control_multi_query.py --user='test_user' --host=127.0.0.1 --port=$MASTER_MYPORT --database='test_db' --weighted-queues;
 exec $exec > $MYSQLTEST_VARDIR/tmp/admission_control_multi_query.output;
 
 drop database test_db;

--- a/mysql-test/suite/thread_pool/t/admission_control_stall_gen.py
+++ b/mysql-test/suite/thread_pool/t/admission_control_stall_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 """
 Stall generator helper script for MTR.

--- a/mysql-test/suite/thread_pool/t/max_db_connections_stress.test
+++ b/mysql-test/suite/thread_pool/t/max_db_connections_stress.test
@@ -19,7 +19,7 @@ while ($i)
 let $error_query = sum_error_raised as "errors present" from performance_schema.events_errors_summary_global_by_error where error_name = "ER_MULTI_TENANCY_MAX_CONNECTION";
 let $error_count_init = `select $error_query`;
 
-let $exec = /usr/bin/python3 $MYSQL_TEST_DIR/t/max_db_connections_stress.py --user='test_user' --host=127.0.0.1 --port=$MASTER_MYPORT --db_prefix='test_db' --db_count=10;
+let $exec = python3 $MYSQL_TEST_DIR/t/max_db_connections_stress.py --user='test_user' --host=127.0.0.1 --port=$MASTER_MYPORT --db_prefix='test_db' --db_count=10;
 exec $exec > $MYSQLTEST_VARDIR/tmp/tp_max_db_connections_stress.output;
 
 let $i = 10;

--- a/mysql-test/suite/thread_pool/t/thread_pool_on_off_stress.test
+++ b/mysql-test/suite/thread_pool/t/thread_pool_on_off_stress.test
@@ -13,7 +13,7 @@ grant all on *.* to super_user@localhost with grant option;
 use test_db;
 create table t1 (a int primary key, b int) engine=InnoDB;
 
-let $exec = /usr/bin/python3 $MYSQL_TEST_DIR/suite/thread_pool/t/admission_control_multi_query.py --user='test_user' --admin='super_user' --host=127.0.0.1 --port=$MASTER_MYPORT --database='test_db' --wait-events --thread-pool-on-off;
+let $exec = python3 $MYSQL_TEST_DIR/suite/thread_pool/t/admission_control_multi_query.py --user='test_user' --admin='super_user' --host=127.0.0.1 --port=$MASTER_MYPORT --database='test_db' --wait-events --thread-pool-on-off;
 exec $exec > $MYSQLTEST_VARDIR/tmp/admission_control_multi_query.output;
 
 drop database test_db;

--- a/mysql-test/t/admission_control_multi_query.test
+++ b/mysql-test/t/admission_control_multi_query.test
@@ -1,5 +1,13 @@
 source include/big_test.inc;
 source include/not_valgrind.inc;
+
+# TODO(laurynas): the path should not be hardcoded
+--let $PYTHON = /usr/bin/python3
+if (`SELECT CONVERT(@@VERSION_COMPILE_OS USING latin1) RLIKE '^(osx|macos)'`)
+{
+--let $PYTHON = python3
+}
+
 create database test_db;
 create user test_user@localhost identified with 'mysql_native_password' BY '';
 grant all on test_db.* to test_user@localhost;
@@ -8,7 +16,7 @@ grant all on test.* to test_user@localhost;
 use test_db;
 create table t1 (a int primary key, b int) engine=InnoDB;
 
-let $exec = /usr/bin/python3 $MYSQL_TEST_DIR/t/admission_control_multi_query.py --user='test_user' --host=127.0.0.1 --port=$MASTER_MYPORT --database='test_db';
+let $exec = $PYTHON $MYSQL_TEST_DIR/t/admission_control_multi_query.py --user='test_user' --host=127.0.0.1 --port=$MASTER_MYPORT --database='test_db';
 exec $exec > $MYSQLTEST_VARDIR/tmp/admission_control_multi_query.output;
 
 drop database test_db;

--- a/mysql-test/t/admission_control_multi_query_wait_events.test
+++ b/mysql-test/t/admission_control_multi_query_wait_events.test
@@ -1,5 +1,13 @@
 source include/big_test.inc;
 source include/not_valgrind.inc;
+
+# TODO(laurynas): the path should not be hardcoded
+--let $PYTHON = /usr/bin/python3
+if (`SELECT CONVERT(@@VERSION_COMPILE_OS USING latin1) RLIKE '^(osx|macos)'`)
+{
+--let $PYTHON = python3
+}
+
 create database test_db;
 create user test_user@localhost identified with 'mysql_native_password' BY '';
 grant all on test_db.* to test_user@localhost;
@@ -8,7 +16,7 @@ grant all on test.* to test_user@localhost;
 use test_db;
 create table t1 (a int primary key, b int) engine=InnoDB;
 
-let $exec = /usr/bin/python3 $MYSQL_TEST_DIR/t/admission_control_multi_query.py --user='test_user' --host=127.0.0.1 --port=$MASTER_MYPORT --database='test_db' --wait-events;
+let $exec = $PYTHON $MYSQL_TEST_DIR/t/admission_control_multi_query.py --user='test_user' --host=127.0.0.1 --port=$MASTER_MYPORT --database='test_db' --wait-events;
 exec $exec > $MYSQLTEST_VARDIR/tmp/admission_control_multi_query.output;
 
 drop database test_db;

--- a/mysql-test/t/admission_control_multi_query_weighted.test
+++ b/mysql-test/t/admission_control_multi_query_weighted.test
@@ -1,5 +1,13 @@
 source include/big_test.inc;
 source include/not_valgrind.inc;
+
+# TODO(laurynas): the path should not be hardcoded
+--let $PYTHON = /usr/bin/python3
+if (`SELECT CONVERT(@@VERSION_COMPILE_OS USING latin1) RLIKE '^(osx|macos)'`)
+{
+--let $PYTHON = python3
+}
+
 create database test_db;
 create user test_user@localhost identified with 'mysql_native_password' BY '';
 grant all on test_db.* to test_user@localhost;
@@ -8,7 +16,7 @@ grant all on test.* to test_user@localhost;
 use test_db;
 create table t1 (a int primary key, b int) engine=InnoDB;
 
-let $exec = /usr/bin/python3 $MYSQL_TEST_DIR/t/admission_control_multi_query.py --user='test_user' --host=127.0.0.1 --port=$MASTER_MYPORT --database='test_db' --weighted-queues;
+let $exec = $PYTHON $MYSQL_TEST_DIR/t/admission_control_multi_query.py --user='test_user' --host=127.0.0.1 --port=$MASTER_MYPORT --database='test_db' --weighted-queues;
 exec $exec > $MYSQLTEST_VARDIR/tmp/admission_control_multi_query.output;
 
 drop database test_db;

--- a/mysql-test/t/max_db_connections_stress.test
+++ b/mysql-test/t/max_db_connections_stress.test
@@ -19,7 +19,7 @@ let $error_query = sum_error_raised as "errors present" from performance_schema.
 let $error_count_init = `select $error_query`;
 
 
-let $exec = /usr/bin/python3 $MYSQL_TEST_DIR/t/max_db_connections_stress.py --user='test_user' --host=127.0.0.1 --port=$MASTER_MYPORT --db_prefix='test_db' --db_count=10;
+let $exec = python3 $MYSQL_TEST_DIR/t/max_db_connections_stress.py --user='test_user' --host=127.0.0.1 --port=$MASTER_MYPORT --db_prefix='test_db' --db_count=10;
 exec $exec > $MYSQLTEST_VARDIR/tmp/max_db_connections_stress.output;
 
 let $i = 10;

--- a/mysql-test/t/max_tmp_disk_usage_stress.test
+++ b/mysql-test/t/max_tmp_disk_usage_stress.test
@@ -32,7 +32,7 @@ set global max_tmp_disk_usage = 100000000;
 set global temptable_max_ram = 2097152;
 set global temptable_use_mmap = off;
 
-let $exec = /usr/bin/python3 $MYSQL_TEST_DIR/t/max_tmp_disk_usage_stress.py --user='test_user' --host=127.0.0.1 --port=$MASTER_MYPORT --database='test_db';
+let $exec = python3 $MYSQL_TEST_DIR/t/max_tmp_disk_usage_stress.py --user='test_user' --host=127.0.0.1 --port=$MASTER_MYPORT --database='test_db';
 exec $exec > $MYSQLTEST_VARDIR/tmp/max_tmp_disk_usage_stress.output;
 
 drop database test_db;

--- a/mysql-test/t/slocket_listen.py
+++ b/mysql-test/t/slocket_listen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 from socket import socket, AF_UNIX, SOCK_DGRAM
 from select import select
 from os import unlink, getcwd, stat


### PR DESCRIPTION
This allows using Python virtualenv directly. This partially reverts changes in
9d0dda0c6565f1a7d926e5c82628cb134d4b1ac9, but its commit message is not stating
anything about absolute paths.
