### PR TITLE
Snapshot time-related cleanups

### DIFF
--- a/mysql-test/suite/rocksdb/include/show_transaction_status.inc
+++ b/mysql-test/suite/rocksdb/include/show_transaction_status.inc
@@ -1,0 +1,5 @@
+# The output from SHOW ENGINE ROCKSDB TRANSACTION STATUS has some
+# non-deterministic results, replace them with deterministic placeholders.
+
+--replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /(ACTIVE) [0-9]+ /\1 NUM / /(thread id) [0-9]+/\1 TID/ /(thread handle) [0-9]+/\1 PTR/ /(query id) [0-9]+/\1 QID/ /(root) [a-z ]+/\1 ACTION/ /WAITING KEY: [0-9a-f]{16}/KEY/ /TRANSACTION ID: [0-9]*/TXN_ID/ /INDEX_ID: [0-9a-f]*/IDX_ID/ /TIMESTAMP: [0-9]*/TSTAMP/
+SHOW ENGINE ROCKSDB TRANSACTION STATUS;

--- a/mysql-test/suite/rocksdb/r/deadlock_tracking.result
+++ b/mysql-test/suite/rocksdb/r/deadlock_tracking.result
@@ -8,7 +8,7 @@ set global rocksdb_max_latest_deadlocks = 0;
 set global rocksdb_max_latest_deadlocks = @prior_max_latest_deadlocks;
 create table t (i int primary key) engine=rocksdb;
 insert into t values (1), (2), (3);
-show engine rocksdb transaction status;
+SHOW ENGINE ROCKSDB TRANSACTION STATUS;
 Type	Name	Status
 rocksdb		
 ============================================================
@@ -39,7 +39,7 @@ rollback;
 i
 2
 rollback;
-show engine rocksdb transaction status;
+SHOW ENGINE ROCKSDB TRANSACTION STATUS;
 Type	Name	Status
 rocksdb		
 ============================================================
@@ -90,7 +90,7 @@ rollback;
 i
 2
 rollback;
-show engine rocksdb transaction status;
+SHOW ENGINE ROCKSDB TRANSACTION STATUS;
 Type	Name	Status
 rocksdb		
 ============================================================
@@ -162,7 +162,7 @@ rollback;
 i
 2
 rollback;
-show engine rocksdb transaction status;
+SHOW ENGINE ROCKSDB TRANSACTION STATUS;
 Type	Name	Status
 rocksdb		
 ============================================================
@@ -238,7 +238,7 @@ END OF ROCKSDB TRANSACTION MONITOR OUTPUT
 =========================================
 
 set global rocksdb_max_latest_deadlocks = 1;
-show engine rocksdb transaction status;
+SHOW ENGINE ROCKSDB TRANSACTION STATUS;
 Type	Name	Status
 rocksdb		
 ============================================================
@@ -303,7 +303,7 @@ i
 2
 rollback;
 set global rocksdb_max_latest_deadlocks = 5;
-show engine rocksdb transaction status;
+SHOW ENGINE ROCKSDB TRANSACTION STATUS;
 Type	Name	Status
 rocksdb		
 ============================================================
@@ -352,7 +352,7 @@ i
 2
 rollback;
 rollback;
-show engine rocksdb transaction status;
+SHOW ENGINE ROCKSDB TRANSACTION STATUS;
 Type	Name	Status
 rocksdb		
 ============================================================
@@ -411,7 +411,7 @@ drop table t1;
 set global rocksdb_lock_wait_timeout = @prior_lock_wait_timeout;
 set global rocksdb_deadlock_detect = @prior_deadlock_detect;
 drop table t;
-show engine rocksdb transaction status;
+SHOW ENGINE ROCKSDB TRANSACTION STATUS;
 Type	Name	Status
 rocksdb		
 ============================================================
@@ -471,7 +471,7 @@ END OF ROCKSDB TRANSACTION MONITOR OUTPUT
 set global rocksdb_max_latest_deadlocks = 0;
 # Clears deadlock buffer of any existent deadlocks.
 set global rocksdb_max_latest_deadlocks = @prior_max_latest_deadlocks;
