### PR TITLE
MyRocks: cleanup Rdb_convert_to_record_key_decoder class

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -4382,7 +4382,7 @@ class Rdb_transaction {
 
   int finish_bulk_load(bool *is_critical_error = nullptr,
                        bool print_client_error = true,
-                       TABLE *table_arg = nullptr) {
+                       const TABLE *table_arg = nullptr) {
     int rtn =
         commit_bulk_load(is_critical_error, print_client_error, table_arg);
     auto ctx = get_bulk_load_ctx();
@@ -4394,7 +4394,7 @@ class Rdb_transaction {
   /* Finish bulk loading for all table handlers belongs to one connection */
   int commit_bulk_load(bool *is_critical_error = nullptr,
                        bool print_client_error = true,
-                       TABLE *table_arg = nullptr) {
+                       const TABLE *table_arg = nullptr) {
     auto ctx = get_bulk_load_ctx();
     if (ctx->num_bulk_load() == 0) {
       if (is_critical_error) {
@@ -4577,7 +4577,7 @@ class Rdb_transaction {
                 break;
               }
               for (uint i = 0; i < keydef->partial_index_keyparts(); i++) {
-                if (keydef->read_memcmp_key_part(&reader, i) > 0) {
+                if (keydef->read_memcmp_key_part(reader, i) > 0) {
                   rc2 = handle_rocksdb_corrupt_data_error(m_thd);
                   break;
                 }
@@ -4683,7 +4683,7 @@ class Rdb_transaction {
                 message shows the duplicate record.
                 */
               if (table_arg &&
-                  keydef->unpack_record(table_arg, table_arg->record[0],
+                  keydef->unpack_record(*table_arg, table_arg->record[0],
                                         &merge_key, &merge_val, false)) {
                 /* Should never reach here */
                 assert(0);
@@ -10570,7 +10570,7 @@ int ha_rocksdb::open(const char *const name,
   init_with_fields();
 
   /* Initialize decoder */
-  m_converter.reset(new Rdb_converter(ha_thd(), m_tbl_def, table, table_def));
+  m_converter.reset(new Rdb_converter(ha_thd(), m_tbl_def, *table, table_def));
 
   /*
      Update m_ttl_bytes address to same as Rdb_converter's m_ttl_bytes.
@@ -11778,7 +11778,7 @@ int ha_rocksdb::create(const char *const name, TABLE *const table_arg,
   if (old_tbl != nullptr) {
     if (thd->lex->sql_command == SQLCOM_TRUNCATE) {
       DBUG_RETURN(truncate_table(old_tbl, create_info->actual_user_table_name,
-                                 table_arg, create_info->auto_increment_value,
+                                 *table_arg, create_info->auto_increment_value,
                                  table_def));
     } else {
       my_error(ER_METADATA_INCONSISTENCY, MYF(0), str.c_str());
@@ -11811,7 +11811,8 @@ int ha_rocksdb::create(const char *const name, TABLE *const table_arg,
 */
 int ha_rocksdb::truncate_table(Rdb_tbl_def *tbl_def_arg,
                                const std::string &actual_user_table_name,
-                               TABLE *table_arg, ulonglong auto_increment_value,
+                               const TABLE &table_arg,
+                               ulonglong auto_increment_value,
                                dd::Table *table_def) {
   DBUG_ENTER_FUNC();
 
@@ -11859,7 +11860,7 @@ int ha_rocksdb::truncate_table(Rdb_tbl_def *tbl_def_arg,
     Attempt to create the table. If this succeeds, then drop the old table.
     Otherwise, try to restore it.
   */
-  err = create_table(orig_tablename, actual_user_table_name, *table_arg,
+  err = create_table(orig_tablename, actual_user_table_name, table_arg,
                      auto_increment_value, table_def, table_type);
   bool should_remove_old_table = true;
 
@@ -11922,7 +11923,7 @@ int ha_rocksdb::delete_all_rows() {
   // TODO(pgl): Transaction::Clear to clear the current intrinsic table write
   // batch.
   DBUG_RETURN(truncate_table(
-      m_tbl_def, "" /* actual_user_table_name */, table,
+      m_tbl_def, "" /* actual_user_table_name */, *table,
       table->found_next_number_field ? 1 : 0 /* auto_increment_value */,
       nullptr));
 }
@@ -12071,7 +12072,7 @@ int ha_rocksdb::secondary_index_read(const int keyno, uchar *const buf,
       }
 
       const uint new_packed_size =
-          kd.pack_record(table, m_pack_buffer, buf, m_sk_packed_tuple_updated,
+          kd.pack_record(*table, m_pack_buffer, buf, m_sk_packed_tuple_updated,
                          nullptr, 0, hidden_pk_id, 0, nullptr, 0);
       const rocksdb::Slice updated_key(
           reinterpret_cast<char *>(m_sk_packed_tuple_updated), new_packed_size);
@@ -12233,7 +12234,7 @@ int ha_rocksdb::index_read_intern(uchar *const buf, const uchar *const key,
           This is a special case, use DB::Get.
           */
         const uint size = kd.pack_index_tuple(
-            table, m_pack_buffer, m_pk_packed_tuple, key, keypart_map);
+            *table, m_pack_buffer, m_pk_packed_tuple, key, keypart_map);
         bool skip_lookup = is_blind_delete_enabled();
         /* TODO(yzha) - row stats are gone in 8.0
         stats.rows_requested++; */
@@ -12283,7 +12284,7 @@ int ha_rocksdb::index_read_intern(uchar *const buf, const uchar *const key,
 
 #ifndef NDEBUG
           packed_size = kd.pack_index_tuple(
-              table, m_pack_buffer, m_sk_packed_tuple, key, keypart_map);
+              *table, m_pack_buffer, m_sk_packed_tuple, key, keypart_map);
           assert(m_dup_key_tuple.length() >= packed_size);
           assert(memcmp(m_dup_key_tuple.ptr(), m_sk_packed_tuple,
                         packed_size) == 0);
@@ -12298,7 +12299,7 @@ int ha_rocksdb::index_read_intern(uchar *const buf, const uchar *const key,
 
         if (using_full_key) {
           packed_size = kd.pack_index_tuple(
-              table, m_pack_buffer, m_sk_packed_tuple, key, keypart_map);
+              *table, m_pack_buffer, m_sk_packed_tuple, key, keypart_map);
           rocksdb::Slice key_slice(
               reinterpret_cast<const char *>(m_sk_packed_tuple), packed_size);
 
@@ -12318,7 +12319,7 @@ int ha_rocksdb::index_read_intern(uchar *const buf, const uchar *const key,
       }
     }
 
-    packed_size = kd.pack_index_tuple(table, m_pack_buffer, m_sk_packed_tuple,
+    packed_size = kd.pack_index_tuple(*table, m_pack_buffer, m_sk_packed_tuple,
                                       key, keypart_map);
   }
 
@@ -12330,7 +12331,7 @@ int ha_rocksdb::index_read_intern(uchar *const buf, const uchar *const key,
       find_flag != HA_READ_PREFIX_LAST) {
     uint end_key_packed_size = 0;
     end_key_packed_size =
-        kd.pack_index_tuple(table, m_pack_buffer, m_end_key_packed_tuple,
+        kd.pack_index_tuple(*table, m_pack_buffer, m_end_key_packed_tuple,
                             end_range->key, end_range->keypart_map);
     end_slice =
         rocksdb::Slice((char *)m_end_key_packed_tuple, end_key_packed_size);
@@ -12530,7 +12531,7 @@ int ha_rocksdb::check(THD *const thd MY_ATTRIBUTE((__unused__)),
         }
         /* Check if we get the same PK value */
         uint packed_size = m_pk_descr->pack_record(
-            table, m_pack_buffer, table->record[0], m_pk_packed_tuple, nullptr,
+            *table, m_pack_buffer, table->record[0], m_pk_packed_tuple, nullptr,
             false, hidden_pk_id);
         if (packed_size != rowkey_copy.length() ||
             memcmp(m_pk_packed_tuple, rowkey_copy.ptr(), packed_size)) {
@@ -12542,7 +12543,7 @@ int ha_rocksdb::check(THD *const thd MY_ATTRIBUTE((__unused__)),
         }
         /* Check if we get the same secondary key value */
         packed_size = m_key_descr_arr[keyno]->pack_record(
-            table, m_pack_buffer, table->record[0], m_sk_packed_tuple,
+            *table, m_pack_buffer, table->record[0], m_sk_packed_tuple,
             &m_sk_tails, false, hidden_pk_id);
         if (packed_size != sec_key_copy.length() ||
             memcmp(m_sk_packed_tuple, sec_key_copy.ptr(), packed_size)) {
@@ -13005,7 +13006,7 @@ int ha_rocksdb::index_next_with_direction_intern(uchar *const buf,
         rc = convert_record_from_storage_format(&key, &value, buf);
       }
     } else {
-      rc = kd.unpack_record(table, buf, &key, &value,
+      rc = kd.unpack_record(*table, buf, &key, &value,
                             m_converter->get_verify_row_debug_checksums());
       if (rc != HA_EXIT_SUCCESS) {
         break;
@@ -13565,7 +13566,7 @@ void ha_rocksdb::dec_table_n_rows() {
 void ha_rocksdb::set_last_rowkey(const uchar *const old_data) {
   if (old_data && use_read_free_rpl()) {
     const int old_pk_size = m_pk_descr->pack_record(
-        table, m_pack_buffer, old_data, m_pk_packed_tuple, nullptr, false);
+        *table, m_pack_buffer, old_data, m_pk_packed_tuple, nullptr, false);
     m_last_rowkey.copy((const char *)m_pk_packed_tuple, old_pk_size,
                        &my_charset_bin);
   }
@@ -13597,7 +13598,7 @@ int ha_rocksdb::get_pk_for_update(struct update_row_info *const row_info) {
     row_info->new_pk_unpack_info = &m_pk_unpack_info;
 
     size = m_pk_descr->pack_record(
-        table, m_pack_buffer, row_info->new_data, m_pk_packed_tuple,
+        *table, m_pack_buffer, row_info->new_data, m_pk_packed_tuple,
         row_info->new_pk_unpack_info, false, 0, 0, nullptr);
   } else if (row_info->old_data == nullptr) {
     row_info->hidden_pk_id = update_hidden_pk_val();
@@ -13697,7 +13698,7 @@ int ha_rocksdb::acquire_prefix_lock(const Rdb_key_def &kd, Rdb_transaction *tx,
                                     const uchar *data) {
   assert(kd.is_partial_index());
   // Obtain shared lock on prefix.
-  uint size = kd.pack_record(table, m_pack_buffer, data, m_sk_packed_tuple,
+  uint size = kd.pack_record(*table, m_pack_buffer, data, m_sk_packed_tuple,
                              nullptr, false, 0, kd.partial_index_keyparts());
   const rocksdb::Slice prefix_slice =
       rocksdb::Slice((const char *)m_sk_packed_tuple, size);
@@ -13777,7 +13778,7 @@ int ha_rocksdb::check_and_lock_sk(const uint key_id,
     include the extended fields.
   */
   int size =
-      kd.pack_record(table, m_pack_buffer, row_info.new_data, m_sk_packed_tuple,
+      kd.pack_record(*table, m_pack_buffer, row_info.new_data, m_sk_packed_tuple,
                      nullptr, false, 0, user_defined_key_parts, &n_null_fields);
   if (n_null_fields > 0) {
     /*
@@ -13794,7 +13795,7 @@ int ha_rocksdb::check_and_lock_sk(const uint key_id,
      Acquire lock on the old key in case of UPDATE
   */
   if (row_info.old_data != nullptr) {
-    size = kd.pack_record(table, m_pack_buffer, row_info.old_data,
+    size = kd.pack_record(*table, m_pack_buffer, row_info.old_data,
                           m_sk_packed_tuple_old, nullptr, false, 0,
                           user_defined_key_parts);
     const rocksdb::Slice old_slice =
@@ -14140,7 +14141,7 @@ int ha_rocksdb::check_partial_index_prefix(const TABLE *table_arg,
   assert(kd.is_partial_index());
   // TODO(mung) - We've already calculated prefix len when locking. If we
   // cache that value, we can avoid recalculating here.
-  int size = kd.pack_record(table_arg, m_pack_buffer, data, m_sk_packed_tuple,
+  int size = kd.pack_record(*table_arg, m_pack_buffer, data, m_sk_packed_tuple,
                             nullptr, false, 0, kd.partial_index_keyparts());
   const rocksdb::Slice prefix_slice =
       rocksdb::Slice((const char *)m_sk_packed_tuple, size);
@@ -14201,14 +14202,14 @@ int ha_rocksdb::update_write_sk(const TABLE *const table_arg,
 
   bool store_row_debug_checksums = should_store_row_debug_checksums();
   new_packed_size =
-      kd.pack_record(table_arg, m_pack_buffer, row_info.new_data,
+      kd.pack_record(*table_arg, m_pack_buffer, row_info.new_data,
                      m_sk_packed_tuple, &m_sk_tails, store_row_debug_checksums,
                      row_info.hidden_pk_id, 0, nullptr, m_ttl_bytes);
 
   if (row_info.old_data != nullptr) {
     // The old value
     old_packed_size = kd.pack_record(
-        table_arg, m_pack_buffer, row_info.old_data, m_sk_packed_tuple_old,
+        *table_arg, m_pack_buffer, row_info.old_data, m_sk_packed_tuple_old,
         &m_sk_tails_old, store_row_debug_checksums, row_info.hidden_pk_id, 0,
         nullptr, m_ttl_bytes);
 
@@ -14697,7 +14698,7 @@ int ha_rocksdb::index_init(uint idx, bool sorted MY_ATTRIBUTE((__unused__))) {
     }
     m_iterator.reset(
         new Rdb_iterator_partial(thd, *m_key_descr_arr[active_index_pos()],
-                                 *m_pk_descr, m_tbl_def, table, dd_table));
+                                 *m_pk_descr, m_tbl_def, *table, dd_table));
   } else {
     m_iterator.reset(new Rdb_iterator_base(thd, this,
                                            *m_key_descr_arr[active_index_pos()],
@@ -14780,7 +14781,7 @@ int ha_rocksdb::truncate(dd::Table *table_def) {
   // Reset auto_increment_value to 1 if auto-increment feature is enabled
   // By default, the starting valid value for auto_increment_value is 1
   DBUG_RETURN(truncate_table(
-      m_tbl_def, "" /* actual_user_table_name */, table,
+      m_tbl_def, "" /* actual_user_table_name */, *table,
       table->found_next_number_field ? 1 : 0 /* auto_increment_value */,
       table_def));
 }
@@ -14874,7 +14875,7 @@ int ha_rocksdb::delete_row(const uchar *const buf) {
         uint user_defined_key_parts = key_info->user_defined_key_parts;
         uint n_null_fields = 0;
 
-        packed_size = kd.pack_record(table, m_pack_buffer, buf,
+        packed_size = kd.pack_record(*table, m_pack_buffer, buf,
                                      m_sk_packed_tuple, nullptr, false, 0,
                                      user_defined_key_parts, &n_null_fields);
 
@@ -14896,8 +14897,9 @@ int ha_rocksdb::delete_row(const uchar *const buf) {
         if (rc) DBUG_RETURN(rc);
       }
 
-      packed_size = kd.pack_record(table, m_pack_buffer, buf, m_sk_packed_tuple,
-                                   nullptr, false, hidden_pk_id);
+      packed_size =
+          kd.pack_record(*table, m_pack_buffer, buf, m_sk_packed_tuple, nullptr,
+                         false, hidden_pk_id);
       rocksdb::Slice secondary_key_slice(
           reinterpret_cast<const char *>(m_sk_packed_tuple), packed_size);
       s = tx->get_indexed_write_batch(m_tbl_def->get_table_type())
@@ -15170,7 +15172,7 @@ void ha_rocksdb::position(const uchar *const record) {
     cannot be restored from its mem-comparable form in the secondary indexes).
   */
   const uint packed_size = m_pk_descr->pack_record(
-      table, m_pack_buffer, record, ref, nullptr, false, hidden_pk_id);
+      *table, m_pack_buffer, record, ref, nullptr, false, hidden_pk_id);
 
   /*
     It could be that mem-comparable form of PK occupies less than ref_length
@@ -15218,7 +15220,7 @@ void ha_rocksdb::change_table_ptr(TABLE *table_arg, TABLE_SHARE *share) {
     assert(dd_table == nullptr);
 #endif
     m_converter.reset(
-        new Rdb_converter(ha_thd(), m_tbl_def, table_arg, dd_table));
+        new Rdb_converter(ha_thd(), m_tbl_def, *table_arg, dd_table));
   }
 }
 
@@ -15316,7 +15318,7 @@ void ha_rocksdb::calc_updated_indexes() {
     for (uint kp = 0; kp < key_parts; kp++) {
       if (has_hidden_pk(*table) && kp + 1 == key_parts) break;
 
-      Field *const field = kd.get_table_field_for_part_no(table, kp);
+      const auto *const field = kd.get_table_field_for_part_no(*table, kp);
       if (bitmap_is_set(table->write_set, field->field_index())) {
         m_update_scope.set_bit(keynr);
         break;
@@ -16305,7 +16307,7 @@ void ha_rocksdb::records_in_range_internal(uint inx, key_range *const min_key,
 
   uint size1 = 0;
   if (min_key) {
-    size1 = kd.pack_index_tuple(table, m_pack_buffer, m_sk_packed_tuple,
+    size1 = kd.pack_index_tuple(*table, m_pack_buffer, m_sk_packed_tuple,
                                 min_key->key, min_key->keypart_map);
     if (min_key->flag == HA_READ_PREFIX_LAST_OR_PREV ||
         min_key->flag == HA_READ_PREFIX_LAST ||
@@ -16318,7 +16320,7 @@ void ha_rocksdb::records_in_range_internal(uint inx, key_range *const min_key,
 
   uint size2 = 0;
   if (max_key) {
-    size2 = kd.pack_index_tuple(table, m_pack_buffer, m_sk_packed_tuple_old,
+    size2 = kd.pack_index_tuple(*table, m_pack_buffer, m_sk_packed_tuple_old,
                                 max_key->key, max_key->keypart_map);
     if (max_key->flag == HA_READ_PREFIX_LAST_OR_PREV ||
         max_key->flag == HA_READ_PREFIX_LAST ||
@@ -17603,7 +17605,7 @@ bool ha_rocksdb::inplace_alter_table(
   }
 
   /* Populate all new secondary keys by scanning the primary key. */
-  if ((err = inplace_populate_sk(altered_table, ctx->m_added_indexes))) {
+  if ((err = inplace_populate_sk(*altered_table, ctx->m_added_indexes))) {
     my_error(ER_SK_POPULATE_DURING_ALTER, MYF(0));
     res = HA_EXIT_FAILURE;
     goto end;
@@ -17679,7 +17681,7 @@ int ha_rocksdb::fill_virtual_columns() {
  Scan the Primary Key index entries and populate the new secondary keys.
 */
 int ha_rocksdb::inplace_populate_sk(
-    TABLE *const new_table_arg,
+    const TABLE &new_table_arg,
     const std::unordered_set<std::shared_ptr<Rdb_key_def>> &indexes) {
   DBUG_ENTER_FUNC();
   int res = HA_EXIT_SUCCESS;
@@ -17805,12 +17807,12 @@ int ha_rocksdb::inplace_populate_sk(
     ha_rnd_end();
 
     bool is_critical_error;
-    res = tx->finish_bulk_load(&is_critical_error, true, new_table_arg);
+    res = tx->finish_bulk_load(&is_critical_error, true, &new_table_arg);
 
     if (res == ER_DUP_ENTRY) {
-      assert(new_table_arg->key_info[index->get_keyno()].flags & HA_NOSAME);
-      print_keydup_error(new_table_arg,
-                         &new_table_arg->key_info[index->get_keyno()], MYF(0),
+      assert(new_table_arg.key_info[index->get_keyno()].flags & HA_NOSAME);
+      print_keydup_error(const_cast<TABLE *>(&new_table_arg),
+                         &new_table_arg.key_info[index->get_keyno()], MYF(0),
                          thd);
     }
 
@@ -20685,9 +20687,9 @@ class Mrr_pk_scan_rowid_source : public Mrr_rowid_source {
     assert(range.end_key.flag == HA_READ_AFTER_KEY);
 
     *range_ptr = range.ptr;
-    *size = self->m_pk_descr->pack_index_tuple(self->table, self->m_pack_buffer,
-                                               buf, range.start_key.key,
-                                               all_parts_map);
+    *size = self->m_pk_descr->pack_index_tuple(
+        *self->table, self->m_pack_buffer, buf, range.start_key.key,
+        all_parts_map);
     return 0;
   }
 

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -884,10 +884,9 @@ class ha_rocksdb : public my_core::handler, public blob_buffer {
   bool contains_foreign_key()
       MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
 
-  int inplace_populate_sk(
-      TABLE *const table_arg,
-      const std::unordered_set<std::shared_ptr<Rdb_key_def>> &indexes)
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+  [[nodiscard]] int inplace_populate_sk(
+      const TABLE &table_arg,
+      const std::unordered_set<std::shared_ptr<Rdb_key_def>> &indexes);
 
   void inc_table_n_rows();
   void dec_table_n_rows();
@@ -972,10 +971,11 @@ class ha_rocksdb : public my_core::handler, public blob_buffer {
   int create(const char *const name, TABLE *const form,
              HA_CREATE_INFO *const create_info, dd::Table *table_def) override
       MY_ATTRIBUTE((__warn_unused_result__));
-  int truncate_table(Rdb_tbl_def *tbl_def,
-                     const std::string &actual_user_table_name,
-                     TABLE *table_arg, ulonglong auto_increment_value,
-                     dd::Table *table_def);
+  [[nodiscard]] int truncate_table(Rdb_tbl_def *tbl_def,
+                                   const std::string &actual_user_table_name,
+                                   const TABLE &table_arg,
+                                   ulonglong auto_increment_value,
+                                   dd::Table *table_def);
   int delete_all_rows() override;
   bool check_if_incompatible_data(HA_CREATE_INFO *const info,
                                   uint table_changes) override

--- a/storage/rocksdb/rdb_converter.h
+++ b/storage/rocksdb/rdb_converter.h
@@ -55,15 +55,15 @@ class Rdb_convert_to_record_value_decoder {
   Rdb_convert_to_record_value_decoder &operator=(
       const Rdb_convert_to_record_value_decoder &decoder) = delete;
 
-  static int decode(uchar *const buf, TABLE *table,
-                    Rdb_field_encoder *field_dec, Rdb_string_reader *reader,
-                    bool decode, bool is_null);
+  [[nodiscard]] static int decode(uchar *buf, const TABLE &table,
+                                  Rdb_field_encoder *field_dec,
+                                  Rdb_string_reader *reader, bool decode,
+                                  bool is_null);
   static int decode_instant(uchar *const buf, Rdb_field_encoder *field_dec);
 
  private:
-  static int decode_blob(TABLE *table, uchar *const buf,
-                         Rdb_field_encoder *field_dec,
-                         Rdb_string_reader *reader, bool decode);
+  [[nodiscard]] static int decode_blob(uchar *buf, Rdb_field_encoder *field_dec,
+                                       Rdb_string_reader *reader, bool decode);
   static int decode_fixed_length_field(uchar *const buf,
                                        Rdb_field_encoder *field_dec,
                                        Rdb_string_reader *const reader,
@@ -89,7 +89,7 @@ class Rdb_value_field_iterator {
   // null value map
   const char *m_null_bytes;
   // The current open table
-  TABLE *m_table;
+  const TABLE &m_table;
   // The current field
   Field *m_field;
   Rdb_field_encoder *m_field_dec;
@@ -97,7 +97,8 @@ class Rdb_value_field_iterator {
   uint m_offset;
 
  public:
-  Rdb_value_field_iterator(TABLE *table, Rdb_string_reader *value_slice_reader,
+  Rdb_value_field_iterator(const TABLE &table,
+                           Rdb_string_reader *value_slice_reader,
                            const Rdb_converter *rdb_converter, dst_type buf);
   Rdb_value_field_iterator(const Rdb_value_field_iterator &field_iterator) =
       delete;
@@ -128,7 +129,7 @@ class Rdb_converter {
   /*
     Initialize converter with table data
   */
-  Rdb_converter(const THD *thd, const Rdb_tbl_def *tbl_def, TABLE *table,
+  Rdb_converter(const THD *thd, const Rdb_tbl_def *tbl_def, const TABLE &table,
                 const dd::Table *dd_table);
   Rdb_converter(const Rdb_converter &) = delete;
   Rdb_converter(Rdb_converter &&) = delete;
@@ -220,7 +221,7 @@ class Rdb_converter {
   /* MyRocks table definition*/
   const Rdb_tbl_def *m_tbl_def;
   /* The current open table */
-  TABLE *m_table;
+  const TABLE &m_table;
   /*
     Number of bytes in on-disk (storage) record format that are used for
     storing SQL NULL flags.

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -64,6 +64,17 @@ extern CHARSET_INFO my_charset_utf32_bin;
 
 namespace myrocks {
 
+/*
+  @brief
+  Field unpacking context being passed to packing helpers
+  This avoids massive changes to all the helpers whenever we need to
+  add/remove arguments
+*/
+struct Rdb_unpack_func_context {
+  const TABLE &table;
+  rocksdb::Slice vector_codes;
+};
+
 void get_mem_comparable_space(const CHARSET_INFO *cs,
                               const std::vector<uchar> **xfrm, size_t *xfrm_len,
                               size_t *mb_len);
@@ -79,33 +90,33 @@ void get_mem_comparable_space(const CHARSET_INFO *cs,
     other              HA_ERR error code
 */
 int Rdb_convert_to_record_key_decoder::decode_field(
-    Rdb_field_packing *fpi, TABLE *table, uchar *buf, Rdb_string_reader *reader,
-    Rdb_string_reader *unpack_reader, Rdb_unpack_func_context *ctx) {
-  if (fpi->m_field_is_nullable) {
+    const Rdb_field_packing &fpi, const TABLE &table, uchar *buf,
+    Rdb_string_reader &reader, Rdb_string_reader *unpack_reader,
+    const Rdb_unpack_func_context &ctx) {
+  if (fpi.m_field_is_nullable) {
     const char *nullp;
-    if (!(nullp = reader->read(1))) {
+    if (!(nullp = reader.read(1))) {
       return HA_EXIT_FAILURE;
     }
 
     if (likely(*nullp == 1)) {
       /* Clear the NULL-bit of this field */
-      buf[fpi->m_field_null_offset] &= (uchar) ~(fpi->m_field_null_bit_mask);
+      buf[fpi.m_field_null_offset] &= (uchar) ~(fpi.m_field_null_bit_mask);
     } else if (*nullp == 0) {
       /* Set the NULL-bit of this field */
-      buf[fpi->m_field_null_offset] |= fpi->m_field_null_bit_mask;
+      buf[fpi.m_field_null_offset] |= fpi.m_field_null_bit_mask;
 
       /* Also set the field to its default value */
-      auto default_value = table->s->default_values + fpi->m_field_offset;
-      memcpy(buf + fpi->m_field_offset, default_value,
-             fpi->m_field_pack_length);
+      const auto default_value = table.s->default_values + fpi.m_field_offset;
+      memcpy(buf + fpi.m_field_offset, default_value, fpi.m_field_pack_length);
       return HA_EXIT_SUCCESS;
     } else {
       return HA_EXIT_FAILURE;
     }
   }
 
-  return (fpi->m_unpack_func)(fpi, ctx, buf + fpi->m_field_offset, reader,
-                              unpack_reader);
+  return (fpi.m_unpack_func)(fpi, ctx, buf + fpi.m_field_offset, reader,
+                             unpack_reader);
 }
 
 /*
@@ -124,18 +135,18 @@ int Rdb_convert_to_record_key_decoder::decode_field(
     other              HA_ERR error code
 */
 int Rdb_convert_to_record_key_decoder::decode(
-    uchar *const buf, Rdb_field_packing *fpi, TABLE *table,
-    bool has_unpack_info, Rdb_string_reader *reader,
-    Rdb_string_reader *unpack_reader, Rdb_unpack_func_context* ctx) {
+    uchar *buf, const Rdb_field_packing &fpi, const TABLE &table,
+    bool has_unpack_info, Rdb_string_reader &reader,
+    Rdb_string_reader &unpack_reader, const Rdb_unpack_func_context &ctx) {
   assert(buf != nullptr);
 
   // If we need unpack info, but there is none, tell the unpack function
   // this by passing unp_reader as nullptr. If we never read unpack_info
   // during unpacking anyway, then there won't an error.
-  bool maybe_missing_unpack = !has_unpack_info && fpi->uses_unpack_info();
+  const auto maybe_missing_unpack = !has_unpack_info && fpi.uses_unpack_info();
 
   int res = decode_field(fpi, table, buf, reader,
-                         maybe_missing_unpack ? nullptr : unpack_reader, ctx);
+                         maybe_missing_unpack ? nullptr : &unpack_reader, ctx);
 
   if (res != UNPACK_SUCCESS) {
     return HA_ERR_ROCKSDB_CORRUPT_DATA;
@@ -143,9 +154,9 @@ int Rdb_convert_to_record_key_decoder::decode(
   return HA_EXIT_SUCCESS;
 }
 
-static int unpack_skip_vector(const Rdb_field_packing *fpi,
-                              Rdb_string_reader *reader) {
-  if (!reader->read(fpi->m_max_image_len)) {
+[[nodiscard]] static int unpack_skip_vector(const Rdb_field_packing &fpi,
+                              Rdb_string_reader &reader) {
+  if (!reader.read(fpi.m_max_image_len)) {
     return UNPACK_FAILURE;
   }
   return UNPACK_SUCCESS;
@@ -163,13 +174,13 @@ static int unpack_skip_vector(const Rdb_field_packing *fpi,
     other              HA_ERR error code
 */
 int Rdb_convert_to_record_key_decoder::skip(
-    const Rdb_field_packing *fpi, const Field *field MY_ATTRIBUTE((__unused__)),
-    Rdb_string_reader *reader, Rdb_string_reader *unp_reader,
-    bool covered_bitmap_format_enabled, Rdb_unpack_func_context *ctx) {
+    const Rdb_field_packing &fpi, Rdb_string_reader &reader,
+    Rdb_string_reader &unp_reader, bool covered_bitmap_format_enabled,
+    Rdb_unpack_func_context &ctx) {
   /* It is impossible to unpack the column. Skip it. */
-  if (fpi->m_field_is_nullable) {
+  if (fpi.m_field_is_nullable) {
     const char *nullp;
-    if (!(nullp = reader->read(1))) {
+    if (!(nullp = reader.read(1))) {
       return HA_ERR_ROCKSDB_CORRUPT_DATA;
     }
     if (*nullp == 0) {
@@ -181,7 +192,7 @@ int Rdb_convert_to_record_key_decoder::skip(
       return HA_ERR_ROCKSDB_CORRUPT_DATA;
     }
   }
-  if ((fpi->m_skip_func)(fpi, reader)) {
+  if ((fpi.m_skip_func)(fpi, reader)) {
     return HA_ERR_ROCKSDB_CORRUPT_DATA;
   }
 
@@ -192,46 +203,78 @@ int Rdb_convert_to_record_key_decoder::skip(
   // There is a special case for prefixed varchars where we do not
   // generate unpack info, because we know prefixed varchars cannot be
   // unpacked. In this case, it is not necessary to skip.
-  if (fpi->m_skip_func == &Rdb_key_def::skip_variable_space_pad &&
-      !fpi->m_unpack_info_stores_value && !covered_bitmap_format_enabled) {
-    unp_reader->read(fpi->m_unpack_info_uses_two_bytes ? 2 : 1);
+  if (fpi.m_skip_func == &Rdb_key_def::skip_variable_space_pad &&
+      !fpi.m_unpack_info_stores_value && !covered_bitmap_format_enabled) {
+    unp_reader.read(fpi.m_unpack_info_uses_two_bytes ? 2 : 1);
   }
 
   // skip the vector codes
-  if (fpi->m_skip_func == &unpack_skip_vector) {
-    const auto vector_codes_begin = unp_reader->get_current_ptr();
+  if (fpi.m_skip_func == &unpack_skip_vector) {
+    const auto vector_codes_begin = unp_reader.get_current_ptr();
     const char *vector_codes_end;
-    if (!(vector_codes_end = unp_reader->read(fpi->m_unpack_data_len))) {
+    if (!(vector_codes_end = unp_reader.read(fpi.m_unpack_data_len))) {
       return HA_ERR_ROCKSDB_CORRUPT_DATA;
     }
-    if (ctx) {
-      ctx->vector_codes = rocksdb::Slice(vector_codes_begin,
-                                         vector_codes_end - vector_codes_begin);
-    }
+    ctx.vector_codes = rocksdb::Slice(vector_codes_begin,
+                                      vector_codes_end - vector_codes_begin);
   }
   return HA_EXIT_SUCCESS;
 }
 
+class Rdb_key_field_iterator {
+ private:
+  const TABLE &m_table;
+  Rdb_string_reader &m_reader;
+  Rdb_string_reader &m_unp_reader;
+  uint m_curr_bitmap_pos;
+  const MY_BITMAP *m_covered_bitmap;
+  uchar *m_buf;
+  bool m_has_unpack_info;
+  const Rdb_key_def *m_key_def;
+  bool m_secondary_key;
+  bool m_hidden_pk_exists;
+  bool m_is_hidden_pk;
+  bool m_is_null;
+  Rdb_field_packing *m_fpi_next;
+  Rdb_field_packing *m_fpi_end;
+  Rdb_unpack_func_context m_unpack_ctx;
+
+ public:
+  Rdb_key_field_iterator(const Rdb_key_field_iterator &) = delete;
+  Rdb_key_field_iterator &operator=(const Rdb_key_field_iterator &) = delete;
+  Rdb_key_field_iterator(const Rdb_key_def *key_def,
+                         Rdb_field_packing *pack_info,
+                         Rdb_string_reader &reader,
+                         Rdb_string_reader &unp_reader, const TABLE &table,
+                         bool has_unpack_info, const MY_BITMAP *covered_bitmap,
+                         uchar *buf);
+
+  int next();
+  bool has_next();
+  const Rdb_unpack_func_context &get_unpack_context() const {
+    return m_unpack_ctx;
+  }
+};
+
 Rdb_key_field_iterator::Rdb_key_field_iterator(
     const Rdb_key_def *key_def, Rdb_field_packing *pack_info,
-    Rdb_string_reader *reader, Rdb_string_reader *unp_reader, TABLE *table,
-    bool has_unpack_info, const MY_BITMAP *covered_bitmap, uchar *const buf) {
+    Rdb_string_reader &reader, Rdb_string_reader &unp_reader,
+    const TABLE &table, bool has_unpack_info, const MY_BITMAP *covered_bitmap,
+    uchar *const buf)
+    : m_table{table}, m_reader{reader}, m_unp_reader{unp_reader},
+      m_unpack_ctx{.table = table} {
   m_key_def = key_def;
   m_fpi_next = pack_info;
   m_fpi_end = pack_info + key_def->get_key_parts();
-  m_reader = reader;
-  m_unp_reader = unp_reader;
-  m_table = table;
   m_has_unpack_info = has_unpack_info;
   m_covered_bitmap = covered_bitmap;
   m_buf = buf;
   m_secondary_key =
       (key_def->m_index_type == Rdb_key_def::INDEX_TYPE_SECONDARY);
-  m_hidden_pk_exists = Rdb_key_def::table_has_hidden_pk(*table);
+  m_hidden_pk_exists = Rdb_key_def::table_has_hidden_pk(table);
   m_is_hidden_pk =
       (key_def->m_index_type == Rdb_key_def::INDEX_TYPE_HIDDEN_PRIMARY);
   m_curr_bitmap_pos = 0;
-  m_unpack_ctx = {.table = table};
 }
 
 bool Rdb_key_field_iterator::has_next() { return m_fpi_next < m_fpi_end; }
@@ -242,42 +285,41 @@ bool Rdb_key_field_iterator::has_next() { return m_fpi_next < m_fpi_end; }
 int Rdb_key_field_iterator::next() {
   int status = HA_EXIT_SUCCESS;
   while (m_fpi_next < m_fpi_end) {
-    auto fpi = m_fpi_next++;
+    const auto &fpi = *m_fpi_next++;
 
     /*
       Hidden pk field is packed at the end of the secondary keys, but the SQL
       layer does not know about it. Skip retrieving field if hidden pk.
     */
-    if ((m_secondary_key && m_hidden_pk_exists && fpi + 1 == m_fpi_end) ||
+    if ((m_secondary_key && m_hidden_pk_exists && m_fpi_next == m_fpi_end) ||
         m_is_hidden_pk) {
-      assert(fpi->m_unpack_func);
-      if ((fpi->m_skip_func)(fpi, m_reader)) {
+      assert(fpi.m_unpack_func);
+      if ((fpi.m_skip_func)(fpi, m_reader)) {
         return HA_ERR_ROCKSDB_CORRUPT_DATA;
       }
       return HA_EXIT_SUCCESS;
     }
 
-    bool covered_column = (fpi->m_covered == Rdb_key_def::KEY_COVERED);
+    auto covered_column = (fpi.m_covered == Rdb_key_def::KEY_COVERED);
     if (m_covered_bitmap != nullptr &&
-        Rdb_key_def::is_variable_length_field(fpi->m_field_real_type) &&
-        fpi->m_covered == Rdb_key_def::KEY_MAY_BE_COVERED) {
+        Rdb_key_def::is_variable_length_field(fpi.m_field_real_type) &&
+        fpi.m_covered == Rdb_key_def::KEY_MAY_BE_COVERED) {
       covered_column = m_curr_bitmap_pos < MAX_REF_PARTS &&
                        bitmap_is_set(m_covered_bitmap, m_curr_bitmap_pos++);
     }
 
-    if (fpi->m_unpack_func && covered_column) {
+    if (fpi.m_unpack_func && covered_column) {
       /* It is possible to unpack this column. Do it. */
       status = Rdb_convert_to_record_key_decoder::decode(
           m_buf, fpi, m_table, m_has_unpack_info, m_reader, m_unp_reader,
-          &m_unpack_ctx);
+          m_unpack_ctx);
       if (status) {
         return status;
       }
       break;
     } else {
-      auto field = fpi->get_field_in_table(m_table);
       status = Rdb_convert_to_record_key_decoder::skip(
-          fpi, field, m_reader, m_unp_reader, m_secondary_key, &m_unpack_ctx);
+          fpi, m_reader, m_unp_reader, m_secondary_key, m_unpack_ctx);
       if (status) {
         return status;
       }
@@ -923,12 +965,12 @@ const std::string Rdb_key_def::parse_comment_for_qualifier(
 
   Returns -1 if field was null, 1 if error, 0 otherwise.
 */
-int Rdb_key_def::read_memcmp_key_part(Rdb_string_reader *reader,
-                                      const uint part_num) const {
+int Rdb_key_def::read_memcmp_key_part(Rdb_string_reader &reader,
+                                      uint part_num) const {
   /* It is impossible to unpack the column. Skip it. */
   if (m_pack_info[part_num].m_field_is_nullable) {
     const char *nullp;
-    if (!(nullp = reader->read(1))) return 1;
+    if (!(nullp = reader.read(1))) return 1;
     if (*nullp == 0) {
       /* This is a NULL value */
       return -1;
@@ -938,8 +980,8 @@ int Rdb_key_def::read_memcmp_key_part(Rdb_string_reader *reader,
     }
   }
 
-  Rdb_field_packing *fpi = &m_pack_info[part_num];
-  if ((fpi->m_skip_func)(fpi, reader)) {
+  const auto &fpi = m_pack_info[part_num];
+  if ((fpi.m_skip_func)(fpi, reader)) {
     return 1;
   }
   return 0;
@@ -1000,7 +1042,7 @@ uint Rdb_key_def::get_primary_key_tuple(const Rdb_key_def &pk_descr,
       start_offs[pk_key_part] = reader.get_current_ptr();
     }
 
-    if (read_memcmp_key_part(&reader, i) > 0) {
+    if (read_memcmp_key_part(reader, i) > 0) {
       return RDB_INVALID_KEY_LEN;
     }
 
@@ -1045,7 +1087,7 @@ uint Rdb_key_def::get_memcmp_sk_parts(const rocksdb::Slice &key,
   if ((!reader.read(INDEX_NUMBER_SIZE))) return RDB_INVALID_KEY_LEN;
 
   for (uint i = 0; i < m_user_defined_sk_parts; i++) {
-    if ((res = read_memcmp_key_part(&reader, i)) > 0) {
+    if ((res = read_memcmp_key_part(reader, i)) > 0) {
       return RDB_INVALID_KEY_LEN;
     } else if (res == -1) {
       (*n_null_fields)++;
@@ -1068,25 +1110,24 @@ uint Rdb_key_def::get_memcmp_sk_parts(const rocksdb::Slice &key,
                      size is at least max_storage_fmt_length() bytes.
 */
 
-uint Rdb_key_def::pack_index_tuple(TABLE *const tbl, uchar *const pack_buffer,
-                                   uchar *const packed_tuple,
-                                   const uchar *const key_tuple,
+uint Rdb_key_def::pack_index_tuple(const TABLE &tbl, uchar *pack_buffer,
+                                   uchar *packed_tuple, const uchar *key_tuple,
                                    const key_part_map &keypart_map) const {
-  assert(tbl != nullptr);
   assert(pack_buffer != nullptr);
   assert(packed_tuple != nullptr);
   assert(key_tuple != nullptr);
 
   /* We were given a record in KeyTupleFormat. First, save it to record */
-  const uint key_len = calculate_key_len(tbl, m_keyno, keypart_map);
-  key_restore(tbl->record[0], const_cast<uchar *>(key_tuple),
-              &tbl->key_info[m_keyno], key_len);
+  const auto key_len =
+      calculate_key_len(const_cast<TABLE *>(&tbl), m_keyno, keypart_map);
+  key_restore(tbl.record[0], const_cast<uchar *>(key_tuple),
+              &tbl.key_info[m_keyno], key_len);
 
   uint n_used_parts = my_count_bits(keypart_map);
   if (keypart_map == HA_WHOLE_KEY) n_used_parts = 0;  // Full key is used
 
   /* Then, convert the record into a mem-comparable form */
-  return pack_record(tbl, pack_buffer, tbl->record[0], packed_tuple, nullptr,
+  return pack_record(tbl, pack_buffer, tbl.record[0], packed_tuple, nullptr,
                      false, 0, n_used_parts);
 }
 
@@ -1153,17 +1194,17 @@ size_t Rdb_key_def::get_unpack_header_size(char tag) {
   the lookup is covered. If it can already be determined that the lookup is
   not covered, map->bitmap will be set to null.
  */
-void Rdb_key_def::get_lookup_bitmap(const TABLE *table, MY_BITMAP *map) const {
+void Rdb_key_def::get_lookup_bitmap(const TABLE &table, MY_BITMAP *map) const {
   assert(map->bitmap == nullptr);
   bitmap_init(map, nullptr, MAX_REF_PARTS);
   uint curr_bitmap_pos = 0;
 
   // Indicates which columns in the read set might be covered.
   MY_BITMAP maybe_covered_bitmap;
-  bitmap_init(&maybe_covered_bitmap, nullptr, table->read_set->n_bits);
+  bitmap_init(&maybe_covered_bitmap, nullptr, table.read_set->n_bits);
 
   for (uint i = 0; i < m_key_parts; i++) {
-    if (table_has_hidden_pk(*table) && i + 1 == m_key_parts) {
+    if (table_has_hidden_pk(table) && i + 1 == m_key_parts) {
       continue;
     }
 
@@ -1172,7 +1213,7 @@ void Rdb_key_def::get_lookup_bitmap(const TABLE *table, MY_BITMAP *map) const {
     // Columns which are always covered are not stored in the covered bitmap so
     // we can ignore them here too.
     if (m_pack_info[i].m_covered == KEY_COVERED &&
-        bitmap_is_set(table->read_set, field->field_index())) {
+        bitmap_is_set(table.read_set, field->field_index())) {
       bitmap_set_bit(&maybe_covered_bitmap, field->field_index());
       continue;
     }
@@ -1186,7 +1227,7 @@ void Rdb_key_def::get_lookup_bitmap(const TABLE *table, MY_BITMAP *map) const {
       case MYSQL_TYPE_LONG_BLOB:
       case MYSQL_TYPE_BLOB:
         if (curr_bitmap_pos < MAX_REF_PARTS) {
-          if (bitmap_is_set(table->read_set, field->field_index())) {
+          if (bitmap_is_set(table.read_set, field->field_index())) {
             bitmap_set_bit(map, curr_bitmap_pos);
             bitmap_set_bit(&maybe_covered_bitmap, field->field_index());
           }
@@ -1200,7 +1241,7 @@ void Rdb_key_def::get_lookup_bitmap(const TABLE *table, MY_BITMAP *map) const {
       // This column is a type which is never covered. If it was requested, we
       // know this lookup will never be covered.
       default:
-        if (bitmap_is_set(table->read_set, field->field_index())) {
+        if (bitmap_is_set(table.read_set, field->field_index())) {
           bitmap_free(&maybe_covered_bitmap);
           bitmap_free(map);
           return;
@@ -1211,7 +1252,7 @@ void Rdb_key_def::get_lookup_bitmap(const TABLE *table, MY_BITMAP *map) const {
 
   // If there are columns which are not covered in the read set, the lookup
   // can't be covered.
-  if (!bitmap_cmp(table->read_set, &maybe_covered_bitmap)) {
+  if (!bitmap_cmp(table.read_set, &maybe_covered_bitmap)) {
     bitmap_free(map);
   }
   bitmap_free(&maybe_covered_bitmap);
@@ -1322,15 +1363,13 @@ uchar *Rdb_key_def::pack_field(
     Length of the packed tuple
 */
 
-uint Rdb_key_def::pack_record(const TABLE *const tbl, uchar *const pack_buffer,
-                              const uchar *const record,
-                              uchar *const packed_tuple,
-                              Rdb_string_writer *const unpack_info,
-                              const bool should_store_row_debug_checksums,
-                              const longlong hidden_pk_id, uint n_key_parts,
-                              uint *const n_null_fields,
-                              const char *const ttl_bytes) const {
-  assert(tbl != nullptr);
+uint Rdb_key_def::pack_record(const TABLE &tbl, uchar *pack_buffer,
+                              const uchar *record, uchar *packed_tuple,
+                              Rdb_string_writer *unpack_info,
+                              bool should_store_row_debug_checksums,
+                              longlong hidden_pk_id, uint n_key_parts,
+                              uint *n_null_fields,
+                              const char *ttl_bytes) const {
   assert(pack_buffer != nullptr);
   assert(record != nullptr);
   assert(packed_tuple != nullptr);
@@ -1345,7 +1384,7 @@ uint Rdb_key_def::pack_record(const TABLE *const tbl, uchar *const pack_buffer,
   size_t unpack_start_pos = size_t(-1);
   size_t unpack_len_pos = size_t(-1);
   size_t covered_bitmap_pos = size_t(-1);
-  const bool hidden_pk_exists = table_has_hidden_pk(*tbl);
+  const auto hidden_pk_exists = table_has_hidden_pk(tbl);
 
   rdb_netbuf_store_index(tuple, get_index_number());
   tuple += INDEX_NUMBER_SIZE;
@@ -1422,8 +1461,8 @@ uint Rdb_key_def::pack_record(const TABLE *const tbl, uchar *const pack_buffer,
     Field *const field = m_pack_info[i].get_field_in_table(tbl);
     assert(field != nullptr);
 
-    uint field_offset = field->field_ptr() - tbl->record[0];
-    uint null_offset = field->null_offset(tbl->record[0]);
+    uint field_offset = field->field_ptr() - tbl.record[0];
+    uint null_offset = field->null_offset(tbl.record[0]);
     bool maybe_null = field->is_nullable();
 
     field->move_field(
@@ -1448,8 +1487,8 @@ uint Rdb_key_def::pack_record(const TABLE *const tbl, uchar *const pack_buffer,
     }
 
     // Restore field->field_ptr() and field->null_ptr
-    field->move_field(tbl->record[0] + field_offset,
-                      maybe_null ? tbl->record[0] + null_offset : nullptr,
+    field->move_field(tbl.record[0] + field_offset,
+                      maybe_null ? tbl.record[0] + null_offset : nullptr,
                       field->null_bit);
   }
 
@@ -1560,8 +1599,8 @@ int Rdb_key_def::compare_keys(const rocksdb::Slice *key1,
   assert(memcmp(indexp1, indexp2, INDEX_NUMBER_SIZE) == 0);
 
   for (uint i = 0; i < m_key_parts; i++) {
-    const Rdb_field_packing *const fpi = &m_pack_info[i];
-    if (fpi->m_field_is_nullable) {
+    const auto &fpi = m_pack_info[i];
+    if (fpi.m_field_is_nullable) {
       const auto nullp1 = reader1.read(1);
       const auto nullp2 = reader2.read(1);
 
@@ -1582,11 +1621,11 @@ int Rdb_key_def::compare_keys(const rocksdb::Slice *key1,
 
     const auto before_skip1 = reader1.get_current_ptr();
     const auto before_skip2 = reader2.get_current_ptr();
-    assert(fpi->m_skip_func);
-    if ((fpi->m_skip_func)(fpi, &reader1)) {
+    assert(fpi.m_skip_func);
+    if ((fpi.m_skip_func)(fpi, reader1)) {
       return HA_EXIT_FAILURE;
     }
-    if ((fpi->m_skip_func)(fpi, &reader2)) {
+    if ((fpi.m_skip_func)(fpi, reader2)) {
       return HA_EXIT_FAILURE;
     }
     const auto size1 = reader1.get_current_ptr() - before_skip1;
@@ -1625,8 +1664,8 @@ size_t Rdb_key_def::key_length(const TABLE *const table
     return size_t(-1);
   }
   for (uint i = 0; i < m_key_parts; i++) {
-    const Rdb_field_packing *fpi = &m_pack_info[i];
-    if ((fpi->m_skip_func)(fpi, &reader)) {
+    const auto &fpi = m_pack_info[i];
+    if ((fpi.m_skip_func)(fpi, reader)) {
       return size_t(-1);
     }
   }
@@ -1666,12 +1705,12 @@ int Rdb_key_def::decode_unpack_info(Rdb_string_reader *unp_reader,
   return HA_EXIT_SUCCESS;
 }
 
-int Rdb_key_def::extract_vector_codes(TABLE *const table,
+int Rdb_key_def::extract_vector_codes(const TABLE &table,
                                       const rocksdb::Slice &packed_key,
                                       const rocksdb::Slice &unpack_info,
                                       rocksdb::Slice &vector_codes) const {
   return unpack_record_inner(
-      table, /**buf*/ table->record[0], &packed_key, &unpack_info,
+      table, /**buf*/ table.record[0], &packed_key, &unpack_info,
       /**verify_row_debug_checksums */ false, &vector_codes);
 }
 
@@ -1685,10 +1724,10 @@ int Rdb_key_def::extract_vector_codes(TABLE *const table,
     HA_EXIT_SUCCESS    OK
     other              HA_ERR error code
 */
-int Rdb_key_def::unpack_record(TABLE *const table, uchar *const buf,
-                               const rocksdb::Slice *const packed_key,
-                               const rocksdb::Slice *const unpack_info,
-                               const bool verify_row_debug_checksums) const {
+int Rdb_key_def::unpack_record(const TABLE &table, uchar *buf,
+                               const rocksdb::Slice *packed_key,
+                               const rocksdb::Slice *unpack_info,
+                               bool verify_row_debug_checksums) const {
   return unpack_record_inner(table, buf, packed_key, unpack_info,
                              verify_row_debug_checksums,
                              /** vector_codes*/ nullptr);
@@ -1707,10 +1746,10 @@ int Rdb_key_def::unpack_record(TABLE *const table, uchar *const buf,
     HA_EXIT_SUCCESS    OK
     other              HA_ERR error code
 */
-int Rdb_key_def::unpack_record_inner(TABLE *const table, uchar *const buf,
-                               const rocksdb::Slice *const packed_key,
-                               const rocksdb::Slice *const unpack_info,
-                               const bool verify_row_debug_checksums, 
+int Rdb_key_def::unpack_record_inner(const TABLE &table, uchar *buf,
+                               const rocksdb::Slice *packed_key,
+                               const rocksdb::Slice *unpack_info,
+                               bool verify_row_debug_checksums,
                                rocksdb::Slice *vector_codes) const {
   Rdb_string_reader reader(packed_key);
   Rdb_string_reader unp_reader = Rdb_string_reader::read_or_empty(unpack_info);
@@ -1736,7 +1775,7 @@ int Rdb_key_def::unpack_record_inner(TABLE *const table, uchar *const buf,
 
   // Reset the blob buffer required for unpacking.
   if (this->m_max_blob_length) {
-    auto bb = dynamic_cast<blob_buffer *>(table->file);
+    auto *const bb = dynamic_cast<blob_buffer *>(table.file);
     assert(bb);
     if (bb->reset_blob_buffer(this->m_max_blob_length)) {
       return HA_ERR_OUT_OF_MEM;
@@ -1755,7 +1794,7 @@ int Rdb_key_def::unpack_record_inner(TABLE *const table, uchar *const buf,
   }
 
   Rdb_key_field_iterator iter(
-      this, m_pack_info, &reader, &unp_reader, table, has_unpack_info,
+      this, m_pack_info, reader, unp_reader, table, has_unpack_info,
       has_covered_bitmap ? &covered_bitmap : nullptr, buf);
   while (iter.has_next()) {
     err = iter.next();
@@ -1801,7 +1840,7 @@ int Rdb_key_def::unpack_record_inner(TABLE *const table, uchar *const buf,
     } else {
       /* The checksums are present but we are not checking checksums */
     }
-    auto handler = dynamic_cast<ha_rocksdb *>(table->file);
+    auto *const handler = dynamic_cast<ha_rocksdb *>(table.file);
     if (handler) handler->m_validated_checksums++;
   }
 
@@ -1853,9 +1892,9 @@ bool Rdb_key_def::index_format_min_check(const int pk_min,
   Function of type rdb_index_field_skip_t
 */
 
-int Rdb_key_def::skip_max_length(const Rdb_field_packing *const fpi,
-                                 Rdb_string_reader *const reader) {
-  if (!reader->read(fpi->m_max_image_len)) return HA_EXIT_FAILURE;
+int Rdb_key_def::skip_max_length(const Rdb_field_packing &fpi,
+                                 Rdb_string_reader &reader) {
+  if (!reader.read(fpi.m_max_image_len)) return HA_EXIT_FAILURE;
   return HA_EXIT_SUCCESS;
 }
 
@@ -1874,17 +1913,17 @@ int Rdb_key_def::skip_max_length(const Rdb_field_packing *const fpi,
   Function of type rdb_index_field_skip_t
 */
 
-int Rdb_key_def::skip_variable_length_encoding(
-    const Rdb_field_packing *const fpi MY_ATTRIBUTE((__unused__)),
-    Rdb_string_reader *const reader) {
+int Rdb_key_def::skip_variable_length_encoding(const Rdb_field_packing &fpi,
+                                               Rdb_string_reader &reader) {
   const uchar *ptr;
   bool finished = false;
 
-  size_t dst_len; /* How much data can be there */
-  dst_len = fpi->m_max_field_bytes;
+  /* How much data can be there */
+  auto dst_len = fpi.m_max_field_bytes;
 
   /* Decode the length-emitted encoding here */
-  while ((ptr = (const uchar *)reader->read(RDB_ESCAPE_LENGTH))) {
+  while (
+      (ptr = reinterpret_cast<const uchar *>(reader.read(RDB_ESCAPE_LENGTH)))) {
     uint used_bytes;
 
     used_bytes =
@@ -1916,22 +1955,23 @@ const int VARCHAR_CMP_GREATER_THAN_SPACES = 3;
   Skip a keypart that uses Variable-Length Space-Padded encoding
 */
 
-int Rdb_key_def::skip_variable_space_pad(const Rdb_field_packing *const fpi,
-                                         Rdb_string_reader *const reader) {
+int Rdb_key_def::skip_variable_space_pad(const Rdb_field_packing &fpi,
+                                         Rdb_string_reader &reader) {
   const uchar *ptr;
   bool finished = false;
 
-  size_t dst_len = fpi->m_max_field_bytes; /* How much data can be there */
+  auto dst_len = fpi.m_max_field_bytes; /* How much data can be there */
 
-  uchar encoded_byte = *(const uchar *)reader->read(1);
+  const auto encoded_byte = *reinterpret_cast<const uchar *>(reader.read(1));
   // Check if lead segment byte is VARCHAR_CMP_EQUAL_TO_SPACES.
   // This indicates empty content and we can return prematurely.
   if (encoded_byte == VARCHAR_CMP_EQUAL_TO_SPACES) return HA_EXIT_SUCCESS;
 
   /* Decode the length-emitted encoding here */
-  while ((ptr = (const uchar *)reader->read(fpi->m_segment_size))) {
+  while ((
+      ptr = reinterpret_cast<const uchar *>(reader.read(fpi.m_segment_size)))) {
     // See pack_with_varlength_space_pad
-    const uchar c = ptr[fpi->m_segment_size - 1];
+    const auto c = ptr[fpi.m_segment_size - 1];
     if (c == VARCHAR_CMP_EQUAL_TO_SPACES) {
       // This is the last segment
       finished = true;
@@ -1939,12 +1979,12 @@ int Rdb_key_def::skip_variable_space_pad(const Rdb_field_packing *const fpi,
     } else if (c == VARCHAR_CMP_LESS_THAN_SPACES ||
                c == VARCHAR_CMP_GREATER_THAN_SPACES) {
       // This is not the last segment
-      if ((fpi->m_segment_size - 1) > dst_len) {
+      if ((fpi.m_segment_size - 1) > dst_len) {
         // The segment is full of data but the table field can't hold that
         // much! This must be data corruption.
         return HA_EXIT_FAILURE;
       }
-      dst_len -= (fpi->m_segment_size - 1);
+      dst_len -= (fpi.m_segment_size - 1);
     } else {
       // Encountered a value that's none of the VARCHAR_CMP* constants
       // It's data corruption.
@@ -2027,21 +2067,20 @@ void Rdb_key_def::pack_unsigned(
 }
 
 template <int length>
-int Rdb_key_def::unpack_integer(
-    Rdb_field_packing *const fpi MY_ATTRIBUTE((__unused__)),
-    Rdb_unpack_func_context *const, uchar *const to,
-    Rdb_string_reader *const reader,
-    Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__))) {
-  assert(length == fpi->m_max_image_len);
+int Rdb_key_def::unpack_integer(const Rdb_field_packing &fpi,
+                                const Rdb_unpack_func_context &, uchar *to,
+                                Rdb_string_reader &reader,
+                                Rdb_string_reader *) {
+  assert(length == fpi.m_max_image_len);
 
   const uchar *from;
-  if (!(from = (const uchar *)reader->read(length))) {
+  if (!(from = reinterpret_cast<const uchar *>(reader.read(length)))) {
     return UNPACK_FAILURE; /* Mem-comparable image doesn't have enough bytes */
   }
 
 #ifdef WORDS_BIGENDIAN
   {
-    if (fpi->m_field_unsigned_flag) {
+    if (fpi.m_field_unsigned_flag) {
       to[0] = from[0];
     } else {
       to[0] = static_cast<char>(from[0] ^ 128);  // Reverse the sign bit.
@@ -2052,7 +2091,7 @@ int Rdb_key_def::unpack_integer(
 #else
   {
     const int sign_byte = from[0];
-    if (fpi->m_field_unsigned_flag) {
+    if (fpi.m_field_unsigned_flag) {
       to[length - 1] = sign_byte;
     } else {
       to[length - 1] =
@@ -2067,15 +2106,14 @@ int Rdb_key_def::unpack_integer(
 }
 
 template <int length>
-int Rdb_key_def::unpack_unsigned(
-    Rdb_field_packing *const fpi MY_ATTRIBUTE((__unused__)),
-    Rdb_unpack_func_context *const, uchar *const to,
-    Rdb_string_reader *const reader,
-    Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__))) {
-  assert(length == fpi->m_max_image_len);
+int Rdb_key_def::unpack_unsigned(const Rdb_field_packing &fpi [[maybe_unused]],
+                                 const Rdb_unpack_func_context &, uchar *to,
+                                 Rdb_string_reader &reader,
+                                 Rdb_string_reader *) {
+  assert(length == fpi.m_max_image_len);
 
   const uchar *from;
-  if (!(from = (const uchar *)reader->read(length))) {
+  if (!(from = reinterpret_cast<const uchar *>(reader.read(length)))) {
     return UNPACK_FAILURE; /* Mem-comparable image doesn't have enough bytes */
   }
 
@@ -2126,10 +2164,10 @@ static void rdb_swap_float_bytes(uchar *const dst, const uchar *const src) {
 #endif
 
 int Rdb_key_def::unpack_floating_point(
-    uchar *const dst, Rdb_string_reader *const reader, const size_t size,
-    const int exp_digit, const uchar *const zero_pattern,
-    const uchar *const zero_val, void (*swap_func)(uchar *, const uchar *)) {
-  const uchar *const from = (const uchar *)reader->read(size);
+    uchar *dst, Rdb_string_reader &reader, size_t size,
+    int exp_digit, const uchar *zero_pattern,
+    const uchar *zero_val, void (*swap_func)(uchar *, const uchar *)) {
+  const auto *const from = reinterpret_cast<const uchar *>(reader.read(size));
   if (from == nullptr) {
     /* Mem-comparable image doesn't have enough bytes */
     return UNPACK_FAILURE;
@@ -2143,7 +2181,7 @@ int Rdb_key_def::unpack_floating_point(
 
 #if defined(WORDS_BIGENDIAN)
   // On big-endian, output can go directly into result
-  uchar *const tmp = dst;
+  auto *const tmp = dst;
 #else
   // Otherwise use a temporary buffer to make byte-swapping easier later
   uchar tmp[8];
@@ -2276,12 +2314,10 @@ void Rdb_key_def::pack_double(
   Note also that this code assumes that NaN and +/-Infinity are never
   allowed in the database.
 */
-int Rdb_key_def::unpack_double(
-    Rdb_field_packing *const fpi MY_ATTRIBUTE((__unused__)),
-    Rdb_unpack_func_context *const, uchar *const field_ptr,
-    Rdb_string_reader *const reader,
-    Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__))) {
-  static double zero_val = 0.0;
+int Rdb_key_def::unpack_double(const Rdb_field_packing &,
+                               const Rdb_unpack_func_context &, uchar *field_ptr,
+                               Rdb_string_reader &reader, Rdb_string_reader *) {
+  static const double zero_val = 0.0;
   static const uchar zero_pattern[8] = {128, 0, 0, 0, 0, 0, 0, 0};
 
   return unpack_floating_point(field_ptr, reader, sizeof(double), DBL_EXP_DIG,
@@ -2379,12 +2415,10 @@ void Rdb_key_def::pack_float(
   Note also that this code assumes that NaN and +/-Infinity are never
   allowed in the database.
 */
-int Rdb_key_def::unpack_float(
-    Rdb_field_packing *const fpi MY_ATTRIBUTE((__unused__)),
-    Rdb_unpack_func_context *const, uchar *const field_ptr,
-    Rdb_string_reader *const reader,
-    Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__))) {
-  static float zero_val = 0.0;
+int Rdb_key_def::unpack_float(const Rdb_field_packing &,
+                              const Rdb_unpack_func_context &, uchar *field_ptr,
+                              Rdb_string_reader &reader, Rdb_string_reader *) {
+  static const float zero_val = 0.0;
   static const uchar zero_pattern[4] = {128, 0, 0, 0};
 
   return unpack_floating_point(field_ptr, reader, sizeof(float), FLT_EXP_DIG,
@@ -2424,15 +2458,14 @@ void Rdb_key_def::pack_newdate(
   Unpack by doing the reverse action to pack_newdate
 */
 
-int Rdb_key_def::unpack_newdate(
-    Rdb_field_packing *const fpi MY_ATTRIBUTE((__unused__)),
-    Rdb_unpack_func_context *const, uchar *const field_ptr,
-    Rdb_string_reader *const reader,
-    Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__))) {
+int Rdb_key_def::unpack_newdate(const Rdb_field_packing &fpi [[maybe_unused]],
+                                const Rdb_unpack_func_context &, uchar *field_ptr,
+                                Rdb_string_reader &reader,
+                                Rdb_string_reader *) {
   const char *from;
-  assert(fpi->m_max_image_len == 3);
+  assert(fpi.m_max_image_len == 3);
 
-  if (!(from = reader->read(3))) {
+  if (!(from = reader.read(3))) {
     /* Mem-comparable image doesn't have enough bytes */
     return UNPACK_FAILURE;
   }
@@ -2475,19 +2508,17 @@ void Rdb_key_def::pack_bit(
   Unpack the bit by copying it over.
   See Field_bit::unpack_bit for more details.
 */
-int Rdb_key_def::unpack_bit(
-    Rdb_field_packing *const fpi, Rdb_unpack_func_context *const,
-    uchar *const to, Rdb_string_reader *const reader,
-    Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__))) {
-  assert(fpi != nullptr);
+int Rdb_key_def::unpack_bit(const Rdb_field_packing &fpi,
+                            const Rdb_unpack_func_context &, uchar *to,
+                            Rdb_string_reader &reader, Rdb_string_reader *) {
   const char *from;
-  if (!(from = reader->read(fpi->m_max_image_len))) {
+  if (!(from = reader.read(fpi.m_max_image_len))) {
     /* Mem-comparable image doesn't have enough bytes */
     return UNPACK_FAILURE;
   }
   /* We don't support uneven high bits / HA_CAN_BIT_FIELD */
   uint data_length =
-      std::min((uint)fpi->m_max_image_len, fpi->m_field_pack_length);
+      std::min(static_cast<uint>(fpi.m_max_image_len), fpi.m_field_pack_length);
   memcpy(to, from, data_length);
   return UNPACK_SUCCESS;
 }
@@ -2519,17 +2550,17 @@ void Rdb_key_def::pack_binary_str(
   This is for BINARY(n) where the value occupies the whole length.
 */
 
-int Rdb_key_def::unpack_binary_str(
-    Rdb_field_packing *const fpi, Rdb_unpack_func_context *const,
-    uchar *const to, Rdb_string_reader *const reader,
-    Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__))) {
+int Rdb_key_def::unpack_binary_str(const Rdb_field_packing &fpi,
+                                   const Rdb_unpack_func_context &, uchar *to,
+                                   Rdb_string_reader &reader,
+                                   Rdb_string_reader *) {
   const char *from;
-  if (!(from = reader->read(fpi->m_max_image_len))) {
+  if (!(from = reader.read(fpi.m_max_image_len))) {
     /* Mem-comparable image doesn't have enough bytes */
     return UNPACK_FAILURE;
   }
 
-  memcpy(to, from, fpi->m_max_image_len);
+  memcpy(to, from, fpi.m_max_image_len);
   return UNPACK_SUCCESS;
 }
 
@@ -2595,20 +2626,20 @@ void Rdb_key_def::pack_string(
 */
 
 template <const int bytes>
-int unpack_utf8_str_templ(
-    Rdb_field_packing *const fpi, Rdb_unpack_func_context *const, uchar *dst,
-    Rdb_string_reader *const reader,
-    Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__))) {
-  my_core::CHARSET_INFO *const cset =
-      (my_core::CHARSET_INFO *)fpi->m_field_charset;
+[[nodiscard]] int unpack_utf8_str_templ(const Rdb_field_packing &fpi,
+                                        const Rdb_unpack_func_context &,
+                                        uchar *dst, Rdb_string_reader &reader,
+                                        Rdb_string_reader *) {
+  const auto *const cset = fpi.m_field_charset;
   const uchar *src;
-  if (!(src = (const uchar *)reader->read(fpi->m_max_image_len))) {
+  if (!(src = reinterpret_cast<const uchar *>(
+            reader.read(fpi.m_max_image_len)))) {
     /* Mem-comparable image doesn't have enough bytes */
     return UNPACK_FAILURE;
   }
 
-  const uchar *const src_end = src + fpi->m_max_image_len;
-  uchar *const dst_end = dst + fpi->m_field_pack_length;
+  const auto *const src_end = src + fpi.m_max_image_len;
+  auto *const dst_end = dst + fpi.m_field_pack_length;
 
   while (src < src_end) {
     my_wc_t wc = (bytes == 3) ? (src[0] << 16) | (src[1] << 8) | src[2]
@@ -3006,12 +3037,11 @@ uint Rdb_key_def::calc_unpack_variable_format(uchar flag, bool *done) {
   return RDB_ESCAPE_LENGTH - 1;
 }
 
-void Rdb_key_def::store_field(const uchar *data, const size_t length,
-                              uchar *ptr, Rdb_field_packing *const fpi,
-                              Rdb_unpack_func_context *const ctx
-                                  MY_ATTRIBUTE((__unused__))) {
-  if (fpi->m_field_real_type == MYSQL_TYPE_VARCHAR) {
-    auto length_bytes = fpi->m_varlength_bytes;
+void Rdb_key_def::store_field(const uchar *data, size_t length, uchar *ptr,
+                              const Rdb_field_packing &fpi,
+                              const Rdb_unpack_func_context &) {
+  if (fpi.m_field_real_type == MYSQL_TYPE_VARCHAR) {
+    auto length_bytes = fpi.m_varlength_bytes;
     if (length_bytes == 1) {
       ptr[0] = length;
     } else {
@@ -3020,8 +3050,8 @@ void Rdb_key_def::store_field(const uchar *data, const size_t length,
     }
     // data is not used for varchar as field->field_ptr() + length_bytes
     // already contains required data.
-  } else if (is_blob(fpi->m_field_real_type)) {
-    auto length_bytes = fpi->m_varlength_bytes;
+  } else if (is_blob(fpi.m_field_real_type)) {
+    auto length_bytes = fpi.m_varlength_bytes;
     store_blob_length(ptr, length_bytes, length);
     auto blob_data = (char *)(data);
     memset(ptr + length_bytes, 0, 8);
@@ -3049,15 +3079,15 @@ const char *Rdb_key_def::get_data_value(const Field *field) {
   }
 }
 
-uchar *Rdb_key_def::get_data_start_ptr(Rdb_field_packing *const fpi, uchar *dst,
-                                       Rdb_unpack_func_context *const ctx) {
+uchar *Rdb_key_def::get_data_start_ptr(const Rdb_field_packing &fpi, uchar *dst,
+                                       const Rdb_unpack_func_context &ctx) {
   uchar *data_start = nullptr;
-  if (fpi->m_field_real_type == MYSQL_TYPE_VARCHAR) {
-    data_start = dst + fpi->m_varlength_bytes;
-  } else if (is_blob(fpi->m_field_real_type)) {
-    auto bb = dynamic_cast<blob_buffer *>(ctx->table->file);
+  if (fpi.m_field_real_type == MYSQL_TYPE_VARCHAR) {
+    data_start = dst + fpi.m_varlength_bytes;
+  } else if (is_blob(fpi.m_field_real_type)) {
+    auto *const bb = dynamic_cast<blob_buffer *>(ctx.table.file);
     assert(bb);
-    data_start = bb->get_blob_buffer(fpi->m_max_field_bytes);
+    data_start = bb->get_blob_buffer(fpi.m_max_field_bytes);
   } else {
     assert(false);
   }
@@ -3139,21 +3169,22 @@ bool check_src_len<3>(uint src_len) {
 /*
   Function of type rdb_index_field_unpack_t
 */
-int Rdb_key_def::unpack_binary_varlength(
-    Rdb_field_packing *const fpi, Rdb_unpack_func_context *const ctx,
-    uchar *dst MY_ATTRIBUTE((__unused__)), Rdb_string_reader *const reader,
-    Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__))) {
-  assert(fpi->m_field_charset == &my_charset_bin);
+int Rdb_key_def::unpack_binary_varlength(const Rdb_field_packing &fpi,
+                                         const Rdb_unpack_func_context &ctx,
+                                         uchar *dst, Rdb_string_reader &reader,
+                                         Rdb_string_reader *) {
+  assert(fpi.m_field_charset == &my_charset_bin);
   const uchar *ptr;
   size_t len = 0;
   bool finished = false;
   uchar *data_start = get_data_start_ptr(fpi, dst, ctx);
   uchar *data = data_start;
   // How much we can unpack
-  size_t data_len = fpi->m_max_field_bytes;
+  auto data_len = fpi.m_max_field_bytes;
 
   /* Decode the length-emitted encoding here */
-  while ((ptr = (const uchar *)reader->read(RDB_ESCAPE_LENGTH))) {
+  while (
+      (ptr = reinterpret_cast<const uchar *>(reader.read(RDB_ESCAPE_LENGTH)))) {
     uint used_bytes;
 
     used_bytes =
@@ -3192,23 +3223,22 @@ int Rdb_key_def::unpack_binary_varlength(
     skip_variable_space_pad - skip function
 */
 
-template <const int bytes>
-int Rdb_key_def::unpack_binary_or_utf8_varlength_space_pad(
-    Rdb_field_packing *const fpi, Rdb_unpack_func_context *const ctx,
-    uchar *dst, Rdb_string_reader *const reader,
-    Rdb_string_reader *const unp_reader) {
+template <int bytes>
+[[nodiscard]] int Rdb_key_def::unpack_binary_or_utf8_varlength_space_pad(
+    const Rdb_field_packing &fpi, const Rdb_unpack_func_context &ctx,
+    uchar *dst, Rdb_string_reader &reader, Rdb_string_reader *unp_reader) {
   const uchar *ptr;
   size_t len = 0;
   bool finished = false;
   uchar *data_start = get_data_start_ptr(fpi, dst, ctx);
   uchar *data = data_start;
-  uchar *data_end = data + fpi->m_max_field_bytes;
+  auto *data_end = data + fpi.m_max_field_bytes;
 
   uint space_padding_bytes = 0;
   uint extra_spaces;
-  if ((fpi->m_unpack_info_uses_two_bytes
+  if ((fpi.m_unpack_info_uses_two_bytes
            ? unp_reader->read_uint16(&extra_spaces)
-           : unp_reader->read_uint8(&extra_spaces))) {
+       : unp_reader->read_uint8(&extra_spaces))) {
     return UNPACK_FAILURE;
   }
 
@@ -3220,31 +3250,32 @@ int Rdb_key_def::unpack_binary_or_utf8_varlength_space_pad(
     extra_spaces -= RDB_TRIMMED_CHARS_OFFSET;
   }
 
-  space_padding_bytes *= fpi->space_xfrm_len;
+  space_padding_bytes *= fpi.space_xfrm_len;
 
   // Check if lead segment byte is VARCHAR_CMP_EQUAL_TO_SPACES.
   // This indicates empty content or just spaces. We can bypass
   // the main loop and check for spaces to be appended.
-  uchar encoded_byte = *(const uchar *)reader->read(1);
+  const auto encoded_byte = *reinterpret_cast<const uchar *>(reader.read(1));
   if (encoded_byte == VARCHAR_CMP_EQUAL_TO_SPACES) goto finished;
 
   /* Decode the length-emitted encoding here */
-  while ((ptr = (const uchar *)reader->read(fpi->m_segment_size))) {
-    const char last_byte = ptr[fpi->m_segment_size - 1];
+  while ((
+      ptr = reinterpret_cast<const uchar *>(reader.read(fpi.m_segment_size)))) {
+    const char last_byte = ptr[fpi.m_segment_size - 1];
     size_t used_bytes;
     if (last_byte == VARCHAR_CMP_EQUAL_TO_SPACES)  // this is the last segment
     {
-      if (space_padding_bytes > (fpi->m_segment_size - 1)) {
+      if (space_padding_bytes > (fpi.m_segment_size - 1)) {
         return UNPACK_FAILURE;  // Cannot happen, corrupted data
       }
-      used_bytes = (fpi->m_segment_size - 1) - space_padding_bytes;
+      used_bytes = (fpi.m_segment_size - 1) - space_padding_bytes;
       finished = true;
     } else {
       if (last_byte != VARCHAR_CMP_LESS_THAN_SPACES &&
           last_byte != VARCHAR_CMP_GREATER_THAN_SPACES) {
         return UNPACK_FAILURE;  // Invalid value
       }
-      used_bytes = fpi->m_segment_size - 1;
+      used_bytes = fpi.m_segment_size - 1;
     }
 
     // Now, need to decode used_bytes of data and append them to the value.
@@ -3257,7 +3288,7 @@ int Rdb_key_def::unpack_binary_or_utf8_varlength_space_pad(
         my_wc_t wc = (bytes == 3) ? (src[0] << 16) | (src[1] << 8) | src[2]
                                   : (src[0] << 8) | src[1];
         src += bytes;
-        const CHARSET_INFO *cset = fpi->m_field_charset;
+        const auto *const cset = fpi.m_field_charset;
         int res = cset->cset->wc_mb(cset, wc, data, data_end);
         assert(res <= bytes + 1);
         if (res <= 0) return UNPACK_FAILURE;
@@ -3282,7 +3313,7 @@ finished:
     // Both binary and UTF-8 charset store space as ' ',
     // so the following is ok:
     if (data + extra_spaces > data_end) return UNPACK_FAILURE;
-    memset(data, fpi->m_field_charset->pad_char, extra_spaces);
+    memset(data, fpi.m_field_charset->pad_char, extra_spaces);
     len += extra_spaces;
   }
   store_field(data_start, len, dst, fpi, ctx);
@@ -3327,13 +3358,12 @@ void Rdb_key_def::dummy_make_unpack_info(
   Function of type rdb_index_field_unpack_t
 */
 
-int Rdb_key_def::unpack_unknown(Rdb_field_packing *const fpi,
-                                Rdb_unpack_func_context *const,
-                                uchar *const dst,
-                                Rdb_string_reader *const reader,
-                                Rdb_string_reader *const unp_reader) {
+int Rdb_key_def::unpack_unknown(const Rdb_field_packing &fpi,
+                                const Rdb_unpack_func_context &, uchar *dst,
+                                Rdb_string_reader &reader,
+                                Rdb_string_reader *unp_reader) {
   const uchar *ptr;
-  const uint len = fpi->m_unpack_data_len;
+  const uint len = fpi.m_unpack_data_len;
   // We don't use anything from the key, so skip over it.
   if (skip_max_length(fpi, reader)) {
     return UNPACK_FAILURE;
@@ -3347,9 +3377,9 @@ int Rdb_key_def::unpack_unknown(Rdb_field_packing *const fpi,
         ERROR_LEVEL, ER_LOG_PRINTF_MSG,
         "Unpack data missing for type:%d csname:%s coll_name:%s "
         "unpack_data_len:%d ",
-        fpi->m_field_real_type,
-        fpi->m_field_charset ? fpi->m_field_charset->csname : "unknown",
-        fpi->m_field_charset ? fpi->m_field_charset->m_coll_name : "unknown",
+        fpi.m_field_real_type,
+        fpi.m_field_charset ? fpi.m_field_charset->csname : "unknown",
+        fpi.m_field_charset ? fpi.m_field_charset->m_coll_name : "unknown",
         len);
     return UNPACK_FAILURE;
   }
@@ -3404,18 +3434,17 @@ static void make_unpack_vector(const Rdb_field_packing *const fpi
     make_unpack_unknown, unpack_unknown
 */
 
-int Rdb_key_def::unpack_unknown_varlength(Rdb_field_packing *const fpi,
-                                          Rdb_unpack_func_context *const ctx,
-                                          uchar *dst,
-                                          Rdb_string_reader *const reader,
-                                          Rdb_string_reader *const unp_reader) {
+int Rdb_key_def::unpack_unknown_varlength(const Rdb_field_packing &fpi,
+                                          const Rdb_unpack_func_context &ctx,
+                                          uchar *dst, Rdb_string_reader &reader,
+                                          Rdb_string_reader *unp_reader) {
   const uchar *ptr;
 
   uchar *data_start = get_data_start_ptr(fpi, dst, ctx);
   uchar *data = data_start;
-  const uint len_bytes = fpi->m_varlength_bytes;
+  const auto len_bytes = fpi.m_varlength_bytes;
   // We don't use anything from the key, so skip over it.
-  if ((fpi->m_skip_func)(fpi, reader)) {
+  if ((fpi.m_skip_func)(fpi, reader)) {
     return UNPACK_FAILURE;
   }
 
@@ -3424,10 +3453,10 @@ int Rdb_key_def::unpack_unknown_varlength(Rdb_field_packing *const fpi,
 
   if ((ptr = (uchar *)unp_reader->read(len_bytes))) {
     uint len = 0;
-    if (fpi->m_field_real_type == MYSQL_TYPE_VARCHAR) {
+    if (fpi.m_field_real_type == MYSQL_TYPE_VARCHAR) {
       len = len_bytes == 1 ? (uint)*ptr : uint2korr(ptr);
     } else {
-      len = Field_blob::get_length(ptr, fpi->m_varlength_bytes);
+      len = Field_blob::get_length(ptr, fpi.m_varlength_bytes);
     }
     if ((ptr = (const uchar *)unp_reader->read(len))) {
       memcpy(data, ptr, len);
@@ -3523,9 +3552,8 @@ void Rdb_key_def::make_unpack_simple_varlength(
 */
 
 int Rdb_key_def::unpack_simple_varlength_space_pad(
-    Rdb_field_packing *const fpi, Rdb_unpack_func_context *const ctx,
-    uchar *dst MY_ATTRIBUTE((__unused__)), Rdb_string_reader *const reader,
-    Rdb_string_reader *const unp_reader) {
+    const Rdb_field_packing &fpi, const Rdb_unpack_func_context &ctx, uchar *dst,
+    Rdb_string_reader &reader, Rdb_string_reader *unp_reader) {
   const uchar *ptr;
   size_t len = 0;
   bool finished = false;
@@ -3533,18 +3561,18 @@ int Rdb_key_def::unpack_simple_varlength_space_pad(
   uchar *data = data_start;
 
   // For simple collations, char_length is also number of bytes.
-  assert((size_t)fpi->m_max_image_len >=
-         (fpi->m_max_field_bytes / fpi->m_field_charset->mbmaxlen));
-  uchar *data_end = data + fpi->m_max_field_bytes;
+  assert(static_cast<size_t>(fpi.m_max_image_len) >=
+         (fpi.m_max_field_bytes / fpi.m_field_charset->mbmaxlen));
+  const auto *const data_end = data + fpi.m_max_field_bytes;
   Rdb_bit_reader bit_reader(unp_reader);
 
   uint space_padding_bytes = 0;
   uint extra_spaces;
   assert(unp_reader != nullptr);
 
-  if ((fpi->m_unpack_info_uses_two_bytes
+  if ((fpi.m_unpack_info_uses_two_bytes
            ? unp_reader->read_uint16(&extra_spaces)
-           : unp_reader->read_uint8(&extra_spaces))) {
+       : unp_reader->read_uint8(&extra_spaces))) {
     return UNPACK_FAILURE;
   }
 
@@ -3555,32 +3583,33 @@ int Rdb_key_def::unpack_simple_varlength_space_pad(
     extra_spaces -= 8;
   }
 
-  space_padding_bytes *= fpi->space_xfrm_len;
+  space_padding_bytes *= fpi.space_xfrm_len;
 
   // Check if lead segment byte is VARCHAR_CMP_EQUAL_TO_SPACES.
   // This indicates empty content or just spaces. We can bypass
   // the main loop and check for spaces to be appended.
-  uchar encoded_byte = *(const uchar *)reader->read(1);
+  const auto encoded_byte = *reinterpret_cast<const uchar *>(reader.read(1));
   if (encoded_byte == VARCHAR_CMP_EQUAL_TO_SPACES) goto finished;
 
   /* Decode the length-emitted encoding here */
-  while ((ptr = (const uchar *)reader->read(fpi->m_segment_size))) {
+  while ((
+      ptr = reinterpret_cast<const uchar *>(reader.read(fpi.m_segment_size)))) {
     const char last_byte =
-        ptr[fpi->m_segment_size - 1];  // number of padding bytes
+        ptr[fpi.m_segment_size - 1];  // number of padding bytes
     size_t used_bytes;
     if (last_byte == VARCHAR_CMP_EQUAL_TO_SPACES) {
       // this is the last one
-      if (space_padding_bytes > (fpi->m_segment_size - 1)) {
+      if (space_padding_bytes > (fpi.m_segment_size - 1)) {
         return UNPACK_FAILURE;  // Cannot happen, corrupted data
       }
-      used_bytes = (fpi->m_segment_size - 1) - space_padding_bytes;
+      used_bytes = (fpi.m_segment_size - 1) - space_padding_bytes;
       finished = true;
     } else {
       if (last_byte != VARCHAR_CMP_LESS_THAN_SPACES &&
           last_byte != VARCHAR_CMP_GREATER_THAN_SPACES) {
         return UNPACK_FAILURE;
       }
-      used_bytes = fpi->m_segment_size - 1;
+      used_bytes = fpi.m_segment_size - 1;
     }
 
     if (data + used_bytes > data_end) {
@@ -3589,7 +3618,7 @@ int Rdb_key_def::unpack_simple_varlength_space_pad(
     }
 
     uint ret;
-    if ((ret = rdb_read_unpack_simple(&bit_reader, fpi->m_charset_codec, ptr,
+    if ((ret = rdb_read_unpack_simple(&bit_reader, fpi.m_charset_codec, ptr,
                                       used_bytes, data)) != UNPACK_SUCCESS) {
       return ret;
     }
@@ -3608,7 +3637,7 @@ finished:
     if (data + extra_spaces > data_end) return UNPACK_FAILURE;
     // pad_char has a 1-byte form in all charsets that
     // are handled by rdb_init_collation_mapping.
-    memset(data, fpi->m_field_charset->pad_char, extra_spaces);
+    memset(data, fpi.m_field_charset->pad_char, extra_spaces);
     len += extra_spaces;
   }
   store_field(data_start, len, dst, fpi, ctx);
@@ -3639,20 +3668,20 @@ void Rdb_key_def::make_unpack_simple(const Rdb_field_packing *const fpi,
   Function of type rdb_index_field_unpack_t
 */
 
-int Rdb_key_def::unpack_simple(Rdb_field_packing *const fpi,
-                               Rdb_unpack_func_context *const, uchar *const dst,
-                               Rdb_string_reader *const reader,
-                               Rdb_string_reader *const unp_reader) {
+int Rdb_key_def::unpack_simple(const Rdb_field_packing &fpi,
+                               const Rdb_unpack_func_context &, uchar *dst,
+                               Rdb_string_reader &reader,
+                               Rdb_string_reader *unp_reader) {
   const uchar *ptr;
-  const uint len = fpi->m_max_image_len;
+  const uint len = fpi.m_max_image_len;
   Rdb_bit_reader bit_reader(unp_reader);
 
-  if (!(ptr = (const uchar *)reader->read(len))) {
+  if (!(ptr = reinterpret_cast<const uchar *>(reader.read(len)))) {
     return UNPACK_FAILURE;
   }
 
   return rdb_read_unpack_simple(unp_reader ? &bit_reader : nullptr,
-                                fpi->m_charset_codec, ptr, len, dst);
+                                fpi.m_charset_codec, ptr, len, dst);
 }
 
 Rdb_field_packing *Rdb_key_def::get_pack_info(uint pack_no) const {
@@ -4315,8 +4344,8 @@ bool Rdb_field_packing::setup(const Rdb_key_def *const key_descr,
   return m_covered == Rdb_key_def::KEY_COVERED;
 }
 
-Field *Rdb_field_packing::get_field_in_table(const TABLE *const tbl) const {
-  return tbl->key_info[m_keynr].key_part[m_key_part].field;
+Field *Rdb_field_packing::get_field_in_table(const TABLE &tbl) const noexcept {
+  return tbl.key_info[m_keynr].key_part[m_key_part].field;
 }
 
 void Rdb_field_packing::fill_hidden_pk_val(uchar **dst,

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -62,29 +62,39 @@ class Rdb_key_def;
 class Rdb_field_packing;
 class Rdb_cf_manager;
 class Rdb_ddl_manager;
-class Rdb_unpack_func_context;
+struct Rdb_unpack_func_context;
 
 class Rdb_convert_to_record_key_decoder {
  public:
-  Rdb_convert_to_record_key_decoder() = default;
-  Rdb_convert_to_record_key_decoder(
-      const Rdb_convert_to_record_key_decoder &decoder) = delete;
+  Rdb_convert_to_record_key_decoder() = delete;
+  Rdb_convert_to_record_key_decoder(const Rdb_convert_to_record_key_decoder &) =
+      delete;
   Rdb_convert_to_record_key_decoder &operator=(
-      const Rdb_convert_to_record_key_decoder &decoder) = delete;
-  static int decode(uchar *const buf, Rdb_field_packing *fpi, TABLE *table,
-                    bool has_unpack_info, Rdb_string_reader *reader,
-                    Rdb_string_reader *unpack_reader,
-                    Rdb_unpack_func_context *ctx);
-  static int skip(const Rdb_field_packing *fpi, const Field *field,
-                  Rdb_string_reader *reader, Rdb_string_reader *unpack_reader,
-                  bool covered_bitmap_format_enabled,
-                  Rdb_unpack_func_context *ctx);
+      const Rdb_convert_to_record_key_decoder &) = delete;
+  Rdb_convert_to_record_key_decoder(Rdb_convert_to_record_key_decoder &&) =
+      delete;
+  Rdb_convert_to_record_key_decoder &operator=(
+      Rdb_convert_to_record_key_decoder &&) = delete;
+  ~Rdb_convert_to_record_key_decoder() = delete;
+
+  [[nodiscard]] static int decode(uchar *buf, const Rdb_field_packing &fpi,
+                                  const TABLE &table, bool has_unpack_info,
+                                  Rdb_string_reader &reader,
+                                  Rdb_string_reader &unpack_reader,
+                                  const Rdb_unpack_func_context &ctx);
+
+  [[nodiscard]] static int skip(const Rdb_field_packing &fpi,
+                                Rdb_string_reader &reader,
+                                Rdb_string_reader &unpack_reader,
+                                bool covered_bitmap_format_enabled,
+                                Rdb_unpack_func_context &ctx);
 
  private:
-  static int decode_field(Rdb_field_packing *fpi, TABLE *table, uchar *buf,
-                          Rdb_string_reader *reader,
-                          Rdb_string_reader *unpack_reader,
-                          Rdb_unpack_func_context *ctx);
+  [[nodiscard]] static int decode_field(const Rdb_field_packing &fpi,
+                                        const TABLE &table, uchar *buf,
+                                        Rdb_string_reader &reader,
+                                        Rdb_string_reader *unpack_reader,
+                                        const Rdb_unpack_func_context &ctx);
 };
 
 /*
@@ -115,53 +125,6 @@ class Rdb_pack_field_context {
   std::string vector_codes;
 };
 
-/*
-  @brief
-  Field unpacking context being passed to packing helpers
-  This avoids massive changes to all the helpers whenever we need to
-  add/remove arguments
-*/
-class Rdb_unpack_func_context {
- public:
-  TABLE *table;
-  rocksdb::Slice vector_codes;
-};
-
-class Rdb_key_field_iterator {
- private:
-  TABLE *m_table;
-  Rdb_string_reader *m_reader;
-  Rdb_string_reader *m_unp_reader;
-  uint m_curr_bitmap_pos;
-  const MY_BITMAP *m_covered_bitmap;
-  uchar *m_buf;
-  bool m_has_unpack_info;
-  const Rdb_key_def *m_key_def;
-  bool m_secondary_key;
-  bool m_hidden_pk_exists;
-  bool m_is_hidden_pk;
-  bool m_is_null;
-  Rdb_field_packing *m_fpi_next;
-  Rdb_field_packing *m_fpi_end;
-  Rdb_unpack_func_context m_unpack_ctx;
-
- public:
-  Rdb_key_field_iterator(const Rdb_key_field_iterator &) = delete;
-  Rdb_key_field_iterator &operator=(const Rdb_key_field_iterator &) = delete;
-  Rdb_key_field_iterator(const Rdb_key_def *key_def,
-                         Rdb_field_packing *pack_info,
-                         Rdb_string_reader *reader,
-                         Rdb_string_reader *unp_reader, TABLE *table,
-                         bool has_unpack_info, const MY_BITMAP *covered_bitmap,
-                         uchar *buf);
-
-  int next();
-  bool has_next();
-  const Rdb_unpack_func_context &get_unpack_context() const {
-    return m_unpack_ctx;
-  }
-};
-
 struct Rdb_collation_codec;
 struct Rdb_index_info;
 
@@ -172,13 +135,13 @@ struct Rdb_index_info;
 using rdb_make_unpack_info_t = void (*)(const Rdb_field_packing *fpi,
                                         const Field *field,
                                         Rdb_pack_field_context *pack_ctx);
-using rdb_index_field_unpack_t = int (*)(Rdb_field_packing *fpi,
-                                         Rdb_unpack_func_context *const ctx,
+using rdb_index_field_unpack_t = int (*)(const Rdb_field_packing &fpi,
+                                         const Rdb_unpack_func_context &ctx,
                                          uchar *field_ptr,
-                                         Rdb_string_reader *reader,
+                                         Rdb_string_reader &reader,
                                          Rdb_string_reader *unpack_reader);
-using rdb_index_field_skip_t = int (*)(const Rdb_field_packing *fpi,
-                                       Rdb_string_reader *reader);
+using rdb_index_field_skip_t = int (*)(const Rdb_field_packing &fpi,
+                                       Rdb_string_reader &reader);
 using rdb_index_field_pack_t = void (*)(Rdb_field_packing *fpi, Field *field,
                                         uchar *buf, uchar **dst,
                                         Rdb_pack_field_context *pack_ctx);
@@ -282,9 +245,10 @@ enum {
 class Rdb_key_def {
  public:
   /* Convert a key from KeyTupleFormat to mem-comparable form */
-  uint pack_index_tuple(TABLE *const tbl, uchar *const pack_buffer,
-                        uchar *const packed_tuple, const uchar *const key_tuple,
-                        const key_part_map &keypart_map) const;
+  [[nodiscard]] uint pack_index_tuple(const TABLE &tbl, uchar *pack_buffer,
+                                      uchar *packed_tuple,
+                                      const uchar *key_tuple,
+                                      const key_part_map &keypart_map) const;
 
   uchar *pack_field(Field *const field, Rdb_field_packing *pack_info,
                     uchar *tuple, uchar *const packed_tuple,
@@ -292,24 +256,26 @@ class Rdb_key_def {
                     Rdb_string_writer *const unpack_info,
                     uint *const n_null_fields) const;
   /* Convert a key from Table->record format to mem-comparable form */
-  uint pack_record(const TABLE *const tbl, uchar *const pack_buffer,
-                   const uchar *const record, uchar *const packed_tuple,
-                   Rdb_string_writer *const unpack_info,
-                   const bool should_store_row_debug_checksums,
-                   const longlong hidden_pk_id = 0, uint n_key_parts = 0,
-                   uint *const n_null_fields = nullptr,
-                   const char *const ttl_bytes = nullptr) const;
+  [[nodiscard]] uint pack_record(const TABLE &tbl, uchar *pack_buffer,
+                                 const uchar *record, uchar *packed_tuple,
+                                 Rdb_string_writer *unpack_info,
+                                 bool should_store_row_debug_checksums,
+                                 longlong hidden_pk_id = 0,
+                                 uint n_key_parts = 0,
+                                 uint *n_null_fields = nullptr,
+                                 const char *ttl_bytes = nullptr) const;
   /* Pack the hidden primary key into mem-comparable form. */
   uint pack_hidden_pk(const longlong hidden_pk_id,
                       uchar *const packed_tuple) const;
-  int unpack_record(TABLE *const table, uchar *const buf,
-                    const rocksdb::Slice *const packed_key,
-                    const rocksdb::Slice *const unpack_info,
-                    const bool verify_row_debug_checksums) const;
+  [[nodiscard]] int unpack_record(const TABLE &table, uchar *buf,
+                                  const rocksdb::Slice *packed_key,
+                                  const rocksdb::Slice *unpack_info,
+                                  bool verify_row_debug_checksums) const;
 
-  int extract_vector_codes(TABLE *const table, const rocksdb::Slice &packed_key,
-                           const rocksdb::Slice &unpack_info,
-                           rocksdb::Slice &vector_codes) const;
+  [[nodiscard]] int extract_vector_codes(const TABLE &table,
+                                         const rocksdb::Slice &packed_key,
+                                         const rocksdb::Slice &unpack_info,
+                                         rocksdb::Slice &vector_codes) const;
 
   int decode_unpack_info(Rdb_string_reader *unp_reader, bool *has_unpack_info,
                          const char **unpack_header) const;
@@ -360,7 +326,7 @@ class Rdb_key_def {
     return true;
   }
 
-  void get_lookup_bitmap(const TABLE *table, MY_BITMAP *map) const;
+  void get_lookup_bitmap(const TABLE &table, MY_BITMAP *map) const;
 
   bool covers_lookup(const rocksdb::Slice *const unpack_info,
                      const MY_BITMAP *const map) const;
@@ -403,8 +369,8 @@ class Rdb_key_def {
     return gl_index_id;
   }
 
-  int read_memcmp_key_part(Rdb_string_reader *reader,
-                           const uint part_num) const;
+  [[nodiscard]] int read_memcmp_key_part(Rdb_string_reader &reader,
+                                         uint part_num) const;
 
   /* Must only be called for secondary keys: */
   uint get_primary_key_tuple(const Rdb_key_def &pk_descr,
@@ -431,7 +397,8 @@ class Rdb_key_def {
       Internally, we always extend all indexes with PK columns. This function
       uses our definition of how the index is Extended.
   */
-  inline Field *get_table_field_for_part_no(TABLE *table, uint part_no) const;
+  [[nodiscard]] inline Field *get_table_field_for_part_no(
+      const TABLE &table, uint part_no) const noexcept;
 
   const std::string &get_name() const { return m_name; }
 
@@ -697,16 +664,16 @@ class Rdb_key_def {
                                 MY_ATTRIBUTE((__unused__)));
 
   template <int length>
-  static int unpack_integer(
-      Rdb_field_packing *const fpi, Rdb_unpack_func_context *const ctx,
-      uchar *const to, Rdb_string_reader *const reader,
-      Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__)));
+  [[nodiscard]] static int unpack_integer(const Rdb_field_packing &fpi,
+                                          const Rdb_unpack_func_context &,
+                                          uchar *to, Rdb_string_reader &reader,
+                                          Rdb_string_reader *);
 
   template <int length>
-  static int unpack_unsigned(
-      Rdb_field_packing *const fpi, Rdb_unpack_func_context *const ctx,
-      uchar *const to, Rdb_string_reader *const reader,
-      Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__)));
+  [[nodiscard]] static int unpack_unsigned(const Rdb_field_packing &fpi,
+                                           const Rdb_unpack_func_context &,
+                                           uchar *to, Rdb_string_reader &reader,
+                                           Rdb_string_reader *);
 
   static void pack_double(Rdb_field_packing *const fpi, Field *const field,
                           uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
@@ -714,57 +681,58 @@ class Rdb_key_def {
                               MY_ATTRIBUTE((__unused__)));
 
   static void pack_double_internal(double nr, uchar *to);
-  static int unpack_double(
-      Rdb_field_packing *const fpi MY_ATTRIBUTE((__unused__)),
-      Rdb_unpack_func_context *const ctx, uchar *const field_ptr,
-      Rdb_string_reader *const reader,
-      Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__)));
+
+  [[nodiscard]] static int unpack_double(const Rdb_field_packing &,
+                                         const Rdb_unpack_func_context &,
+                                         uchar *field_ptr,
+                                         Rdb_string_reader &reader,
+                                         Rdb_string_reader *);
 
   static void pack_float(Rdb_field_packing *const fpi, Field *const field,
                          uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
                          Rdb_pack_field_context *const pack_ctx
                              MY_ATTRIBUTE((__unused__)));
 
-  static int unpack_float(
-      Rdb_field_packing *const fpi, Rdb_unpack_func_context *const,
-      uchar *const field_ptr, Rdb_string_reader *const reader,
-      Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__)));
+  [[nodiscard]] static int unpack_float(const Rdb_field_packing &,
+                                        const Rdb_unpack_func_context &,
+                                        uchar *field_ptr,
+                                        Rdb_string_reader &reader,
+                                        Rdb_string_reader *);
 
   static void pack_bit(Rdb_field_packing *const fpi, Field *const field,
                        uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
                        Rdb_pack_field_context *const pack_ctx
                            MY_ATTRIBUTE((__unused__)));
 
-  static int unpack_bit(
-      Rdb_field_packing *const fpi, Rdb_unpack_func_context *const ctx,
-      uchar *const to, Rdb_string_reader *const reader,
-      Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__)));
+  [[nodiscard]] static int unpack_bit(const Rdb_field_packing &fpi,
+                                      const Rdb_unpack_func_context &,
+                                      uchar *to, Rdb_string_reader &reader,
+                                      Rdb_string_reader *);
 
   static void pack_binary_str(
       Rdb_field_packing *const fpi, Field *const field,
       uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
       Rdb_pack_field_context *const pack_ctx MY_ATTRIBUTE((__unused__)));
 
-  static int unpack_binary_str(
-      Rdb_field_packing *const fpi, Rdb_unpack_func_context *const ctx,
-      uchar *const to, Rdb_string_reader *const reader,
-      Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__)));
+  [[nodiscard]] static int unpack_binary_str(const Rdb_field_packing &fpi,
+                                             const Rdb_unpack_func_context &,
+                                             uchar *to,
+                                             Rdb_string_reader &reader,
+                                             Rdb_string_reader *);
 
   static void pack_string(
       Rdb_field_packing *const fpi, Field *const field,
       uchar *const buf MY_ATTRIBUTE((__unused__)), uchar **dst,
       Rdb_pack_field_context *const pack_ctx MY_ATTRIBUTE((__unused__)));
 
-  static int unpack_binary_varlength(
-      Rdb_field_packing *const fpi, Rdb_unpack_func_context *const ctx,
-      uchar *dst MY_ATTRIBUTE((__unused__)), Rdb_string_reader *const reader,
-      Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__)));
+  [[nodiscard]] static int unpack_binary_varlength(
+      const Rdb_field_packing &fpi, const Rdb_unpack_func_context &ctx,
+      uchar *dst, Rdb_string_reader &reader, Rdb_string_reader *);
 
-  template <const int bytes>
-  static int unpack_binary_or_utf8_varlength_space_pad(
-      Rdb_field_packing *const fpi, Rdb_unpack_func_context *const ctx,
-      uchar *dst MY_ATTRIBUTE((__unused__)), Rdb_string_reader *const reader,
-      Rdb_string_reader *const unp_reader);
+  template <int bytes>
+  [[nodiscard]] static int unpack_binary_or_utf8_varlength_space_pad(
+      const Rdb_field_packing &fpi, const Rdb_unpack_func_context &ctx,
+      uchar *dst, Rdb_string_reader &reader, Rdb_string_reader *unp_reader);
 
   static rdb_index_field_unpack_t unpack_binary_varlength_space_pad;
   static rdb_index_field_unpack_t unpack_utf8_varlength_space_pad;
@@ -774,41 +742,37 @@ class Rdb_key_def {
                            uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
                            Rdb_pack_field_context *const pack_ctx
                                MY_ATTRIBUTE((__unused__)));
-  static int unpack_newdate(
-      Rdb_field_packing *const fpi, Rdb_unpack_func_context *const ctx,
-      uchar *const field_ptr, Rdb_string_reader *const reader,
-      Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__)));
+  [[nodiscard]] static int unpack_newdate(const Rdb_field_packing &fpi,
+                                          const Rdb_unpack_func_context &,
+                                          uchar *field_ptr,
+                                          Rdb_string_reader &reader,
+                                          Rdb_string_reader *);
 
   static rdb_index_field_unpack_t unpack_utf8_str;
   static rdb_index_field_unpack_t unpack_utf8mb4_str;
 
-  static int unpack_unknown_varlength(Rdb_field_packing *const fpi,
-                                      Rdb_unpack_func_context *const ctx,
-                                      uchar *dst MY_ATTRIBUTE((__unused__)),
-                                      Rdb_string_reader *const reader,
-                                      Rdb_string_reader *const unp_reader);
+  [[nodiscard]] static int unpack_unknown_varlength(
+      const Rdb_field_packing &fpi, const Rdb_unpack_func_context &ctx,
+      uchar *dst, Rdb_string_reader &reader, Rdb_string_reader *unp_reader);
 
-  static int unpack_simple_varlength_space_pad(
-      Rdb_field_packing *const fpi, Rdb_unpack_func_context *const ctx,
-      uchar *dst MY_ATTRIBUTE((__unused__)), Rdb_string_reader *const reader,
-      Rdb_string_reader *const unp_reader);
+  [[nodiscard]] static int unpack_simple_varlength_space_pad(
+      const Rdb_field_packing &fpi, const Rdb_unpack_func_context &ctx,
+      uchar *dst, Rdb_string_reader &reader, Rdb_string_reader *unp_reader);
 
-  static int unpack_simple(Rdb_field_packing *const fpi,
-                           Rdb_unpack_func_context *const ctx, uchar *const dst,
-                           Rdb_string_reader *const reader,
-                           Rdb_string_reader *const unp_reader);
+  [[nodiscard]] static int unpack_simple(const Rdb_field_packing &fpi,
+                                         const Rdb_unpack_func_context &,
+                                         uchar *dst, Rdb_string_reader &reader,
+                                         Rdb_string_reader *unp_reader);
 
-  static int unpack_unknown(Rdb_field_packing *const fpi,
-                            Rdb_unpack_func_context *const ctx,
-                            uchar *const dst, Rdb_string_reader *const reader,
-                            Rdb_string_reader *const unp_reader);
+  [[nodiscard]] static int unpack_unknown(const Rdb_field_packing &fpi,
+                                          const Rdb_unpack_func_context &,
+                                          uchar *dst, Rdb_string_reader &reader,
+                                          Rdb_string_reader *unp_reader);
 
-  static int unpack_floating_point(uchar *const dst,
-                                   Rdb_string_reader *const reader,
-                                   const size_t size, const int exp_digit,
-                                   const uchar *const zero_pattern,
-                                   const uchar *const zero_val,
-                                   void (*swap_func)(uchar *, const uchar *));
+  [[nodiscard]] static int unpack_floating_point(
+      uchar *dst, Rdb_string_reader &reader, size_t size, int exp_digit,
+      const uchar *zero_pattern, const uchar *zero_val,
+      void (*swap_func)(uchar *, const uchar *));
 
   static void make_unpack_simple_varlength(
       const Rdb_field_packing *const fpi, const Field *const field,
@@ -831,14 +795,14 @@ class Rdb_key_def {
       const Field *field MY_ATTRIBUTE((__unused__)),
       Rdb_pack_field_context *pack_ctx MY_ATTRIBUTE((__unused__)));
 
-  static int skip_max_length(const Rdb_field_packing *const fpi,
-                             Rdb_string_reader *const reader);
+  [[nodiscard]] static int skip_max_length(const Rdb_field_packing &fpi,
+                                           Rdb_string_reader &reader);
 
-  static int skip_variable_length_encoding(const Rdb_field_packing *const fpi,
-                                           Rdb_string_reader *const reader);
+  [[nodiscard]] static int skip_variable_length_encoding(
+      const Rdb_field_packing &fpi, Rdb_string_reader &reader);
 
-  static int skip_variable_space_pad(const Rdb_field_packing *const fpi,
-                                     Rdb_string_reader *const reader);
+  [[nodiscard]] static int skip_variable_space_pad(const Rdb_field_packing &fpi,
+                                                   Rdb_string_reader &reader);
 
   static inline bool is_unpack_data_tag(char c) {
     return c == RDB_UNPACK_DATA_TAG || c == RDB_UNPACK_COVERED_DATA_TAG ||
@@ -875,11 +839,10 @@ class Rdb_key_def {
 
   std::unique_ptr<Rdb_vector_index> m_vector_index;
 
-  [[nodiscard]] int unpack_record_inner(TABLE *const table, uchar *const buf,
-                                        const rocksdb::Slice *const packed_key,
-                                        const rocksdb::Slice *const unpack_info,
-                                        const bool verify_row_debug_checksums,
-                                        rocksdb::Slice *vector_codes) const;
+  [[nodiscard]] int unpack_record_inner(
+      const TABLE &table, uchar *buf, const rocksdb::Slice *packed_key,
+      const rocksdb::Slice *unpack_info, bool verify_row_debug_checksums,
+      rocksdb::Slice *vector_codes) const;
 
   [[nodiscard]] uint setup_vector_index(const TABLE &tbl,
                                         const Rdb_tbl_def &tbl_def,
@@ -894,9 +857,9 @@ class Rdb_key_def {
     Stores data and len for the given field.
     Currently this support varchar and blob data types.
   */
-  static void store_field(const uchar *data, const size_t length, uchar *dst,
-                          Rdb_field_packing *const fpi,
-                          Rdb_unpack_func_context *const ctx);
+  static void store_field(const uchar *data, size_t length, uchar *dst,
+                          const Rdb_field_packing &fpi,
+                          const Rdb_unpack_func_context &);
   /*
     Returns the data pointer from field.
     Currently this support varchar and blob data types.
@@ -907,8 +870,9 @@ class Rdb_key_def {
     Returns the pointer where the field data will be stored.
     Currently this support varchar and blob data types.
   */
-  static uchar *get_data_start_ptr(Rdb_field_packing *const fpi, uchar *dst,
-                                   Rdb_unpack_func_context *const ctx);
+  [[nodiscard]] static uchar *get_data_start_ptr(
+      const Rdb_field_packing &fpi, uchar *dst,
+      const Rdb_unpack_func_context &ctx);
 
   /*
     Returns number of bytes used to store the length for field.
@@ -1173,7 +1137,7 @@ class Rdb_field_packing {
   bool setup(const Rdb_key_def *const key_descr, const Field *const field,
              const uint keynr_arg, const uint key_part_arg,
              const uint16 key_length);
-  Field *get_field_in_table(const TABLE *const tbl) const;
+  [[nodiscard]] Field *get_field_in_table(const TABLE &tbl) const noexcept;
   void fill_hidden_pk_val(uchar **dst, const longlong hidden_pk_id) const;
 };
 
@@ -1232,8 +1196,8 @@ class Rdb_field_encoder {
   }
 };
 
-inline Field *Rdb_key_def::get_table_field_for_part_no(TABLE *table,
-                                                       uint part_no) const {
+inline Field *Rdb_key_def::get_table_field_for_part_no(
+    const TABLE &table, uint part_no) const noexcept {
   assert(part_no < get_key_parts());
   return m_pack_info[part_no].get_field_in_table(table);
 }

--- a/storage/rocksdb/rdb_iterator.cc
+++ b/storage/rocksdb/rdb_iterator.cc
@@ -490,7 +490,7 @@ void Rdb_iterator_base::multi_get(
 Rdb_iterator_partial::Rdb_iterator_partial(THD *thd, const Rdb_key_def &kd,
                                            const Rdb_key_def &pkd,
                                            const Rdb_tbl_def *tbl_def,
-                                           TABLE *table,
+                                           const TABLE &table,
                                            const dd::Table *dd_table)
     : Rdb_iterator_base(thd, nullptr, kd, pkd, tbl_def),
       m_table(table),
@@ -511,7 +511,7 @@ Rdb_iterator_partial::Rdb_iterator_partial(THD *thd, const Rdb_key_def &kd,
   if (max_mem) {
     m_mem_root.set_max_capacity(max_mem);
   }
-  m_converter.setup_field_decoders(table->read_set, table->s->primary_key,
+  m_converter.setup_field_decoders(table.read_set, table.s->primary_key,
                                    true /* keyread_only */,
                                    true /* decode all */);
 
@@ -520,7 +520,7 @@ Rdb_iterator_partial::Rdb_iterator_partial(THD *thd, const Rdb_key_def &kd,
   m_cur_prefix_key = reinterpret_cast<uchar *>(
       my_malloc(PSI_NOT_INSTRUMENTED, packed_len, MYF(0)));
   m_record_buf = reinterpret_cast<uchar *>(
-      my_malloc(PSI_NOT_INSTRUMENTED, table->s->reclength, MYF(0)));
+      my_malloc(PSI_NOT_INSTRUMENTED, table.s->reclength, MYF(0)));
   m_pack_buffer = reinterpret_cast<uchar *>(
       my_malloc(PSI_NOT_INSTRUMENTED, packed_len, MYF(0)));
   m_sk_packed_tuple = reinterpret_cast<uchar *>(
@@ -553,7 +553,7 @@ int Rdb_iterator_partial::get_prefix_len(const rocksdb::Slice &start_key,
       return HA_EXIT_SUCCESS;
     }
 
-    if (m_kd.read_memcmp_key_part(&reader, i) > 0) {
+    if (m_kd.read_memcmp_key_part(reader, i) > 0) {
       return HA_ERR_INTERNAL_ERROR;
     }
   }

--- a/storage/rocksdb/rdb_iterator.h
+++ b/storage/rocksdb/rdb_iterator.h
@@ -184,7 +184,7 @@ class Rdb_iterator_base : public Rdb_iterator {
 
 class Rdb_iterator_partial : public Rdb_iterator_base {
  private:
-  TABLE *m_table;
+  const TABLE &m_table;
   MEM_ROOT m_mem_root;
 
   Rdb_iterator_base m_iterator_pk;
@@ -262,7 +262,7 @@ class Rdb_iterator_partial : public Rdb_iterator_base {
 
  public:
   Rdb_iterator_partial(THD *thd, const Rdb_key_def &kd, const Rdb_key_def &pkd,
-                       const Rdb_tbl_def *tbl_def, TABLE *table,
+                       const Rdb_tbl_def *tbl_def, const TABLE &table,
                        const dd::Table *dd_table);
   ~Rdb_iterator_partial() override;
 

--- a/storage/rocksdb/rdb_vector_db.cc
+++ b/storage/rocksdb/rdb_vector_db.cc
@@ -79,7 +79,7 @@ static void write_inverted_list_item_key(Rdb_string_writer &writer,
 class Rdb_faiss_inverted_list_context {
  public:
   explicit Rdb_faiss_inverted_list_context(
-      Rdb_vector_search_params &search_params)
+      const Rdb_vector_search_params &search_params)
       : m_search_params{search_params} {}
   // the context object lives beyond the initial search call,
   // need to keep a copy of search params here
@@ -251,7 +251,7 @@ class Rdb_vector_iterator : public faiss::InvertedListsIterator {
          */
         const auto min_key_packed_size =
             search_params.m_pk_descr->pack_index_tuple(
-                const_cast<TABLE *>(search_params.m_tbl),
+                *search_params.m_tbl,
                 search_params.m_pack_buffer, search_params.m_sk_packed_tuple,
                 min_key.key, min_key.keypart_map);
 
@@ -270,7 +270,7 @@ class Rdb_vector_iterator : public faiss::InvertedListsIterator {
          */
         const auto max_key_packed_size =
             search_params.m_pk_descr->pack_index_tuple(
-                const_cast<TABLE *>(search_params.m_tbl),
+                *search_params.m_tbl,
                 search_params.m_pack_buffer,
                 search_params.m_end_key_packed_tuple, max_key.key,
                 max_key.keypart_map);
@@ -323,7 +323,7 @@ class Rdb_vector_iterator : public faiss::InvertedListsIterator {
       std::string buf;
       buf.resize(search_params.m_sk_descr->max_storage_fmt_length());
       const uint pack_size = search_params.m_sk_descr->pack_index_tuple(
-          const_cast<TABLE *>(search_params.m_tbl), search_params.m_pack_buffer,
+          *search_params.m_tbl, search_params.m_pack_buffer,
           reinterpret_cast<uchar *>(buf.data()),
           search_params.m_start_range.key,
           search_params.m_start_range.keypart_map);
@@ -399,8 +399,8 @@ class Rdb_vector_iterator : public faiss::InvertedListsIterator {
 
        */
       m_context->m_error = params.m_sk_descr->unpack_record(
-          const_cast<TABLE *>(params.m_tbl), params.m_tbl->record[0],
-          &key_slice, &value_slice, false);
+          *params.m_tbl, params.m_tbl->record[0], &key_slice, &value_slice,
+          false);
 
       /* propagate error and terminate iterator in case of unpacking error */
       if (m_context->m_error) break;
@@ -457,8 +457,7 @@ class Rdb_vector_iterator : public faiss::InvertedListsIterator {
 
     auto key_descr = m_context->m_search_params.m_sk_descr;
     auto unpack_rtn = key_descr->extract_vector_codes(
-        const_cast<TABLE *const>(m_context->m_search_params.m_tbl), key, value,
-        codes);
+        *m_context->m_search_params.m_tbl, key, value, codes);
 
     if (unpack_rtn) {
       return unpack_rtn;
@@ -675,11 +674,13 @@ class Rdb_vector_index_ivf : public Rdb_vector_index {
     return m_index_def.dimension();
   }
 
-  uint code_size() const override { return m_index_l2->code_size; }
+  [[nodiscard]] uint code_size() const noexcept override {
+    return m_index_l2->code_size;
+  }
 
-  virtual uint index_scan(Rdb_vector_search_params &params,
-                          std::unique_ptr<Rdb_vector_db_iterator>
-                              &index_scan_result_iter) override {
+  [[nodiscard]] virtual uint index_scan(const Rdb_vector_search_params &params,
+                                        std::unique_ptr<Rdb_vector_db_iterator>
+                                            &index_scan_result_iter) override {
     m_hit++;
 
     constexpr faiss::idx_t vector_count = 1;

--- a/storage/rocksdb/rdb_vector_db.h
+++ b/storage/rocksdb/rdb_vector_db.h
@@ -69,10 +69,9 @@ class Rdb_vector_index_info {
   uint m_median_list_size{0};
 };
 
-class Rdb_vector_search_params {
- public:
+struct Rdb_vector_search_params {
   THD *m_thd = nullptr;
-  const TABLE *const m_tbl = nullptr;
+  const TABLE *m_tbl = nullptr;
   const Rdb_key_def *m_pk_descr = nullptr;
 
   // buffers
@@ -114,11 +113,11 @@ class Rdb_vector_index {
   virtual void assign_vector(const float *data,
                              Rdb_vector_index_assignment &assignment) = 0;
 
-  virtual uint index_scan(
-      Rdb_vector_search_params &params,
+  [[nodiscard]] virtual uint index_scan(
+      const Rdb_vector_search_params &params,
       std::unique_ptr<Rdb_vector_db_iterator> &index_scan_result_iter) = 0;
 
-  virtual uint knn_search(
+  [[nodiscard]] virtual uint knn_search(
       Rdb_vector_search_params &params,
       std::vector<std::pair<std::string, float>> &result) = 0;
   /**
@@ -185,7 +184,8 @@ class Rdb_vector_db_handler {
 
   uint current_key(std::string &key) const;
 
-  uint search(Rdb_vector_index *index, const Rdb_key_def *sk_descr);
+  [[nodiscard]] uint search(Rdb_vector_index *index,
+                            const Rdb_key_def *sk_descr);
 
   int vector_index_orderby_init(Item *sort_func, AccessPath *rangePath) {
     if (!sort_func) {


### PR DESCRIPTION
- Since this class is a non-instantiable collection of static methods, delete
  the rest of special methods (default constructor, move constructor, move
  assignment operator, destructor) in addition to the currently deleted ones.
- Convert method arguments from pointers to references and propagate this up and
  down the call hierarchy. Most notably this converts many "TABLE *" uses to
  "const TABLE &" throughout MyRocks, deletes a bit of dead code, converts some
  constructor assignments to initializer list items.
- For touched methods, add [[nodiscard]] as applicable and remove redundant
  const from parameters, do other minor cleanups.
- Move struct Rdb_unpack_func_context definition from rdb_datadic.h to
  rdb_datadic.cc leaving a forward declaration in the header file.
