### PR TITLE
Fix LLVM 18 compilation errors

### DIFF
--- a/include/m_ctype.h
+++ b/include/m_ctype.h
@@ -380,40 +380,43 @@ extern MY_CHARSET_HANDLER my_charset_ascii_handler;
 extern MY_CHARSET_HANDLER my_charset_ucs2_handler;
 
 /* See strings/CHARSET_INFO.txt about information on this structure  */
+// If upstream adds or changes any fields, keep them zero-initialized.
 struct CHARSET_INFO {
-  uint number;
-  uint primary_number;
-  uint binary_number;
-  std::atomic<uint> state;
-  const char *csname;
-  const char *m_coll_name;
-  const char *comment;
-  const char *tailoring;
-  struct Coll_param *coll_param;
-  const uchar *ctype;
-  const uchar *to_lower;
-  const uchar *to_upper;
-  const uchar *sort_order;
-  struct MY_UCA_INFO *uca; /* This can be changed in apply_one_rule() */
-  const uint16 *tab_to_uni;
-  const MY_UNI_IDX *tab_from_uni;
-  const MY_UNICASE_INFO *caseinfo;
-  const struct lex_state_maps_st *state_maps; /* parser internal data */
-  const uchar *ident_map;                     /* parser internal data */
-  uint strxfrm_multiply;
-  uchar caseup_multiply;
-  uchar casedn_multiply;
-  uint mbminlen;
-  uint mbmaxlen;
-  uint mbmaxlenlen;
-  my_wc_t min_sort_char;
-  my_wc_t max_sort_char; /* For LIKE optimization */
-  uchar pad_char;
-  bool escape_with_backslash_is_dangerous;
-  uchar levels_for_compare;
+  uint number{0U};
+  uint primary_number{0U};
+  uint binary_number{0U};
+  std::atomic<uint> state{0U};
+  const char *csname{nullptr};
+  const char *m_coll_name{nullptr};
+  const char *comment{nullptr};
+  const char *tailoring{nullptr};
+  struct Coll_param *coll_param{nullptr};
+  const uchar *ctype{nullptr};
+  const uchar *to_lower{nullptr};
+  const uchar *to_upper{nullptr};
+  const uchar *sort_order{nullptr};
+  /* This can be changed in apply_one_rule() */
+  struct MY_UCA_INFO *uca{nullptr};
+  const uint16 *tab_to_uni{nullptr};
+  const MY_UNI_IDX *tab_from_uni{nullptr};
+  const MY_UNICASE_INFO *caseinfo{nullptr};
+  /* parser internal data */
+  const struct lex_state_maps_st *state_maps{nullptr};
+  const uchar *ident_map{nullptr}; /* parser internal data */
+  uint strxfrm_multiply{0U};
+  uchar caseup_multiply{0};
+  uchar casedn_multiply{0};
+  uint mbminlen{0U};
+  uint mbmaxlen{0U};
+  uint mbmaxlenlen{0U};
+  my_wc_t min_sort_char{0UL};
+  my_wc_t max_sort_char{0UL}; /* For LIKE optimization */
+  uchar pad_char{0};
+  bool escape_with_backslash_is_dangerous{false};
+  uchar levels_for_compare{0};
 
-  MY_CHARSET_HANDLER *cset;
-  MY_COLLATION_HANDLER *coll;
+  MY_CHARSET_HANDLER *cset{nullptr};
+  MY_COLLATION_HANDLER *coll{nullptr};
 
   /**
     If this collation is PAD_SPACE, it collates as if all inputs were
@@ -422,7 +425,7 @@ struct CHARSET_INFO {
 
     Note that this is fundamentally about the behavior of coll->strnxfrm.
   */
-  enum Pad_attribute pad_attribute;
+  enum Pad_attribute pad_attribute { static_cast<Pad_attribute>(0) };
 };
 #define ILLEGAL_CHARSET_INFO_NUMBER (~0U)
 

--- a/mysys/charset.cc
+++ b/mysys/charset.cc
@@ -226,9 +226,10 @@ int MY_CHARSET_LOADER::add_collation(CHARSET_INFO *cs) {
        (cs->number = get_collation_number_internal(cs->m_coll_name))) &&
       cs->number < array_elements(all_charsets)) {
     if (!all_charsets[cs->number]) {
-      if (!(all_charsets[cs->number] = (CHARSET_INFO *)my_once_alloc(
-                sizeof(CHARSET_INFO), MYF(MY_ZEROFILL))))
+      if (!(all_charsets[cs->number] =
+                (CHARSET_INFO *)my_once_alloc(sizeof(CHARSET_INFO), MYF(0))))
         return MY_XML_ERROR;
+      new (all_charsets[cs->number]) CHARSET_INFO;
     } else if (all_charsets[cs->number]->state & MY_CS_COMPILED) {
       // Disallow overwriting compiled character sets
       clear_cs_info(cs);

--- a/strings/conf_to_src.cc
+++ b/strings/conf_to_src.cc
@@ -289,7 +289,6 @@ int main(int argc, char **argv [[maybe_unused]]) {
     exit(EXIT_FAILURE);
   }
 
-  memset(&ncs, 0, sizeof(ncs));
   memset(&all_charsets, 0, sizeof(all_charsets));
 
   sprintf(filename, "%s/%s", argv[1], "Index.xml");

--- a/strings/ctype.cc
+++ b/strings/ctype.cc
@@ -300,7 +300,7 @@ typedef struct my_cs_file_info {
 } MY_CHARSET_FILE;
 
 static void my_charset_file_reset_charset(MY_CHARSET_FILE *i) {
-  memset(&i->cs, 0, sizeof(i->cs));
+  new (&i->cs) CHARSET_INFO;
 }
 
 static void my_charset_file_reset_collation(MY_CHARSET_FILE *i) {


### PR DESCRIPTION
- my_charset_file_reset_charset: placement-new construct an new default object
  instead of memset'ing it to zero, fixing [1]
- strings/conf_to_src.cc: do not memset an object that is already
  default-initialized to zero, fixing [2]

Squash with 6637b51c7df3fb8e2c4994dd0358acb92f7ba017

[1]:

strings/ctype.cc: In function ‘void my_charset_file_reset_charset(MY_CHARSET_FILE*)’:
strings/ctype.cc:303:9: error: ‘void* memset(void*, int, size_t)’ clearing an object of type ‘struct CHARSET_INFO’ with no trivial copy-assignment; use value-initialization instead [-Werror=class-memaccess]
  303 |   memset(&i->cs, 0, sizeof(i->cs));
      |   ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from strings/ctype.cc:36:
include/m_ctype.h:383:8: note: ‘struct CHARSET_INFO’ declared here
  383 | struct CHARSET_INFO {
      |        ^~~~~~~~~~~~

[2]:

strings/conf_to_src.cc: In function ‘int main(int, char**)’:
strings/conf_to_src.cc:292:9: error: ‘void* memset(void*, int, size_t)’ clearing an object of type ‘struct CHARSET_INFO’ with no trivial copy-assignment; use value-initialization instead [-Werror=class-memaccess]
  292 |   memset(&ncs, 0, sizeof(ncs));
      |   ~~~~~~^~~~~~~~~~~~~~~~~~~~~~
In file included from strings/conf_to_src.cc:32:
include/m_ctype.h:383:8: note: ‘struct CHARSET_INFO’ declared here
  383 | struct CHARSET_INFO {
      |        ^~~~~~~~~~~~
