### PR TITLE
MyRocks: skip row lock during DDSE upgrade

### DIFF
--- a/mysql-test/suite/rocksdb/r/ddse_upgrade_row_lock.result
+++ b/mysql-test/suite/rocksdb/r/ddse_upgrade_row_lock.result
@@ -1,0 +1,6 @@
+upgrade from INNODB->ROCKSDB DDSE
+# restart: --default_dd_system_storage_engine=rocksdb --datadir=DATADIR --rocksdb_max_row_locks=20000
+select @@rocksdb_max_row_locks, @@default_dd_system_storage_engine;
+@@rocksdb_max_row_locks	@@default_dd_system_storage_engine
+20000	RocksDB
+# restart

--- a/mysql-test/suite/rocksdb/t/ddse_upgrade_row_lock.test
+++ b/mysql-test/suite/rocksdb/t/ddse_upgrade_row_lock.test
@@ -1,0 +1,41 @@
+--source include/have_rocksdb.inc
+--source include/have_innodb_ddse.inc
+
+--let $MYSQLD_DATADIR= `select @@datadir`
+
+# shutdown for backup
+--source include/shutdown_mysqld.inc
+
+# backup data
+let $tmp_dir = $MYSQLTEST_VARDIR/tmp;
+let $saved_datadir = $tmp_dir/saved_datadir;
+force-cpdir $MYSQLD_DATADIR $saved_datadir;
+
+# There are 3 places during DD upgrade that may involve a lot row locks:
+# - Insert select statement: This involves copy data from one storage engine to
+#       another storage engine. This only happens for DD SE upgrade, and with
+#       this change, no row locks are hold.
+# - Drop DD tables: when dropping old DD tables, the SQL layer reads one rows
+#       and deletes it. This happens for both DD SE upgrade and DD version
+#       upgrade. The required max number of row lock is the max number of rows
+#       among these DD tables.
+# - SYSTEM table update: there are many SQL scripts involving insertion of data
+#       into system tables. This happens for both DD SE upgrade and DD version
+#       upgrade. Currently, some tables involve 15-20K rows locks during
+#       insertion. Consider to use bulk load in future if more row lock required
+--echo upgrade from INNODB->ROCKSDB DDSE
+let restart_parameters = restart: --default_dd_system_storage_engine=rocksdb;
+let $restart_parameters = $restart_parameters --datadir=$saved_datadir;
+let $restart_parameters = $restart_parameters --rocksdb_max_row_locks=20000;
+--replace_result $saved_datadir DATADIR
+--source include/start_mysqld.inc
+
+select @@rocksdb_max_row_locks, @@default_dd_system_storage_engine;
+
+# restart
+let $restart_parameters = "restart";
+--replace_result $MYSQLD_DATADIR DATADIR
+--source include/restart_mysqld.inc
+
+# cleanup
+--force-rmdir $saved_datadir

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -13264,10 +13264,11 @@ int ha_rocksdb::update_write_row(const uchar *const old_data,
   }
 
   // Case: We skip both unique checks and rows locks only when bulk load is
-  // enabled or if rocksdb_skip_locks_if_skip_unique_check is ON
+  // enabled or if rocksdb_skip_locks_if_skip_unique_check is ON or DDSE upgrade
   if (!THDVAR(table->in_use, bulk_load) &&
       (!rocksdb_skip_locks_if_skip_unique_check ||
-       !row_info.skip_unique_check)) {
+       !row_info.skip_unique_check) &&
+      !dd::is_dd_engine_change_in_progress()) {
     /*
       Check to see if we are going to have failures because of unique
       keys.  Also lock the appropriate key values.
@@ -18166,12 +18167,13 @@ bool ha_rocksdb::should_recreate_snapshot(const int rc,
 /**
  * If calling put/delete/singledelete without locking the row,
  * it is necessary to pass assume_tracked=false to RocksDB TX API.
- * Read Free Replication, Blind Deletes and intrinsic tmp tables
+ * Read Free Replication, Blind Deletes, intrinsic tmp tables and DDSE change
  * are the cases when using TX API and skipping row locking.
  */
 bool ha_rocksdb::can_assume_tracked(THD *thd) {
   if (use_read_free_rpl() || (THDVAR(thd, blind_delete_primary_key)) ||
-      m_tbl_def->is_intrinsic_tmp_table()) {
+      m_tbl_def->is_intrinsic_tmp_table() ||
+      dd::is_dd_engine_change_in_progress()) {
     return false;
   }
   return true;


### PR DESCRIPTION
There are some instance contain huge number of DBs and each DB contains a lot tables/columns(such as 500K).
During DDSE upgrade, It use single transaction to insert select statement to copy data from old SE to new SE. if new DDSE is rocksdb, it may hit max row lock error.

There are 3 places during DD upgrade that may involve a lot row locks:
- Insert select statement: This involves copy data from one storage engine to
       another storage engine. This only happens for DD SE upgrade, and with
       this change, no row locks are hold.
- Drop DD tables: when dropping old DD tables, the SQL layer reads one rows
        and deletes it. This happens for both DD SE upgrade and DD version
        upgrade. The required max number of row lock is the max number of rows
        among these DD tables.
 - SYSTEM table update: there are many SQL scripts involving insertion of data
        into system tables. This happens for both DD SE upgrade and DD version
        upgrade. Currently, some tables involve 15-20K rows locks during
        insertion. Consider to use bulk load in future if more row lock required     
        
The change is to skip row lock during DDSE upgrade for Insert select statement. Future change may required to skip other two places(Drop DD tables and SYSTEM table update)