### PR TITLE
Enable file checksum for clone startup

### DIFF
--- a/mysql-test/suite/rocksdb_clone/r/checksum_verification_after_clone.result
+++ b/mysql-test/suite/rocksdb_clone/r/checksum_verification_after_clone.result
@@ -1,0 +1,29 @@
+CREATE TABLE t1(col1 INT PRIMARY KEY, col2 CHAR(64));
+INSERT INTO t1 VALUES(1, "string 1");
+INSERT INTO t1 VALUES(2, "string 2");
+INSERT INTO t1 VALUES(3, "string 3");
+INSTALL PLUGIN clone SONAME 'CLONE_PLUGIN';
+SET GLOBAL clone_autotune_concurrency = OFF;
+SET GLOBAL clone_max_concurrency = 8;
+SET GLOBAL clone_valid_donor_list = 'HOST:PORT';
+CLONE INSTANCE FROM USER@HOST:PORT IDENTIFIED BY '' DATA DIRECTORY = 'CLONE_DATADIR';
+select ID, STATE, ERROR_NO from performance_schema.clone_status;
+ID	STATE	ERROR_NO
+1	Completed	0
+select ID, STAGE, STATE from performance_schema.clone_progress;
+ID	STAGE	STATE
+1	DROP DATA	Completed
+1	FILE COPY	Completed
+1	PAGE COPY	Completed
+1	SST COPY	Completed
+1	REDO COPY	Completed
+1	FILE SYNC	Completed
+1	RESTART	Not Started
+1	RECOVERY	Not Started
+# restart: --rocksdb-file-checksums=CHECKSUMS_WRITE_AND_VERIFY_ON_CLONE --datadir=CLONE_DATADIR --log-error=MYSQLD_LOG1
+include/assert_grep.inc [Check checksum verification]
+# restart: --rocksdb-file-checksums=CHECKSUMS_WRITE_AND_VERIFY_ON_CLONE --datadir=CLONE_DATADIR --log-error=MYSQLD_LOG2
+include/assert_grep.inc [Check checksum verification]
+# restart:
+DROP TABLE t1;
+UNINSTALL PLUGIN clone;

--- a/mysql-test/suite/rocksdb_clone/t/checksum_verification_after_clone.test
+++ b/mysql-test/suite/rocksdb_clone/t/checksum_verification_after_clone.test
@@ -1,0 +1,58 @@
+--source include/have_rocksdb.inc
+
+--let $HOST = 127.0.0.1
+--let $PORT =`select @@port`
+--let $USER = root
+--let remote_clone = 1
+
+--let MYSQLD_LOG1=$MYSQL_TMP_DIR/restart_after_clone.log
+--let MYSQLD_LOG2=$MYSQL_TMP_DIR/regular_restart.log
+--let CLONE_DATADIR = $MYSQL_TMP_DIR/data_new
+
+CREATE TABLE t1(col1 INT PRIMARY KEY, col2 CHAR(64));
+
+INSERT INTO t1 VALUES(1, "string 1");
+INSERT INTO t1 VALUES(2, "string 2");
+INSERT INTO t1 VALUES(3, "string 3");
+
+--replace_result $CLONE_PLUGIN CLONE_PLUGIN
+--eval INSTALL PLUGIN clone SONAME '$CLONE_PLUGIN'
+
+--source ../../clone/include/clone_command.inc
+
+--connection default
+# Restart server on cloned data directory
+--replace_result $CLONE_DATADIR CLONE_DATADIR $MYSQLD_LOG1 MYSQLD_LOG1
+--let restart_parameters="restart: --rocksdb-file-checksums=CHECKSUMS_WRITE_AND_VERIFY_ON_CLONE --datadir=$CLONE_DATADIR --log-error=$MYSQLD_LOG1"
+--source include/restart_mysqld.inc
+
+--let $assert_file = $MYSQLD_LOG1
+--let $assert_count = 1
+
+--let $assert_text = Check checksum verification
+--let $assert_select = Verifying file checksums...
+--source include/assert_grep.inc
+	
+--remove_file $MYSQLD_LOG1
+
+--replace_result $CLONE_DATADIR CLONE_DATADIR $MYSQLD_LOG2 MYSQLD_LOG2
+--let restart_parameters="restart: --rocksdb-file-checksums=CHECKSUMS_WRITE_AND_VERIFY_ON_CLONE --datadir=$CLONE_DATADIR --log-error=$MYSQLD_LOG2"
+--source include/restart_mysqld.inc
+
+--let $assert_file = $MYSQLD_LOG2
+--let $assert_count = 0
+
+--let $assert_text = Check checksum verification
+--let $assert_select = Verifying file checksums...
+--source include/assert_grep.inc
+	
+--remove_file $MYSQLD_LOG2
+
+# clean up
+--let restart_parameters="restart:"
+--source include/restart_mysqld.inc
+
+DROP TABLE t1;
+UNINSTALL PLUGIN clone;
+
+--force-rmdir $CLONE_DATADIR