-show engine rocksdb transaction status;
+SHOW ENGINE ROCKSDB TRANSACTION STATUS;
 Type	Name	Status
 rocksdb		
 ============================================================

--- a/mysql-test/suite/rocksdb/r/issue243_transactionStatus.result
+++ b/mysql-test/suite/rocksdb/r/issue243_transactionStatus.result
@@ -15,7 +15,7 @@ SELECT * FROM t1;
 id	val1	val2
 1	1	1
 2	2	2
-SHOW ENGINE rocksdb TRANSACTION STATUS;
+SHOW ENGINE ROCKSDB TRANSACTION STATUS;
 Type	Name	Status
 rocksdb		
 ============================================================
@@ -47,7 +47,7 @@ id	val1	val2
 20	20	20
 30	30	30
 DELETE FROM t1 WHERE id=30;
-SHOW ENGINE rocksdb TRANSACTION STATUS;
+SHOW ENGINE ROCKSDB TRANSACTION STATUS;
 Type	Name	Status
 rocksdb		
 ============================================================
@@ -59,7 +59,7 @@ SNAPSHOTS
 LIST OF SNAPSHOTS FOR EACH SESSION:
 ---SNAPSHOT, ACTIVE NUM sec
 MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
-SHOW ENGINE rocksdb TRANSACTION STATUS
+SHOW ENGINE ROCKSDB TRANSACTION STATUS
 lock count 4, write count 4
 insert count 2, update count 1, delete count 1
 ----------LATEST DETECTED DEADLOCKS----------
@@ -68,7 +68,7 @@ END OF ROCKSDB TRANSACTION MONITOR OUTPUT
 =========================================
 
 ROLLBACK;
-SHOW ENGINE rocksdb TRANSACTION STATUS;
+SHOW ENGINE ROCKSDB TRANSACTION STATUS;
 Type	Name	Status
 rocksdb		
 ============================================================
@@ -85,7 +85,7 @@ END OF ROCKSDB TRANSACTION MONITOR OUTPUT
 
 START TRANSACTION;
 INSERT INTO t1 VALUES(40,40,40);
-SHOW ENGINE rocksdb TRANSACTION STATUS;
+SHOW ENGINE ROCKSDB TRANSACTION STATUS;
 Type	Name	Status
 rocksdb		
 ============================================================
@@ -97,7 +97,7 @@ SNAPSHOTS
 LIST OF SNAPSHOTS FOR EACH SESSION:
 ---SNAPSHOT, ACTIVE NUM sec
 MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
-SHOW ENGINE rocksdb TRANSACTION STATUS
+SHOW ENGINE ROCKSDB TRANSACTION STATUS
 lock count 1, write count 1
 insert count 1, update count 0, delete count 0
 ----------LATEST DETECTED DEADLOCKS----------
@@ -106,7 +106,7 @@ END OF ROCKSDB TRANSACTION MONITOR OUTPUT
 =========================================
 
 COMMIT;
-SHOW ENGINE rocksdb TRANSACTION STATUS;
+SHOW ENGINE ROCKSDB TRANSACTION STATUS;
 Type	Name	Status
 rocksdb		
 ============================================================
@@ -136,7 +136,7 @@ START TRANSACTION;
 INSERT INTO t2 VALUES(1,2,0),(10,20,30);
 UPDATE t2 SET value=3 WHERE id2=2;
 DELETE FROM t2 WHERE id1=10;
-SHOW ENGINE rocksdb TRANSACTION STATUS;
+SHOW ENGINE ROCKSDB TRANSACTION STATUS;
 Type	Name	Status
 rocksdb		
 ============================================================
@@ -148,7 +148,7 @@ SNAPSHOTS
 LIST OF SNAPSHOTS FOR EACH SESSION:
 ---SNAPSHOT, ACTIVE NUM sec
 MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
-SHOW ENGINE rocksdb TRANSACTION STATUS
+SHOW ENGINE ROCKSDB TRANSACTION STATUS
 lock count 4, write count 7
 insert count 2, update count 1, delete count 1
 ----------LATEST DETECTED DEADLOCKS----------
