### PR TITLE
Cast an enum class argument to int before printf-formatting it

### DIFF
--- a/storage/rocksdb/rdb_bulk_load.cc
+++ b/storage/rocksdb/rdb_bulk_load.cc
@@ -102,7 +102,7 @@ class Rdb_bulk_load_manager {
     } else {
       assert(false);
       LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
-                      "unexpected bulk load type %d", type);
+                      "unexpected bulk load type %d", static_cast<int>(type));
       return HA_EXIT_FAILURE;
     }
 


### PR DESCRIPTION
This fixes a LLVM 17 build regression:

storage/rocksdb/rdb_bulk_load.cc:105:55: error: format specifies type 'int' but the argument has type 'Rdb_bulk_load_type' [-Werror,-Wformat]
  105 |                       "unexpected bulk load type %d", type);
      |                                                  ~~   ^~~~
      |                                                       static_cast<int>( )
include/mysql/components/services/log_builtins.h:838:66: note: expanded from macro 'LogPluginErrMsg'
  838 |       .message_quoted("Plugin " LOG_COMPONENT_TAG " reported", ##__VA_ARGS__)
      |                                                                  ^~~~~~~~~~~
