### PR TITLE
Fix LLVM 14 build regression under macOS

### DIFF
--- a/sql/xa/recovery.cc
+++ b/sql/xa/recovery.cc
@@ -231,11 +231,13 @@ static void recover_binlog_pos(const char *plugin_name, handlerton *hton,
     *info->binlog_pos = binlog_pos;
 
     // Track the smallest low watermark opid and the largest max opid
-    if (info->smallest_lwm_opid == std::make_pair(-1L, -1L) ||
+    if (info->smallest_lwm_opid ==
+            std::make_pair<std::int64_t, std::int64_t>(-1, -1) ||
         info->smallest_lwm_opid > lwm_opid) {
       info->smallest_lwm_opid = lwm_opid;
     }
-    if (info->largest_max_opid == std::make_pair(-1L, -1L) ||
+    if (info->largest_max_opid ==
+            std::make_pair<std::int64_t, std::int64_t>(-1, -1) ||
         info->largest_max_opid < max_opid) {
       info->largest_max_opid = max_opid;
     }


### PR DESCRIPTION
This fixes, trivially:

sql/xa/recovery.cc:234:33: error: invalid operands to binary expression ('std::pair<int64_t, int64_t>' (aka 'pair<long long, long long>') and 'pair<typename __unwrap_ref_decay<long>::type, typename __unwrap_ref_decay<long>::type>' (aka 'pair<long, long>'))
    if (info->smallest_lwm_opid == std::make_pair(-1L, -1L) ||
        ~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~

Squash with 9fc35fa64fb68b443d632e831db50ab02ac9bfce

This fixes the same class of errors as 2dc2bdd4c1b1a63b48ff61610702d0dc3a43dca1,
but the current error does not trigger with XCode clang for some reason, and is
only visible with LLVM 14 (possibly other versions too) from Homebrew.