@@ -172,7 +172,7 @@ START TRANSACTION;
 INSERT INTO t2 VALUES(1,2,0),(10,20,30);
 UPDATE t2 SET value=3 WHERE id2=2;
 DELETE FROM t2 WHERE id1=10;
-SHOW ENGINE rocksdb TRANSACTION STATUS;
+SHOW ENGINE ROCKSDB TRANSACTION STATUS;
 Type	Name	Status
 rocksdb		
 ============================================================
@@ -184,7 +184,7 @@ SNAPSHOTS
 LIST OF SNAPSHOTS FOR EACH SESSION:
 ---SNAPSHOT, ACTIVE NUM sec
 MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
-SHOW ENGINE rocksdb TRANSACTION STATUS
+SHOW ENGINE ROCKSDB TRANSACTION STATUS
 lock count 4, write count 7
 insert count 2, update count 1, delete count 1
 ----------LATEST DETECTED DEADLOCKS----------

--- a/mysql-test/suite/rocksdb/r/max_row_locks.result
+++ b/mysql-test/suite/rocksdb/r/max_row_locks.result
@@ -2,7 +2,7 @@ create table t1 (id1 bigint, id2 bigint, c1 bigint, c2 bigint, c3 bigint, c4 big
 begin;
 select * from t1 where c3=1 for update;
 id1	id2	c1	c2	c3	c4	c5	c6	c7
-SHOW ENGINE rocksdb TRANSACTION STATUS;
+SHOW ENGINE ROCKSDB TRANSACTION STATUS;
 Type	Name	Status
 rocksdb		
 ============================================================
@@ -14,7 +14,7 @@ SNAPSHOTS
 LIST OF SNAPSHOTS FOR EACH SESSION:
 ---SNAPSHOT, ACTIVE NUM sec
 MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
-SHOW ENGINE rocksdb TRANSACTION STATUS
+SHOW ENGINE ROCKSDB TRANSACTION STATUS
 lock count 0, write count 0
 insert count 0, update count 0, delete count 0
 ----------LATEST DETECTED DEADLOCKS----------
@@ -34,7 +34,7 @@ id1	id2	c1	c2	c3	c4	c5	c6	c7
 108	0	108	0	0	0	0	0	108
 109	0	109	0	0	0	0	0	109
 110	0	110	0	0	0	0	0	110
-SHOW ENGINE rocksdb TRANSACTION STATUS;
+SHOW ENGINE ROCKSDB TRANSACTION STATUS;
 Type	Name	Status
 rocksdb		
 ============================================================
@@ -46,7 +46,7 @@ SNAPSHOTS
 LIST OF SNAPSHOTS FOR EACH SESSION:
 ---SNAPSHOT, ACTIVE NUM sec
 MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
-SHOW ENGINE rocksdb TRANSACTION STATUS
+SHOW ENGINE ROCKSDB TRANSACTION STATUS
 lock count 10, write count 0
 insert count 0, update count 0, delete count 0
 ----------LATEST DETECTED DEADLOCKS----------
@@ -59,7 +59,7 @@ set session rocksdb_lock_scanned_rows=on;
 begin;
 select * from t1 where c3=1 for update;
 id1	id2	c1	c2	c3	c4	c5	c6	c7
-SHOW ENGINE rocksdb TRANSACTION STATUS;
+SHOW ENGINE ROCKSDB TRANSACTION STATUS;
 Type	Name	Status
 rocksdb		
 ============================================================
@@ -71,7 +71,7 @@ SNAPSHOTS
 LIST OF SNAPSHOTS FOR EACH SESSION:
 ---SNAPSHOT, ACTIVE NUM sec
 MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
-SHOW ENGINE rocksdb TRANSACTION STATUS
+SHOW ENGINE ROCKSDB TRANSACTION STATUS
 lock count 1000, write count 0
 insert count 0, update count 0, delete count 0
 ----------LATEST DETECTED DEADLOCKS----------

--- a/mysql-test/suite/rocksdb/r/show_engine.result
+++ b/mysql-test/suite/rocksdb/r/show_engine.result
@@ -435,7 +435,7 @@ DROP TABLE t4;
 SHOW ENGINE rocksdb MUTEX;
 Type	Name	Status
 SHOW ENGINE ALL MUTEX;
-SHOW ENGINE rocksdb TRANSACTION STATUS;
+SHOW ENGINE ROCKSDB TRANSACTION STATUS;
 Type	Name	Status
 rocksdb		
 ============================================================
@@ -451,7 +451,7 @@ END OF ROCKSDB TRANSACTION MONITOR OUTPUT
 =========================================
 
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
-SHOW ENGINE rocksdb TRANSACTION STATUS;
+SHOW ENGINE ROCKSDB TRANSACTION STATUS;
 Type	Name	Status
 rocksdb		
 ============================================================
@@ -463,7 +463,7 @@ SNAPSHOTS
 LIST OF SNAPSHOTS FOR EACH SESSION:
 ---SNAPSHOT, ACTIVE NUM sec
 MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
-SHOW ENGINE rocksdb TRANSACTION STATUS
+SHOW ENGINE ROCKSDB TRANSACTION STATUS
 lock count 0, write count 0
 insert count 0, update count 0, delete count 0
 ----------LATEST DETECTED DEADLOCKS----------

--- a/mysql-test/suite/rocksdb/t/deadlock_tracking.test
+++ b/mysql-test/suite/rocksdb/t/deadlock_tracking.test
@@ -21,30 +21,25 @@ let $con3= `SELECT CONNECTION_ID()`;
 connection default;
 eval create table t (i int primary key) engine=$engine;
 insert into t values (1), (2), (3);
---replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /WAITING KEY: [0-9a-f]{16}/KEY/ /TRANSACTION ID: [0-9]*/TXN_ID/ /TIMESTAMP: [0-9]*/TSTAMP/
-show engine rocksdb transaction status;
+--source ../include/show_transaction_status.inc
 
 echo Deadlock #1;
 --source include/simple_deadlock.inc
 connection default;
---replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /WAITING KEY: [0-9a-f]{16}/KEY/ /TRANSACTION ID: [0-9]*/TXN_ID/ /TIMESTAMP: [0-9]*/TSTAMP/
-show engine rocksdb transaction status;
+--source ../include/show_transaction_status.inc
 
 echo Deadlock #2;
 --source include/simple_deadlock.inc
 connection default;
---replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /WAITING KEY: [0-9a-f]{16}/KEY/ /TRANSACTION ID: [0-9]*/TXN_ID/ /TIMESTAMP: [0-9]*/TSTAMP/
-show engine rocksdb transaction status;
+--source ../include/show_transaction_status.inc
 set global rocksdb_max_latest_deadlocks = 10;
 
 echo Deadlock #3;
 --source include/simple_deadlock.inc
 connection default;
---replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /WAITING KEY: [0-9a-f]{16}/KEY/ /TRANSACTION ID: [0-9]*/TXN_ID/ /TIMESTAMP: [0-9]*/TSTAMP/
-show engine rocksdb transaction status;
+--source ../include/show_transaction_status.inc
 set global rocksdb_max_latest_deadlocks = 1;
---replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /WAITING KEY: [0-9a-f]{16}/KEY/ /TRANSACTION ID: [0-9]*/TXN_ID/ /TIMESTAMP: [0-9]*/TSTAMP/
-show engine rocksdb transaction status;
+--source ../include/show_transaction_status.inc
 
 connection con3;
 set rocksdb_deadlock_detect_depth = 2;
@@ -93,8 +88,7 @@ rollback;
 
 connection default;
 set global rocksdb_max_latest_deadlocks = 5;
---replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /WAITING KEY: [0-9a-f]{16}/KEY/ /TRANSACTION ID: [0-9]*/TXN_ID/ /TIMESTAMP: [0-9]*/TSTAMP/
-show engine rocksdb transaction status;
+--source ../include/show_transaction_status.inc
 
 echo Deadlock #5;
 connection con1;
@@ -135,8 +129,7 @@ connection con3;
 rollback;
 
 connection default;
---replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /WAITING KEY: [0-9a-f]{16}/KEY/ /TRANSACTION ID: [0-9]*/TXN_ID/ /TIMESTAMP: [0-9]*/TSTAMP/
-show engine rocksdb transaction status;
+--source ../include/show_transaction_status.inc
 
 echo Deadlock #6;
 connection con1;
@@ -175,11 +168,9 @@ disconnect con3;
 set global rocksdb_lock_wait_timeout = @prior_lock_wait_timeout;
 set global rocksdb_deadlock_detect = @prior_deadlock_detect;
 drop table t;
---replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /WAITING KEY: [0-9a-f]{16}/KEY/ /TRANSACTION ID: [0-9]*/TXN_ID/ /INDEX_ID: [0-9a-f]*/IDX_ID/ /TIMESTAMP: [0-9]*/TSTAMP/
-show engine rocksdb transaction status;
+--source ../include/show_transaction_status.inc
 set global rocksdb_max_latest_deadlocks = 0;
 --echo # Clears deadlock buffer of any existent deadlocks.
 set global rocksdb_max_latest_deadlocks = @prior_max_latest_deadlocks;
---replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /WAITING KEY: [0-9a-f]{16}/KEY/ /TRANSACTION ID: [0-9]*/TXN_ID/ /INDEX_ID: [0-9a-f]*/IDX_ID/ /TIMESTAMP: [0-9]*/TSTAMP/
-show engine rocksdb transaction status;
+--source ../include/show_transaction_status.inc
 --source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/rocksdb/t/issue243_transactionStatus.test
+++ b/mysql-test/suite/rocksdb/t/issue243_transactionStatus.test
@@ -19,8 +19,7 @@ INSERT INTO t1 VALUES(1,1,1),(2,1,2);
 SELECT * FROM t1;
 UPDATE t1 SET val1=2 WHERE id=2;
 SELECT * FROM t1;
---replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /(ACTIVE) [0-9]+ /\1 NUM / /(thread id) [0-9]+/\1 TID/ /(thread handle) [0-9]+/\1 PTR/ /(query id) [0-9]+/\1 QID/ /(root) [a-z ]+/\1 ACTION/
-SHOW ENGINE rocksdb TRANSACTION STATUS;
+--source ../include/show_transaction_status.inc
 
 #
 # DB operations with Tansaction, insert_count, update_count, delete_count
@@ -34,20 +33,16 @@ SELECT * FROM t1;
 UPDATE t1 SET val1=20, val2=20 WHERE id=20;
 SELECT * FROM t1;
 DELETE FROM t1 WHERE id=30;
---replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /(ACTIVE) [0-9]+ /\1 NUM / /(thread id) [0-9]+/\1 TID/ /(thread handle) [0-9]+/\1 PTR/ /(query id) [0-9]+/\1 QID/ /(root) [a-z ]+/\1 ACTION/
-SHOW ENGINE rocksdb TRANSACTION STATUS;
+--source ../include/show_transaction_status.inc
 
 ROLLBACK;
---replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /(ACTIVE) [0-9]+ /\1 NUM / /(thread id) [0-9]+/\1 TID/ /(thread handle) [0-9]+/\1 PTR/ /(query id) [0-9]+/\1 QID/ /(root) [a-z ]+/\1 ACTION/
-SHOW ENGINE rocksdb TRANSACTION STATUS;
+--source ../include/show_transaction_status.inc
 
 START TRANSACTION;
 INSERT INTO t1 VALUES(40,40,40);
---replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /(ACTIVE) [0-9]+ /\1 NUM / /(thread id) [0-9]+/\1 TID/ /(thread handle) [0-9]+/\1 PTR/ /(query id) [0-9]+/\1 QID/ /(root) [a-z ]+/\1 ACTION/
-SHOW ENGINE rocksdb TRANSACTION STATUS;
+--source ../include/show_transaction_status.inc
 COMMIT;
---replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /(ACTIVE) [0-9]+ /\1 NUM / /(thread id) [0-9]+/\1 TID/ /(thread handle) [0-9]+/\1 PTR/ /(query id) [0-9]+/\1 QID/ /(root) [a-z ]+/\1 ACTION/
-SHOW ENGINE rocksdb TRANSACTION STATUS;
+--source ../include/show_transaction_status.inc
 
 SET AUTOCOMMIT=1;
 DROP TABLE t1;
@@ -73,8 +68,7 @@ INSERT INTO t2 VALUES(1,2,0),(10,20,30);
 UPDATE t2 SET value=3 WHERE id2=2;
 DELETE FROM t2 WHERE id1=10;
 
---replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /(ACTIVE) [0-9]+ /\1 NUM / /(thread id) [0-9]+/\1 TID/ /(thread handle) [0-9]+/\1 PTR/ /(query id) [0-9]+/\1 QID/ /(root) [a-z ]+/\1 ACTION/
-SHOW ENGINE rocksdb TRANSACTION STATUS;
+--source ../include/show_transaction_status.inc
 ROLLBACK;
 
 SET AUTOCOMMIT=1;
@@ -101,8 +95,7 @@ INSERT INTO t2 VALUES(1,2,0),(10,20,30);
 UPDATE t2 SET value=3 WHERE id2=2;
 DELETE FROM t2 WHERE id1=10;
 
---replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /(ACTIVE) [0-9]+ /\1 NUM / /(thread id) [0-9]+/\1 TID/ /(thread handle) [0-9]+/\1 PTR/ /(query id) [0-9]+/\1 QID/ /(root) [a-z ]+/\1 ACTION/
-SHOW ENGINE rocksdb TRANSACTION STATUS;
+--source ../include/show_transaction_status.inc
 ROLLBACK;
 
 SET AUTOCOMMIT=1;

--- a/mysql-test/suite/rocksdb/t/max_row_locks.test
+++ b/mysql-test/suite/rocksdb/t/max_row_locks.test
@@ -16,14 +16,12 @@ begin;
 select * from t1 where c3=1 for update;
 
 # This should report 0 row lock
---replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /(ACTIVE) [0-9]+ /\1 NUM / /(thread id) [0-9]+/\1 TID/ /(OS thread handle) [0-9a-f]+/\1 PTR/ /(query id) [0-9]+/\1 QID/ /(root) [a-z ]+/\1 ACTION/
-SHOW ENGINE rocksdb TRANSACTION STATUS;
+--source ../include/show_transaction_status.inc
 
 select * from t1 where c7 between 101 and 110 for update;
 
 # This should report 10 row locks
---replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /(ACTIVE) [0-9]+ /\1 NUM / /(thread id) [0-9]+/\1 TID/ /(OS thread handle) [0-9a-f]+/\1 PTR/ /(query id) [0-9]+/\1 QID/ /(root) [a-z ]+/\1 ACTION/
-SHOW ENGINE rocksdb TRANSACTION STATUS;
+--source ../include/show_transaction_status.inc
 
 rollback;
 
@@ -32,8 +30,7 @@ set session rocksdb_lock_scanned_rows=on;
 begin;
 select * from t1 where c3=1 for update;
 # This should report 1000 row locks
---replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /(ACTIVE) [0-9]+ /\1 NUM / /(thread id) [0-9]+/\1 TID/ /(OS thread handle) [0-9a-f]+/\1 PTR/ /(query id) [0-9]+/\1 QID/ /(root) [a-z ]+/\1 ACTION/
-SHOW ENGINE rocksdb TRANSACTION STATUS;
+--source ../include/show_transaction_status.inc
 
 rollback;
 set session rocksdb_lock_scanned_rows=off;

--- a/mysql-test/suite/rocksdb/t/show_engine.test
+++ b/mysql-test/suite/rocksdb/t/show_engine.test
@@ -67,20 +67,11 @@ SHOW ENGINE rocksdb MUTEX;
 SHOW ENGINE ALL MUTEX;
 --enable_result_log
 
-# The output from SHOW ENGINE ROCKSDB TRANSACTION STATUS has some
-# non-deterministic results.  Replace the timestamp with 'TIMESTAMP', the
-# number of seconds active with 'NUM', the thread id with 'TID' and the thread
-# pointer with 'PTR'.  This test may fail in the future if it is being run in
-# parallel with other tests as the number of snapshots would then be greater
-# than expected.  We may need to turn off the result log if that is the case.
---replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /(ACTIVE) [0-9]+ /\1 NUM / /(thread id) [0-9]+/\1 TID/ /(thread handle) [0-9]+/\1 PTR/ /(query id) [0-9]+/\1 QID/ /(root) [a-z ]+/\1 ACTION/
-SHOW ENGINE rocksdb TRANSACTION STATUS;
+--source ../include/show_transaction_status.inc
 
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
 
-#select sleep(10);
---replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /(ACTIVE) [0-9]+ /\1 NUM / /(thread id) [0-9]+/\1 TID/ /(thread handle) [0-9]+/\1 PTR/ /(query id) [0-9]+/\1 QID/ /(root) [a-z ]+/\1 ACTION/
-SHOW ENGINE rocksdb TRANSACTION STATUS;
+--source ../include/show_transaction_status.inc
 
 ROLLBACK;
 

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -1210,7 +1210,7 @@ Rdb_transaction *get_tx_from_thd(THD *const thd);
 void add_tmp_table_handler(THD *const thd, ha_rocksdb *rocksdb_handler);
 void remove_tmp_table_handler(THD *const thd, ha_rocksdb *rocksdb_handler);
 
-const rocksdb::ReadOptions &rdb_tx_acquire_snapshot(Rdb_transaction *tx);
+void rdb_tx_acquire_snapshot(Rdb_transaction &tx);
 
 [[nodiscard]] std::unique_ptr<rocksdb::Iterator> rdb_tx_get_iterator(
     THD *thd, rocksdb::ColumnFamilyHandle &cf, bool skip_bloom_filter,

--- a/storage/rocksdb/nosql_access.cc
+++ b/storage/rocksdb/nosql_access.cc
@@ -1504,7 +1504,7 @@ class select_exec {
     }
 
     bool start() {
-      rdb_tx_acquire_snapshot(m_tx);
+      rdb_tx_acquire_snapshot(*m_tx);
 
       return false;
     }

--- a/storage/rocksdb/rdb_compact_filter.h
+++ b/storage/rocksdb/rdb_compact_filter.h
@@ -236,9 +236,11 @@ class Rdb_compact_filter_factory : public rocksdb::CompactionFilterFactory {
   Rdb_compact_filter_factory(const Rdb_compact_filter_factory &) = delete;
   Rdb_compact_filter_factory &operator=(const Rdb_compact_filter_factory &) =
       delete;
-  Rdb_compact_filter_factory() {}
+  Rdb_compact_filter_factory(Rdb_compact_filter_factory &&) = delete;
+  Rdb_compact_filter_factory &operator=(Rdb_compact_filter_factory &&) = delete;
+  Rdb_compact_filter_factory() = default;
 
-  ~Rdb_compact_filter_factory() {}
+  ~Rdb_compact_filter_factory() = default;
 
   const char *Name() const override { return "Rdb_compact_filter_factory"; }
 


### PR DESCRIPTION
- Make m_earliest_snapshot_ts and m_read_opts protected fields in
  Rdb_transaction class. To replace
  their previous public uses, introduce new methods get_snapshot_timestamp &
  create_explicit_snapshot; use has_snapshot in more places.
  Remove unused return value for rdb_tx_acquire_snapshot.
- Factor out Rdb_transaction::on_finish for the common code in on_commit and
  on_rollback methods.
- Delete move constructor and move assignment operator for
  Rdb_compact_filter_factory class, replace "{}" with "= default" for other
  special members.
- Extract the gnarly regexes to make SHOW ENGINE ROCKSDB TRANSACTION STATUS
  output deterministic to a separate include file
  mysql-test/suite/rocksdb/include/show_transaction_status.inc
