### PR TITLE
MyRocks: allocate WriteBatch objects directly on stack or in containing object

### DIFF
--- a/storage/rocksdb/rdb_cf_manager.cc
+++ b/storage/rocksdb/rdb_cf_manager.cc
@@ -283,8 +283,7 @@ int Rdb_cf_manager::remove_dropped_cf(Rdb_dict_manager *const dict_manager,
                                       const uint32 &cf_id) {
   dict_manager->assert_lock_held();
   RDB_MUTEX_LOCK_CHECK(m_mutex);
-  const std::unique_ptr<rocksdb::WriteBatch> wb = dict_manager->begin();
-  rocksdb::WriteBatch *const batch = wb.get();
+  auto batch = Rdb_dict_manager::begin();
 
   const auto it = m_cf_id_map.find(cf_id);
   if (it == m_cf_id_map.end()) {
@@ -443,8 +442,7 @@ int Rdb_cf_manager::drop_cf(Rdb_ddl_manager *const ddl_manager,
   // we don't delete handle object. Here we mark the column family
   // as dropped.
 
-  const std::unique_ptr<rocksdb::WriteBatch> wb = dict_manager->begin();
-  rocksdb::WriteBatch *const batch = wb.get();
+  auto batch = Rdb_dict_manager::begin();
 
   dict_manager->add_dropped_cf(batch, cf_id);
   dict_manager->commit(batch);
@@ -483,8 +481,7 @@ int Rdb_cf_manager::create_cf_flags_if_needed(
       return HA_EXIT_FAILURE;
     }
   } else {
-    const auto wb = dict_manager.begin();
-    rocksdb::WriteBatch *const batch = wb.get();
+    auto batch = Rdb_dict_manager::begin();
 
     dict_manager.add_cf_flags(batch, cf_id, flags);
     dict_manager.commit(batch);


### PR DESCRIPTION
This saves one level of indirection and an extra heap allocation.

- Rdb_writebatch_impl: remove pointer from m_batch field, make is_tx_started
  return true instead of checking the pointer, remove pointer check from
  rollback_stmt, remove new/delete from the constructor and the destructor.
- Make Rdb_dict_manager::begin return object directly instead of a unique_ptr
  and make this method static.
- In the affected callstacks, replace WriteBatchBase / WriteBatch pointer
  arguments with reference ones, remove an unused error return from
  Rdb_dict_manager::commit and any "!= nullptr" assertions.
- Rdb_transaction: change get_write_batch return type to WriteBatchBase
  reference instead of a pointer.
- Add [[nodiscard]] to touched methods, although not universally, as several
  methods have their return values ignored. Remove redundant const from by-value
  parameters.
