### PR TITLE
Partially fix -DWITHOUT_SERVER=ON build

### DIFF
--- a/include/mysql/psi/mysql_statement.h
+++ b/include/mysql/psi/mysql_statement.h
@@ -429,6 +429,7 @@ static inline void mysql_statement_set_secondary_engine(
 #endif /* HAVE_PSI_STATEMENT_INTERFACE */
 }
 
+#ifdef HAVE_PSI_STATEMENT_INTERFACE
 static inline unsigned long long inline_mysql_get_statement_cpu_time(
     PSI_statement_locker *locker) {
   unsigned long long cpu_time = 0;
@@ -438,6 +439,7 @@ static inline unsigned long long inline_mysql_get_statement_cpu_time(
   }
   return cpu_time;
 }
+#endif /* HAVE_PSI_STATEMENT_INTERFACE */
 
 /** @} (end of group psi_api_statement) */
 


### PR DESCRIPTION
Do not declare inline_mysql_get_statement_cpu_time if
HAVE_PSI_STATEMENT_INTERFACE is not defined.

Will fix https://github.com/facebook/mysql-5.6/issues/1476 together with other
PRs that squash to different commits.

Squash with f6743061c2a1bcf7e10d103409d192e6b1df7d5a
