### PR TITLE
Fix mysqldump macOS build regression

### DIFF
--- a/client/mysqldump.cc
+++ b/client/mysqldump.cc
@@ -34,6 +34,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
+#include <cinttypes>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -6343,8 +6344,8 @@ static bool process_dbtids(const char *dbtids_str) {
 static void print_dbtids(const char *db) {
   auto itr = dbtids.find(db);
   if (!opt_set_dbtids || itr == dbtids.end()) return;
-  fprintf(md_result_file, "SET @@GLOBAL.DBTIDS='%s:%lu';\n", itr->first.c_str(),
-          itr->second);
+  fprintf(md_result_file, "SET @@GLOBAL.DBTIDS='%s:%" PRIu64 "';\n",
+          itr->first.c_str(), itr->second);
 }
 
 /*


### PR DESCRIPTION
Use the standard macro to fprintf a uint64_t value. This fixes
client/mysqldump.cc:6347:11: error: format specifies type 'unsigned long' but the argument has type 'unsigned long long' [-Werror,-Wformat]
          itr->second);
          ^~~~~~~~~~~

Squash with fb8bf5e253e8ccaf7abf9094f50ef80f74c60ae3
