### PR TITLE
Fix GCC build regression

### DIFF
--- a/mysys/charset.cc
+++ b/mysys/charset.cc
@@ -226,10 +226,9 @@ int MY_CHARSET_LOADER::add_collation(CHARSET_INFO *cs) {
        (cs->number = get_collation_number_internal(cs->m_coll_name))) &&
       cs->number < array_elements(all_charsets)) {
     if (!all_charsets[cs->number]) {
-      if (!(all_charsets[cs->number] =
-                (CHARSET_INFO *)my_once_alloc(sizeof(CHARSET_INFO), MYF(0))))
+      if (!(all_charsets[cs->number] = (CHARSET_INFO *)my_once_alloc(
+                sizeof(CHARSET_INFO), MYF(MY_ZEROFILL))))
         return MY_XML_ERROR;
-      memset(all_charsets[cs->number], 0, sizeof(CHARSET_INFO));
     } else if (all_charsets[cs->number]->state & MY_CS_COMPILED) {
       // Disallow overwriting compiled character sets
       clear_cs_info(cs);


### PR DESCRIPTION
This fixes

mysys/charset.cc: In member function 'virtual int MY_CHARSET_LOADER::add_collation(CHARSET_INFO*)':
mysys/charset.cc:232:13: error: 'void* memset(void*, int, size_t)' clearing an object of type 'struct CHARSET_INFO' with no trivial copy-assignment; use value-initialization instead [-Werror=class-memaccess]
  232 |       memset(all_charsets[cs->number], 0, sizeof(CHARSET_INFO));
      |       ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from mysys/charset.cc:43:
include/m_ctype.h:383:8: note: 'struct CHARSET_INFO' declared here
  383 | struct CHARSET_INFO {
      |        ^~~~~~~~~~~~

Fix by removing memset and passing MY_ZEROFILL flag to the allocation function
instead.

Squash with 6637b51c7df3fb8e2c4994dd0358acb92f7ba017
