### PR TITLE
Fix GCC compilation error in memory_debugging.h

### DIFF
--- a/include/memory_debugging.h
+++ b/include/memory_debugging.h
@@ -41,8 +41,10 @@
 #include <valgrind/memcheck.h>
 
 #define MEM_UNDEFINED(a, len) VALGRIND_MAKE_MEM_UNDEFINED(a, len)
-// #define MEM_DEFINED_IF_ADDRESSABLE(a, len) \
-//   VALGRIND_MAKE_MEM_DEFINED_IF_ADDRESSABLE(a, len)
+#if 0
+#define MEM_DEFINED_IF_ADDRESSABLE(a, len) \
+  VALGRIND_MAKE_MEM_DEFINED_IF_ADDRESSABLE(a, len)
+#endif
 #define MEM_NOACCESS(a, len) VALGRIND_MAKE_MEM_NOACCESS(a, len)
 #define MEM_CHECK_ADDRESSABLE(a, len) VALGRIND_CHECK_MEM_IS_ADDRESSABLE(a, len)
 


### PR DESCRIPTION
Replace a multi-line comment with a disabled preprocessor block

This fixes, with GCC:

In file included from include/my_alloc.h:41,
                 from mysys/array.cc:38:
include/memory_debugging.h:44:1: error: multi-line comment [-Werror=comment]
   44 | // #define MEM_DEFINED_IF_ADDRESSABLE(a, len) \
      | ^

Squash with fdf68f720c84fba51b0ef02029577ef970d3b914