--- a/storage/rocksdb/clone/common.cc
+++ b/storage/rocksdb/clone/common.cc
@@ -235,6 +235,16 @@ void fixup_on_startup() {
   if (path_exists(current_datadir_in_progress_marker_path))
     rdb_fatal_error("In-progress clone marker found in the MyRocks datadir");
 
+  // Enable sst file checksum verification if
+  // CHECKSUMS_WRITE_AND_VERIFY_ON_CLONE flag is enabled and this restart is
+  // after a clone.
+  if (myrocks::rocksdb_file_checksums ==
+          myrocks::file_checksums_type::CHECKSUMS_WRITE_AND_VERIFY_ON_CLONE &&
+      temp_dir_exists_abort_if_not_dir(in_place_temp_datadir)) {
+    myrocks::rocksdb_file_checksums =
+        myrocks::file_checksums_type::CHECKSUMS_WRITE_AND_VERIFY;
+  }
+
   move_temp_dir_to_destination(in_place_temp_datadir, in_place_old_datadir,
                                rocksdb_datadir);
 

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -919,12 +919,7 @@ static bool rocksdb_debug_skip_bloom_filter_check_on_iterator_bounds = 0;
 bool rocksdb_enable_autoinc_compact_mode = false;
 char max_timestamp_uint64[ROCKSDB_SIZEOF_TTL_RECORD];
 
-enum file_checksums_type {
-  CHECKSUMS_OFF = 0,
-  CHECKSUMS_WRITE_ONLY,
-  CHECKSUMS_WRITE_AND_VERIFY
-};
-static ulong rocksdb_file_checksums = file_checksums_type::CHECKSUMS_OFF;
+ulong rocksdb_file_checksums = file_checksums_type::CHECKSUMS_OFF;
 static std::time_t last_binlog_ttl_compaction_ts = std::time(nullptr);
 
 static std::atomic<uint64_t> rocksdb_row_lock_deadlocks(0);
@@ -1171,7 +1166,7 @@ static TYPELIB read_free_rpl_typelib = {array_elements(read_free_rpl_names) - 1,
  * myrocks::rocksdb_file_checksum_type */
 static const char *file_checksums_names[] = {
     "CHECKSUMS_OFF", "CHECKSUMS_WRITE_ONLY", "CHECKSUMS_WRITE_AND_VERIFY",
-    NullS};
+    "CHECKSUMS_WRITE_AND_VERIFY_ON_CLONE", NullS};
 
 static TYPELIB file_checksums_typelib = {
     array_elements(file_checksums_names) - 1, "file_checksums_typelib",
@@ -8414,7 +8409,7 @@ static int rocksdb_init_internal(void *const p) {
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
-  if (rocksdb_file_checksums >=
+  if (rocksdb_file_checksums ==
       file_checksums_type::CHECKSUMS_WRITE_AND_VERIFY) {
     LogPluginErrMsg(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
                     "Verifying file checksums...");

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -127,6 +127,13 @@ enum TABLE_TYPE {
   USER_TABLE = 1,
 };
 
+enum file_checksums_type {
+  CHECKSUMS_OFF = 0,
+  CHECKSUMS_WRITE_ONLY,
+  CHECKSUMS_WRITE_AND_VERIFY,
+  CHECKSUMS_WRITE_AND_VERIFY_ON_CLONE,
+};
+
 class Mrr_rowid_source;
 
 uint32_t rocksdb_perf_context_level(THD *const thd);
@@ -1303,6 +1310,8 @@ extern char *rocksdb_datadir;
 
 extern uint rocksdb_clone_checkpoint_max_age;
 extern uint rocksdb_clone_checkpoint_max_count;
+
+extern ulong rocksdb_file_checksums;
 
 extern unsigned long long rocksdb_converter_record_cached_length;
 


### PR DESCRIPTION
Summary: This change is to enable file checksum check only for recipients of clone. For regular startup, we don't do the sst file checksum check.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: