### PR TITLE
Fix -DWITHOUT_SERVER=ON build, part 2

### DIFF
--- a/include/mysql/psi/mysql_thread.h
+++ b/include/mysql/psi/mysql_thread.h
@@ -201,7 +201,8 @@ static inline void mysql_thread_set_secondary_engine(bool secondary
   @param max_count Max size of held_lock_names array.
 */
 static inline int inline_mysql_thread_get_held_locks(
-    const char **held_lock_names, int max_count) {
+    const char **held_lock_names [[maybe_unused]],
+    int max_count [[maybe_unused]]) {
   int result = 0;
 #ifdef HAVE_PSI_THREAD_INTERFACE
   struct PSI_thread *psi = PSI_THREAD_CALL(get_thread)();


### PR DESCRIPTION
Mark inline_mysql_thread_get_held_locks arguments as maybe_unused to fix
compilation error when HAVE_PSI_THREAD_INTERFACE is not declared.

This partially fixes https://github.com/facebook/mysql-5.6/issues/1476 together
with other PRs

Squash with d69bb8a2ab39b2bf207a527300eb77ebf0a2e20d
