### PR TITLE
Do not assume that std::int64_t is identical to long int

### DIFF
--- a/sql/xa.cc
+++ b/sql/xa.cc
@@ -22,6 +22,7 @@
 
 #include "sql/xa.h"
 
+#include <cstdint>
 #include <memory>
 #include <new>
 #include <string>
@@ -387,8 +388,8 @@ int ha_recover(xid_to_gtid_container *commit_list, Xa_state_list *xa_list,
   }
 
   fprintf(stderr,
-          "Opid recovery info: Smallest low watermark Opid %ld:%ld, "
-          "Largest max Opid %ld:%ld\n",
+          "Opid recovery info: Smallest low watermark Opid %" PRId64 ":%" PRId64
+          ", Largest max Opid %" PRId64 ":%" PRId64 "\n",
           info.smallest_lwm_opid.first, info.smallest_lwm_opid.second,
           info.largest_max_opid.first, info.largest_max_opid.second);
 

--- a/sql/xa/recovery.cc
+++ b/sql/xa/recovery.cc
@@ -283,11 +283,13 @@ static void recover_binlog_pos(const char *plugin_name, handlerton *hton,
   }
 
   // Track the smallest low watermark opid and the largest max opid
-  if (info->smallest_lwm_opid == std::make_pair(-1L, -1L) ||
+  if (info->smallest_lwm_opid ==
+          std::make_pair<std::int64_t, std::int64_t>(-1, -1) ||
       info->smallest_lwm_opid > lwm_opid) {
     info->smallest_lwm_opid = lwm_opid;
   }
-  if (info->largest_max_opid == std::make_pair(-1L, -1L) ||
+  if (info->largest_max_opid ==
+          std::make_pair<std::int64_t, std::int64_t>(-1, -1) ||
       info->largest_max_opid < max_opid) {
     info->largest_max_opid = max_opid;
   }

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -1416,8 +1416,8 @@ void srv_printf_innodb_binlog_position(FILE *file) /*!< in: output stream */
 
   std::string opid_info;
 
-  if (lwm_opid != std::make_pair(-1L, -1L) &&
-      max_opid != std::make_pair(-1L, -1L)) {
+  if (lwm_opid != std::make_pair<std::int64_t, std::int64_t>(-1, -1) &&
+      max_opid != std::make_pair<std::int64_t, std::int64_t>(-1, -1)) {
     opid_info += "LWM OPID " + std::to_string(lwm_opid.first) + ":" +
                  std::to_string(lwm_opid.second);
     opid_info += "\nMAX OPID " + std::to_string(max_opid.first) + ":" +

--- a/storage/innobase/trx/trx0sys.cc
+++ b/storage/innobase/trx/trx0sys.cc
@@ -268,14 +268,14 @@ static void write_binlog_position(const char *file_name, uint64_t offset,
 
   DBUG_EXECUTE_IF("innodb_skip_binlog_opid_update", { return; };);
 
-  if (lwm_opid != std::make_pair(-1L, -1L)) {
+  if (lwm_opid != std::make_pair<std::int64_t, std::int64_t>(-1, -1)) {
     mlog_write_ull(binlog_buf + TRX_SYS_MYSQL_LWM_OPID_TERM, lwm_opid.first,
                    mtr);
     mlog_write_ull(binlog_buf + TRX_SYS_MYSQL_LWM_OPID_INDEX, lwm_opid.second,
                    mtr);
   }
 
-  if (max_opid != std::make_pair(-1L, -1L)) {
+  if (max_opid != std::make_pair<std::int64_t, std::int64_t>(-1, -1)) {
     mlog_write_ull(binlog_buf + TRX_SYS_MYSQL_MAX_OPID_TERM, max_opid.first,
                    mtr);
     mlog_write_ull(binlog_buf + TRX_SYS_MYSQL_MAX_OPID_INDEX, max_opid.second,

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -6659,15 +6659,16 @@ static void rocksdb_recover_binlog_pos_internal(
     fprintf(stderr, "RocksDB: Last MySQL Gtid %s\n", marker->max_gtid);
   }
 
-  if (marker->lwm_opid != std::pair(-1L, -1L)) {
+  if (marker->lwm_opid != std::pair<std::int64_t, std::int64_t>(-1, -1)) {
     // NO_LINT_DEBUG
-    fprintf(stderr, "RocksDB: Low watermark binlog opid: %lu:%lu\n",
+    fprintf(stderr,
+            "RocksDB: Low watermark binlog opid: %" PRId64 ":%" PRId64 "\n",
             marker->lwm_opid.first, marker->lwm_opid.second);
   }
 
-  if (marker->max_opid != std::pair(-1L, -1L)) {
+  if (marker->max_opid != std::pair<std::int64_t, std::int64_t>(-1, -1)) {
     // NO_LINT_DEBUG
-    fprintf(stderr, "RocksDB: Max binlog opid: %lu:%lu\n",
+    fprintf(stderr, "RocksDB: Max binlog opid: %" PRId64 ":%" PRId64 "\n",
             marker->max_opid.first, marker->max_opid.second);
   }
 }
@@ -6727,8 +6728,10 @@ static bool rocksdb_update_binlog_pos(
   strcpy(marker.file, file);
   strcpy(marker.max_gtid, max_gtid_buf);
   marker.offset = *offset;
-  if (lwm_opid != std::make_pair(-1L, -1L)) marker.lwm_opid = lwm_opid;
-  if (max_opid != std::make_pair(-1L, -1L)) marker.max_opid = max_opid;
+  if (lwm_opid != std::make_pair<std::int64_t, std::int64_t>(-1, -1))
+    marker.lwm_opid = lwm_opid;
+  if (max_opid != std::make_pair<std::int64_t, std::int64_t>(-1, -1))
+    marker.max_opid = max_opid;
 
   if (binlog_manager.persist_pos(marker, sync)) return true;
 
@@ -7320,12 +7323,12 @@ static bool rocksdb_show_binlog_position(THD *const thd,
       << "BINLOG OFFSET " << marker.offset << "\n"
       << "MAX GTID " << marker.max_gtid << "\n";
 
-  if (marker.lwm_opid != std::make_pair(-1L, -1L)) {
+  if (marker.lwm_opid != std::make_pair<std::int64_t, std::int64_t>(-1, -1)) {
     oss << "LWM OPID " << marker.lwm_opid.first << ":" << marker.lwm_opid.second
         << "\n";
   }
 
-  if (marker.max_opid != std::make_pair(-1L, -1L)) {
+  if (marker.max_opid != std::make_pair<std::int64_t, std::int64_t>(-1, -1)) {
     oss << "MAX OPID " << marker.max_opid.first << ":" << marker.max_opid.second
         << "\n";
   }

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -5346,12 +5346,12 @@ void Rdb_binlog_manager::update(rocksdb::WriteBatchBase *const batch,
     return;
   };);
 
-  if (marker.lwm_opid != std::pair(-1L, -1L)) {
+  if (marker.lwm_opid != std::pair<std::int64_t, std::int64_t>(-1, -1)) {
     value_writer.write_uint64(marker.lwm_opid.first);
     value_writer.write_uint64(marker.lwm_opid.second);
   }
 
-  if (marker.max_opid != std::pair(-1L, -1L)) {
+  if (marker.max_opid != std::pair<std::int64_t, std::int64_t>(-1, -1)) {
     value_writer.write_uint64(marker.max_opid.first);
     value_writer.write_uint64(marker.max_opid.second);
   }


### PR DESCRIPTION
- printf int64_t values with PRId64
- Specify std::make_pair template arguments. Alternatively we could introduce a
  constexpr variable for uninitialized opids.

This fixes new macOS build regressions, only one example per error class:

sql/xa.cc:382:11: error: format specifies type 'long' but the argument has type 'long long' [-Werror,-Wformat]
          info.smallest_lwm_opid.first, info.smallest_lwm_opid.second,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~

storage/innobase/trx/trx0sys.cc:271:16: error: invalid operands to binary expression ('const std::pair<int64_t, int64_t>' (aka 'const pair<long long, long long>') and 'pair<typename __unwrap_ref_decay<long>::type, typename __unwrap_ref_decay<long>::type>' (aka 'pair<long, long>'))
  if (lwm_opid != std::make_pair(-1L, -1L)) {
      ~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~

Squash with 5f045b49ed3a2b451773dcebdf7b179fad768045