### PR TITLE
Skip drop system tables during clone drop user data

### DIFF
--- a/mysql-test/suite/rocksdb_clone/r/ddse_debug.result
+++ b/mysql-test/suite/rocksdb_clone/r/ddse_debug.result
@@ -1,0 +1,23 @@
+call mtr.add_suppression("Clone removing all user data for provisioning: Started");
+call mtr.add_suppression("Clone removing all user data for provisioning: Finished");
+Install clone plugin on recipient server
+INSTALL PLUGIN clone SONAME 'CLONE_PLUGIN';
+CREATE TABLE t_recipient(col1 INT PRIMARY KEY, col2 int);
+INSERT INTO t_recipient VALUES(1, 10);
+CREATE UNDO TABLESPACE undo_005 ADD DATAFILE 'undo_005.ibu';
+CREATE TABLESPACE tbs1_recipient ADD DATAFILE 'tbs1_data1.ibd';
+INSTALL PLUGIN clone SONAME 'CLONE_PLUGIN';
+select @@default_dd_system_storage_engine;
+@@default_dd_system_storage_engine
+InnoDB
+SET DEBUG_SYNC = 'clone_after_drop_user_data SIGNAL check_user_table WAIT_FOR resume_clone';
+SET GLOBAL clone_valid_donor_list = 'HOST:PORT';
+CLONE INSTANCE FROM USER@HOST:PORT IDENTIFIED BY '' ;
+SET DEBUG_SYNC = 'now WAIT_FOR check_user_table';
+select count(*) > 0 from mysql.user;
+count(*) > 0
+1
+SET DEBUG_SYNC = 'now SIGNAL resume_clone';
+Uninstall clone plugin on recipient server
+UNINSTALL PLUGIN clone;
+UNINSTALL PLUGIN clone;

--- a/mysql-test/suite/rocksdb_clone/t/ddse_debug.cnf
+++ b/mysql-test/suite/rocksdb_clone/t/ddse_debug.cnf
@@ -1,0 +1,10 @@
+# Test remote clone command to replace data directory
+!include ../../clone/t/remote_dml_replace.cnf
+
+[mysqld.1]
+default_storage_engine=RocksDB
+default_dd_system_storage_engine=InnoDB
+
+[mysqld.2]
+default_storage_engine=RocksDB
+default_dd_system_storage_engine=InnoDB

--- a/mysql-test/suite/rocksdb_clone/t/ddse_debug.test
+++ b/mysql-test/suite/rocksdb_clone/t/ddse_debug.test
@@ -1,0 +1,47 @@
+--source include/have_rocksdb.inc
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+
+call mtr.add_suppression("Clone removing all user data for provisioning: Started");
+call mtr.add_suppression("Clone removing all user data for provisioning: Finished");
+
+--let $HOST = 127.0.0.1
+--let $PORT = `select @@port`
+--let $USER = root
+--let remote_clone = 1
+--let clone_remote_replace = 1
+--let clone_inst_number = 2
+--let inst_monitor = 1
+--let clone_connections = 2
+
+--source ../../clone/include/clone_connection_begin.inc
+
+--replace_result $CLONE_PLUGIN CLONE_PLUGIN
+--eval INSTALL PLUGIN clone SONAME '$CLONE_PLUGIN'
+
+--connection clone_conn_1
+select @@default_dd_system_storage_engine;
+SET DEBUG_SYNC = 'clone_after_drop_user_data SIGNAL check_user_table WAIT_FOR resume_clone';
+
+--replace_result $HOST HOST $PORT PORT
+--eval SET GLOBAL clone_valid_donor_list = '$HOST:$PORT'
+
+--replace_result $HOST HOST $PORT PORT $USER USER
+--send_eval CLONE INSTANCE FROM $USER@$HOST:$PORT IDENTIFIED BY '' 
+
+--connection clone_conn_2  
+SET DEBUG_SYNC = 'now WAIT_FOR check_user_table';
+
+# quick check mysql.user table still exists
+select count(*) > 0 from mysql.user;
+
+SET DEBUG_SYNC = 'now SIGNAL resume_clone';
+
+--connection clone_conn_1
+--reap
+
+--source ../../clone/include/clone_connection_end.inc
+
+# cleanup
+--connection default 
+UNINSTALL PLUGIN clone;

--- a/storage/innobase/clone/clone0api.cc
+++ b/storage/innobase/clone/clone0api.cc
@@ -1889,8 +1889,8 @@ class Fixup_data {
     }
 
     /* Skip DD system tables. */
-    if (table->is_explicit_tablespace() &&
-        table->tablespace_id() == dd::Dictionary_impl::dd_tablespace_id()) {
+    if (dd::get_dictionary()->is_dd_table_name(schema_name, table_name) ||
+        dd::get_dictionary()->is_system_table_name(schema_name, table_name)) {
       return (true);
     }
 
@@ -2458,6 +2458,7 @@ static int clone_drop_user_data(THD *thd, bool allow_threads) {
   }
   ib::info(ER_IB_CLONE_SQL) << "Clone Drop: finished successfully";
   ib::warn(ER_IB_CLONE_USER_DATA, "Finished");
+  DEBUG_SYNC_C("clone_after_drop_user_data");
   return (0);
 }
 


### PR DESCRIPTION
For MyRocks DDSE, its system table doesn't have valid tablespace id, thus these system tables(such as mysql.user) in the recipient instance will be droped during drop user data stage. if at same time,  some automations may check the instance and found out the instance doesn't have these important tables. 

The change is to use table name to check whether these table are DD/systems tables 