### PR TITLE
Guard server-specific includes with MYSQL_SERVER

### DIFF
--- a/sql-common/net_serv.cc
+++ b/sql-common/net_serv.cc
@@ -46,8 +46,10 @@
 #include <mysql/plugin.h>
 #include <mysql/thread_pool_priv.h>
 #include "../sql/current_thd.h"
+#ifdef MYSQL_SERVER
 #include "../sql/mysqld.h"  // send_error_before_closing_timed_out_connection
 #include "../sql/sql_class.h"
+#endif
 #include "../sql/sql_thd_internal_api.h"
 #include "my_byteorder.h"
 #include "my_compiler.h"


### PR DESCRIPTION
This fixes https://github.com/facebook/mysql-5.6/issues/1476 together with the
other PRs

Squash with 66f9d887436c1c30b30dd0784293677b8ba3f0d7
